### PR TITLE
fix: widget dynamic colors and RemoteViews crash

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidget.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidget.kt
@@ -1,7 +1,7 @@
 package com.pennywiseai.tracker.widget
 
 import android.content.Context
-import android.content.res.Configuration
+import android.os.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -9,7 +9,6 @@ import androidx.compose.ui.unit.sp
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
-import androidx.glance.LocalContext
 import androidx.glance.LocalSize
 import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
@@ -31,14 +30,7 @@ import androidx.glance.layout.width
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
-import androidx.glance.unit.ColorProvider
 import com.pennywiseai.tracker.MainActivity
-import com.pennywiseai.tracker.ui.theme.budget_danger_dark
-import com.pennywiseai.tracker.ui.theme.budget_danger_light
-import com.pennywiseai.tracker.ui.theme.budget_safe_dark
-import com.pennywiseai.tracker.ui.theme.budget_safe_light
-import com.pennywiseai.tracker.ui.theme.budget_warning_dark
-import com.pennywiseai.tracker.ui.theme.budget_warning_light
 import com.pennywiseai.tracker.utils.CurrencyFormatter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
@@ -64,7 +56,12 @@ class BudgetWidget : GlanceAppWidget() {
         }
 
         provideContent {
-            GlanceTheme {
+            GlanceTheme(
+                colors = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+                    GlanceTheme.colors
+                else
+                    PennyWiseWidgetTheme.colors
+            ) {
                 BudgetWidgetContent(data)
             }
         }
@@ -120,14 +117,7 @@ class BudgetWidget : GlanceAppWidget() {
     private fun BudgetOverviewContent(data: BudgetWidgetData) {
         val size = LocalSize.current
         val isSmall = size.width < 280.dp
-        val isDark = (LocalContext.current.resources.configuration.uiMode and
-            Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
-
-        val statusColor = when {
-            data.percentageUsed > 90f -> ColorProvider(if (isDark) budget_danger_dark else budget_danger_light)
-            data.percentageUsed > 70f -> ColorProvider(if (isDark) budget_warning_dark else budget_warning_light)
-            else -> ColorProvider(if (isDark) budget_safe_dark else budget_safe_light)
-        }
+        val statusColor = PennyWiseWidgetTheme.budgetStatusColor(data.percentageUsed)
 
         // Title row with percentage
         Row(
@@ -241,11 +231,7 @@ class BudgetWidget : GlanceAppWidget() {
                 if (data.totalIncome > BigDecimal.ZERO) {
                     Spacer(modifier = GlanceModifier.defaultWeight())
 
-                    val savingsColor = if (data.netSavings >= BigDecimal.ZERO) {
-                        ColorProvider(if (isDark) budget_safe_dark else budget_safe_light)
-                    } else {
-                        ColorProvider(if (isDark) budget_danger_dark else budget_danger_light)
-                    }
+                    val savingsColor = PennyWiseWidgetTheme.savingsColor(data.netSavings >= BigDecimal.ZERO)
 
                     val savingsText = buildString {
                         append(if (data.netSavings >= BigDecimal.ZERO) "Saved " else "Over ")

--- a/app/src/main/java/com/pennywiseai/tracker/widget/PennyWiseWidgetTheme.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/PennyWiseWidgetTheme.kt
@@ -1,0 +1,122 @@
+package com.pennywiseai.tracker.widget
+
+import android.content.res.Configuration
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.glance.LocalContext
+import androidx.glance.material3.ColorProviders
+import androidx.glance.unit.ColorProvider
+import com.pennywiseai.tracker.data.database.entity.TransactionType
+import com.pennywiseai.tracker.ui.theme.*
+
+object PennyWiseWidgetTheme {
+
+    private val LightColors = lightColorScheme(
+        primary = md_theme_light_primary,
+        onPrimary = md_theme_light_onPrimary,
+        primaryContainer = md_theme_light_primaryContainer,
+        onPrimaryContainer = md_theme_light_onPrimaryContainer,
+        secondary = md_theme_light_secondary,
+        onSecondary = md_theme_light_onSecondary,
+        secondaryContainer = md_theme_light_secondaryContainer,
+        onSecondaryContainer = md_theme_light_onSecondaryContainer,
+        tertiary = md_theme_light_tertiary,
+        onTertiary = md_theme_light_onTertiary,
+        tertiaryContainer = md_theme_light_tertiaryContainer,
+        onTertiaryContainer = md_theme_light_onTertiaryContainer,
+        error = md_theme_light_error,
+        onError = md_theme_light_onError,
+        errorContainer = md_theme_light_errorContainer,
+        onErrorContainer = md_theme_light_onErrorContainer,
+        outline = md_theme_light_outline,
+        background = md_theme_light_background,
+        onBackground = md_theme_light_onBackground,
+        surface = md_theme_light_surface,
+        onSurface = md_theme_light_onSurface,
+        surfaceVariant = md_theme_light_surfaceVariant,
+        onSurfaceVariant = md_theme_light_onSurfaceVariant,
+        inverseSurface = md_theme_light_inverseSurface,
+        inverseOnSurface = md_theme_light_inverseOnSurface,
+        inversePrimary = md_theme_light_inversePrimary,
+        surfaceTint = md_theme_light_surfaceTint,
+        outlineVariant = md_theme_light_outlineVariant,
+        scrim = md_theme_light_scrim,
+    )
+
+    private val DarkColors = darkColorScheme(
+        primary = md_theme_dark_primary,
+        onPrimary = md_theme_dark_onPrimary,
+        primaryContainer = md_theme_dark_primaryContainer,
+        onPrimaryContainer = md_theme_dark_onPrimaryContainer,
+        secondary = md_theme_dark_secondary,
+        onSecondary = md_theme_dark_onSecondary,
+        secondaryContainer = md_theme_dark_secondaryContainer,
+        onSecondaryContainer = md_theme_dark_onSecondaryContainer,
+        tertiary = md_theme_dark_tertiary,
+        onTertiary = md_theme_dark_onTertiary,
+        tertiaryContainer = md_theme_dark_tertiaryContainer,
+        onTertiaryContainer = md_theme_dark_onTertiaryContainer,
+        error = md_theme_dark_error,
+        onError = md_theme_dark_onError,
+        errorContainer = md_theme_dark_errorContainer,
+        onErrorContainer = md_theme_dark_onErrorContainer,
+        outline = md_theme_dark_outline,
+        background = md_theme_dark_background,
+        onBackground = md_theme_dark_onBackground,
+        surface = md_theme_dark_surface,
+        onSurface = md_theme_dark_onSurface,
+        surfaceVariant = md_theme_dark_surfaceVariant,
+        onSurfaceVariant = md_theme_dark_onSurfaceVariant,
+        inverseSurface = md_theme_dark_inverseSurface,
+        inverseOnSurface = md_theme_dark_inverseOnSurface,
+        inversePrimary = md_theme_dark_inversePrimary,
+        surfaceTint = md_theme_dark_surfaceTint,
+        outlineVariant = md_theme_dark_outlineVariant,
+        scrim = md_theme_dark_scrim,
+    )
+
+    val colors = ColorProviders(
+        light = LightColors,
+        dark = DarkColors
+    )
+
+    @Composable
+    fun budgetStatusColor(percentageUsed: Float): ColorProvider {
+        val isDark = isWidgetDarkMode()
+        return when {
+            percentageUsed > 90f -> ColorProvider(if (isDark) budget_danger_dark else budget_danger_light)
+            percentageUsed > 70f -> ColorProvider(if (isDark) budget_warning_dark else budget_warning_light)
+            else -> ColorProvider(if (isDark) budget_safe_dark else budget_safe_light)
+        }
+    }
+
+    @Composable
+    fun savingsColor(isPositive: Boolean): ColorProvider {
+        val isDark = isWidgetDarkMode()
+        return if (isPositive) {
+            ColorProvider(if (isDark) budget_safe_dark else budget_safe_light)
+        } else {
+            ColorProvider(if (isDark) budget_danger_dark else budget_danger_light)
+        }
+    }
+
+    @Composable
+    fun transactionAmountColor(type: TransactionType): ColorProvider {
+        val isDark = isWidgetDarkMode()
+        return when (type) {
+            TransactionType.INCOME ->
+                ColorProvider(if (isDark) income_dark else income_light)
+            TransactionType.TRANSFER ->
+                ColorProvider(if (isDark) transfer_dark else transfer_light)
+            else ->
+                ColorProvider(if (isDark) expense_dark else expense_light)
+        }
+    }
+
+    @Composable
+    private fun isWidgetDarkMode(): Boolean {
+        return (LocalContext.current.resources.configuration.uiMode and
+            Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/widget/RecentTransactionsWidget.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/RecentTransactionsWidget.kt
@@ -1,8 +1,8 @@
 package com.pennywiseai.tracker.widget
 
 import android.content.Context
+import android.os.Build
 import android.content.Intent
-import android.content.res.Configuration
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -12,7 +12,6 @@ import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
 import androidx.glance.Image
 import androidx.glance.ImageProvider
-import androidx.glance.LocalContext
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.action.ActionCallback
 import androidx.glance.appwidget.action.actionRunCallback
@@ -40,12 +39,7 @@ import androidx.glance.text.TextAlign
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
-import androidx.glance.unit.ColorProvider
 import com.pennywiseai.tracker.MainActivity
-import com.pennywiseai.tracker.ui.theme.expense_dark
-import com.pennywiseai.tracker.ui.theme.expense_light
-import com.pennywiseai.tracker.ui.theme.income_dark
-import com.pennywiseai.tracker.ui.theme.income_light
 import com.pennywiseai.tracker.R
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.utils.CurrencyFormatter
@@ -72,7 +66,12 @@ class RecentTransactionsWidget : GlanceAppWidget() {
         }
 
         provideContent {
-            GlanceTheme {
+            GlanceTheme(
+                colors = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+                    GlanceTheme.colors
+                else
+                    PennyWiseWidgetTheme.colors
+            ) {
                 RecentTransactionsContent(data)
             }
         }
@@ -215,12 +214,10 @@ class RecentTransactionsWidget : GlanceAppWidget() {
                 )
             }
 
-            val isDark = (LocalContext.current.resources.configuration.uiMode and
-                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
             val amountColor = when (item.transactionType) {
-                TransactionType.INCOME -> ColorProvider(if (isDark) income_dark else income_light)
+                TransactionType.INCOME -> PennyWiseWidgetTheme.transactionAmountColor(TransactionType.INCOME)
                 TransactionType.TRANSFER -> GlanceTheme.colors.onSurfaceVariant
-                else -> ColorProvider(if (isDark) expense_dark else expense_light)
+                else -> PennyWiseWidgetTheme.transactionAmountColor(item.transactionType)
             }
 
             Text(

--- a/app/src/main/res/layout/recent_transactions_widget_preview.xml
+++ b/app/src/main/res/layout/recent_transactions_widget_preview.xml
@@ -4,6 +4,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:padding="16dp"
+    android:theme="@android:style/Theme.DeviceDefault.DayNight"
     android:background="?android:attr/colorBackground">
 
     <LinearLayout
@@ -87,7 +88,7 @@
                 android:textColor="#D32F2F" />
         </LinearLayout>
 
-        <View
+        <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="1dp"
             android:layout_marginVertical="10dp"

--- a/app/src/main/res/layout/widget_loading.xml
+++ b/app/src/main/res/layout/widget_loading.xml
@@ -3,6 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="16dp"
+    android:theme="@android:style/Theme.DeviceDefault.DayNight"
     android:background="?android:attr/colorBackground">
 
     <TextView

--- a/app/src/main/res/layout/widget_preview.xml
+++ b/app/src/main/res/layout/widget_preview.xml
@@ -5,6 +5,7 @@
     android:orientation="vertical"
     android:padding="16dp"
     android:gravity="center_vertical"
+    android:theme="@android:style/Theme.DeviceDefault.DayNight"
     android:background="?android:attr/colorBackground">
 
     <LinearLayout
@@ -45,7 +46,7 @@
         android:layout_marginTop="8dp"
         android:background="#E0E0E0">
 
-        <View
+        <FrameLayout
             android:layout_width="160dp"
             android:layout_height="match_parent"
             android:background="#2E7D32" />


### PR DESCRIPTION
## Summary
- **Fix "Can't load widget" crash**: Replaced banned `<View>` elements with `<FrameLayout>` in widget preview XMLs — `<View>` is not allowed in RemoteViews
- **System dynamic colors**: Widgets now use `GlanceTheme.colors` (wallpaper-derived) on Android 12+ instead of hardcoded branded colors, matching system widgets like Google Calendar
- **Centralized widget theming**: New `PennyWiseWidgetTheme` provides `ColorProviders` fallback for pre-Android 12 and semantic color helpers (`budgetStatusColor`, `savingsColor`, `transactionAmountColor`)
- **Preview XML theming**: Added `Theme.DeviceDefault.DayNight` to preview/loading layouts for proper system color inheritance in widget picker

## Test plan
- [ ] Add Budget widget — should load without crash, background matches system dynamic color
- [ ] Add Recent Transactions widget — should load without crash
- [ ] Verify widget colors adapt to wallpaper on Android 12+ (Material You)
- [ ] Test light and dark mode — widget background and text should follow system theme
- [ ] Test on pre-Android 12 device/emulator — should fall back to branded colors