### PR TITLE
feat: GPay & PhonePe PDF statement import with cross-source dedup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,6 +98,10 @@ android {
 
 
     buildTypes {
+        debug {
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
+        }
         release {
             isMinifyEnabled = true
             isShrinkResources = true
@@ -274,5 +278,8 @@ dependencies {
     
     // OpenCSV for CSV export
     implementation(libs.opencsv)
+
+    // PDFBox Android for PDF statement parsing
+    implementation(libs.pdfbox.android)
     testImplementation(kotlin("test"))
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -117,3 +117,12 @@
 
 # SLF4J (used by OpenCSV)
 -dontwarn org.slf4j.impl.StaticLoggerBinder
+
+# PDFBox Android (used for PDF statement parsing)
+-keep class com.tom_roush.pdfbox.** { *; }
+-dontwarn com.tom_roush.pdfbox.filter.JPXFilter
+-dontwarn com.tom_roush.pdfbox.pdmodel.graphics.image.SampledImageReader
+-dontwarn com.gemalto.jp2.JP2Decoder
+-dontwarn org.bouncycastle.**
+-dontwarn org.apache.harmony.**
+-dontwarn javax.xml.stream.**

--- a/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/34.json
+++ b/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/34.json
@@ -1,0 +1,1305 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 34,
+    "identityHash": "ced95b262e59ad68a726ba5de590724d",
+    "entities": [
+      {
+        "tableName": "transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` TEXT NOT NULL, `merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `transaction_type` TEXT NOT NULL, `date_time` TEXT NOT NULL, `description` TEXT, `sms_body` TEXT, `bank_name` TEXT, `sms_sender` TEXT, `account_number` TEXT, `balance_after` TEXT, `transaction_hash` TEXT NOT NULL DEFAULT '', `is_recurring` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `from_account` TEXT, `to_account` TEXT, `reference` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionType",
+            "columnName": "transaction_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateTime",
+            "columnName": "date_time",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsSender",
+            "columnName": "sms_sender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountNumber",
+            "columnName": "account_number",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "balanceAfter",
+            "columnName": "balance_after",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "transactionHash",
+            "columnName": "transaction_hash",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isRecurring",
+            "columnName": "is_recurring",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "fromAccount",
+            "columnName": "from_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toAccount",
+            "columnName": "to_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transactions_transaction_hash",
+            "unique": true,
+            "columnNames": [
+              "transaction_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_transactions_transaction_hash` ON `${TABLE_NAME}` (`transaction_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `merchant_name` TEXT NOT NULL, `amount` TEXT NOT NULL, `next_payment_date` TEXT, `state` TEXT NOT NULL, `bank_name` TEXT, `umn` TEXT, `category` TEXT, `sms_body` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextPaymentDate",
+            "columnName": "next_payment_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umn",
+            "columnName": "umn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `message` TEXT NOT NULL, `isUser` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `isSystemPrompt` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUser",
+            "columnName": "isUser",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemPrompt",
+            "columnName": "isSystemPrompt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "merchant_mappings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`merchant_name`))",
+        "fields": [
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "merchant_name"
+          ]
+        }
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `color` TEXT NOT NULL, `is_system` INTEGER NOT NULL, `is_income` INTEGER NOT NULL, `display_order` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIncome",
+            "columnName": "is_income",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_categories_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_categories_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "account_balances",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT NOT NULL, `balance` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `transaction_id` INTEGER, `credit_limit` TEXT, `is_credit_card` INTEGER NOT NULL DEFAULT 0, `sms_source` TEXT, `source_type` TEXT, `account_type` TEXT, `created_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "creditLimit",
+            "columnName": "credit_limit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isCreditCard",
+            "columnName": "is_credit_card",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "smsSource",
+            "columnName": "sms_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "source_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountType",
+            "columnName": "account_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_account_balances_bank_name_account_last4_timestamp",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "account_last4",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4_timestamp` ON `${TABLE_NAME}` (`bank_name`, `account_last4`, `timestamp`)"
+          },
+          {
+            "name": "index_account_balances_bank_name_account_last4",
+            "unique": false,
+            "columnNames": [
+              "bank_name",
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4` ON `${TABLE_NAME}` (`bank_name`, `account_last4`)"
+          },
+          {
+            "name": "index_account_balances_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "unrecognized_sms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sender` TEXT NOT NULL, `sms_body` TEXT NOT NULL, `received_at` TEXT NOT NULL, `reported` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receivedAt",
+            "columnName": "received_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reported",
+            "columnName": "reported",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_unrecognized_sms_sender_sms_body",
+            "unique": true,
+            "columnNames": [
+              "sender",
+              "sms_body"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_unrecognized_sms_sender_sms_body` ON `${TABLE_NAME}` (`sender`, `sms_body`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `card_last4` TEXT NOT NULL, `card_type` TEXT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT, `nickname` TEXT, `is_active` INTEGER NOT NULL DEFAULT 1, `last_balance` TEXT, `last_balance_source` TEXT, `last_balance_date` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardLast4",
+            "columnName": "card_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardType",
+            "columnName": "card_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastBalance",
+            "columnName": "last_balance",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceSource",
+            "columnName": "last_balance_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceDate",
+            "columnName": "last_balance_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cards_bank_name_card_last4",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cards_bank_name_card_last4` ON `${TABLE_NAME}` (`bank_name`, `card_last4`)"
+          },
+          {
+            "name": "index_cards_card_last4",
+            "unique": false,
+            "columnNames": [
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_card_last4` ON `${TABLE_NAME}` (`card_last4`)"
+          },
+          {
+            "name": "index_cards_account_last4",
+            "unique": false,
+            "columnNames": [
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_account_last4` ON `${TABLE_NAME}` (`account_last4`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `conditions` TEXT NOT NULL, `actions` TEXT NOT NULL, `is_active` INTEGER NOT NULL, `is_system_template` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conditions",
+            "columnName": "conditions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actions",
+            "columnName": "actions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemTemplate",
+            "columnName": "is_system_template",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_rules_priority_is_active",
+            "unique": false,
+            "columnNames": [
+              "priority",
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_priority_is_active` ON `${TABLE_NAME}` (`priority`, `is_active`)"
+          },
+          {
+            "name": "index_transaction_rules_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "rule_applications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `rule_id` TEXT NOT NULL, `rule_name` TEXT NOT NULL, `transaction_id` TEXT NOT NULL, `fields_modified` TEXT NOT NULL, `applied_at` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`rule_id`) REFERENCES `transaction_rules`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "rule_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleName",
+            "columnName": "rule_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fieldsModified",
+            "columnName": "fields_modified",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedAt",
+            "columnName": "applied_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rule_applications_rule_id",
+            "unique": false,
+            "columnNames": [
+              "rule_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_rule_id` ON `${TABLE_NAME}` (`rule_id`)"
+          },
+          {
+            "name": "index_rule_applications_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          },
+          {
+            "name": "index_rule_applications_applied_at",
+            "unique": false,
+            "columnNames": [
+              "applied_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_applied_at` ON `${TABLE_NAME}` (`applied_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transaction_rules",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "rule_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "exchange_rates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `from_currency` TEXT NOT NULL, `to_currency` TEXT NOT NULL, `rate` TEXT NOT NULL, `provider` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `updated_at_unix` INTEGER NOT NULL DEFAULT 0, `expires_at` TEXT NOT NULL, `expires_at_unix` INTEGER NOT NULL DEFAULT 0, `is_custom_rate` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCurrency",
+            "columnName": "from_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCurrency",
+            "columnName": "to_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtUnix",
+            "columnName": "updated_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expires_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAtUnix",
+            "columnName": "expires_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isCustomRate",
+            "columnName": "is_custom_rate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_exchange_rates_from_currency_to_currency",
+            "unique": true,
+            "columnNames": [
+              "from_currency",
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_exchange_rates_from_currency_to_currency` ON `${TABLE_NAME}` (`from_currency`, `to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_from_currency",
+            "unique": false,
+            "columnNames": [
+              "from_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_from_currency` ON `${TABLE_NAME}` (`from_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_to_currency",
+            "unique": false,
+            "columnNames": [
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_to_currency` ON `${TABLE_NAME}` (`to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          },
+          {
+            "name": "index_exchange_rates_expires_at_unix",
+            "unique": false,
+            "columnNames": [
+              "expires_at_unix"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_expires_at_unix` ON `${TABLE_NAME}` (`expires_at_unix`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `period_type` TEXT NOT NULL, `start_date` TEXT NOT NULL, `end_date` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `is_active` INTEGER NOT NULL DEFAULT 1, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "periodType",
+            "columnName": "period_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budgets_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_budgets_is_active",
+            "unique": false,
+            "columnNames": [
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_is_active` ON `${TABLE_NAME}` (`is_active`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budget_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL DEFAULT '0', FOREIGN KEY(`budget_id`) REFERENCES `budgets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budget_categories_budget_id",
+            "unique": false,
+            "columnNames": [
+              "budget_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budget_categories_budget_id` ON `${TABLE_NAME}` (`budget_id`)"
+          },
+          {
+            "name": "index_budget_categories_budget_id_category_name",
+            "unique": true,
+            "columnNames": [
+              "budget_id",
+              "category_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_budget_categories_budget_id_category_name` ON `${TABLE_NAME}` (`budget_id`, `category_name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "budgets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "budget_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_splits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `transaction_id` INTEGER NOT NULL, `category` TEXT NOT NULL, `amount` TEXT NOT NULL, `created_at` TEXT NOT NULL, FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_splits_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_splits_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "category_budget_limits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `category_name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_category_budget_limits_category_name",
+            "unique": true,
+            "columnNames": [
+              "category_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_category_budget_limits_category_name` ON `${TABLE_NAME}` (`category_name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ced95b262e59ad68a726ba5de590724d')"
+    ]
+  }
+}

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">PennyWise Debug</string>
+</resources>

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
@@ -51,7 +51,7 @@ import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
  */
 @Database(
     entities = [TransactionEntity::class, SubscriptionEntity::class, ChatMessage::class, MerchantMappingEntity::class, CategoryEntity::class, AccountBalanceEntity::class, UnrecognizedSmsEntity::class, CardEntity::class, RuleEntity::class, RuleApplicationEntity::class, ExchangeRateEntity::class, BudgetEntity::class, BudgetCategoryEntity::class, TransactionSplitEntity::class, CategoryBudgetLimitEntity::class],
-    version = 33,
+    version = 34,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
@@ -82,7 +82,8 @@ import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
         AutoMigration(from = 29, to = 30),
         AutoMigration(from = 30, to = 31),
         AutoMigration(from = 31, to = 32),
-        AutoMigration(from = 32, to = 33)
+        AutoMigration(from = 32, to = 33),
+        AutoMigration(from = 33, to = 34)
     ]
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
@@ -4,6 +4,7 @@ import androidx.room.*
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import kotlinx.coroutines.flow.Flow
+import java.math.BigDecimal
 import java.time.LocalDateTime
 
 @Dao
@@ -169,9 +170,9 @@ interface TransactionDao {
     ): Flow<List<TransactionEntity>>
     
     @Query("""
-        SELECT * FROM transactions 
-        WHERE is_deleted = 0 
-        AND bank_name = :bankName 
+        SELECT * FROM transactions
+        WHERE is_deleted = 0
+        AND bank_name = :bankName
         AND account_number = :accountLast4
         AND date_time BETWEEN :startDate AND :endDate
         ORDER BY date_time DESC
@@ -182,4 +183,19 @@ interface TransactionDao {
         startDate: LocalDateTime,
         endDate: LocalDateTime
     ): Flow<List<TransactionEntity>>
+
+    @Query("SELECT * FROM transactions WHERE reference = :reference AND is_deleted = 0 LIMIT 1")
+    suspend fun getTransactionByReference(reference: String): TransactionEntity?
+
+    @Query("""
+        SELECT * FROM transactions
+        WHERE is_deleted = 0
+        AND amount = :amount
+        AND date_time BETWEEN :dateStart AND :dateEnd
+    """)
+    suspend fun getTransactionByAmountAndDate(
+        amount: BigDecimal,
+        dateStart: LocalDateTime,
+        dateEnd: LocalDateTime
+    ): List<TransactionEntity>
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/TransactionEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/TransactionEntity.kt
@@ -71,7 +71,10 @@ data class TransactionEntity(
     val fromAccount: String? = null,
 
     @ColumnInfo(name = "to_account")
-    val toAccount: String? = null
+    val toAccount: String? = null,
+
+    @ColumnInfo(name = "reference")
+    val reference: String? = null
 )
 
 enum class TransactionType {

--- a/app/src/main/java/com/pennywiseai/tracker/data/mapper/ParsedTransactionMapper.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/mapper/ParsedTransactionMapper.kt
@@ -50,7 +50,8 @@ fun ParsedTransaction.toEntity(): TransactionEntity {
         updatedAt = LocalDateTime.now(),
         currency = currency,
         fromAccount = fromAccount,
-        toAccount = toAccount
+        toAccount = toAccount,
+        reference = reference
     )
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
@@ -133,6 +133,16 @@ class TransactionRepository @Inject constructor(
     // Helper method to check if transaction exists by hash
     suspend fun getTransactionByHash(transactionHash: String): TransactionEntity? =
         transactionDao.getTransactionByHash(transactionHash)
+
+    suspend fun getTransactionByReference(reference: String): TransactionEntity? =
+        transactionDao.getTransactionByReference(reference)
+
+    suspend fun getTransactionByAmountAndDate(
+        amount: BigDecimal,
+        dateStart: LocalDateTime,
+        dateEnd: LocalDateTime
+    ): List<TransactionEntity> =
+        transactionDao.getTransactionByAmountAndDate(amount, dateStart, dateEnd)
     
     suspend fun undoDeleteTransaction(transaction: TransactionEntity) {
         transactionDao.updateTransaction(transaction.copy(isDeleted = false))

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/GPayPdfParser.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/GPayPdfParser.kt
@@ -1,0 +1,149 @@
+package com.pennywiseai.tracker.data.statement
+
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+class GPayPdfParser : PdfStatementParser {
+
+    companion object {
+        private val GPAY_KEYWORDS = listOf("gpay", "google pay")
+
+        private val DATE_FORMAT = SimpleDateFormat("dd MMM yyyy h:mm a", Locale.ENGLISH).apply {
+            timeZone = TimeZone.getTimeZone("Asia/Kolkata")
+        }
+
+        private val AMOUNT_PATTERN = Regex("""[₹Rs.]+\s*([\d,]+(?:\.\d{1,2})?)""")
+        private val UPI_TXN_ID_PATTERN = Regex("""UPI\s+[Tt]ransaction\s+ID\s*[:\-]?\s*(\d+)""")
+        private val PAID_TO_MERCHANT_PATTERN = Regex("""Paid\s+to\s+(.+?)(?:\n|$)""")
+        private val RECEIVED_FROM_PATTERN = Regex("""Received\s+from\s+(.+?)(?:\n|$)""")
+        private val PAID_BY_ACCOUNT_PATTERN = Regex("""Paid\s+by\s+(.+?)(?:\n|$)""")
+        private val ACCOUNT_LAST4_PATTERN = Regex("""[Xx*]+(\d{4})""")
+        private val DATE_PATTERN = Regex("""(\d{1,2}\s+\w{3}\s+\d{4}\s+\d{1,2}:\d{2}\s*[AaPp][Mm])""")
+    }
+
+    override fun canHandle(text: String): Boolean {
+        val lower = text.lowercase()
+        return GPAY_KEYWORDS.any { it in lower } && lower.contains("upi transaction id")
+    }
+
+    override fun parse(text: String): List<ParsedTransaction> {
+        val transactions = mutableListOf<ParsedTransaction>()
+        val blocks = splitIntoTransactionBlocks(text)
+
+        for (block in blocks) {
+            parseBlock(block)?.let { transactions.add(it) }
+        }
+
+        return transactions
+    }
+
+    private fun splitIntoTransactionBlocks(text: String): List<String> {
+        val blocks = mutableListOf<String>()
+        val lines = text.lines()
+        var currentBlock = StringBuilder()
+        var inTransaction = false
+
+        for (line in lines) {
+            val isPaidTo = line.trimStart().startsWith("Paid to", ignoreCase = true)
+            val isReceivedFrom = line.trimStart().startsWith("Received from", ignoreCase = true)
+
+            if (isPaidTo || isReceivedFrom) {
+                if (inTransaction && currentBlock.isNotEmpty()) {
+                    blocks.add(currentBlock.toString())
+                    currentBlock = StringBuilder()
+                }
+                inTransaction = true
+            }
+
+            if (inTransaction) {
+                currentBlock.appendLine(line)
+            }
+        }
+
+        if (currentBlock.isNotEmpty()) {
+            blocks.add(currentBlock.toString())
+        }
+
+        return blocks
+    }
+
+    private fun parseBlock(block: String): ParsedTransaction? {
+        val amount = extractAmount(block) ?: return null
+        val type = extractTransactionType(block) ?: return null
+        val merchant = extractMerchant(block, type) ?: return null
+        val reference = extractUpiTransactionId(block)
+        val timestamp = extractTimestamp(block) ?: System.currentTimeMillis()
+        val accountInfo = extractAccountInfo(block)
+
+        return ParsedTransaction(
+            amount = amount,
+            type = type,
+            merchant = merchant.trim(),
+            reference = reference,
+            accountLast4 = accountInfo.last4,
+            balance = null,
+            smsBody = block.trim(),
+            sender = "GPay PDF",
+            timestamp = timestamp,
+            bankName = accountInfo.bankName ?: "Google Pay"
+        )
+    }
+
+    private fun extractAmount(block: String): BigDecimal? {
+        val match = AMOUNT_PATTERN.find(block) ?: return null
+        val amountStr = match.groupValues[1].replace(",", "")
+        return try {
+            BigDecimal(amountStr)
+        } catch (_: NumberFormatException) {
+            null
+        }
+    }
+
+    private fun extractTransactionType(block: String): TransactionType? {
+        return when {
+            block.trimStart().startsWith("Paid to", ignoreCase = true) -> TransactionType.EXPENSE
+            block.trimStart().startsWith("Received from", ignoreCase = true) -> TransactionType.INCOME
+            else -> null
+        }
+    }
+
+    private fun extractMerchant(block: String, type: TransactionType): String? {
+        val pattern = if (type == TransactionType.EXPENSE) PAID_TO_MERCHANT_PATTERN else RECEIVED_FROM_PATTERN
+        return pattern.find(block)?.groupValues?.get(1)?.trim()
+    }
+
+    private fun extractUpiTransactionId(block: String): String? {
+        return UPI_TXN_ID_PATTERN.find(block)?.groupValues?.get(1)
+    }
+
+    private fun extractTimestamp(block: String): Long? {
+        val match = DATE_PATTERN.find(block) ?: return null
+        return try {
+            synchronized(DATE_FORMAT) {
+                DATE_FORMAT.parse(match.groupValues[1].trim())?.time
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun extractAccountInfo(block: String): AccountInfo {
+        val paidByMatch = PAID_BY_ACCOUNT_PATTERN.find(block)
+        val paidByText = paidByMatch?.groupValues?.get(1) ?: ""
+
+        val last4 = ACCOUNT_LAST4_PATTERN.find(paidByText)?.groupValues?.get(1)
+        val bankName = paidByText
+            .replace(ACCOUNT_LAST4_PATTERN, "")
+            .replace(Regex("""[•\-–]"""), "")
+            .trim()
+            .takeIf { it.isNotEmpty() }
+
+        return AccountInfo(bankName = bankName, last4 = last4)
+    }
+
+    private data class AccountInfo(val bankName: String?, val last4: String?)
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/ImportStatementUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/ImportStatementUseCase.kt
@@ -1,0 +1,96 @@
+package com.pennywiseai.tracker.data.statement
+
+import android.content.Context
+import android.net.Uri
+import com.pennywiseai.tracker.data.mapper.toEntity
+import com.pennywiseai.tracker.data.repository.TransactionRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import javax.inject.Inject
+
+class ImportStatementUseCase @Inject constructor(
+    private val transactionRepository: TransactionRepository,
+    @ApplicationContext private val context: Context
+) {
+    suspend fun import(uri: Uri): StatementImportResult = withContext(Dispatchers.IO) {
+        try {
+            val text = PdfTextExtractor.extractText(context, uri)
+
+            val parser = PdfParserFactory.getParser(text)
+                ?: return@withContext StatementImportResult.Error(
+                    "Unsupported statement format. Currently supported: Google Pay, PhonePe."
+                )
+
+            val parsedTransactions = parser.parse(text)
+            if (parsedTransactions.isEmpty()) {
+                return@withContext StatementImportResult.Error(
+                    "No transactions found in the statement."
+                )
+            }
+
+            var skippedByHash = 0
+            var skippedByReference = 0
+            var skippedByAmountDate = 0
+
+            val toInsert = parsedTransactions.mapNotNull { parsed ->
+                val hash = parsed.transactionHash?.takeIf { it.isNotBlank() }
+                    ?: parsed.generateTransactionId()
+
+                // Tier 0: Exact re-import detection via hash
+                if (transactionRepository.getTransactionByHash(hash) != null) {
+                    skippedByHash++
+                    return@mapNotNull null
+                }
+
+                // Tier 1: Cross-source dedup via UPI reference
+                val ref = parsed.reference
+                if (ref != null && transactionRepository.getTransactionByReference(ref) != null) {
+                    skippedByReference++
+                    return@mapNotNull null
+                }
+
+                // Tier 2: Cross-source dedup via amount + same calendar day
+                val dateTime = LocalDateTime.ofInstant(
+                    Instant.ofEpochMilli(parsed.timestamp),
+                    ZoneId.systemDefault()
+                )
+                val startOfDay = dateTime.toLocalDate().atStartOfDay()
+                val endOfDay = dateTime.toLocalDate().atTime(LocalTime.MAX)
+
+                val amountMatches = transactionRepository.getTransactionByAmountAndDate(
+                    parsed.amount, startOfDay, endOfDay
+                )
+                if (amountMatches.isNotEmpty()) {
+                    skippedByAmountDate++
+                    return@mapNotNull null
+                }
+
+                parsed.toEntity()
+            }
+
+            if (toInsert.isNotEmpty()) {
+                transactionRepository.insertTransactions(toInsert)
+            }
+
+            val skippedDuplicates = skippedByHash + skippedByReference + skippedByAmountDate
+
+            StatementImportResult.Success(
+                imported = toInsert.size,
+                skippedDuplicates = skippedDuplicates,
+                skippedByReference = skippedByReference,
+                skippedByAmountDate = skippedByAmountDate,
+                skippedByHash = skippedByHash,
+                totalParsed = parsedTransactions.size
+            )
+        } catch (e: Exception) {
+            StatementImportResult.Error(
+                e.message ?: "Failed to import statement."
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/PdfParserFactory.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/PdfParserFactory.kt
@@ -1,0 +1,13 @@
+package com.pennywiseai.tracker.data.statement
+
+object PdfParserFactory {
+
+    private val parsers = listOf(
+        GPayPdfParser(),
+        PhonePePdfParser()
+    )
+
+    fun getParser(extractedText: String): PdfStatementParser? {
+        return parsers.firstOrNull { it.canHandle(extractedText) }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/PdfStatementParser.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/PdfStatementParser.kt
@@ -1,0 +1,8 @@
+package com.pennywiseai.tracker.data.statement
+
+import com.pennywiseai.parser.core.ParsedTransaction
+
+interface PdfStatementParser {
+    fun canHandle(text: String): Boolean
+    fun parse(text: String): List<ParsedTransaction>
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/PdfTextExtractor.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/PdfTextExtractor.kt
@@ -1,0 +1,32 @@
+package com.pennywiseai.tracker.data.statement
+
+import android.content.Context
+import android.net.Uri
+import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
+import com.tom_roush.pdfbox.pdmodel.PDDocument
+import com.tom_roush.pdfbox.text.PDFTextStripper
+
+object PdfTextExtractor {
+
+    private var initialized = false
+
+    private fun ensureInitialized(context: Context) {
+        if (!initialized) {
+            PDFBoxResourceLoader.init(context.applicationContext)
+            initialized = true
+        }
+    }
+
+    fun extractText(context: Context, uri: Uri): String {
+        ensureInitialized(context)
+
+        val inputStream = context.contentResolver.openInputStream(uri)
+            ?: throw IllegalArgumentException("Cannot open PDF at $uri")
+
+        return inputStream.use { stream ->
+            PDDocument.load(stream).use { document ->
+                PDFTextStripper().getText(document)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/PhonePePdfParser.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/PhonePePdfParser.kt
@@ -1,0 +1,164 @@
+package com.pennywiseai.tracker.data.statement
+
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+class PhonePePdfParser : PdfStatementParser {
+
+    companion object {
+        private val PHONEPE_KEYWORDS = listOf("phonepe", "phone pe")
+
+        private val DATE_FORMATS = listOf(
+            SimpleDateFormat("MMM dd, yyyy", Locale.ENGLISH),
+            SimpleDateFormat("dd MMM, yyyy", Locale.ENGLISH),
+            SimpleDateFormat("MMM dd yyyy", Locale.ENGLISH),
+            SimpleDateFormat("dd MMM yyyy", Locale.ENGLISH)
+        ).onEach { it.timeZone = TimeZone.getTimeZone("Asia/Kolkata") }
+
+        private val AMOUNT_PATTERN = Regex("""[₹Rs.]+\s*([\d,]+(?:\.\d{1,2})?)""")
+        private val TXN_ID_PATTERN = Regex("""(?:Transaction\s+ID|UTR(?:\s+No)?)[:\s]*([A-Za-z0-9]+)""", RegexOption.IGNORE_CASE)
+        private val DATE_PATTERN = Regex("""(\d{1,2}\s+\w{3}[,]?\s+\d{4}|\w{3}\s+\d{1,2}[,]?\s+\d{4})""")
+        private val MERCHANT_PATTERN = Regex("""(?:Paid\s+to|Sent\s+to|Transferred\s+to|Received\s+from)\s+(.+?)(?:\n|$)""", RegexOption.IGNORE_CASE)
+    }
+
+    override fun canHandle(text: String): Boolean {
+        val lower = text.lowercase()
+        return PHONEPE_KEYWORDS.any { it in lower }
+    }
+
+    override fun parse(text: String): List<ParsedTransaction> {
+        val transactions = mutableListOf<ParsedTransaction>()
+        val blocks = splitIntoTransactionBlocks(text)
+
+        for (block in blocks) {
+            parseBlock(block)?.let { transactions.add(it) }
+        }
+
+        return transactions
+    }
+
+    private fun splitIntoTransactionBlocks(text: String): List<String> {
+        val blocks = mutableListOf<String>()
+        val lines = text.lines()
+        var currentBlock = StringBuilder()
+        var inTransaction = false
+
+        for (line in lines) {
+            val trimmed = line.trim()
+            val isDebit = trimmed.equals("DEBIT", ignoreCase = true) ||
+                    trimmed.startsWith("DEBIT ", ignoreCase = true)
+            val isCredit = trimmed.equals("CREDIT", ignoreCase = true) ||
+                    trimmed.startsWith("CREDIT ", ignoreCase = true)
+            val isPaidTo = trimmed.startsWith("Paid to", ignoreCase = true) ||
+                    trimmed.startsWith("Sent to", ignoreCase = true) ||
+                    trimmed.startsWith("Transferred to", ignoreCase = true)
+            val isReceivedFrom = trimmed.startsWith("Received from", ignoreCase = true)
+
+            if (isDebit || isCredit || isPaidTo || isReceivedFrom) {
+                if (inTransaction && currentBlock.isNotEmpty()) {
+                    blocks.add(currentBlock.toString())
+                    currentBlock = StringBuilder()
+                }
+                inTransaction = true
+            }
+
+            if (inTransaction) {
+                currentBlock.appendLine(line)
+            }
+        }
+
+        if (currentBlock.isNotEmpty()) {
+            blocks.add(currentBlock.toString())
+        }
+
+        return blocks
+    }
+
+    private fun parseBlock(block: String): ParsedTransaction? {
+        val amount = extractAmount(block) ?: return null
+        val type = extractTransactionType(block) ?: return null
+        val merchant = extractMerchant(block)
+        val reference = extractTransactionId(block)
+        val timestamp = extractTimestamp(block) ?: System.currentTimeMillis()
+
+        return ParsedTransaction(
+            amount = amount,
+            type = type,
+            merchant = merchant?.trim(),
+            reference = reference,
+            accountLast4 = null,
+            balance = null,
+            smsBody = block.trim(),
+            sender = "PhonePe PDF",
+            timestamp = timestamp,
+            bankName = "PhonePe"
+        )
+    }
+
+    private fun extractAmount(block: String): BigDecimal? {
+        val match = AMOUNT_PATTERN.find(block) ?: return null
+        val amountStr = match.groupValues[1].replace(",", "")
+        return try {
+            BigDecimal(amountStr)
+        } catch (_: NumberFormatException) {
+            null
+        }
+    }
+
+    private fun extractTransactionType(block: String): TransactionType? {
+        val firstLine = block.lines().firstOrNull()?.trim()?.uppercase() ?: return null
+        return when {
+            firstLine.startsWith("DEBIT") -> TransactionType.EXPENSE
+            firstLine.startsWith("CREDIT") -> TransactionType.INCOME
+            firstLine.startsWith("PAID TO", ignoreCase = true) ||
+                    firstLine.startsWith("SENT TO", ignoreCase = true) ||
+                    firstLine.startsWith("TRANSFERRED TO", ignoreCase = true) -> TransactionType.EXPENSE
+            firstLine.startsWith("RECEIVED FROM", ignoreCase = true) -> TransactionType.INCOME
+            block.contains("DEBIT", ignoreCase = true) -> TransactionType.EXPENSE
+            block.contains("CREDIT", ignoreCase = true) -> TransactionType.INCOME
+            else -> null
+        }
+    }
+
+    private fun extractMerchant(block: String): String? {
+        val match = MERCHANT_PATTERN.find(block)
+        if (match != null) return match.groupValues[1].trim()
+
+        val lines = block.lines().map { it.trim() }.filter { it.isNotEmpty() }
+        if (lines.size >= 2) {
+            val secondLine = lines[1]
+            if (!secondLine.matches(Regex("""^[₹Rs.\d,]+.*""")) &&
+                !secondLine.startsWith("Transaction", ignoreCase = true) &&
+                !secondLine.startsWith("UTR", ignoreCase = true)
+            ) {
+                return secondLine
+            }
+        }
+
+        return null
+    }
+
+    private fun extractTransactionId(block: String): String? {
+        return TXN_ID_PATTERN.find(block)?.groupValues?.get(1)
+    }
+
+    private fun extractTimestamp(block: String): Long? {
+        val match = DATE_PATTERN.find(block) ?: return null
+        val dateStr = match.groupValues[1].trim()
+
+        for (format in DATE_FORMATS) {
+            try {
+                synchronized(format) {
+                    return format.parse(dateStr)?.time
+                }
+            } catch (_: Exception) {
+                continue
+            }
+        }
+        return null
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/StatementImportResult.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/StatementImportResult.kt
@@ -1,0 +1,14 @@
+package com.pennywiseai.tracker.data.statement
+
+sealed class StatementImportResult {
+    data class Success(
+        val imported: Int,
+        val skippedDuplicates: Int,
+        val skippedByReference: Int,
+        val skippedByAmountDate: Int,
+        val skippedByHash: Int,
+        val totalParsed: Int
+    ) : StatementImportResult()
+
+    data class Error(val message: String) : StatementImportResult()
+}

--- a/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseDestinations.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseDestinations.kt
@@ -72,3 +72,6 @@ object BudgetGroups
 
 @Serializable
 data class BudgetGroupEdit(val groupId: Long = -1L)
+
+@Serializable
+object ImportStatement

--- a/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseNavHost.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseNavHost.kt
@@ -144,6 +144,9 @@ fun PennyWiseNavHost(
                 },
                 onNavigateToExchangeRates = {
                     navController.navigate(ExchangeRates)
+                },
+                onNavigateToImportStatement = {
+                    navController.navigate(ImportStatement)
                 }
             )
         }
@@ -352,6 +355,19 @@ fun PennyWiseNavHost(
             popExitTransition = { fadeOut(tween(200)) + slideOutVertically { it / 4 } }
         ) {
             com.pennywiseai.tracker.presentation.exchangerates.ExchangeRatesScreen(
+                onNavigateBack = {
+                    navController.safePopBackStack()
+                }
+            )
+        }
+
+        composable<ImportStatement>(
+            enterTransition = { fadeIn(tween(300)) + slideInVertically { it / 4 } },
+            exitTransition = { fadeOut(tween(200)) },
+            popEnterTransition = { fadeIn(tween(300)) },
+            popExitTransition = { fadeOut(tween(200)) + slideOutVertically { it / 4 } }
+        ) {
+            com.pennywiseai.tracker.presentation.statement.ImportStatementScreen(
                 onNavigateBack = {
                     navController.safePopBackStack()
                 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/statement/ImportStatementScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/statement/ImportStatementScreen.kt
@@ -1,0 +1,389 @@
+package com.pennywiseai.tracker.presentation.statement
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import com.pennywiseai.tracker.ui.effects.overScrollVertical
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.pennywiseai.tracker.ui.components.CustomTitleTopAppBar
+import com.pennywiseai.tracker.ui.theme.Dimensions
+import com.pennywiseai.tracker.ui.theme.Spacing
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ImportStatementScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: ImportStatementViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val pdfPicker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent(),
+        onResult = { uri ->
+            uri?.let { viewModel.importStatement(it) }
+        }
+    )
+
+    val scrollBehaviorSmall = TopAppBarDefaults.pinnedScrollBehavior()
+    val scrollBehaviorLarge = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    val hazeState = remember { HazeState() }
+
+    Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehaviorLarge.nestedScrollConnection),
+        containerColor = Color.Transparent,
+        topBar = {
+            CustomTitleTopAppBar(
+                scrollBehaviorSmall = scrollBehaviorSmall,
+                scrollBehaviorLarge = scrollBehaviorLarge,
+                title = "Import Statement",
+                hasBackButton = true,
+                hasActionButton = true,
+                navigationContent = {
+                    Box(
+                        modifier = Modifier
+                            .animateContentSize()
+                            .padding(start = 16.dp)
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null,
+                                onClick = onNavigateBack,
+                            ),
+                    ) {
+                        IconButton(
+                            onClick = onNavigateBack,
+                            colors = IconButtonDefaults.iconButtonColors(
+                                containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                                contentColor = MaterialTheme.colorScheme.onBackground
+                            )
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "Back",
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
+                    }
+                },
+                hazeState = hazeState
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .hazeSource(hazeState)
+                .background(MaterialTheme.colorScheme.background)
+                .overScrollVertical()
+                .verticalScroll(rememberScrollState())
+                .padding(paddingValues)
+                .padding(Dimensions.Padding.content),
+            verticalArrangement = Arrangement.spacedBy(Spacing.md),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            when (val state = uiState) {
+                is ImportStatementUiState.Idle -> IdleContent(
+                    onSelectPdf = { pdfPicker.launch("application/pdf") }
+                )
+                is ImportStatementUiState.Loading -> LoadingContent()
+                is ImportStatementUiState.Success -> SuccessContent(
+                    result = state.result,
+                    onImportAnother = {
+                        viewModel.resetState()
+                        pdfPicker.launch("application/pdf")
+                    },
+                    onDone = onNavigateBack
+                )
+                is ImportStatementUiState.Error -> ErrorContent(
+                    message = state.message,
+                    onTryAgain = {
+                        viewModel.resetState()
+                        pdfPicker.launch("application/pdf")
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun IdleContent(onSelectPdf: () -> Unit) {
+    Spacer(modifier = Modifier.height(Spacing.xl))
+
+    Icon(
+        imageVector = Icons.Default.Description,
+        contentDescription = null,
+        modifier = Modifier.size(80.dp),
+        tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+    )
+
+    Spacer(modifier = Modifier.height(Spacing.md))
+
+    Text(
+        text = "Import Statement",
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.onBackground
+    )
+
+    Text(
+        text = "Import transactions from Google Pay or PhonePe PDF statements. Duplicates are automatically detected and skipped.",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(horizontal = Spacing.md)
+    )
+
+    Spacer(modifier = Modifier.height(Spacing.lg))
+
+    Button(
+        onClick = onSelectPdf,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(Dimensions.Component.buttonHeight),
+        shape = RoundedCornerShape(Dimensions.CornerRadius.large)
+    ) {
+        Icon(
+            imageVector = Icons.Default.PictureAsPdf,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp)
+        )
+        Spacer(modifier = Modifier.width(Spacing.sm))
+        Text("Select PDF Statement")
+    }
+}
+
+@Composable
+private fun LoadingContent() {
+    Spacer(modifier = Modifier.height(Spacing.xxxl))
+
+    CircularProgressIndicator(
+        modifier = Modifier.size(48.dp),
+        strokeWidth = 4.dp
+    )
+
+    Spacer(modifier = Modifier.height(Spacing.md))
+
+    Text(
+        text = "Importing transactions...",
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
+
+    Text(
+        text = "Parsing PDF and checking for duplicates",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+    )
+}
+
+@Composable
+private fun SuccessContent(
+    result: com.pennywiseai.tracker.data.statement.StatementImportResult.Success,
+    onImportAnother: () -> Unit,
+    onDone: () -> Unit
+) {
+    Spacer(modifier = Modifier.height(Spacing.lg))
+
+    Icon(
+        imageVector = Icons.Default.CheckCircle,
+        contentDescription = null,
+        modifier = Modifier.size(64.dp),
+        tint = MaterialTheme.colorScheme.primary
+    )
+
+    Spacer(modifier = Modifier.height(Spacing.md))
+
+    Text(
+        text = "Import Complete",
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.onBackground
+    )
+
+    Spacer(modifier = Modifier.height(Spacing.sm))
+
+    // Results card
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        shape = RoundedCornerShape(Dimensions.CornerRadius.large)
+    ) {
+        Column(
+            modifier = Modifier.padding(Spacing.md),
+            verticalArrangement = Arrangement.spacedBy(Spacing.sm)
+        ) {
+            ResultRow(
+                label = "Transactions imported",
+                value = "${result.imported}",
+                isHighlighted = true
+            )
+
+            ResultRow(
+                label = "Total parsed from PDF",
+                value = "${result.totalParsed}"
+            )
+
+            if (result.skippedDuplicates > 0) {
+                HorizontalDivider(modifier = Modifier.padding(vertical = Spacing.xs))
+
+                Text(
+                    text = "Duplicates skipped: ${result.skippedDuplicates}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                if (result.skippedByHash > 0) {
+                    ResultRow(
+                        label = "Exact re-imports",
+                        value = "${result.skippedByHash}",
+                        indent = true
+                    )
+                }
+                if (result.skippedByReference > 0) {
+                    ResultRow(
+                        label = "By UPI reference",
+                        value = "${result.skippedByReference}",
+                        indent = true
+                    )
+                }
+                if (result.skippedByAmountDate > 0) {
+                    ResultRow(
+                        label = "By amount & date",
+                        value = "${result.skippedByAmountDate}",
+                        indent = true
+                    )
+                }
+            }
+        }
+    }
+
+    Spacer(modifier = Modifier.height(Spacing.lg))
+
+    Button(
+        onClick = onImportAnother,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(Dimensions.Component.buttonHeight),
+        shape = RoundedCornerShape(Dimensions.CornerRadius.large)
+    ) {
+        Icon(
+            imageVector = Icons.Default.Add,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp)
+        )
+        Spacer(modifier = Modifier.width(Spacing.sm))
+        Text("Import Another")
+    }
+
+    OutlinedButton(
+        onClick = onDone,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(Dimensions.Component.buttonHeight),
+        shape = RoundedCornerShape(Dimensions.CornerRadius.large)
+    ) {
+        Text("Done")
+    }
+}
+
+@Composable
+private fun ResultRow(
+    label: String,
+    value: String,
+    isHighlighted: Boolean = false,
+    indent: Boolean = false
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(if (indent) Modifier.padding(start = Spacing.md) else Modifier),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            style = if (isHighlighted) MaterialTheme.typography.bodyLarge else MaterialTheme.typography.bodyMedium,
+            color = if (isHighlighted) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = if (isHighlighted) FontWeight.Medium else FontWeight.Normal
+        )
+        Text(
+            text = value,
+            style = if (isHighlighted) MaterialTheme.typography.titleMedium else MaterialTheme.typography.bodyMedium,
+            color = if (isHighlighted) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = if (isHighlighted) FontWeight.Bold else FontWeight.Medium
+        )
+    }
+}
+
+@Composable
+private fun ErrorContent(
+    message: String,
+    onTryAgain: () -> Unit
+) {
+    Spacer(modifier = Modifier.height(Spacing.xxxl))
+
+    Icon(
+        imageVector = Icons.Default.Error,
+        contentDescription = null,
+        modifier = Modifier.size(64.dp),
+        tint = MaterialTheme.colorScheme.error
+    )
+
+    Spacer(modifier = Modifier.height(Spacing.md))
+
+    Text(
+        text = "Import Failed",
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.onBackground
+    )
+
+    Text(
+        text = message,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(horizontal = Spacing.md)
+    )
+
+    Spacer(modifier = Modifier.height(Spacing.lg))
+
+    Button(
+        onClick = onTryAgain,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(Dimensions.Component.buttonHeight),
+        shape = RoundedCornerShape(Dimensions.CornerRadius.large)
+    ) {
+        Icon(
+            imageVector = Icons.Default.Refresh,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp)
+        )
+        Spacer(modifier = Modifier.width(Spacing.sm))
+        Text("Try Again")
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/statement/ImportStatementViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/statement/ImportStatementViewModel.kt
@@ -1,0 +1,47 @@
+package com.pennywiseai.tracker.presentation.statement
+
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.pennywiseai.tracker.data.statement.ImportStatementUseCase
+import com.pennywiseai.tracker.data.statement.StatementImportResult
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+sealed class ImportStatementUiState {
+    data object Idle : ImportStatementUiState()
+    data object Loading : ImportStatementUiState()
+    data class Success(val result: StatementImportResult.Success) : ImportStatementUiState()
+    data class Error(val message: String) : ImportStatementUiState()
+}
+
+@HiltViewModel
+class ImportStatementViewModel @Inject constructor(
+    private val importStatementUseCase: ImportStatementUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<ImportStatementUiState>(ImportStatementUiState.Idle)
+    val uiState: StateFlow<ImportStatementUiState> = _uiState.asStateFlow()
+
+    fun importStatement(uri: Uri) {
+        _uiState.value = ImportStatementUiState.Loading
+        viewModelScope.launch {
+            when (val result = importStatementUseCase.import(uri)) {
+                is StatementImportResult.Success -> {
+                    _uiState.value = ImportStatementUiState.Success(result)
+                }
+                is StatementImportResult.Error -> {
+                    _uiState.value = ImportStatementUiState.Error(result.message)
+                }
+            }
+        }
+    }
+
+    fun resetState() {
+        _uiState.value = ImportStatementUiState.Idle
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
@@ -372,6 +372,11 @@ fun MainScreen(
                         navController.navigate("appearance") {
                             launchSingleTop = true
                         }
+                    },
+                    onNavigateToImportStatement = {
+                        navController.navigate("import_statement") {
+                            launchSingleTop = true
+                        }
                     }
                 )
             }
@@ -418,6 +423,14 @@ fun MainScreen(
                         navController.navigate("add_account") {
                             launchSingleTop = true
                         }
+                    }
+                )
+            }
+
+            composable("import_statement") {
+                com.pennywiseai.tracker.presentation.statement.ImportStatementScreen(
+                    onNavigateBack = {
+                        navController.safePopBackStack()
                     }
                 )
             }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -82,6 +82,7 @@ fun SettingsScreen(
     onNavigateToBudgets: () -> Unit = {},
     onNavigateToExchangeRates: () -> Unit = {},
     onNavigateToAppearance: () -> Unit = {},
+    onNavigateToImportStatement: () -> Unit = {},
     settingsViewModel: SettingsViewModel = hiltViewModel(),
     appLockViewModel: com.pennywiseai.tracker.ui.viewmodel.AppLockViewModel = hiltViewModel()
 ) {
@@ -330,6 +331,15 @@ fun SettingsScreen(
                     title = "Import Data",
                     subtitle = "Restore data from backup",
                     onClick = { importLauncher.launch("*/*") },
+                    position = ItemPosition.MIDDLE
+                )
+                SettingsNavItem(
+                    icon = Icons.Default.Description,
+                    iconBgColor = indigo_light,
+                    iconTint = indigo_dark,
+                    title = "Import Statement",
+                    subtitle = "Import from GPay, PhonePe",
+                    onClick = onNavigateToImportStatement,
                     position = ItemPosition.MIDDLE
                 )
                 SettingsNavItem(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ lifecycleViewmodelCompose = "2.10.0"
 markdown = "0.7.3"
 navVersion = "2.9.6"
 opencsv = "5.12.0"
+pdfboxAndroid = "2.0.27.0"
 review = "2.0.2"
 reviewKtx = "2.0.2"
 roomVersion = "2.8.4"
@@ -86,6 +87,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktorVer
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktorVersion" }
 markdown = { module = "org.jetbrains:markdown", version.ref = "markdown" }
 opencsv = { module = "com.opencsv:opencsv", version.ref = "opencsv" }
+pdfbox-android = { module = "com.tom-roush:pdfbox-android", version.ref = "pdfboxAndroid" }
 review = { module = "com.google.android.play:review", version.ref = "review" }
 review-ktx = { module = "com.google.android.play:review-ktx", version.ref = "reviewKtx" }
 tasks-genai = { module = "com.google.mediapipe:tasks-genai", version.ref = "tasksGenai" }


### PR DESCRIPTION
## Summary
- Add GPay and PhonePe PDF statement upload so users can import transactions beyond SMS capture
- Add `reference` column to TransactionEntity (Room migration v33→v34) for UPI Ref ID / UTR storage
- Implement three-tier deduplication: transactionHash (re-import) → UPI Ref ID (cross-source) → amount+date (fallback)
- New Import Statement screen in Settings > Data Management with file picker, progress, and results display
- Add debug `applicationIdSuffix` for side-by-side install with production app

## New files
- `data/statement/` — `GPayPdfParser`, `PhonePePdfParser`, `PdfParserFactory`, `PdfTextExtractor`, `PdfStatementParser`, `ImportStatementUseCase`, `StatementImportResult`
- `presentation/statement/` — `ImportStatementScreen`, `ImportStatementViewModel`
- PDFBox Android dependency + ProGuard rules

## Deduplication strategy
For each parsed PDF transaction:
1. **Hash match** — same `transactionHash` already in DB → skip (re-import protection)
2. **Reference match** — same UPI Ref ID / UTR in `reference` column → skip (cross-source SMS↔PDF dedup)
3. **Amount+date match** — same amount on same calendar day → skip (fallback for non-UPI transactions)

## Test plan
- [ ] `./gradlew assembleDebug` builds successfully
- [ ] Verify Room migration runs without crash on fresh install and upgrade
- [ ] Settings → Import Statement → select GPay PDF → verify transactions imported
- [ ] Settings → Import Statement → select PhonePe PDF → verify transactions imported  
- [ ] Import PDF when same transactions already exist from SMS → verify duplicates skipped
- [ ] Re-import same PDF → verify all skipped
- [ ] Select non-statement PDF → verify error message shown
- [ ] Debug build installs alongside production build on same device