### PR TITLE
fix: improve balance card comparison clarity

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
@@ -324,6 +324,7 @@ fun HomeScreen(
                             balanceHistory = uiState.balanceHistory,
                             spendingHistory = uiState.spendingHistory,
                             lastMonthSpendingHistory = uiState.lastMonthSpendingHistory,
+                            lastMonthSpending = uiState.lastMonthExpenses,
                             availableCurrencies = uiState.availableCurrencies,
                             isUnifiedMode = uiState.isUnifiedMode,
                             isBalanceHidden = uiState.isBalanceHidden,

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceCard.kt
@@ -72,6 +72,7 @@ fun BalanceCard(
     balanceHistory: List<BigDecimal>,
     spendingHistory: List<BigDecimal> = emptyList(),
     lastMonthSpendingHistory: List<BigDecimal> = emptyList(),
+    lastMonthSpending: BigDecimal = BigDecimal.ZERO,
     availableCurrencies: List<String>,
     isUnifiedMode: Boolean = false,
     onCurrencyClick: () -> Unit,
@@ -102,8 +103,8 @@ fun BalanceCard(
 
     val containerColor = MaterialTheme.colorScheme.surfaceContainerLow
 
-    val changeSign = if (isPositive) "+" else ""
-    val changeText = "$changeSign${CurrencyFormatter.formatCurrency(monthlyChange, currency)} ($monthlyChangePercent%)"
+    val absPercent = kotlin.math.abs(monthlyChangePercent)
+    val changeText = if (isPositive) "$absPercent% more vs last month" else "$absPercent% less vs last month"
 
     Box(modifier = modifier.fillMaxWidth()) {
         PennyWiseCardV2(
@@ -279,6 +280,13 @@ fun BalanceCard(
                                 )
                             }
                         }
+
+                        // Last month subtitle
+                        Text(
+                            text = if (isBalanceHidden) "Last month: ••••" else "Last month: ${CurrencyFormatter.formatCurrency(lastMonthSpending, currency)}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                        )
 
                         Spacer(modifier = Modifier.height(Spacing.sm))
 


### PR DESCRIPTION
## Summary
- Replace raw delta pill text (`+₹5,048 (62%)`) with human-readable `X% more/less vs last month`
- Add "Last month: ₹X,XXX" subtitle in expanded view between hero amount and pill row
- Hidden balance mode masks the last month amount with `••••`

## Test plan
- [ ] Visual QA on device in light and dark themes
- [ ] Verify pill text shows percentage-only format ("62% more vs last month")
- [ ] Verify expanded view shows "Last month: ₹X,XXX" subtitle
- [ ] Verify hidden balance mode masks last month amount
- [ ] `./gradlew assembleDebug` passes