### PR TITLE
fix: RRN-based deduplication for GPay duplicate SMS (issue #96)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
@@ -198,4 +198,37 @@ interface TransactionDao {
         dateStart: LocalDateTime,
         dateEnd: LocalDateTime
     ): List<TransactionEntity>
+
+    @Query("""
+        SELECT * FROM transactions 
+        WHERE is_deleted = 0 
+        AND reference = :reference 
+        AND id != :excludeId
+        AND date_time >= :startDate AND date_time <= :endDate
+        ORDER BY date_time ASC
+    """)
+    suspend fun findPotentialDuplicatesByReference(
+        reference: String,
+        excludeId: Long,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime
+    ): List<TransactionEntity>
+
+    // Find duplicates by amount + account + time window (fuzzy match)
+    @Query("""
+        SELECT * FROM transactions 
+        WHERE is_deleted = 0 
+        AND amount = :amount 
+        AND account_number = :accountLast4
+        AND id != :excludeId
+        AND date_time >= :startDate AND date_time <= :endDate
+        ORDER BY date_time ASC
+    """)
+    suspend fun findPotentialDuplicatesByAmountAndAccount(
+        amount: BigDecimal,
+        accountLast4: String,
+        excludeId: Long,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime
+    ): List<TransactionEntity>
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
@@ -7,6 +7,7 @@ import com.pennywiseai.tracker.data.database.entity.TransactionSplitEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.database.entity.TransactionWithSplits
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -143,6 +144,62 @@ class TransactionRepository @Inject constructor(
         dateEnd: LocalDateTime
     ): List<TransactionEntity> =
         transactionDao.getTransactionByAmountAndDate(amount, dateStart, dateEnd)
+
+    suspend fun findPotentialDuplicatesByReference(
+        reference: String,
+        excludeId: Long,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime
+    ): List<TransactionEntity> =
+        transactionDao.findPotentialDuplicatesByReference(reference, excludeId, startDate, endDate)
+
+    suspend fun findPotentialDuplicatesByAmountAndAccount(
+        amount: BigDecimal,
+        accountLast4: String,
+        excludeId: Long,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime
+    ): List<TransactionEntity> =
+        transactionDao.findPotentialDuplicatesByAmountAndAccount(amount, accountLast4, excludeId, startDate, endDate)
+
+    /**
+     * Cleanup utility for GPay duplicates - finds and removes duplicate transactions
+     * that were imported due to no RRN-based deduplication.
+     * Returns the number of duplicates deleted.
+     */
+    suspend fun cleanupGPayDuplicates(): Int {
+        var deletedCount = 0
+        val deletedIds = mutableSetOf<Long>()
+        
+        val allTransactions = transactionDao.getAllTransactions().first()
+        val transactionsWithRef = allTransactions.filter { it.reference != null && it.reference.isNotBlank() }
+        
+        for (transaction in transactionsWithRef) {
+            if (transaction.id in deletedIds) continue
+            
+            val ref = transaction.reference ?: continue
+            
+            val startOfDay = transaction.dateTime.toLocalDate().atStartOfDay()
+            val endOfDay = transaction.dateTime.toLocalDate().atTime(23, 59, 59)
+            
+            val duplicates = transactionDao.findPotentialDuplicatesByReference(
+                reference = ref,
+                excludeId = transaction.id,
+                startDate = startOfDay,
+                endDate = endOfDay
+            )
+            
+            for (duplicate in duplicates) {
+                if (duplicate.id !in deletedIds) {
+                    transactionDao.softDeleteTransaction(duplicate.id)
+                    deletedIds.add(duplicate.id)
+                    deletedCount++
+                }
+            }
+        }
+        
+        return deletedCount
+    }
     
     suspend fun undoDeleteTransaction(transaction: TransactionEntity) {
         transactionDao.updateTransaction(transaction.copy(isDeleted = false))

--- a/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
@@ -216,6 +216,7 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
         val parsed    = AtomicInteger(0)
         val saved     = AtomicInteger(0)
         val blocked   = AtomicInteger(0)
+        val duplicates = AtomicInteger(0)
         val startTime = System.currentTimeMillis()
 
         // Must be a power of 2 (for bitmask) and large enough that the ring never
@@ -587,6 +588,24 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
             // getTransactionByHash returns rows where is_deleted=1 too, so
             // soft-deleted transactions are never re-imported.
             if (transactionRepository.getTransactionByHash(entity.transactionHash) != null) return false
+
+            // RRN-based deduplication: check if a transaction with same reference exists within 3 minutes
+            // This handles GPay duplicate SMS from different banks (SBI + partner bank)
+            // RRN is always 12 digits - short numeric references could cause false positives
+            val reference = parsed.reference
+            if (reference != null && reference.length == 12 && reference.all { it.isDigit() }) {
+                val existingByRef = transactionRepository.getTransactionByReference(reference)
+                if (existingByRef != null && !existingByRef.isDeleted) {
+                    val timeDiffMinutes = java.time.Duration.between(
+                        existingByRef.dateTime, entity.dateTime
+                    ).toMinutes().let { if (it < 0) -it else it }
+                    if (timeDiffMinutes <= 3) {
+                        Log.d(TAG, "Skipping duplicate transaction with matching RRN $reference within $timeDiffMinutes minutes")
+                        stats.duplicates.incrementAndGet()
+                        return false
+                    }
+                }
+            }
 
             val customCategory = merchantMappingCache[entity.merchantName]
             val mapped = if (customCategory != null) entity.copy(category = customCategory) else entity

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/CompiledPatterns.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/CompiledPatterns.kt
@@ -15,7 +15,8 @@ object CompiledPatterns {
         )
         val UPI_REF = Regex("""UPI[:\s]+([0-9]+)""", RegexOption.IGNORE_CASE)
         val REF_NUMBER = Regex("""Reference\s+Number[:\s]+([A-Z0-9]+)""", RegexOption.IGNORE_CASE)
-        val ALL_PATTERNS = listOf(GENERIC_REF, UPI_REF, REF_NUMBER)
+        val RRN_PATTERN = Regex("""RRN[:\s]*(\d{12})""", RegexOption.IGNORE_CASE)
+        val ALL_PATTERNS = listOf(GENERIC_REF, UPI_REF, REF_NUMBER, RRN_PATTERN)
     }
 
     object Account {

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SouthIndianBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SouthIndianBankParser.kt
@@ -236,6 +236,18 @@ class SouthIndianBankParser : BaseIndianBankParser() {
     }
 
     override fun extractReference(message: String): String? {
+        // Pattern for UPI credit/debit with reference: "Info: UPI/TGRB/190200588907/ Sham Ak"
+        val upiRefPattern = Regex(
+            """Info:\s*UPI/[^/]+/(\d+)(?:/|\s)""",
+            RegexOption.IGNORE_CASE
+        )
+        upiRefPattern.find(message)?.let { match ->
+            val ref = match.groupValues[1].trim()
+            if (ref.isNotEmpty() && ref.all { it.isDigit() }) {
+                return ref
+            }
+        }
+
         // Pattern for IMPS reference in "Info: IMPS/xxx/reference/merchant" format
         // Handle variations with or without space after the last slash
         if (message.contains("IMPS", ignoreCase = true) && message.contains(

--- a/parser-core/src/test/kotlin/TestSouthIndianBankParser.kt
+++ b/parser-core/src/test/kotlin/TestSouthIndianBankParser.kt
@@ -89,6 +89,34 @@ class SouthIndianBankParserTest {
                     reference = "123456789012",
                     merchant = "METRO TRADERS"
                 )
+            ),
+            ParserTestCase(
+                name = "UPI Credit with reference from GPay (partner bank)",
+                message = "UPI Credit:INR Rs.15000.00 in A/c X7377. Info: UPI/TGRB/190200588907/ Sham Ak on 26-12-25 19:02:01.Final balance is Rs.34567.67 -South Indian Bank",
+                sender = "SIBSMS",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("15000.00"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "7377",
+                    balance = BigDecimal("34567.67"),
+                    reference = "190200588907",
+                    merchant = "UPI Credit"
+                )
+            ),
+            ParserTestCase(
+                name = "UPI Credit with reference and balance",
+                message = "UPI Credit:INR Rs.25730.00 in A/c X4821. Info: UPI/ICICI/528908998134/ RAHULKU on 16-10-25 12:11:27. Final balance is Rs.29990.75 -South Indian Bank",
+                sender = "SIBSMS",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("25730.00"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "4821",
+                    balance = BigDecimal("29990.75"),
+                    reference = "528908998134",
+                    merchant = "UPI Credit"
+                )
             )
         )
 


### PR DESCRIPTION
## Problem
GPay sends duplicate SMS for same UPI transaction from two different banks:
- SBI: `Ref No 190200588907`
- South Indian Bank: `UPI/TGRB/190200588907/`

Since SMS body text differs, current `smsBodyHash` deduplication fails, causing duplicate transactions.

## Solution
Added RRN (12-digit UPI reference) based deduplication:

1. **SouthIndianBankParser.kt** - Added UPI reference extraction for `UPI/<provider>/<RRN>/` format
2. **OptimizedSmsReaderWorker.kt** - Before saving, check if transaction with same reference exists within 3 minutes → skip if found
3. **TransactionDao.kt** - Added duplicate finder queries for cleanup
4. **TransactionRepository.kt** - Added `cleanupGPayDuplicates()` utility to clean up existing duplicates

## Changes
- `SouthIndianBankParser.kt`: New pattern `Info: UPI/<provider>/<RRN>/`
- `OptimizedSmsReaderWorker.kt`: RRN deduplication + `duplicates` counter
- `TransactionDao.kt`: `findPotentialDuplicatesByReference`, `findPotentialDuplicatesByAmountAndAccount`
- `TransactionRepository.kt`: `cleanupGPayDuplicates()` - finds duplicates by same reference on same day, keeps earliest
- Added test cases for UPI Credit SMS parsing

## Testing
- Parser-core compiles successfully
- Tests pass for SouthIndianBankParser

Closes #96