### PR TITLE
feat: modernize home screen widgets with Material 3 guidelines

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/widget/RecentTransactionsWidget.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/RecentTransactionsWidget.kt
@@ -79,11 +79,11 @@ class RecentTransactionsWidget : GlanceAppWidget() {
 
             Column(
                 modifier = GlanceModifier
-                    .padding(horizontal = 16.dp, vertical = 12.dp)
+                    .padding(horizontal = 16.dp, vertical = 14.dp)
             ) {
                 Summary(totalSpent = data.totalSpent, currency = data.currency)
 
-                Spacer(modifier = GlanceModifier.height(10.dp))
+                Spacer(modifier = GlanceModifier.height(12.dp))
 
                 if (data.transactions.isEmpty()) {
                     EmptyState()
@@ -99,14 +99,14 @@ class RecentTransactionsWidget : GlanceAppWidget() {
         Box(
             modifier = GlanceModifier
                 .fillMaxWidth()
-                .background(GlanceTheme.colors.primary)
-                .padding(horizontal = 14.dp, vertical = 10.dp)
+                .background(GlanceTheme.colors.surfaceVariant)
+                .padding(horizontal = 16.dp, vertical = 12.dp)
         ) {
             Text(
                 text = "Recent Transactions",
                 style = TextStyle(
-                    color = GlanceTheme.colors.onPrimary,
-                    fontSize = 14.sp,
+                    color = GlanceTheme.colors.onSurfaceVariant,
+                    fontSize = 15.sp,
                     fontWeight = FontWeight.Medium
                 )
             )
@@ -117,16 +117,16 @@ class RecentTransactionsWidget : GlanceAppWidget() {
             ) {
                 Box(
                     modifier = GlanceModifier
-                        .size(28.dp)
-                        .cornerRadius(14.dp)
-                        .background(GlanceTheme.colors.surface)
+                        .size(36.dp)
+                        .cornerRadius(18.dp)
+                        .background(GlanceTheme.colors.primary)
                         .clickable(actionRunCallback<OpenAddTransactionAction>()),
                     contentAlignment = Alignment.Center
                 ) {
                     Image(
                         provider = ImageProvider(R.drawable.ic_widget_add),
                         contentDescription = "Add Transaction",
-                        modifier = GlanceModifier.size(16.dp)
+                        modifier = GlanceModifier.size(20.dp)
                     )
                 }
             }
@@ -142,7 +142,7 @@ class RecentTransactionsWidget : GlanceAppWidget() {
                 text = "Total spend this month",
                 style = TextStyle(
                     color = GlanceTheme.colors.onSurfaceVariant,
-                    fontSize = 12.sp
+                    fontSize = 13.sp
                 )
             )
             Spacer(modifier = GlanceModifier.height(4.dp))
@@ -150,7 +150,7 @@ class RecentTransactionsWidget : GlanceAppWidget() {
                 text = CurrencyFormatter.formatCurrency(totalSpent, currency),
                 style = TextStyle(
                     color = GlanceTheme.colors.onSurface,
-                    fontSize = 20.sp,
+                    fontSize = 22.sp,
                     fontWeight = FontWeight.Bold
                 )
             )
@@ -164,26 +164,31 @@ class RecentTransactionsWidget : GlanceAppWidget() {
         ) {
             items(items) { item ->
                 TransactionRow(item)
-                Spacer(modifier = GlanceModifier.height(8.dp))
+                Box(
+                    modifier = GlanceModifier
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .background(GlanceTheme.colors.surfaceVariant)
+                ) {}
+                Spacer(modifier = GlanceModifier.height(4.dp))
             }
         }
     }
 
     @Composable
     private fun TransactionRow(item: RecentTransactionItem) {
-        Box(
-            modifier = GlanceModifier.fillMaxWidth()
+        Row(
+            modifier = GlanceModifier.fillMaxWidth().padding(vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Column(
-                modifier = GlanceModifier
-                    .fillMaxWidth()
-                    .padding(end = 72.dp)
+                modifier = GlanceModifier.defaultWeight()
             ) {
                 Text(
                     text = item.title,
                     style = TextStyle(
                         color = GlanceTheme.colors.onSurface,
-                        fontSize = 12.sp,
+                        fontSize = 13.sp,
                         fontWeight = FontWeight.Medium
                     )
                 )
@@ -192,7 +197,7 @@ class RecentTransactionsWidget : GlanceAppWidget() {
                     text = item.subtitle,
                     style = TextStyle(
                         color = GlanceTheme.colors.onSurfaceVariant,
-                        fontSize = 10.sp
+                        fontSize = 12.sp
                     )
                 )
             }
@@ -203,20 +208,15 @@ class RecentTransactionsWidget : GlanceAppWidget() {
                 else -> ColorProvider(Color(0xFFD32F2F))
             }
 
-            Box(
-                modifier = GlanceModifier.fillMaxWidth(),
-                contentAlignment = Alignment.CenterEnd
-            ) {
-                Text(
-                    text = CurrencyFormatter.formatCurrency(item.amount, item.currency),
-                    style = TextStyle(
-                        color = amountColor,
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight.Bold,
-                        textAlign = TextAlign.End
-                    )
+            Text(
+                text = CurrencyFormatter.formatCurrency(item.amount, item.currency),
+                style = TextStyle(
+                    color = amountColor,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.End
                 )
-            }
+            )
         }
     }
 
@@ -233,7 +233,7 @@ class RecentTransactionsWidget : GlanceAppWidget() {
                 text = "No transactions yet",
                 style = TextStyle(
                     color = GlanceTheme.colors.onSurfaceVariant,
-                    fontSize = 11.sp
+                    fontSize = 13.sp
                 )
             )
             Spacer(modifier = GlanceModifier.height(2.dp))
@@ -241,7 +241,7 @@ class RecentTransactionsWidget : GlanceAppWidget() {
                 text = "Tap + to add manually",
                 style = TextStyle(
                     color = GlanceTheme.colors.onSurfaceVariant,
-                    fontSize = 10.sp
+                    fontSize = 12.sp
                 )
             )
         }

--- a/app/src/main/res/layout/recent_transactions_widget_preview.xml
+++ b/app/src/main/res/layout/recent_transactions_widget_preview.xml
@@ -3,8 +3,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="14dp"
-    android:background="@android:color/white">
+    android:padding="16dp"
+    android:background="?android:attr/colorBackground">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -19,13 +19,12 @@
             android:text="Recent Transactions"
             android:textSize="14sp"
             android:textStyle="bold"
-            android:textColor="#333333" />
+            android:textColor="?android:attr/textColorPrimary" />
 
         <ImageView
-            android:layout_width="28dp"
-            android:layout_height="28dp"
-            android:padding="6dp"
-            android:background="#EEEEEE"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:padding="8dp"
             android:src="@drawable/ic_widget_add" />
     </LinearLayout>
 
@@ -36,7 +35,7 @@
         android:text="₹12,450"
         android:textSize="22sp"
         android:textStyle="bold"
-        android:textColor="#222222" />
+        android:textColor="?android:attr/textColorPrimary" />
 
     <TextView
         android:layout_width="wrap_content"
@@ -44,12 +43,12 @@
         android:layout_marginTop="2dp"
         android:text="Total spend this month"
         android:textSize="12sp"
-        android:textColor="#666666" />
+        android:textColor="?android:attr/textColorSecondary" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
+        android:layout_marginTop="14dp"
         android:orientation="vertical">
 
         <LinearLayout
@@ -69,13 +68,14 @@
                     android:text="Zomato"
                     android:textSize="13sp"
                     android:textStyle="bold"
-                    android:textColor="#222222" />
+                    android:textColor="?android:attr/textColorPrimary" />
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
                     android:text="Food • Sep 12"
-                    android:textSize="11sp"
-                    android:textColor="#666666" />
+                    android:textSize="12sp"
+                    android:textColor="?android:attr/textColorSecondary" />
             </LinearLayout>
 
             <TextView
@@ -90,8 +90,8 @@
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:layout_marginVertical="8dp"
-            android:background="#EEEEEE" />
+            android:layout_marginVertical="10dp"
+            android:background="#E0E0E0" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -110,13 +110,14 @@
                     android:text="Salary"
                     android:textSize="13sp"
                     android:textStyle="bold"
-                    android:textColor="#222222" />
+                    android:textColor="?android:attr/textColorPrimary" />
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
                     android:text="Income • Sep 05"
-                    android:textSize="11sp"
-                    android:textColor="#666666" />
+                    android:textSize="12sp"
+                    android:textColor="?android:attr/textColorSecondary" />
             </LinearLayout>
 
             <TextView

--- a/app/src/main/res/layout/widget_loading.xml
+++ b/app/src/main/res/layout/widget_loading.xml
@@ -2,13 +2,14 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="12dp"
-    android:background="@android:color/transparent">
+    android:padding="16dp"
+    android:background="?android:attr/colorBackground">
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:text="@string/widget_loading"
-        android:textSize="14sp" />
+        android:textSize="14sp"
+        android:textColor="?android:attr/textColorSecondary" />
 </FrameLayout>

--- a/app/src/main/res/layout/widget_preview.xml
+++ b/app/src/main/res/layout/widget_preview.xml
@@ -3,9 +3,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="14dp"
+    android:padding="16dp"
     android:gravity="center_vertical"
-    android:background="@android:color/white">
+    android:background="?android:attr/colorBackground">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -19,7 +19,7 @@
             android:text="Monthly Budget"
             android:textSize="12sp"
             android:textStyle="bold"
-            android:textColor="#666666" />
+            android:textColor="?android:attr/textColorSecondary" />
 
         <TextView
             android:layout_width="wrap_content"
@@ -35,15 +35,15 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:text="₹45,000"
-        android:textSize="24sp"
+        android:textSize="22sp"
         android:textStyle="bold"
         android:textColor="#2E7D32" />
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="6dp"
-        android:layout_marginTop="6dp"
-        android:background="@android:color/darker_gray">
+        android:layout_height="8dp"
+        android:layout_marginTop="8dp"
+        android:background="#E0E0E0">
 
         <View
             android:layout_width="160dp"
@@ -54,7 +54,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="6dp"
+        android:layout_marginTop="8dp"
         android:orientation="horizontal">
 
         <TextView
@@ -63,7 +63,7 @@
             android:layout_weight="1"
             android:text="of ₹80,000"
             android:textSize="12sp"
-            android:textColor="#666666" />
+            android:textColor="?android:attr/textColorSecondary" />
 
         <TextView
             android:layout_width="wrap_content"
@@ -71,7 +71,7 @@
             android:text="₹35,000 left"
             android:textSize="12sp"
             android:textStyle="bold"
-            android:textColor="#333333" />
+            android:textColor="?android:attr/textColorPrimary" />
     </LinearLayout>
 
     <LinearLayout
@@ -86,7 +86,7 @@
             android:layout_weight="1"
             android:text="₹2,333/day"
             android:textSize="11sp"
-            android:textColor="#666666" />
+            android:textColor="?android:attr/textColorSecondary" />
 
         <TextView
             android:layout_width="wrap_content"


### PR DESCRIPTION
## Summary
- **Budget Widget**: Switched to `SizeMode.Responsive` with small (180x100dp) and large (280x160dp) breakpoints, removed custom corner radius in favor of system-provided radius, full-width progress bar (8dp height, 4dp corner radius), improved typography hierarchy (14sp title, 28sp amount, 13sp status)
- **Recent Transactions Widget**: Replaced bold primary header with subtle `surfaceVariant` tonal surface, enlarged add button to 36dp (from 28dp) for proper touch targets, fixed overlapping Box layout with proper Row + defaultWeight, added dividers between transactions, increased minimum font size to 12sp
- **Preview layouts**: Updated all 3 XML preview files (budget, recent transactions, loading) to match the modernized widget designs

## Test plan
- [ ] Verify Budget Widget renders correctly on small (2x1) and large (3x2) widget sizes
- [ ] Verify Recent Transactions Widget renders correctly at both responsive breakpoints
- [ ] Confirm add transaction button is easily tappable (36dp target)
- [ ] Check both widgets respect system corner radius
- [ ] Verify dynamic color theming works on Android 12+
- [ ] Test light and dark theme appearance
- [ ] Confirm widget preview images match actual widget rendering