### PR TITLE
fix: scan history banner respects All Time scan setting

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -205,13 +205,22 @@ class TransactionsViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = 3
         )
-    
+
+    private val smsScanAllTime: StateFlow<Boolean> = userPreferencesRepository.smsScanAllTime
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = false
+        )
+
     fun isShowingLimitedData(): Boolean {
+        if (smsScanAllTime.value) return false
+
         val currentPeriod = _selectedPeriod.value
         val scanMonthsValue = smsScanMonths.value
 
         return when (currentPeriod) {
-            TimePeriod.ALL -> true  // Always show for "All Time"
+            TimePeriod.ALL -> true
             TimePeriod.CURRENT_FY -> {
                 // Check if FY start is before scan period
                 val dateRange = getDateRangeForPeriod(TimePeriod.CURRENT_FY)


### PR DESCRIPTION
Closes #136

## Summary
- Fix info banner in TransactionsScreen always showing for "All Time" period even when user configured SMS scan to cover all history
- Add `smsScanAllTime` check in `isShowingLimitedData()` — if user set scan to "All Time", banner never shows

## Root Cause
`isShowingLimitedData()` had `TimePeriod.ALL -> true` which unconditionally showed the banner when viewing "All Time", regardless of whether the scan actually covered all history.

## Fix
Added `smsScanAllTime` StateFlow from `UserPreferencesRepository` and early-return `false` when it's enabled, before the period-based checks.

## Test plan
- [x] `./gradlew assembleDebug` — builds successfully
- [ ] Manual: Set scan period to "All Time" → banner should NOT appear
- [ ] Manual: Set scan period to 3 months, view "All Time" → banner should appear
- [ ] Manual: Set scan period to 3 months, view "Last Month" → banner should NOT appear