### PR TITLE
feat: rework balance card to spending-first design with comparison sp…

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
@@ -322,6 +322,8 @@ fun HomeScreen(
                             currentMonthExpenses = uiState.currentMonthExpenses,
                             currentMonthTotal = uiState.currentMonthTotal,
                             balanceHistory = uiState.balanceHistory,
+                            spendingHistory = uiState.spendingHistory,
+                            lastMonthSpendingHistory = uiState.lastMonthSpendingHistory,
                             availableCurrencies = uiState.availableCurrencies,
                             isUnifiedMode = uiState.isUnifiedMode,
                             isBalanceHidden = uiState.isBalanceHidden,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -281,94 +281,93 @@ class HomeViewModel @Inject constructor(
         }
         
         viewModelScope.launch {
-            // Load balance history for sparkline (last 30 days) from actual account balances
-            val thirtyDaysAgo = LocalDate.now().minusDays(30)
-            val startDateTime = thirtyDaysAgo.atStartOfDay()
+            // Load cumulative spending sparkline for current month + last month comparison
+            val now = LocalDate.now()
+            val firstOfMonth = now.withDayOfMonth(1)
+            val lastMonthStart = firstOfMonth.minusMonths(1)
 
-            combine(
-                accountBalanceRepository.getBalancesFromDate(startDateTime),
-                accountBalanceRepository.getAllLatestBalances()
-            ) { recentBalances, allLatestBalances ->
-                Pair(recentBalances, allLatestBalances)
-            }.collect { (recentBalances, allLatestBalances) ->
+            transactionRepository.getTransactionsBetweenDates(
+                startDate = lastMonthStart,
+                endDate = now
+            ).collect { allTransactions ->
                 val selectedCurrency = _uiState.value.selectedCurrency
                 val isUnified = _uiState.value.isUnifiedMode
-                val hiddenAccounts = sharedPrefs.getStringSet("hidden_accounts", emptySet()) ?: emptySet()
 
-                fun isRelevant(bankName: String, accountLast4: String, isCreditCard: Boolean, currency: String): Boolean {
-                    val accountKey = "${bankName}_${accountLast4}"
-                    return !hiddenAccounts.contains(accountKey) &&
-                        !isCreditCard &&
-                        (isUnified || currency == selectedCurrency)
+                // Split into current month and last month
+                val currentMonthTxs = allTransactions.filter { it.dateTime.toLocalDate() >= firstOfMonth }
+                val lastMonthTxs = allTransactions.filter {
+                    val d = it.dateTime.toLocalDate()
+                    d >= lastMonthStart && d < firstOfMonth
                 }
 
-                suspend fun convertBalance(balance: BigDecimal, currency: String): BigDecimal {
-                    return if (isUnified && currency != selectedCurrency) {
-                        currencyConversionService.convertAmount(balance, currency, selectedCurrency)
+                // Filter to EXPENSE only, respect currency/unified mode
+                val currentExpenses = if (isUnified) {
+                    currentMonthTxs.filter { it.transactionType == TransactionType.EXPENSE }
+                } else {
+                    currentMonthTxs.filter {
+                        it.transactionType == TransactionType.EXPENSE && it.currency == selectedCurrency
+                    }
+                }
+
+                // Group by day and sum amounts (convert if unified mode)
+                val dailySums = mutableMapOf<LocalDate, BigDecimal>()
+                for (tx in currentExpenses) {
+                    val day = tx.dateTime.toLocalDate()
+                    val amount = if (isUnified && tx.currency != selectedCurrency) {
+                        currencyConversionService.convertAmount(tx.amount, tx.currency, selectedCurrency)
                     } else {
-                        balance
+                        tx.amount
                     }
+                    dailySums[day] = (dailySums[day] ?: BigDecimal.ZERO) + amount
                 }
 
-                // Build timelines from recent balances (within 30-day window)
-                val relevantRecent = recentBalances.filter { bal ->
-                    isRelevant(bal.bankName, bal.accountLast4, bal.isCreditCard, bal.currency)
-                }
-
-                val accountTimelines = mutableMapOf<String, MutableList<Pair<LocalDate, BigDecimal>>>()
-                for (bal in relevantRecent) {
-                    val key = "${bal.bankName}_${bal.accountLast4}"
-                    val amount = convertBalance(bal.balance, bal.currency)
-                    accountTimelines.getOrPut(key) { mutableListOf() }
-                        .add(Pair(bal.timestamp.toLocalDate(), amount))
-                }
-                accountTimelines.values.forEach { it.sortBy { pair -> pair.first } }
-
-                // Seed initial balances from ALL latest balances (covers accounts with old updates)
-                val latestBalancePerAccount = mutableMapOf<String, BigDecimal>()
-                for (bal in allLatestBalances) {
-                    if (!isRelevant(bal.bankName, bal.accountLast4, bal.isCreditCard, bal.currency)) continue
-                    val key = "${bal.bankName}_${bal.accountLast4}"
-                    val hasTimelineEntry = accountTimelines.containsKey(key)
-                    if (!hasTimelineEntry) {
-                        // Account has no updates in the 30-day window — use its latest known balance
-                        latestBalancePerAccount[key] = convertBalance(bal.balance, bal.currency)
-                    }
-                }
-
-                // For accounts with timeline entries starting after day 1, seed with the first entry's value
-                for ((key, timeline) in accountTimelines) {
-                    if (!latestBalancePerAccount.containsKey(key) && timeline.isNotEmpty()) {
-                        latestBalancePerAccount[key] = timeline.first().second
-                    }
-                }
-
-                if (latestBalancePerAccount.isEmpty() && accountTimelines.isEmpty()) {
-                    _uiState.value = _uiState.value.copy(balanceHistory = emptyList())
-                    calculateMonthlyChange()
-                    return@collect
-                }
-
-                // Build daily totals
-                val history = mutableListOf<BigDecimal>()
-                var day = thirtyDaysAgo
-                val today = LocalDate.now()
-
-                while (!day.isAfter(today)) {
-                    for ((key, timeline) in accountTimelines) {
-                        val dayBalances = timeline.filter { it.first == day }
-                        if (dayBalances.isNotEmpty()) {
-                            latestBalancePerAccount[key] = dayBalances.last().second
-                        }
-                    }
-
-                    val dailyTotal = latestBalancePerAccount.values.fold(BigDecimal.ZERO) { acc, bal -> acc + bal }
-                    history.add(dailyTotal)
-
+                // Build cumulative list: one entry per day from 1st to today
+                val cumulativeList = mutableListOf<BigDecimal>()
+                var cumulative = BigDecimal.ZERO
+                var day = firstOfMonth
+                while (!day.isAfter(now)) {
+                    cumulative += (dailySums[day] ?: BigDecimal.ZERO)
+                    cumulativeList.add(cumulative)
                     day = day.plusDays(1)
                 }
 
-                _uiState.value = _uiState.value.copy(balanceHistory = history)
+                // Build last month's cumulative spending (same day count for comparison)
+                val lastMonthExpenses = if (isUnified) {
+                    lastMonthTxs.filter { it.transactionType == TransactionType.EXPENSE }
+                } else {
+                    lastMonthTxs.filter {
+                        it.transactionType == TransactionType.EXPENSE && it.currency == selectedCurrency
+                    }
+                }
+
+                val lastMonthDailySums = mutableMapOf<LocalDate, BigDecimal>()
+                for (tx in lastMonthExpenses) {
+                    val txDay = tx.dateTime.toLocalDate()
+                    val amount = if (isUnified && tx.currency != selectedCurrency) {
+                        currencyConversionService.convertAmount(tx.amount, tx.currency, selectedCurrency)
+                    } else {
+                        tx.amount
+                    }
+                    lastMonthDailySums[txDay] = (lastMonthDailySums[txDay] ?: BigDecimal.ZERO) + amount
+                }
+
+                val daysToInclude = now.dayOfMonth
+                val lastMonthCumulative = mutableListOf<BigDecimal>()
+                var lastCum = BigDecimal.ZERO
+                var lastDay = lastMonthStart
+                var dayCount = 0
+                while (dayCount < daysToInclude && lastDay < firstOfMonth) {
+                    lastCum += (lastMonthDailySums[lastDay] ?: BigDecimal.ZERO)
+                    lastMonthCumulative.add(lastCum)
+                    lastDay = lastDay.plusDays(1)
+                    dayCount++
+                }
+
+                _uiState.value = _uiState.value.copy(
+                    spendingHistory = cumulativeList,
+                    balanceHistory = cumulativeList,
+                    lastMonthSpendingHistory = lastMonthCumulative
+                )
                 calculateMonthlyChange()
             }
         }
@@ -470,26 +469,18 @@ class HomeViewModel @Inject constructor(
     }
     
     private fun calculateMonthlyChange() {
-        val history = _uiState.value.balanceHistory
-        if (history.size >= 2) {
-            val currentBalance = history.last()
-            val pastBalance = history.first()
-            val change = currentBalance - pastBalance
-            val changePercent = if (pastBalance != BigDecimal.ZERO) {
-                change.multiply(BigDecimal(100)).divide(pastBalance, 0, RoundingMode.HALF_UP).toInt()
-            } else {
-                0
-            }
-            _uiState.value = _uiState.value.copy(
-                monthlyChange = change,
-                monthlyChangePercent = changePercent
-            )
+        val currentExpenses = _uiState.value.currentMonthExpenses
+        val lastExpenses = _uiState.value.lastMonthExpenses
+        val change = currentExpenses - lastExpenses
+        val changePercent = if (lastExpenses != BigDecimal.ZERO) {
+            change.multiply(BigDecimal(100)).divide(lastExpenses, 0, RoundingMode.HALF_UP).toInt()
         } else {
-            _uiState.value = _uiState.value.copy(
-                monthlyChange = BigDecimal.ZERO,
-                monthlyChangePercent = 0
-            )
+            0
         }
+        _uiState.value = _uiState.value.copy(
+            monthlyChange = change,
+            monthlyChangePercent = changePercent
+        )
     }
     
     fun refreshHiddenAccounts() {
@@ -902,6 +893,7 @@ class HomeViewModel @Inject constructor(
                     selectedCurrency = selectedCurrency,
                     availableCurrencies = availableCurrencies
                 )
+                calculateMonthlyChange()
             }
         } else {
             // Get breakdown for selected currency from stored maps
@@ -927,6 +919,7 @@ class HomeViewModel @Inject constructor(
                 selectedCurrency = selectedCurrency,
                 availableCurrencies = availableCurrencies
             )
+            calculateMonthlyChange()
         }
     }
 
@@ -1090,6 +1083,7 @@ data class HomeUiState(
     val selectedCurrency: String = "INR",
     val availableCurrencies: List<String> = emptyList(),
     val recentTransactionConvertedAmounts: Map<Long, BigDecimal> = emptyMap(),
+    val spendingHistory: List<BigDecimal> = emptyList(),
     val balanceHistory: List<BigDecimal> = emptyList(),
     val isLoading: Boolean = true,
     val isScanning: Boolean = false,
@@ -1097,5 +1091,6 @@ data class HomeUiState(
     val isUnifiedMode: Boolean = false,
     val transactionHeatmap: Map<Long, Int> = emptyMap(),
     val isBalanceHidden: Boolean = true,
-    val isBalanceReady: Boolean = false
+    val isBalanceReady: Boolean = false,
+    val lastMonthSpendingHistory: List<BigDecimal> = emptyList()
 )

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceCard.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -69,6 +70,8 @@ fun BalanceCard(
     currentMonthExpenses: BigDecimal,
     currentMonthTotal: BigDecimal,
     balanceHistory: List<BigDecimal>,
+    spendingHistory: List<BigDecimal> = emptyList(),
+    lastMonthSpendingHistory: List<BigDecimal> = emptyList(),
     availableCurrencies: List<String>,
     isUnifiedMode: Boolean = false,
     onCurrencyClick: () -> Unit,
@@ -90,10 +93,11 @@ fun BalanceCard(
 
     val isDark = isSystemInDarkTheme()
     val isPositive = monthlyChange >= BigDecimal.ZERO
+    // Inverted for spending context: more spending (positive) = red, less spending (negative) = green
     val changeColor = if (isPositive) {
-        if (isDark) income_dark else income_light
-    } else {
         if (isDark) expense_dark else expense_light
+    } else {
+        if (isDark) income_dark else income_light
     }
 
     val containerColor = MaterialTheme.colorScheme.surfaceContainerLow
@@ -138,14 +142,14 @@ fun BalanceCard(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 if (!isExpanded) {
-                    // ── Collapsed View ── Balance is the hero, no sparkline
+                    // ── Collapsed View ── Spending is the hero, no sparkline
                     Column(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(bottom = Spacing.xs)
                     ) {
                         Text(
-                            text = "Total Balance",
+                            text = "Spent this month",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
                             fontWeight = FontWeight.Medium
@@ -156,7 +160,7 @@ fun BalanceCard(
                             horizontalArrangement = Arrangement.spacedBy(Spacing.xs)
                         ) {
                             AnimatedCurrencyText(
-                                text = if (isBalanceHidden) "••••••" else CurrencyFormatter.formatCurrency(totalBalance, currency),
+                                text = if (isBalanceHidden) "••••••" else CurrencyFormatter.formatCurrency(currentMonthExpenses, currency),
                                 style = MaterialTheme.typography.headlineSmall,
                                 fontWeight = FontWeight.Bold,
                                 color = MaterialTheme.colorScheme.onSurface
@@ -240,22 +244,22 @@ fun BalanceCard(
                 } else {
                     // ── Expanded View ──
                     Column(modifier = Modifier.fillMaxWidth()) {
-                        // Total Balance label
+                        // Spending label
                         Text(
-                            text = "Total Balance",
+                            text = "Spent this month",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
                             fontWeight = FontWeight.Medium
                         )
                         Spacer(modifier = Modifier.height(2.dp))
 
-                        // Balance at top as hero
+                        // Spending at top as hero
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(Spacing.xs)
                         ) {
                             AnimatedCurrencyText(
-                                text = if (isBalanceHidden) "••••••" else CurrencyFormatter.formatCurrency(totalBalance, currency),
+                                text = if (isBalanceHidden) "••••••" else CurrencyFormatter.formatCurrency(currentMonthExpenses, currency),
                                 style = MaterialTheme.typography.headlineMedium,
                                 fontWeight = FontWeight.Bold,
                                 color = MaterialTheme.colorScheme.onSurface
@@ -335,6 +339,60 @@ fun BalanceCard(
                                 )
                             }
                         }
+                        // Spending sparkline
+                        if (spendingHistory.isNotEmpty()) {
+                            Spacer(modifier = Modifier.height(Spacing.md))
+                            val expenseColor = if (isDark) expense_dark else expense_light
+                            BalanceSparkline(
+                                data = spendingHistory,
+                                lineColor = expenseColor,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(80.dp),
+                                currency = currency,
+                                isBalanceHidden = isBalanceHidden,
+                                comparisonData = lastMonthSpendingHistory.ifEmpty { null },
+                                comparisonLineColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                            )
+                            // Legend
+                            if (lastMonthSpendingHistory.isNotEmpty()) {
+                                Spacer(modifier = Modifier.height(Spacing.xs))
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.Center,
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Box(
+                                        modifier = Modifier
+                                            .size(8.dp)
+                                            .background(expenseColor, CircleShape)
+                                    )
+                                    Spacer(modifier = Modifier.width(4.dp))
+                                    Text(
+                                        text = "This month",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                                    )
+                                    Spacer(modifier = Modifier.width(Spacing.md))
+                                    Box(
+                                        modifier = Modifier
+                                            .width(12.dp)
+                                            .height(2.dp)
+                                            .background(
+                                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f),
+                                                RoundedCornerShape(1.dp)
+                                            )
+                                    )
+                                    Spacer(modifier = Modifier.width(4.dp))
+                                    Text(
+                                        text = "Last month",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                                    )
+                                }
+                            }
+                        }
+
                         Spacer(modifier = Modifier.height(Spacing.sm))
                         HorizontalDivider(
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)
@@ -350,7 +408,7 @@ fun BalanceCard(
                         )
                         Spacer(modifier = Modifier.height(Spacing.sm))
 
-                        // Summary row: Income | Expenses | Net — with colored accent bars
+                        // Summary row: Income | Expenses | Saved — with colored accent bars
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.SpaceEvenly
@@ -374,7 +432,7 @@ fun BalanceCard(
                                 accentColor = expenseColor
                             )
                             SummaryItem(
-                                label = "Net",
+                                label = "Saved",
                                 value = if (isBalanceHidden) "••••" else CurrencyFormatter.formatCurrency(currentMonthTotal, currency),
                                 accentColor = netColor
                             )

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceSparkline.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceSparkline.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
@@ -22,12 +23,17 @@ fun BalanceSparkline(
     lineColor: Color,
     modifier: Modifier = Modifier,
     currency: String = "INR",
-    isBalanceHidden: Boolean = false
+    isBalanceHidden: Boolean = false,
+    comparisonData: List<BigDecimal>? = null,
+    comparisonLineColor: Color = Color.Gray
 ) {
     if (data.size < 2) return
 
-    val max = data.maxOf { it }.toFloat()
-    val min = data.minOf { it }.toFloat()
+    // Compute min/max from both datasets for shared Y scale
+    val hasComparison = comparisonData != null && comparisonData.size >= 2
+    val allValues = if (hasComparison) data + comparisonData!! else data
+    val max = allValues.maxOf { it }.toFloat()
+    val min = allValues.minOf { it }.toFloat()
     val range = (max - min).takeIf { it > 0f } ?: 1f
 
     val textMeasurer = rememberTextMeasurer()
@@ -47,6 +53,36 @@ fun BalanceSparkline(
         val chartHeight = height - labelHeight
         val stepX = width / (data.size - 1)
 
+        // Draw comparison line FIRST (behind main line)
+        if (hasComparison) {
+            val compData = comparisonData!!
+            val compStepX = if (compData.size > 1) width / (compData.size - 1) else width
+            val compPath = Path()
+
+            compData.forEachIndexed { index, value ->
+                val x = index * compStepX
+                val y = chartHeight - ((value.toFloat() - min) / range * chartHeight * 0.85f + chartHeight * 0.075f)
+
+                if (index == 0) {
+                    compPath.moveTo(x, y)
+                } else {
+                    val prevX = (index - 1) * compStepX
+                    val prevValue = compData[index - 1]
+                    val prevY = chartHeight - ((prevValue.toFloat() - min) / range * chartHeight * 0.85f + chartHeight * 0.075f)
+                    val midX = (prevX + x) / 2f
+                    compPath.cubicTo(midX, prevY, midX, y, x, y)
+                }
+            }
+
+            val dashEffect = PathEffect.dashPathEffect(floatArrayOf(8.dp.toPx(), 6.dp.toPx()), 0f)
+            drawPath(
+                path = compPath,
+                color = comparisonLineColor,
+                style = Stroke(width = 1.5.dp.toPx(), pathEffect = dashEffect)
+            )
+        }
+
+        // Draw main line
         val linePath = Path()
 
         data.forEachIndexed { index, value ->
@@ -64,14 +100,13 @@ fun BalanceSparkline(
             }
         }
 
-        // Draw the line
         drawPath(
             path = linePath,
             color = lineColor,
             style = Stroke(width = 2.dp.toPx())
         )
 
-        // Gradient fill under the line
+        // Gradient fill under the main line
         val fillPath = Path().apply {
             addPath(linePath)
             lineTo(width, chartHeight)


### PR DESCRIPTION
…arkline

- Hero number changed from bank balance to "Spent this month" (currentMonthExpenses)
- Cumulative spending sparkline with dotted last-month comparison line (cricket run-rate style)
- Shared Y scale between both lines for accurate visual comparison
- Legend below sparkline: "● This month" / "─ Last month"
- Inverted change pill colors: more spending = red, less = green
- Bottom row label changed from "Net" to "Saved"
- calculateMonthlyChange() now spending-based instead of balance-based
- Added spendingHistory and lastMonthSpendingHistory to HomeUiState

Agent-Id: agent-5708fcbd-137c-4536-8c0a-f217e2081497

## Summary

<!-- Briefly explain the change and why it’s needed. Keep it focused. -->

## Type of change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Code improvement (no behavior change)
- [ ] perf: Performance improvement
- [ ] style: Formatting (no behavior change)
- [ ] test: Add/update tests
- [ ] chore/ci: Build or CI changes

## Screenshots/Recordings (optional)

<!-- Add images or videos for UI changes. -->

## How to test

<!-- Steps for reviewers to verify the change locally. -->
1. 
2. 
3. 

## Breaking changes

- [ ] No breaking changes
- [ ] Yes (describe): 

## Related issues

<!-- e.g., Closes #123, Fixes #456 -->

## Checklist

- [ ] Focused PR (single purpose)
- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `./gradlew test` passes locally
- [ ] `./gradlew lint` passes locally
- [ ] Follows existing code style and patterns


