### PR TITLE
fix: detect credit card type in Standard Chartered parser

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/CardRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/CardRepository.kt
@@ -54,6 +54,15 @@ class CardRepository @Inject constructor(
     ): CardEntity {
         val existingCard = cardDao.getCard(bankName, cardLast4)
         if (existingCard != null) {
+            // Upgrade DEBIT → CREDIT if we now know it's a credit card
+            if (isCredit && existingCard.cardType == CardType.DEBIT) {
+                val upgraded = existingCard.copy(
+                    cardType = CardType.CREDIT,
+                    updatedAt = LocalDateTime.now()
+                )
+                cardDao.updateCard(upgraded)
+                return upgraded
+            }
             return existingCard
         }
         

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/StandardCharteredBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/StandardCharteredBankParser.kt
@@ -112,13 +112,17 @@ class StandardCharteredBankParser : BankParser() {
     override fun extractTransactionType(message: String): TransactionType? {
         val lowerMessage = message.lowercase()
 
+        val isCreditCard = lowerMessage.contains("credit card")
+
         return when {
             // Pakistan-specific
             lowerMessage.contains("payment of") && lowerMessage.contains("financing") -> TransactionType.EXPENSE
             lowerMessage.contains("transaction of pkr") && lowerMessage.contains("using online banking") -> TransactionType.EXPENSE
             lowerMessage.contains("withdrawn from account") -> TransactionType.EXPENSE
-            lowerMessage.contains("cash withdrawal transaction") -> TransactionType.EXPENSE
-            lowerMessage.contains("paid at") -> TransactionType.EXPENSE
+            lowerMessage.contains("cash withdrawal transaction") ->
+                if (isCreditCard) TransactionType.CREDIT else TransactionType.EXPENSE
+            lowerMessage.contains("paid at") ->
+                if (isCreditCard) TransactionType.CREDIT else TransactionType.EXPENSE
             lowerMessage.contains("transaction of pkr") && lowerMessage.contains("to") -> TransactionType.TRANSFER
             lowerMessage.contains("sent to scb pk") -> TransactionType.INCOME
             lowerMessage.contains("electronic funds transfer") && lowerMessage.contains("into your account") -> TransactionType.INCOME

--- a/parser-core/src/test/kotlin/TestStandardCharteredBankParser.kt
+++ b/parser-core/src/test/kotlin/TestStandardCharteredBankParser.kt
@@ -230,7 +230,7 @@ class StandardCharteredBankParserTest {
                 expected = ExpectedTransaction(
                     amount = BigDecimal("30000.00"),
                     currency = "PKR",
-                    type = TransactionType.EXPENSE,
+                    type = TransactionType.CREDIT,
                     merchant = "ATM Cash Withdrawal",
                     isFromCard = true,
                     balance = BigDecimal("18062.81"),
@@ -257,6 +257,20 @@ class StandardCharteredBankParserTest {
                     currency = "PKR",
                     type = TransactionType.EXPENSE,
                     accountLast4 = "9901"
+                )
+            ),
+            ParserTestCase(
+                name = "PKR Credit card purchase",
+                message = "Dear Client, PKR 1,958.98 have been paid at FOOD PANDA KARACHI PAK on 23-03-26 using Credit Card no 0141. Avail Limit PKR5174.79. SCBPL",
+                sender = "9220",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1958.98"),
+                    currency = "PKR",
+                    type = TransactionType.CREDIT,
+                    merchant = "FOOD PANDA KARACHI PAK",
+                    isFromCard = true,
+                    balance = BigDecimal("5174.79"),
+                    accountLast4 = "0141"
                 )
             ),
             ParserTestCase(


### PR DESCRIPTION

## Summary

Fix Standard Chartered Bank credit card transactions being incorrectly classified as debit card in Manage Accounts. Two issues:
- The SCB parser returned `EXPENSE` for all "paid at" and "cash withdrawal" messages regardless of card type, so credit card purchases never signaled `CREDIT` for card type detection
- `CardRepository.findOrCreateCard` never upgraded an existing DEBIT card to CREDIT, so even after fixing the parser, cards created by earlier SMS messages stayed as DEBIT

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Code improvement (no behavior change)
- [ ] perf: Performance improvement
- [ ] style: Formatting (no behavior change)
- [x] test: Add/update tests
- [ ] chore/ci: Build or CI changes

## Screenshots/Recordings (optional)

<!-- Add images or videos for UI changes. -->

## How to test

1. Uninstall the app and do a fresh install
2. Scan SMS messages that include SCB credit card transactions (e.g., "PKR 1,958.98 have been paid at FOOD PANDA ... using Credit Card no 0141")
3. Go to **Manage Accounts** → verify the card shows as "Credit Card" not "Debit Card"
4. Also verify debit card transactions (e.g., "using Debit Card no. 53119xxxxxxxx1640") still show as Debit Card

## Breaking changes

- [x] No breaking changes
- [ ] Yes (describe): 

## Related issues

<!-- e.g., Closes #123, Fixes #456 -->

## Checklist

- [x] Focused PR (single purpose)
- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `./gradlew test` passes locally
- [ ] `./gradlew lint` passes locally
- [x] Follows existing code style and patterns