### PR TITLE
feat(parser): add Thai bank support (11 banks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For Android users worldwide who want automatic expense tracking from bank SMS �
 
 ## Supported Banks & Countries
 
-Supporting **49+ banks** across **11 countries** with **multi-currency** capabilities:
+Supporting **60+ banks** across **12 countries** with **multi-currency** capabilities:
 
 ### 🇮🇳 India (35 banks) - INR ₹
 - **HDFC Bank**, **State Bank of India (SBI)**, **ICICI Bank**
@@ -91,6 +91,12 @@ Supporting **49+ banks** across **11 countries** with **multi-currency** capabil
 
 ### 🇮🇷 Iran (2 banks) - IRR ﷼
 - **Melli Bank (بانک ملی)**, **Parsian Bank (بانک پارسیان)** - Persian SMS support
+
+### 🇹🇭 Thailand (11 banks) - THB ฿
+- **Bangkok Bank (BBL)**, **Kasikorn Bank (KBank)**, **Siam Commercial Bank (SCB)**
+- **Krungthai Bank (KTB)**, **Krungsri (BAY)**, **TTB (TMBThanachart)**
+- **Government Savings Bank (GSB)**, **BAAC**, **UOB Thailand**
+- **CIMB Thai**, **KTC Credit Card** - Thai and English SMS support
 
 ### 🇰🇪 Kenya (1 service) - KES Ksh
 - **M-PESA** - Mobile money service

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BAACBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BAACBankParser.kt
@@ -1,0 +1,15 @@
+package com.pennywiseai.parser.core.bank
+
+/**
+ * Bank for Agriculture and Agricultural Cooperatives (BAAC) parser for Thai banking SMS messages.
+ */
+class BAACBankParser : BaseThailandBankParser() {
+
+    override fun getBankName() = "BAAC"
+
+    override fun canHandle(sender: String): Boolean {
+        val upperSender = sender.uppercase()
+        return upperSender == "BAAC" ||
+                upperSender.contains("AGRICULTURE")
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BangkokBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BangkokBankParser.kt
@@ -1,0 +1,16 @@
+package com.pennywiseai.parser.core.bank
+
+/**
+ * Bangkok Bank (BBL) parser for Thai banking SMS messages.
+ */
+class BangkokBankParser : BaseThailandBankParser() {
+
+    override fun getBankName() = "Bangkok Bank"
+
+    override fun canHandle(sender: String): Boolean {
+        val upperSender = sender.uppercase()
+        return upperSender == "BBL" ||
+                upperSender.contains("BANGKOK BANK") ||
+                upperSender.contains("BANGKOKBANK")
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -79,7 +79,18 @@ object BankParserFactory {
         DashenBankParser(),  // Dashen Bank (Ethiopia)
         FaysalBankParser(),  // Faysal Bank (Pakistan)
         MelliBankParser(),  // Melli Bank (Iran)
-        ParsianBankParser()  // Parsian Bank (Iran)
+        ParsianBankParser(),  // Parsian Bank (Iran)
+        BangkokBankParser(),  // Bangkok Bank (Thailand)
+        KasikornBankParser(),  // Kasikorn Bank (Thailand)
+        SiamCommercialBankParser(),  // Siam Commercial Bank (Thailand)
+        KrungThaiBankParser(),  // Krungthai Bank (Thailand)
+        KrungsriBankParser(),  // Krungsri / Bank of Ayudhya (Thailand)
+        TTBBankParser(),  // TMBThanachart Bank (Thailand)
+        GSBBankParser(),  // Government Savings Bank (Thailand)
+        BAACBankParser(),  // BAAC (Thailand)
+        UOBThailandParser(),  // UOB Thailand
+        CIMBThaiParser(),  // CIMB Thai (Thailand)
+        KTCCreditCardParser()  // KTC Credit Card (Thailand)
         // Add more bank parsers here as we implement them
     )
 

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BaseThailandBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BaseThailandBankParser.kt
@@ -1,0 +1,206 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Base class for Thai bank parsers to share common logic.
+ * Handles both Thai and English language transaction patterns with THB currency.
+ */
+abstract class BaseThailandBankParser : BankParser() {
+
+    override fun getCurrency(): String = "THB"
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // Pattern 1: "1,250.00 THB" or "1,250.00 บาท"
+        val patterns = listOf(
+            Regex("""(\d{1,3}(?:,\d{3})*(?:\.\d{1,2})?)\s*(?:THB|บาท)"""),
+            Regex("""(?:THB|฿)\s*(\d{1,3}(?:,\d{3})*(?:\.\d{1,2})?)"""),
+            // Pattern 3: "1,250.00 USD" for international transactions
+            Regex("""(\d{1,3}(?:,\d{3})*(?:\.\d{1,2})?)\s*USD""")
+        )
+
+        for (pattern in patterns) {
+            pattern.find(message)?.let { match ->
+                val cleanAmount = match.groupValues[1].replace(",", "")
+                return try {
+                    cleanAmount.toBigDecimal()
+                } catch (e: NumberFormatException) {
+                    null
+                }
+            }
+        }
+
+        return null
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lowerMessage = message.lowercase()
+
+        if (isInvestmentTransaction(lowerMessage)) {
+            return TransactionType.INVESTMENT
+        }
+
+        return when {
+            // Credit card spending (check before expense — "ยอดใช้จ่าย" contains "ใช้จ่าย")
+            lowerMessage.contains("credit card spending") ||
+            lowerMessage.contains("ยอดใช้จ่ายต่างประเทศ") ||
+            lowerMessage.contains("ยอดใช้จ่าย") -> TransactionType.CREDIT
+
+            // Thai expense keywords
+            lowerMessage.contains("เงินออก") ||
+            lowerMessage.contains("ถอนเงิน") ||
+            lowerMessage.contains("ถอนเงินสด") ||
+            lowerMessage.contains("โอนเงินออก") ||
+            lowerMessage.contains("โอนเงินผ่าน") ||
+            lowerMessage.contains("ใช้จ่ายบัตร") ||
+            lowerMessage.contains("ใช้จ่าย") ||
+            // English expense keywords
+            lowerMessage.contains("withdrawal") ||
+            lowerMessage.contains("payment") ||
+            lowerMessage.contains("you spent") ||
+            lowerMessage.contains("transfer out") ||
+            lowerMessage.contains("card payment") ||
+            lowerMessage.contains("card transaction") ||
+            lowerMessage.contains("atm withdrawal") -> TransactionType.EXPENSE
+
+            // Thai income keywords
+            lowerMessage.contains("เงินเข้า") ||
+            lowerMessage.contains("เงินฝาก") ||
+            lowerMessage.contains("รับเงิน") ||
+            lowerMessage.contains("โอนเงินเข้า") ||
+            lowerMessage.contains("รับเงินพร้อมเพย์") ||
+            lowerMessage.contains("รับเงินโอน") ||
+            lowerMessage.contains("เงินฝากเข้า") ||
+            // English income keywords
+            lowerMessage.contains("deposit") ||
+            lowerMessage.contains("receive") ||
+            lowerMessage.contains("transfer in") ||
+            lowerMessage.contains("transfer received") -> TransactionType.INCOME
+
+            else -> null
+        }
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        // Thai: "คงเหลือ 15,820.45 บาท" or English: "Bal 15,820.45 THB"
+        val patterns = listOf(
+            Regex("""(?:Bal|คงเหลือ)\s+(\d{1,3}(?:,\d{3})*(?:\.\d{1,2})?)\s*(?:THB|บาท)""", RegexOption.IGNORE_CASE),
+            Regex("""(?:Bal|คงเหลือ)\s+(\d{1,3}(?:,\d{3})*(?:\.\d{1,2})?)""", RegexOption.IGNORE_CASE)
+        )
+
+        for (pattern in patterns) {
+            pattern.find(message)?.let { match ->
+                val cleanAmount = match.groupValues[1].replace(",", "")
+                return try {
+                    cleanAmount.toBigDecimal()
+                } catch (e: NumberFormatException) {
+                    null
+                }
+            }
+        }
+
+        return null
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        // Pattern: "A/C xNNNN" or "บช xNNNN"
+        val pattern = Regex("""(?:A/C|บช)\s*x(\d{4})""", RegexOption.IGNORE_CASE)
+        pattern.find(message)?.let { match ->
+            return match.groupValues[1]
+        }
+        return null
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // Thai: "ร้าน MERCHANT" or English: "at MERCHANT"
+        val patterns = listOf(
+            Regex("""(?:at|ร้าน)\s+([A-Za-z0-9\s&._-]+?)(?:\s+(?:A/C|บช|Bal|คงเหลือ|Available|on|$))""", RegexOption.IGNORE_CASE),
+            Regex("""(?:at|ร้าน)\s+([A-Za-z0-9\s&._-]+)$""", RegexOption.IGNORE_CASE)
+        )
+
+        for (pattern in patterns) {
+            pattern.find(message)?.let { match ->
+                val merchant = cleanMerchantName(match.groupValues[1].trim())
+                if (isValidMerchantName(merchant)) {
+                    return merchant
+                }
+            }
+        }
+
+        return null
+    }
+
+    override fun extractAvailableLimit(message: String): BigDecimal? {
+        val pattern = Regex("""(?:Available limit|วงเงินคงเหลือ)\s+(\d{1,3}(?:,\d{3})*(?:\.\d{1,2})?)\s*(?:THB|บาท)""", RegexOption.IGNORE_CASE)
+        pattern.find(message)?.let { match ->
+            val cleanAmount = match.groupValues[1].replace(",", "")
+            return try {
+                cleanAmount.toBigDecimal()
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+        return null
+    }
+
+    fun isCreditCardMessage(message: String): Boolean {
+        val lowerMessage = message.lowercase()
+        val cardKeywords = listOf(
+            "credit card", "บัตรเครดิต",
+            "card spending", "card payment", "card transaction",
+            "ใช้จ่ายบัตร", "ยอดใช้จ่าย"
+        )
+        return cardKeywords.any { lowerMessage.contains(it) }
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lowerMessage = message.lowercase()
+
+        // Skip OTP messages
+        if (lowerMessage.contains("otp") ||
+            lowerMessage.contains("รหัส") ||
+            lowerMessage.contains("ยืนยัน")
+        ) {
+            return false
+        }
+
+        // Skip promotional messages
+        if (lowerMessage.contains("สมัคร") ||
+            lowerMessage.contains("โปรโมชั่น") ||
+            lowerMessage.contains("promotion") ||
+            lowerMessage.contains("cashback offer")
+        ) {
+            return false
+        }
+
+        val transactionKeywords = listOf(
+            // Thai
+            "เงินเข้า", "เงินออก", "ถอนเงิน", "โอนเงิน", "ใช้จ่าย",
+            "เงินฝาก", "รับเงิน", "คงเหลือ", "บาท", "ยอดใช้จ่าย",
+            // English
+            "withdrawal", "deposit", "transfer", "payment", "spent",
+            "receive", "bal", "thb", "card transaction", "card payment",
+            "credit card spending", "available limit"
+        )
+
+        return transactionKeywords.any { lowerMessage.contains(it) }
+    }
+
+    override fun cleanMerchantName(merchant: String): String {
+        return merchant.trim()
+    }
+
+    override fun isValidMerchantName(name: String): Boolean {
+        val commonWords = setOf(
+            "USING", "VIA", "THROUGH", "BY", "WITH", "FOR", "TO", "FROM", "AT", "THE",
+            "ผ่าน", "โดย", "จาก", "ที่", "ไปยัง", "ถึง"
+        )
+
+        return name.length >= 2 &&
+                name.any { it.isLetter() } &&
+                name.uppercase() !in commonWords &&
+                !name.all { it.isDigit() } &&
+                !name.contains("@")
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CIMBThaiParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CIMBThaiParser.kt
@@ -1,0 +1,16 @@
+package com.pennywiseai.parser.core.bank
+
+/**
+ * CIMB Thai Bank parser for Thai banking SMS messages.
+ */
+class CIMBThaiParser : BaseThailandBankParser() {
+
+    override fun getBankName() = "CIMB Thai"
+
+    override fun canHandle(sender: String): Boolean {
+        val upperSender = sender.uppercase()
+        return upperSender == "CIMB" ||
+                upperSender.contains("CIMB THAI") ||
+                upperSender.contains("CIMBTHAI")
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/GSBBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/GSBBankParser.kt
@@ -1,0 +1,16 @@
+package com.pennywiseai.parser.core.bank
+
+/**
+ * Government Savings Bank (GSB) parser for Thai banking SMS messages.
+ */
+class GSBBankParser : BaseThailandBankParser() {
+
+    override fun getBankName() = "Government Savings Bank"
+
+    override fun canHandle(sender: String): Boolean {
+        val upperSender = sender.uppercase()
+        return upperSender == "GSB" ||
+                upperSender.contains("GOVERNMENT SAVINGS") ||
+                upperSender.contains("GOVT SAVINGS")
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KTCCreditCardParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KTCCreditCardParser.kt
@@ -1,0 +1,31 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType
+
+/**
+ * KTC Credit Card parser for Thai banking SMS messages.
+ * Handles credit card spending with available limit extraction.
+ */
+class KTCCreditCardParser : BaseThailandBankParser() {
+
+    override fun getBankName() = "KTC"
+
+    override fun canHandle(sender: String): Boolean {
+        val upperSender = sender.uppercase()
+        return upperSender == "KTC" ||
+                upperSender.contains("KRUNGTHAI CARD")
+    }
+
+    override fun parse(smsBody: String, sender: String, timestamp: Long): ParsedTransaction? {
+        val parsed = super.parse(smsBody, sender, timestamp) ?: return null
+
+        val creditLimit = extractAvailableLimit(smsBody)
+
+        return parsed.copy(
+            type = parsed.type ?: TransactionType.CREDIT,
+            isFromCard = true,
+            creditLimit = creditLimit
+        )
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KasikornBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KasikornBankParser.kt
@@ -1,0 +1,16 @@
+package com.pennywiseai.parser.core.bank
+
+/**
+ * Kasikorn Bank (KBank) parser for Thai banking SMS messages.
+ */
+class KasikornBankParser : BaseThailandBankParser() {
+
+    override fun getBankName() = "Kasikorn Bank"
+
+    override fun canHandle(sender: String): Boolean {
+        val upperSender = sender.uppercase()
+        return upperSender == "KBANK" ||
+                upperSender.contains("KASIKORN") ||
+                upperSender.contains("KASIKORNBANK")
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KrungThaiBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KrungThaiBankParser.kt
@@ -1,0 +1,16 @@
+package com.pennywiseai.parser.core.bank
+
+/**
+ * Krungthai Bank (KTB) parser for Thai banking SMS messages.
+ */
+class KrungThaiBankParser : BaseThailandBankParser() {
+
+    override fun getBankName() = "Krungthai Bank"
+
+    override fun canHandle(sender: String): Boolean {
+        val upperSender = sender.uppercase()
+        return upperSender == "KTB" ||
+                upperSender.contains("KRUNGTHAI") ||
+                upperSender.contains("KRUNG THAI")
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KrungsriBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KrungsriBankParser.kt
@@ -1,0 +1,16 @@
+package com.pennywiseai.parser.core.bank
+
+/**
+ * Krungsri (Bank of Ayudhya - BAY) parser for Thai banking SMS messages.
+ */
+class KrungsriBankParser : BaseThailandBankParser() {
+
+    override fun getBankName() = "Krungsri"
+
+    override fun canHandle(sender: String): Boolean {
+        val upperSender = sender.uppercase()
+        return upperSender == "BAY" ||
+                upperSender.contains("KRUNGSRI") ||
+                upperSender.contains("AYUDHYA")
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SiamCommercialBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SiamCommercialBankParser.kt
@@ -1,0 +1,16 @@
+package com.pennywiseai.parser.core.bank
+
+/**
+ * Siam Commercial Bank (SCB) parser for Thai banking SMS messages.
+ */
+class SiamCommercialBankParser : BaseThailandBankParser() {
+
+    override fun getBankName() = "Siam Commercial Bank"
+
+    override fun canHandle(sender: String): Boolean {
+        val upperSender = sender.uppercase()
+        return upperSender == "SCB" ||
+                upperSender.contains("SIAM COMMERCIAL") ||
+                upperSender.contains("SIAMCOMMERCIAL")
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/TTBBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/TTBBankParser.kt
@@ -1,0 +1,16 @@
+package com.pennywiseai.parser.core.bank
+
+/**
+ * TTB (TMBThanachart Bank) parser for Thai banking SMS messages.
+ */
+class TTBBankParser : BaseThailandBankParser() {
+
+    override fun getBankName() = "TTB"
+
+    override fun canHandle(sender: String): Boolean {
+        val upperSender = sender.uppercase()
+        return upperSender == "TTB" ||
+                upperSender.contains("TMBTHANACHART") ||
+                upperSender.contains("TMB")
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/UOBThailandParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/UOBThailandParser.kt
@@ -1,0 +1,16 @@
+package com.pennywiseai.parser.core.bank
+
+/**
+ * UOB Thailand parser for Thai banking SMS messages.
+ */
+class UOBThailandParser : BaseThailandBankParser() {
+
+    override fun getBankName() = "UOB Thailand"
+
+    override fun canHandle(sender: String): Boolean {
+        val upperSender = sender.uppercase()
+        return upperSender == "UOB" ||
+                upperSender.contains("UOB THAILAND") ||
+                upperSender.contains("UOBTHAILAND")
+    }
+}

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/ThailandBankParsersTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/ThailandBankParsersTest.kt
@@ -1,0 +1,631 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import com.pennywiseai.parser.core.test.SimpleTestCase
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class ThailandBankParsersTest {
+
+    // === Bangkok Bank (BBL) ===
+
+    @TestFactory
+    fun `bangkok bank parser handles key paths`(): List<DynamicTest> {
+        val parser = BangkokBankParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "BBL ATM withdrawal (English)",
+                message = "BBL: Withdrawal 2,000.00 THB from A/C x1234 via ATM on 21/01/26 14:32 Bal 15,820.45 THB",
+                sender = "BBL",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2000.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "1234",
+                    balance = BigDecimal("15820.45")
+                )
+            ),
+            ParserTestCase(
+                name = "BBL deposit (English)",
+                message = "BBL: Deposit 5,000.00 THB to A/C x1234 on 21/01/26 16:01 Bal 20,820.45 THB",
+                sender = "BBL",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("5000.00"),
+                    currency = "THB",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "1234",
+                    balance = BigDecimal("20820.45")
+                )
+            ),
+            ParserTestCase(
+                name = "BBL transfer out (Thai)",
+                message = "BBL: โอนเงินออก 1,500.00 บาท บช x1234 คงเหลือ 19,320.45 บาท",
+                sender = "BBL",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1500.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "1234",
+                    balance = BigDecimal("19320.45")
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            Pair("BBL", true),
+            Pair("BANGKOK BANK", true),
+            Pair("OTHER", false)
+        )
+
+        return ParserTestUtils.runTestSuite(parser, testCases, handleCases, "Bangkok Bank")
+    }
+
+    // === Kasikorn Bank (KBank) ===
+
+    @TestFactory
+    fun `kasikorn bank parser handles key paths`(): List<DynamicTest> {
+        val parser = KasikornBankParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "KBank spending (English)",
+                message = "KBank: You spent 1,250.00 THB at SHOPEE. A/C x5678 Bal 8,430.20 THB",
+                sender = "KBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1250.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "5678",
+                    balance = BigDecimal("8430.20")
+                )
+            ),
+            ParserTestCase(
+                name = "KBank receive (English)",
+                message = "KBank: Receive 10,000.00 THB from A/C x5678 Bal 18,430.20 THB",
+                sender = "KBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("10000.00"),
+                    currency = "THB",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "5678",
+                    balance = BigDecimal("18430.20")
+                )
+            ),
+            ParserTestCase(
+                name = "KBank PromptPay transfer (Thai)",
+                message = "KBank: โอนเงินผ่านพร้อมเพย์ 500.00 บาท บช x5678 คงเหลือ 17,930.20 บาท",
+                sender = "KBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("500.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "5678",
+                    balance = BigDecimal("17930.20")
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            Pair("KBank", true),
+            Pair("KASIKORN", true),
+            Pair("OTHER", false)
+        )
+
+        return ParserTestUtils.runTestSuite(parser, testCases, handleCases, "Kasikorn Bank")
+    }
+
+    // === Siam Commercial Bank (SCB) ===
+
+    @TestFactory
+    fun `siam commercial bank parser handles key paths`(): List<DynamicTest> {
+        val parser = SiamCommercialBankParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "SCB transfer out (English)",
+                message = "SCB: Transfer out 3,500.00 THB to A/C x8899 Bal 6,200.00 THB",
+                sender = "SCB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("3500.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "8899",
+                    balance = BigDecimal("6200.00")
+                )
+            ),
+            ParserTestCase(
+                name = "SCB transfer in (English)",
+                message = "SCB: Transfer in 12,000.00 THB A/C x8899 Bal 18,200.00 THB",
+                sender = "SCB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("12000.00"),
+                    currency = "THB",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "8899",
+                    balance = BigDecimal("18200.00")
+                )
+            ),
+            ParserTestCase(
+                name = "SCB card spending (Thai)",
+                message = "SCB: ใช้จ่ายบัตร 890.00 บาท ร้าน 7-ELEVEN บช x8899",
+                sender = "SCB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("890.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "8899",
+                    merchant = "7-ELEVEN"
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            Pair("SCB", true),
+            Pair("SIAM COMMERCIAL", true),
+            Pair("OTHER", false)
+        )
+
+        return ParserTestUtils.runTestSuite(parser, testCases, handleCases, "Siam Commercial Bank")
+    }
+
+    // === Krungthai Bank (KTB) ===
+
+    @TestFactory
+    fun `krungthai bank parser handles key paths`(): List<DynamicTest> {
+        val parser = KrungThaiBankParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "KTB deposit (Thai)",
+                message = "KTB: เงินเข้า 4,200.00 บาท บช x7788 คงเหลือ 12,350.75 บาท",
+                sender = "KTB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("4200.00"),
+                    currency = "THB",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "7788",
+                    balance = BigDecimal("12350.75")
+                )
+            ),
+            ParserTestCase(
+                name = "KTB ATM withdrawal (Thai)",
+                message = "KTB: ถอนเงินสด 500.00 บาท บช x7788 คงเหลือ 11,850.75 บาท",
+                sender = "KTB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("500.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "7788",
+                    balance = BigDecimal("11850.75")
+                )
+            ),
+            ParserTestCase(
+                name = "KTB PromptPay receive (Thai)",
+                message = "KTB: รับเงินพร้อมเพย์ 2,000.00 บาท บช x7788",
+                sender = "KTB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2000.00"),
+                    currency = "THB",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "7788"
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            Pair("KTB", true),
+            Pair("KRUNGTHAI", true),
+            Pair("OTHER", false)
+        )
+
+        return ParserTestUtils.runTestSuite(parser, testCases, handleCases, "Krungthai Bank")
+    }
+
+    // === Krungsri (BAY) ===
+
+    @TestFactory
+    fun `krungsri bank parser handles key paths`(): List<DynamicTest> {
+        val parser = KrungsriBankParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "Krungsri ATM withdrawal (English)",
+                message = "Krungsri: ATM withdrawal 1,000.00 THB A/C x3344 Bal 9,540.00 THB",
+                sender = "BAY",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1000.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "3344",
+                    balance = BigDecimal("9540.00")
+                )
+            ),
+            ParserTestCase(
+                name = "Krungsri card payment (English)",
+                message = "Krungsri: Card payment 890.00 THB at 7-ELEVEN A/C x3344",
+                sender = "BAY",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("890.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "3344",
+                    merchant = "7-ELEVEN"
+                )
+            ),
+            ParserTestCase(
+                name = "Krungsri transfer in (Thai)",
+                message = "Krungsri: โอนเงินเข้า 6,000.00 บาท บช x3344",
+                sender = "BAY",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("6000.00"),
+                    currency = "THB",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "3344"
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            Pair("BAY", true),
+            Pair("KRUNGSRI", true),
+            Pair("OTHER", false)
+        )
+
+        return ParserTestUtils.runTestSuite(parser, testCases, handleCases, "Krungsri")
+    }
+
+    // === TTB ===
+
+    @TestFactory
+    fun `ttb bank parser handles key paths`(): List<DynamicTest> {
+        val parser = TTBBankParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "TTB payment (English)",
+                message = "ttb: Payment 1,500.00 THB via PromptPay A/C x9012 Bal 7,200.00 THB",
+                sender = "TTB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1500.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "9012",
+                    balance = BigDecimal("7200.00")
+                )
+            ),
+            ParserTestCase(
+                name = "TTB receive transfer (Thai)",
+                message = "ttb: รับเงินโอน 8,000.00 บาท บช x9012",
+                sender = "TTB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("8000.00"),
+                    currency = "THB",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "9012"
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            Pair("TTB", true),
+            Pair("OTHER", false)
+        )
+
+        return ParserTestUtils.runTestSuite(parser, testCases, handleCases, "TTB")
+    }
+
+    // === Government Savings Bank (GSB) ===
+
+    @TestFactory
+    fun `gsb bank parser handles key paths`(): List<DynamicTest> {
+        val parser = GSBBankParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "GSB deposit (Thai)",
+                message = "GSB: เงินฝากเข้า 2,500.00 บาท บช x1122 คงเหลือ 9,300.00 บาท",
+                sender = "GSB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2500.00"),
+                    currency = "THB",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "1122",
+                    balance = BigDecimal("9300.00")
+                )
+            ),
+            ParserTestCase(
+                name = "GSB withdrawal (Thai)",
+                message = "GSB: ถอนเงิน 1,000.00 บาท บช x1122",
+                sender = "GSB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1000.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "1122"
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            Pair("GSB", true),
+            Pair("OTHER", false)
+        )
+
+        return ParserTestUtils.runTestSuite(parser, testCases, handleCases, "GSB")
+    }
+
+    // === BAAC ===
+
+    @TestFactory
+    fun `baac bank parser handles key paths`(): List<DynamicTest> {
+        val parser = BAACBankParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "BAAC transfer out (Thai)",
+                message = "BAAC: โอนเงินออก 1,200.00 บาท บช x4455 คงเหลือ 5,640.00 บาท",
+                sender = "BAAC",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1200.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "4455",
+                    balance = BigDecimal("5640.00")
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            Pair("BAAC", true),
+            Pair("OTHER", false)
+        )
+
+        return ParserTestUtils.runTestSuite(parser, testCases, handleCases, "BAAC")
+    }
+
+    // === UOB Thailand ===
+
+    @TestFactory
+    fun `uob thailand parser handles key paths`(): List<DynamicTest> {
+        val parser = UOBThailandParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "UOB card transaction (English)",
+                message = "UOB: Card transaction 3,200.00 THB at AMAZON Bal 22,400.00 THB",
+                sender = "UOB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("3200.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE,
+                    balance = BigDecimal("22400.00"),
+                    merchant = "AMAZON"
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            Pair("UOB", true),
+            Pair("OTHER", false)
+        )
+
+        return ParserTestUtils.runTestSuite(parser, testCases, handleCases, "UOB Thailand")
+    }
+
+    // === CIMB Thai ===
+
+    @TestFactory
+    fun `cimb thai parser handles key paths`(): List<DynamicTest> {
+        val parser = CIMBThaiParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "CIMB transfer received (English)",
+                message = "CIMB: Transfer received 6,000.00 THB A/C x5566 Bal 14,980.00 THB",
+                sender = "CIMB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("6000.00"),
+                    currency = "THB",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "5566",
+                    balance = BigDecimal("14980.00")
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            Pair("CIMB", true),
+            Pair("OTHER", false)
+        )
+
+        return ParserTestUtils.runTestSuite(parser, testCases, handleCases, "CIMB Thai")
+    }
+
+    // === KTC Credit Card ===
+
+    @TestFactory
+    fun `ktc credit card parser handles key paths`(): List<DynamicTest> {
+        val parser = KTCCreditCardParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "KTC credit card spending (English)",
+                message = "KTC: Credit card spending 2,999.00 THB at LAZADA Available limit 47,001.00 THB",
+                sender = "KTC",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2999.00"),
+                    currency = "THB",
+                    type = TransactionType.CREDIT,
+                    merchant = "LAZADA",
+                    isFromCard = true,
+                    creditLimit = BigDecimal("47001.00")
+                )
+            ),
+            ParserTestCase(
+                name = "KTC international spending (Thai)",
+                message = "KTC: ยอดใช้จ่ายต่างประเทศ 120.50 USD",
+                sender = "KTC",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("120.50"),
+                    currency = "THB",
+                    type = TransactionType.CREDIT,
+                    isFromCard = true
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            Pair("KTC", true),
+            Pair("OTHER", false)
+        )
+
+        return ParserTestUtils.runTestSuite(parser, testCases, handleCases, "KTC Credit Card")
+    }
+
+    // === Factory Resolution Tests ===
+
+    @TestFactory
+    fun `factory resolves all thai bank senders`(): List<DynamicTest> {
+        val cases = listOf(
+            SimpleTestCase(
+                bankName = "Bangkok Bank",
+                sender = "BBL",
+                currency = "THB",
+                message = "BBL: Withdrawal 2,000.00 THB from A/C x1234 via ATM on 21/01/26 14:32 Bal 15,820.45 THB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2000.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE
+                ),
+                shouldHandle = true
+            ),
+            SimpleTestCase(
+                bankName = "Kasikorn Bank",
+                sender = "KBank",
+                currency = "THB",
+                message = "KBank: You spent 1,250.00 THB at SHOPEE. A/C x5678 Bal 8,430.20 THB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1250.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE
+                ),
+                shouldHandle = true
+            ),
+            SimpleTestCase(
+                bankName = "Siam Commercial Bank",
+                sender = "SCB",
+                currency = "THB",
+                message = "SCB: Transfer out 3,500.00 THB to A/C x8899 Bal 6,200.00 THB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("3500.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE
+                ),
+                shouldHandle = true
+            ),
+            SimpleTestCase(
+                bankName = "Krungthai Bank",
+                sender = "KTB",
+                currency = "THB",
+                message = "KTB: เงินเข้า 4,200.00 บาท บช x7788 คงเหลือ 12,350.75 บาท",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("4200.00"),
+                    currency = "THB",
+                    type = TransactionType.INCOME
+                ),
+                shouldHandle = true
+            ),
+            SimpleTestCase(
+                bankName = "Krungsri",
+                sender = "BAY",
+                currency = "THB",
+                message = "Krungsri: ATM withdrawal 1,000.00 THB A/C x3344 Bal 9,540.00 THB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1000.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE
+                ),
+                shouldHandle = true
+            ),
+            SimpleTestCase(
+                bankName = "TTB",
+                sender = "TTB",
+                currency = "THB",
+                message = "ttb: Payment 1,500.00 THB via PromptPay A/C x9012 Bal 7,200.00 THB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1500.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE
+                ),
+                shouldHandle = true
+            ),
+            SimpleTestCase(
+                bankName = "Government Savings Bank",
+                sender = "GSB",
+                currency = "THB",
+                message = "GSB: เงินฝากเข้า 2,500.00 บาท บช x1122 คงเหลือ 9,300.00 บาท",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2500.00"),
+                    currency = "THB",
+                    type = TransactionType.INCOME
+                ),
+                shouldHandle = true
+            ),
+            SimpleTestCase(
+                bankName = "BAAC",
+                sender = "BAAC",
+                currency = "THB",
+                message = "BAAC: โอนเงินออก 1,200.00 บาท บช x4455 คงเหลือ 5,640.00 บาท",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1200.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE
+                ),
+                shouldHandle = true
+            ),
+            SimpleTestCase(
+                bankName = "UOB Thailand",
+                sender = "UOB",
+                currency = "THB",
+                message = "UOB: Card transaction 3,200.00 THB at AMAZON Bal 22,400.00 THB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("3200.00"),
+                    currency = "THB",
+                    type = TransactionType.EXPENSE
+                ),
+                shouldHandle = true
+            ),
+            SimpleTestCase(
+                bankName = "CIMB Thai",
+                sender = "CIMB",
+                currency = "THB",
+                message = "CIMB: Transfer received 6,000.00 THB A/C x5566 Bal 14,980.00 THB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("6000.00"),
+                    currency = "THB",
+                    type = TransactionType.INCOME
+                ),
+                shouldHandle = true
+            ),
+            SimpleTestCase(
+                bankName = "KTC",
+                sender = "KTC",
+                currency = "THB",
+                message = "KTC: Credit card spending 2,999.00 THB at LAZADA Available limit 47,001.00 THB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2999.00"),
+                    currency = "THB",
+                    type = TransactionType.CREDIT
+                ),
+                shouldHandle = true
+            )
+        )
+
+        return ParserTestUtils.runFactoryTestSuite(cases, "Thai bank factory tests")
+    }
+}


### PR DESCRIPTION
Closes #157

## Summary
- Add **11 Thai bank parsers** with both Thai and English SMS support
- Add **BaseThailandBankParser** shared base class for THB currency and Thai language patterns
- Support **PromptPay transfers**, **ATM withdrawals**, **card transactions**, **bank transfers**
- **KTC Credit Card** parser with available credit limit extraction

## Banks Added
| Bank | Sender | Type |
|------|--------|------|
| Bangkok Bank (BBL) | BBL | Savings/Current |
| Kasikorn Bank (KBank) | KBank | Savings/Current |
| Siam Commercial Bank (SCB) | SCB | Savings/Current |
| Krungthai Bank (KTB) | KTB | Savings/Current |
| Krungsri (Bank of Ayudhya) | BAY | Savings/Current |
| TTB (TMBThanachart) | TTB | Savings/Current |
| Government Savings Bank (GSB) | GSB | Savings |
| BAAC | BAAC | Savings/Current |
| UOB Thailand | UOB | Savings/Current |
| CIMB Thai | CIMB | Savings/Current |
| KTC Credit Card | KTC | Credit Card |

## Thai Language Keywords Supported
- **Income**: เงินเข้า, เงินฝาก, รับเงิน, โอนเงินเข้า, รับเงินพร้อมเพย์, รับเงินโอน
- **Expense**: เงินออก, ถอนเงิน, โอนเงินออก, โอนเงินผ่านพร้อมเพย์, ใช้จ่ายบัตร
- **Balance**: คงเหลือ
- **Account**: บช xNNNN
- **Merchant**: ร้าน

## Changes
- **12 new files**: BaseThailandBankParser + 11 bank parsers
- **Modified**: `BankParserFactory.kt` — registered all 11 parsers
- **Modified**: `README.md` — added Thailand section (12 countries, 60+ banks)
- **1 new test file**: `ThailandBankParsersTest.kt` — 62 test cases

## Test plan
- [x] `./gradlew parser-core:test --tests "*Thailand*"` — 62/62 pass
- [x] `./gradlew parser-core:test` — all parser tests pass, no regressions