### PR TITLE
feat: add MCP server for AI tool integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -213,6 +213,14 @@ dependencies {
     implementation(libs.ktor.client.android)
     implementation(libs.ktor.client.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
+
+    // MCP Server SDK + Ktor Server
+    implementation(libs.mcp.kotlin.server)
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.cio)
+    implementation(libs.ktor.server.content.negotiation)
+    implementation(libs.ktor.server.sse)
+    implementation(libs.slf4j.nop)
     
     // Gson for backup/restore
     implementation(libs.gson)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,8 +12,12 @@
     <!-- Telephony hardware feature (optional for ChromeOS compatibility) -->
     <uses-feature android:name="android.hardware.telephony" android:required="false" />
 
-    <!-- Internet permission for downloading AI model -->
+    <!-- Internet permission for downloading AI model and MCP server -->
     <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- Foreground service permission for MCP server -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
     <!-- Biometric permission for app lock feature -->
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
@@ -95,6 +99,16 @@
             <intent-filter>
                 <action android:name="android.service.notification.NotificationListenerService" />
             </intent-filter>
+        </service>
+
+        <!-- MCP Server foreground service (developer feature) -->
+        <service
+            android:name=".mcp.McpServerService"
+            android:foregroundServiceType="specialUse"
+            android:exported="false">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Developer MCP server for AI tool integration" />
         </service>
 
         <!-- Budget Widget -->

--- a/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
@@ -32,6 +32,7 @@ class UserPreferencesRepository @Inject constructor(
         val HAS_SKIPPED_SMS_PERMISSION = booleanPreferencesKey("has_skipped_sms_permission")
         val DEVELOPER_MODE_ENABLED = booleanPreferencesKey("developer_mode_enabled")
         val SYSTEM_PROMPT = stringPreferencesKey("system_prompt")
+        val MCP_SERVER_ENABLED = booleanPreferencesKey("mcp_server_enabled")
         val HAS_SHOWN_SCAN_TUTORIAL = booleanPreferencesKey("has_shown_scan_tutorial")
         val ACTIVE_DOWNLOAD_ID = longPreferencesKey("active_download_id")
         val SMS_SCAN_MONTHS = intPreferencesKey("sms_scan_months")
@@ -149,6 +150,17 @@ class UserPreferencesRepository @Inject constructor(
         .map { preferences ->
             preferences[PreferencesKeys.DEVELOPER_MODE_ENABLED] ?: false
         }
+
+    val isMcpServerEnabled: Flow<Boolean> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.MCP_SERVER_ENABLED] ?: false
+        }
+
+    suspend fun setMcpServerEnabled(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.MCP_SERVER_ENABLED] = enabled
+        }
+    }
 
     suspend fun updateDarkThemeEnabled(enabled: Boolean?) {
         context.dataStore.edit { preferences ->

--- a/app/src/main/java/com/pennywiseai/tracker/mcp/McpServer.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/mcp/McpServer.kt
@@ -1,0 +1,49 @@
+package com.pennywiseai.tracker.mcp
+
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.modelcontextprotocol.kotlin.sdk.server.mcpStreamableHttp
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class McpServer(
+    private val toolHandler: McpToolHandler,
+    private val port: Int = DEFAULT_PORT
+) {
+    companion object {
+        const val DEFAULT_PORT = 8765
+    }
+
+    private var server: EmbeddedServer<*, *>? = null
+
+    suspend fun start() {
+        withContext(Dispatchers.IO) {
+            server = embeddedServer(CIO, host = "0.0.0.0", port = port) {
+                install(ContentNegotiation) { json(McpJson) }
+                mcpStreamableHttp {
+                    toolHandler.createServer()
+                }
+                routing {
+                    get("/health") {
+                        call.respondText("PennyWise MCP Server running")
+                    }
+                }
+            }.also {
+                it.start(wait = false)
+            }
+        }
+    }
+
+    fun stop() {
+        server?.stop(gracePeriodMillis = 1000, timeoutMillis = 2000)
+        server = null
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/mcp/McpServerService.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/mcp/McpServerService.kt
@@ -1,0 +1,94 @@
+package com.pennywiseai.tracker.mcp
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import com.pennywiseai.tracker.R
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class McpServerService : Service() {
+
+    companion object {
+        private const val CHANNEL_ID = "mcp_server_channel"
+        private const val NOTIFICATION_ID = 9876
+        const val EXTRA_PORT = "extra_port"
+
+        fun start(context: Context, port: Int = McpServer.DEFAULT_PORT) {
+            val intent = Intent(context, McpServerService::class.java).apply {
+                putExtra(EXTRA_PORT, port)
+            }
+            context.startForegroundService(intent)
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, McpServerService::class.java))
+        }
+    }
+
+    @Inject
+    lateinit var toolHandler: McpToolHandler
+
+    private var mcpServer: McpServer? = null
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val port = intent?.getIntExtra(EXTRA_PORT, McpServer.DEFAULT_PORT) ?: McpServer.DEFAULT_PORT
+
+        startForeground(NOTIFICATION_ID, createNotification(port))
+
+        serviceScope.launch {
+            mcpServer = McpServer(toolHandler, port).also { it.start() }
+        }
+
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        mcpServer?.stop()
+        mcpServer = null
+        serviceScope.cancel()
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "MCP Server",
+            NotificationManager.IMPORTANCE_LOW
+        ).apply {
+            description = "Shows when the MCP developer server is running"
+            setShowBadge(false)
+        }
+        val manager = getSystemService(NotificationManager::class.java)
+        manager.createNotificationChannel(channel)
+    }
+
+    private fun createNotification(port: Int): Notification {
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("MCP Server Running")
+            .setContentText("Listening on port $port")
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setOngoing(true)
+            .setSilent(true)
+            .build()
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/mcp/McpToolHandler.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/mcp/McpToolHandler.kt
@@ -1,0 +1,381 @@
+package com.pennywiseai.tracker.mcp
+
+import com.pennywiseai.tracker.data.database.dao.AccountBalanceDao
+import com.pennywiseai.tracker.data.database.dao.CategoryDao
+import com.pennywiseai.tracker.data.database.dao.SubscriptionDao
+import com.pennywiseai.tracker.data.database.dao.TransactionDao
+import com.pennywiseai.tracker.data.database.entity.SubscriptionState
+import com.pennywiseai.tracker.data.database.entity.TransactionType
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolAnnotations
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class McpToolHandler @Inject constructor(
+    private val transactionDao: TransactionDao,
+    private val categoryDao: CategoryDao,
+    private val accountBalanceDao: AccountBalanceDao,
+    private val subscriptionDao: SubscriptionDao
+) {
+
+    fun createServer(): Server {
+        val server = Server(
+            serverInfo = Implementation(name = "pennywise-mcp", version = "1.0.0"),
+            options = ServerOptions(
+                capabilities = ServerCapabilities(
+                    tools = ServerCapabilities.Tools(listChanged = false)
+                )
+            )
+        )
+
+        registerTools(server)
+        return server
+    }
+
+    private fun registerTools(server: Server) {
+        server.addTool(
+            name = "get_transactions",
+            description = "Fetch transactions with optional filters. Returns transaction details including amount, merchant, category, type, date, and bank.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("date_from") {
+                        put("type", "string")
+                        put("description", "Start date inclusive (YYYY-MM-DD). Defaults to 30 days ago.")
+                    }
+                    putJsonObject("date_to") {
+                        put("type", "string")
+                        put("description", "End date inclusive (YYYY-MM-DD). Defaults to today.")
+                    }
+                    putJsonObject("category") {
+                        put("type", "string")
+                        put("description", "Filter by category name (e.g. Food & Dining, Shopping)")
+                    }
+                    putJsonObject("type") {
+                        put("type", "string")
+                        put("description", "Filter by transaction type: INCOME, EXPENSE, CREDIT, TRANSFER, or INVESTMENT")
+                    }
+                    putJsonObject("merchant") {
+                        put("type", "string")
+                        put("description", "Filter by merchant name (partial match)")
+                    }
+                    putJsonObject("min_amount") {
+                        put("type", "number")
+                        put("description", "Minimum transaction amount")
+                    }
+                    putJsonObject("max_amount") {
+                        put("type", "number")
+                        put("description", "Maximum transaction amount")
+                    }
+                    putJsonObject("limit") {
+                        put("type", "integer")
+                        put("description", "Max results to return (default 50, max 200)")
+                    }
+                    putJsonObject("offset") {
+                        put("type", "integer")
+                        put("description", "Number of results to skip for pagination")
+                    }
+                }
+            ),
+            toolAnnotations = ToolAnnotations(readOnlyHint = true)
+        ) { request ->
+            getTransactions(request.arguments)
+        }
+
+        server.addTool(
+            name = "get_spending_summary",
+            description = "Get aggregated spending totals grouped by category or merchant for a date range. Useful for understanding spending patterns.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("date_from") {
+                        put("type", "string")
+                        put("description", "Start date inclusive (YYYY-MM-DD)")
+                    }
+                    putJsonObject("date_to") {
+                        put("type", "string")
+                        put("description", "End date inclusive (YYYY-MM-DD)")
+                    }
+                    putJsonObject("group_by") {
+                        put("type", "string")
+                        put("description", "Group results by 'category' (default) or 'merchant'")
+                    }
+                },
+                required = listOf("date_from", "date_to")
+            ),
+            toolAnnotations = ToolAnnotations(readOnlyHint = true)
+        ) { request ->
+            getSpendingSummary(request.arguments)
+        }
+
+        server.addTool(
+            name = "get_categories",
+            description = "List all transaction categories with their type (income/expense).",
+            inputSchema = ToolSchema(properties = buildJsonObject {}),
+            toolAnnotations = ToolAnnotations(readOnlyHint = true)
+        ) { _ ->
+            getCategories()
+        }
+
+        server.addTool(
+            name = "search_transactions",
+            description = "Full-text search across transaction merchant names, descriptions, and SMS bodies.",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("query") {
+                        put("type", "string")
+                        put("description", "Search query string")
+                    }
+                    putJsonObject("limit") {
+                        put("type", "integer")
+                        put("description", "Max results to return (default 20, max 100)")
+                    }
+                },
+                required = listOf("query")
+            ),
+            toolAnnotations = ToolAnnotations(readOnlyHint = true)
+        ) { request ->
+            searchTransactions(request.arguments)
+        }
+
+        server.addTool(
+            name = "get_balance_overview",
+            description = "Get current balances across all bank accounts. Shows bank name, account, balance, and currency.",
+            inputSchema = ToolSchema(properties = buildJsonObject {}),
+            toolAnnotations = ToolAnnotations(readOnlyHint = true)
+        ) { _ ->
+            getBalanceOverview()
+        }
+
+        server.addTool(
+            name = "get_subscriptions",
+            description = "Get active subscriptions and recurring payments with amounts and next payment dates.",
+            inputSchema = ToolSchema(properties = buildJsonObject {}),
+            toolAnnotations = ToolAnnotations(readOnlyHint = true)
+        ) { _ ->
+            getSubscriptions()
+        }
+    }
+
+    private suspend fun getTransactions(args: Map<String, kotlinx.serialization.json.JsonElement>?): CallToolResult {
+        val dateFrom = args?.get("date_from")?.jsonPrimitive?.content
+            ?.let { LocalDate.parse(it) }
+            ?: LocalDate.now().minusDays(30)
+        val dateTo = args?.get("date_to")?.jsonPrimitive?.content
+            ?.let { LocalDate.parse(it) }
+            ?: LocalDate.now()
+        val category = args?.get("category")?.jsonPrimitive?.content
+        val type = args?.get("type")?.jsonPrimitive?.content
+            ?.let { runCatching { TransactionType.valueOf(it) }.getOrNull() }
+        val merchant = args?.get("merchant")?.jsonPrimitive?.content
+        val minAmount = args?.get("min_amount")?.jsonPrimitive?.content?.toDoubleOrNull()
+        val maxAmount = args?.get("max_amount")?.jsonPrimitive?.content?.toDoubleOrNull()
+        val limit = (args?.get("limit")?.jsonPrimitive?.content?.toIntOrNull() ?: 50).coerceIn(1, 200)
+        val offset = (args?.get("offset")?.jsonPrimitive?.content?.toIntOrNull() ?: 0).coerceAtLeast(0)
+
+        val startDateTime = dateFrom.atStartOfDay()
+        val endDateTime = dateTo.atTime(LocalTime.MAX)
+
+        val transactions = transactionDao.getTransactionsBetweenDatesList(startDateTime, endDateTime)
+            .asSequence()
+            .filter { category == null || it.category.equals(category, ignoreCase = true) }
+            .filter { type == null || it.transactionType == type }
+            .filter { merchant == null || it.merchantName.contains(merchant, ignoreCase = true) }
+            .filter { minAmount == null || it.amount.toDouble() >= minAmount }
+            .filter { maxAmount == null || it.amount.toDouble() <= maxAmount }
+            .drop(offset)
+            .take(limit)
+            .toList()
+
+        val result = buildJsonObject {
+            put("total_matching", transactions.size)
+            put("date_range", buildJsonObject {
+                put("from", dateFrom.toString())
+                put("to", dateTo.toString())
+            })
+            put("transactions", buildJsonArray {
+                transactions.forEach { tx ->
+                    add(buildJsonObject {
+                        put("id", tx.id)
+                        put("amount", tx.amount.toDouble())
+                        put("merchant", tx.merchantName)
+                        put("category", tx.category)
+                        put("type", tx.transactionType.name)
+                        put("date", tx.dateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                        put("currency", tx.currency)
+                        tx.bankName?.let { put("bank", it) }
+                        tx.accountNumber?.let { put("account", it) }
+                        tx.description?.let { put("description", it) }
+                        tx.reference?.let { put("reference", it) }
+                    })
+                }
+            })
+        }
+        return CallToolResult(content = listOf(TextContent(text = result.toString())))
+    }
+
+    private suspend fun getSpendingSummary(args: Map<String, kotlinx.serialization.json.JsonElement>?): CallToolResult {
+        val dateFrom = args?.get("date_from")?.jsonPrimitive?.content
+            ?.let { LocalDate.parse(it) }
+            ?: return CallToolResult(
+                content = listOf(TextContent(text = "date_from is required")),
+                isError = true
+            )
+        val dateTo = args?.get("date_to")?.jsonPrimitive?.content
+            ?.let { LocalDate.parse(it) }
+            ?: return CallToolResult(
+                content = listOf(TextContent(text = "date_to is required")),
+                isError = true
+            )
+        val groupBy = args?.get("group_by")?.jsonPrimitive?.content ?: "category"
+
+        val startDateTime = dateFrom.atStartOfDay()
+        val endDateTime = dateTo.atTime(LocalTime.MAX)
+
+        val transactions = transactionDao.getTransactionsBetweenDatesList(startDateTime, endDateTime)
+            .filter { it.transactionType == TransactionType.EXPENSE || it.transactionType == TransactionType.CREDIT }
+
+        val totalSpent = transactions.sumOf { it.amount.toDouble() }
+
+        val grouped = when (groupBy) {
+            "merchant" -> transactions.groupBy { it.merchantName }
+            else -> transactions.groupBy { it.category }
+        }
+
+        val summaries = grouped.map { (key, txs) ->
+            Triple(key, txs.sumOf { it.amount.toDouble() }, txs.size)
+        }.sortedByDescending { it.second }
+
+        val result = buildJsonObject {
+            put("date_range", buildJsonObject {
+                put("from", dateFrom.toString())
+                put("to", dateTo.toString())
+            })
+            put("total_spent", totalSpent)
+            put("transaction_count", transactions.size)
+            put("group_by", groupBy)
+            put("groups", buildJsonArray {
+                summaries.forEach { (name, total, count) ->
+                    add(buildJsonObject {
+                        put("name", name)
+                        put("total", total)
+                        put("count", count)
+                        put("percentage", if (totalSpent > 0) (total / totalSpent * 100) else 0.0)
+                    })
+                }
+            })
+        }
+        return CallToolResult(content = listOf(TextContent(text = result.toString())))
+    }
+
+    private suspend fun getCategories(): CallToolResult {
+        val categories = categoryDao.getAllCategories().first()
+        val result = buildJsonObject {
+            put("categories", buildJsonArray {
+                categories.forEach { cat ->
+                    add(buildJsonObject {
+                        put("name", cat.name)
+                        put("type", if (cat.isIncome) "income" else "expense")
+                        put("color", cat.color)
+                        put("is_system", cat.isSystem)
+                    })
+                }
+            })
+        }
+        return CallToolResult(content = listOf(TextContent(text = result.toString())))
+    }
+
+    private suspend fun searchTransactions(args: Map<String, kotlinx.serialization.json.JsonElement>?): CallToolResult {
+        val query = args?.get("query")?.jsonPrimitive?.content
+            ?: return CallToolResult(
+                content = listOf(TextContent(text = "query is required")),
+                isError = true
+            )
+        val limit = (args?.get("limit")?.jsonPrimitive?.content?.toIntOrNull() ?: 20).coerceIn(1, 100)
+
+        val transactions = transactionDao.searchTransactions(query).first().take(limit)
+
+        val result = buildJsonObject {
+            put("query", query)
+            put("result_count", transactions.size)
+            put("transactions", buildJsonArray {
+                transactions.forEach { tx ->
+                    add(buildJsonObject {
+                        put("id", tx.id)
+                        put("amount", tx.amount.toDouble())
+                        put("merchant", tx.merchantName)
+                        put("category", tx.category)
+                        put("type", tx.transactionType.name)
+                        put("date", tx.dateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                        put("currency", tx.currency)
+                        tx.bankName?.let { put("bank", it) }
+                        tx.description?.let { put("description", it) }
+                    })
+                }
+            })
+        }
+        return CallToolResult(content = listOf(TextContent(text = result.toString())))
+    }
+
+    private suspend fun getBalanceOverview(): CallToolResult {
+        val balances = accountBalanceDao.getAllLatestBalances().first()
+        val totalBalance = balances.sumOf { it.balance.toDouble() }
+
+        val result = buildJsonObject {
+            put("total_balance", totalBalance)
+            put("account_count", balances.size)
+            put("accounts", buildJsonArray {
+                balances.forEach { bal ->
+                    add(buildJsonObject {
+                        put("bank", bal.bankName)
+                        put("account_last4", bal.accountLast4)
+                        put("balance", bal.balance.toDouble())
+                        put("currency", bal.currency)
+                        put("is_credit_card", bal.isCreditCard)
+                        bal.creditLimit?.let { put("credit_limit", it.toDouble()) }
+                        bal.accountType?.let { put("account_type", it) }
+                        put("last_updated", bal.timestamp.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                    })
+                }
+            })
+        }
+        return CallToolResult(content = listOf(TextContent(text = result.toString())))
+    }
+
+    private suspend fun getSubscriptions(): CallToolResult {
+        val subscriptions = subscriptionDao.getSubscriptionsByStateList(SubscriptionState.ACTIVE)
+        val totalMonthly = subscriptions.sumOf { it.amount.toDouble() }
+
+        val result = buildJsonObject {
+            put("total_monthly", totalMonthly)
+            put("subscription_count", subscriptions.size)
+            put("subscriptions", buildJsonArray {
+                subscriptions.forEach { sub ->
+                    add(buildJsonObject {
+                        put("merchant", sub.merchantName)
+                        put("amount", sub.amount.toDouble())
+                        put("currency", sub.currency)
+                        sub.nextPaymentDate?.let { put("next_payment", it.toString()) }
+                        sub.category?.let { put("category", it) }
+                        sub.bankName?.let { put("bank", it) }
+                    })
+                }
+            })
+        }
+        return CallToolResult(content = listOf(TextContent(text = result.toString())))
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -94,6 +94,7 @@ fun SettingsScreen(
     val downloadedMB by settingsViewModel.downloadedMB.collectAsStateWithLifecycle()
     val totalMB by settingsViewModel.totalMB.collectAsStateWithLifecycle()
     val isDeveloperModeEnabled by settingsViewModel.isDeveloperModeEnabled.collectAsStateWithLifecycle(initialValue = false)
+    val isMcpServerEnabled by settingsViewModel.isMcpServerEnabled.collectAsStateWithLifecycle(initialValue = false)
     val smsScanMonths by settingsViewModel.smsScanMonths.collectAsStateWithLifecycle(initialValue = 3)
     val smsScanAllTime by settingsViewModel.smsScanAllTime.collectAsStateWithLifecycle(initialValue = false)
     val baseCurrency by settingsViewModel.baseCurrency.collectAsStateWithLifecycle(initialValue = "INR")
@@ -405,8 +406,20 @@ fun SettingsScreen(
                     subtitle = "Show technical information in chat",
                     checked = isDeveloperModeEnabled,
                     onCheckedChange = { settingsViewModel.toggleDeveloperMode(it) },
-                    position = ItemPosition.SINGLE
+                    position = if (isDeveloperModeEnabled) ItemPosition.TOP else ItemPosition.SINGLE
                 )
+                if (isDeveloperModeEnabled) {
+                    SettingsSwitchRow(
+                        icon = Icons.Default.Dns,
+                        iconBgColor = teal_light,
+                        iconTint = teal_dark,
+                        title = "MCP Server",
+                        subtitle = if (isMcpServerEnabled) "Running on port 8765" else "Expose data to AI tools via MCP",
+                        checked = isMcpServerEnabled,
+                        onCheckedChange = { settingsViewModel.toggleMcpServer(it) },
+                        position = ItemPosition.BOTTOM
+                    )
+                }
             }
 
             // ── Support & Community ──

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -75,6 +75,7 @@ class SettingsViewModel @Inject constructor(
     
     // Developer mode state
     val isDeveloperModeEnabled = userPreferencesRepository.isDeveloperModeEnabled
+    val isMcpServerEnabled = userPreferencesRepository.isMcpServerEnabled
     
     // SMS scan period state
     val smsScanMonths = userPreferencesRepository.smsScanMonths
@@ -414,6 +415,20 @@ class SettingsViewModel @Inject constructor(
     fun toggleDeveloperMode(enabled: Boolean) {
         viewModelScope.launch {
             userPreferencesRepository.setDeveloperModeEnabled(enabled)
+            if (!enabled) {
+                toggleMcpServer(false)
+            }
+        }
+    }
+
+    fun toggleMcpServer(enabled: Boolean) {
+        viewModelScope.launch {
+            userPreferencesRepository.setMcpServerEnabled(enabled)
+            if (enabled) {
+                com.pennywiseai.tracker.mcp.McpServerService.start(context)
+            } else {
+                com.pennywiseai.tracker.mcp.McpServerService.stop(context)
+            }
         }
     }
     

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,9 @@ junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 kotlinxSerializationJson = "1.9.0"
-ktorVersion = "2.3.12"
+ktorVersion = "3.2.3"
+mcpKotlinSdk = "0.9.0"
+slf4j = "2.0.17"
 lifecycleRuntimeCompose = "2.10.0"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.12.2"
@@ -86,6 +88,12 @@ ktor-client-android = { module = "io.ktor:ktor-client-android", version.ref = "k
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktorVersion" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktorVersion" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktorVersion" }
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktorVersion" }
+ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktorVersion" }
+ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktorVersion" }
+ktor-server-sse = { module = "io.ktor:ktor-server-sse", version.ref = "ktorVersion" }
+mcp-kotlin-server = { module = "io.modelcontextprotocol:kotlin-sdk-server", version.ref = "mcpKotlinSdk" }
+slf4j-nop = { module = "org.slf4j:slf4j-nop", version.ref = "slf4j" }
 markdown = { module = "org.jetbrains:markdown", version.ref = "markdown" }
 opencsv = { module = "com.opencsv:opencsv", version.ref = "opencsv" }
 pdfbox-android = { module = "com.tom-roush:pdfbox-android", version.ref = "pdfboxAndroid" }


### PR DESCRIPTION
## Summary
- Adds an embedded MCP (Model Context Protocol) server using the official `kotlin-sdk-server` (v0.9.0)
- Runs as a foreground service on port 8765 with Ktor CIO + Streamable HTTP transport
- Exposes 6 read-only tools: `get_transactions`, `get_spending_summary`, `get_categories`, `search_transactions`, `get_balance_overview`, `get_subscriptions`
- Developer toggle in Settings > Developer > MCP Server
- Upgrades Ktor from 2.3.12 to 3.2.3 for SDK compatibility

## Usage
1. Enable **Developer Mode** in Settings
2. Toggle **MCP Server** on
3. From desktop: `adb forward tcp:8765 tcp:8765`
4. Connect any MCP client to `http://localhost:8765/mcp`

## Test plan
- [ ] Toggle MCP server on/off, verify foreground notification appears/disappears
- [ ] `curl http://localhost:8765/health` returns OK
- [ ] MCP Inspector connects and lists all 6 tools
- [ ] Test each tool returns valid JSON results
- [ ] Turning off Developer Mode auto-stops MCP server
- [ ] Verify existing Ktor client (ExchangeRateProvider) still works after Ktor 3 upgrade