### PR TITLE
fix: currency conversion race condition showing wrong balance values

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -478,11 +478,28 @@ class HomeViewModel @Inject constructor(
                     )
                 }
             }
+            // Determine if balance is ready (all conversions successful)
+            val accountCurrencies = regularAccounts.map { it.currency }.distinct()
+            val creditCardCurrencies = creditCards.map { it.currency }.distinct()
+            val allAccountCurrencies = (accountCurrencies + creditCardCurrencies).distinct()
+            val needsConversion = allAccountCurrencies.size > 1 &&
+                allAccountCurrencies.any { it != selectedCurrency }
+            val balanceReady = if (needsConversion) {
+                allAccountCurrencies
+                    .filter { it != selectedCurrency }
+                    .all { currency ->
+                        currencyConversionService.hasValidRate(currency, selectedCurrency)
+                    }
+            } else {
+                true
+            }
+
             _uiState.value = _uiState.value.copy(
                 accountBalances = regularAccounts,
                 creditCards = creditCards,
                 totalBalance = totalBalance,
-                totalAvailableCredit = totalAvailableCredit
+                totalAvailableCredit = totalAvailableCredit,
+                isBalanceReady = balanceReady
             )
         }
     }
@@ -601,12 +618,25 @@ class HomeViewModel @Inject constructor(
                 }
             }
 
+            // Determine if balance is ready (all conversions successful)
+            val needsConversion = allAccountCurrencies.size > 1 &&
+                allAccountCurrencies.any { it != selectedCurrency }
+            val balanceReady = if (needsConversion) {
+                allAccountCurrencies
+                    .filter { it != selectedCurrency }
+                    .all { currency ->
+                        currencyConversionService.hasValidRate(currency, selectedCurrency)
+                    }
+            } else {
+                true
+            }
+
             _uiState.value = _uiState.value.copy(
                 accountBalances = regularAccounts,
                 creditCards = creditCards,
                 totalBalance = totalBalanceInSelectedCurrency,
                 totalAvailableCredit = totalAvailableCreditInSelectedCurrency,
-                isBalanceReady = true
+                isBalanceReady = balanceReady
             )
         }
     }


### PR DESCRIPTION
- Add balanceReady validation to refreshAccountBalances() and refreshHiddenAccounts() to match existing loadHomeData() pattern
- Balance stays in loading state until all currency conversion rates are confirmed available, preventing partial/wrong totals
- Previously isBalanceReady was set unconditionally, silently skipping accounts without valid exchange rates

## Summary

<!-- Briefly explain the change and why it’s needed. Keep it focused. -->

## Type of change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Code improvement (no behavior change)
- [ ] perf: Performance improvement
- [ ] style: Formatting (no behavior change)
- [ ] test: Add/update tests
- [ ] chore/ci: Build or CI changes

## Screenshots/Recordings (optional)

<!-- Add images or videos for UI changes. -->

## How to test

<!-- Steps for reviewers to verify the change locally. -->
1. 
2. 
3. 

## Breaking changes

- [ ] No breaking changes
- [ ] Yes (describe): 

## Related issues

<!-- e.g., Closes #123, Fixes #456 -->

## Checklist

- [ ] Focused PR (single purpose)
- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `./gradlew test` passes locally
- [ ] `./gradlew lint` passes locally
- [ ] Follows existing code style and patterns


