### PR TITLE
fix(parser): handle SBI Card Unicode Math Sans-Serif SMS

### DIFF
--- a/parser-core/src/test/kotlin/TestSBIParser.kt
+++ b/parser-core/src/test/kotlin/TestSBIParser.kt
@@ -3,6 +3,7 @@ import com.pennywiseai.parser.core.bank.SBIBankParser
 import com.pennywiseai.parser.core.test.ExpectedTransaction
 import com.pennywiseai.parser.core.test.ParserTestCase
 import com.pennywiseai.parser.core.test.ParserTestUtils
+import com.pennywiseai.parser.core.test.SimpleTestCase
 import org.junit.jupiter.api.*
 import java.math.BigDecimal
 
@@ -47,6 +48,7 @@ class SBIBankParserTest {
             "ATMSBI" to true,
             "SBICRD" to true,
             "SBIBK" to true,
+            "SBI CARDS AND PAYMENT SERVICES" to true,
             "UNKNOWN" to false
         )
 
@@ -56,7 +58,81 @@ class SBIBankParserTest {
             handleCases = handleChecks,
             suiteName = "SBI Parser"
         )
+    }
 
+    @TestFactory
+    fun `sbi card parser handles unicode math sans-serif SMS`(): List<DynamicTest> {
+        val parser = SBIBankParser()
 
+        val testCases = listOf(
+            ParserTestCase(
+                name = "SBI Card Unicode Math Sans-Serif spending SMS",
+                message = "Rs.90.00 𝗌𝗉𝖾𝗇𝗍 𝗈𝗇 𝗒𝗈𝗎𝗋 𝖲𝖡𝖨 𝖢𝗋𝖾𝖽𝗂𝗍 𝖢𝖺𝗋𝖽 𝖾𝗇𝖽𝗂𝗇𝗀 5667 at SUPREMEGOURMET on 13/02/26. 𝖳𝗋𝗑𝗇. 𝗇𝗈𝗍 𝖽𝗈𝗇𝖾 𝖻𝗒 𝗒𝗈𝗎? 𝖱𝖾𝗉𝗈𝗋𝗍 𝖺𝗍 https://sbicard.com/Dispute",
+                sender = "SBI CARDS AND PAYMENT SERVICES",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("90.00"),
+                    currency = "INR",
+                    type = TransactionType.CREDIT,
+                    merchant = "SUPREMEGOURMET",
+                    accountLast4 = "5667",
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "SBI Card standard credit card spending",
+                message = "Rs.259.00 spent on your SBI Credit Card ending with 1234 on 15Jan26. Your available limit is Rs.1,235.00. If not done by you, call 39 02 02 02.",
+                sender = "SBICRD",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("259.00"),
+                    currency = "INR",
+                    type = TransactionType.CREDIT,
+                    accountLast4 = "1234",
+                    isFromCard = true,
+                    creditLimit = BigDecimal("1235.00")
+                )
+            ),
+            ParserTestCase(
+                name = "SBI Card payment credited",
+                message = "Your payment of Rs.1,644.55 has been credited to your SBI Credit Card ending with 5667. Your available limit is Rs.48,355.45.",
+                sender = "SBICRD",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1644.55"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "5667",
+                    isFromCard = true,
+                    creditLimit = BigDecimal("48355.45")
+                )
+            )
+        )
+
+        val handleCases = emptyList<Pair<String, Boolean>>()
+
+        return ParserTestUtils.runTestSuite(
+            parser = parser,
+            testCases = testCases,
+            handleCases = handleCases,
+            suiteName = "SBI Card"
+        )
+    }
+
+    @TestFactory
+    fun `factory resolves sbi card senders`(): List<DynamicTest> {
+        val cases = listOf(
+            SimpleTestCase(
+                bankName = "State Bank of India",
+                sender = "SBI CARDS AND PAYMENT SERVICES",
+                currency = "INR",
+                message = "Rs.90.00 spent on your SBI Credit Card ending 5667 at SUPREMEGOURMET on 13/02/26.",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("90.00"),
+                    currency = "INR",
+                    type = TransactionType.CREDIT
+                ),
+                shouldHandle = true
+            )
+        )
+
+        return ParserTestUtils.runFactoryTestSuite(cases, "SBI Card factory tests")
     }
 }


### PR DESCRIPTION
Closes #171

## Summary
- Fix SBI Card SMS parsing where messages use **Unicode Mathematical Sans-Serif characters** (`𝗌𝗉𝖾𝗇𝗍` instead of `spent`)
- Add **NFKD Unicode normalization** to SBIBankParser (same approach PNB parser uses)
- Recognize **"SBI CARDS AND PAYMENT SERVICES"** as a valid sender
- Extract merchant from **"at MERCHANT on DATE"** pattern in credit card SMS
- Handle **"ending NNNN"** card number format (in addition to existing "ending with NNNN")

## The Problem
SBI Card sends SMS/RCS messages using Unicode Mathematical Sans-Serif characters that look identical to regular text but use different codepoints (U+1D5xx range). The parser couldn't match keywords like `spent`, `Credit Card`, `ending` because they were actually `𝗌𝗉𝖾𝗇𝗍`, `𝖢𝗋𝖾𝖽𝗂𝗍 𝖢𝖺𝗋𝖽`, `𝖾𝗇𝖽𝗂𝗇𝗀`.

## The Fix
Apply `Normalizer.normalize(text, Normalizer.Form.NFKD)` + ASCII stripping before parsing, which converts these Unicode variants back to plain ASCII.

## Changes
- **Modified**: `SBIBankParser.kt` — Unicode normalization, new sender, merchant extraction, card number pattern
- **Modified**: `TestSBIParser.kt` — 4 new test cases + sender check

## Test plan
- [x] `./gradlew parser-core:test --tests "*SBI*"` — 11/11 pass
- [x] `./gradlew parser-core:test` — all parser tests pass, no regressions