### PR TITLE
feat: add SNB-AlAhli and STC Bank (Saudi Arabia) parsers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Bank parsers are now in the `parser-core` module for reusability across platform
 - Use `com.pennywiseai.tracker.data.mapper.toEntity()` to convert ParsedTransaction to TransactionEntity
 - The mapper handles type conversions between modules
 
-## Supported Banks (51 parsers)
+## Supported Banks (53 parsers)
 - Airtel Payments Bank
 - **Al Rajhi Bank (Saudi Arabia)** - Arabic SMS support
 - **Alinma Bank (Saudi Arabia)** - Arabic SMS support
@@ -129,11 +129,13 @@ Bank parsers are now in the `parser-core` module for reusability across platform
 - **Priorbank (Belarus)** - Russian/Belarusian SMS support
 - Punjab National Bank (PNB)
 - Saraswat Co-operative Bank
+- **Saudi National Bank / Al Ahli (SNB-AlAhli, Saudi Arabia)** - Arabic SMS support
 - **Siddhartha Bank Limited (Nepal)**
 - State Bank of India (SBI)
 - Slice
 - South Indian Bank
 - **Standard Chartered Bank**
+- **STC Bank (Saudi Arabia)**
 - **T-Bank / Tinkoff (Russia)** - Russian SMS support
 - Union Bank
 - Utkarsh Bank

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -97,6 +97,8 @@ object BankParserFactory {
         TBankParser(),  // T-Bank / Tinkoff (Russia)
         ChaseBankParser(),  // Chase Bank (USA)
         AlRajhiBankParser(),  // Al Rajhi Bank (Saudi Arabia)
+        SNBAlAhliBankParser(),  // Saudi National Bank / Al Ahli Bank (Saudi Arabia)
+        STCBankParser(),  // STC Bank (Saudi Arabia)
         MBankCZParser(),  // mBank CZ (Czech Republic)
         BankMuscatParser()  // Bank Muscat (Oman)
         // Add more bank parsers here as we implement them

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SNBAlAhliBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SNBAlAhliBankParser.kt
@@ -1,0 +1,162 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Saudi National Bank / Al Ahli Bank (SNB-AlAhli, Saudi Arabia).
+ *
+ * Handles Arabic POS purchase, withdrawal and transfer formats such as:
+ *   شراء نقاط بيع SamsungPay
+ *   بـSAR 19.45
+ *   من filwah al
+ *   مدى *2342
+ *   في 07:53 03/04/26
+ *
+ * Sender examples: SNB-AlAhli, SNB, AlAhliBank, الأهلي
+ */
+class SNBAlAhliBankParser : BankParser() {
+
+    override fun getBankName() = "Saudi National Bank"
+
+    override fun getCurrency() = "SAR"
+
+    override fun canHandle(sender: String): Boolean {
+        val normalized = sender.uppercase()
+        return normalized.contains("SNB") ||
+                normalized.contains("ALAHLI") ||
+                normalized.contains("AL-AHLI") ||
+                normalized.contains("AL AHLI") ||
+                sender.contains("الأهلي")
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // Pattern 1: "بـSAR 19.45" (POS purchase, card transaction)
+        val bPattern = Regex(
+            """بـ\s*SAR\s*([0-9,]+(?:\.\d{1,2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        bPattern.find(message)?.let { return parseSarAmount(it.groupValues[1]) }
+
+        // Pattern 2: "مبلغ: SAR 100" or "مبلغ:SAR 100"
+        val amountPattern = Regex(
+            """مبلغ\s*:?\s*SAR\s*([0-9,]+(?:\.\d{1,2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        amountPattern.find(message)?.let { return parseSarAmount(it.groupValues[1]) }
+
+        // Pattern 3: "SAR 19.45" (loose fallback)
+        val looseSarPattern = Regex(
+            """SAR\s+([0-9,]+(?:\.\d{1,2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        looseSarPattern.find(message)?.let { return parseSarAmount(it.groupValues[1]) }
+
+        return null
+    }
+
+    private fun parseSarAmount(raw: String): BigDecimal? {
+        val cleaned = raw.replace(",", "")
+        return try {
+            BigDecimal(cleaned)
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        return when {
+            message.contains("واردة") -> TransactionType.INCOME          // incoming transfer
+            message.contains("إيداع") -> TransactionType.INCOME          // deposit
+            message.contains("شراء") -> TransactionType.EXPENSE          // purchase
+            message.contains("سحب") -> TransactionType.EXPENSE           // withdrawal
+            message.contains("صادرة") -> TransactionType.EXPENSE         // outgoing transfer
+            message.contains("خصم") -> TransactionType.EXPENSE           // deduction
+            message.contains("سداد") -> TransactionType.EXPENSE          // bill payment
+            else -> null
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // For outgoing purchases/transfers, merchant follows "من" (from) on its own line.
+        // For incoming transfers it is also "من" (sender), so we extract it the same way.
+        val fromPattern = Regex("""من\s+([^\n]+?)(?:\n|$)""")
+        fromPattern.find(message)?.let { match ->
+            val raw = match.groupValues[1].trim()
+            if (raw.isNotBlank() && !raw.all { it == '*' || it.isDigit() }) {
+                val merchant = cleanMerchantName(raw)
+                if (isValidMerchantName(merchant)) {
+                    return merchant
+                }
+            }
+        }
+
+        // "الى: NAME" (to: recipient) for outgoing transfers
+        val toPattern = Regex("""الى\s*:?\s*([^\n]+?)(?:\n|$)""")
+        toPattern.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(merchant)) {
+                return merchant
+            }
+        }
+
+        // ATM fallback
+        if (message.contains("صراف")) {
+            return "ATM Withdrawal"
+        }
+
+        return null
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        // "مدى *2342" or "مدى*2342" (Mada card)
+        val madaPattern = Regex("""مدى\s*\*+\s*(\d{3,4})""")
+        madaPattern.find(message)?.let { return extractLast4Digits(it.groupValues[1]) }
+
+        // "بطاقة *2342" (card)
+        val cardPattern = Regex("""بطاقة\s*\*+\s*(\d{3,4})""")
+        cardPattern.find(message)?.let { return extractLast4Digits(it.groupValues[1]) }
+
+        return super.extractAccountLast4(message)
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        // "الرصيد: SAR 1234.56" or "الرصيد المتاح: SAR 1234.56"
+        val balancePattern = Regex(
+            """الرصيد(?:\s*المتاح)?\s*:?\s*SAR\s*([0-9,]+(?:\.\d{1,2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        balancePattern.find(message)?.let { return parseSarAmount(it.groupValues[1]) }
+
+        return null
+    }
+
+    override fun detectIsCard(message: String): Boolean {
+        if (message.contains("مدى") || message.contains("بطاقة") ||
+            message.contains("نقاط بيع") || message.contains("SamsungPay", ignoreCase = true) ||
+            message.contains("ApplePay", ignoreCase = true)
+        ) {
+            return true
+        }
+        return super.detectIsCard(message)
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        if (message.contains("رمز") || message.contains("OTP", ignoreCase = true) ||
+            message.contains("كلمة المرور")
+        ) {
+            return false
+        }
+
+        val keywords = listOf(
+            "شراء",      // purchase
+            "سحب",       // withdrawal
+            "حوالة",     // transfer
+            "خصم",       // deduction
+            "سداد",      // payment
+            "إيداع",     // deposit
+            "SAR"
+        )
+        return keywords.any { message.contains(it) }
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/STCBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/STCBankParser.kt
@@ -1,0 +1,146 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for STC Bank (Saudi Arabia).
+ *
+ * Handles English purchase / transfer formats such as:
+ *   **4561 Purchase
+ *   Via:4561
+ *   Amount: 3 SAR
+ *   From: ABDULLAH SALEM MUEEN
+ *   At: 26/07/25 21:58
+ *   STC Bank
+ *
+ * Sender examples: STC Bank, STCBank, STC-Bank, STC
+ */
+class STCBankParser : BankParser() {
+
+    override fun getBankName() = "STC Bank"
+
+    override fun getCurrency() = "SAR"
+
+    override fun canHandle(sender: String): Boolean {
+        val normalized = sender.uppercase().replace(Regex("[\\s\\-_]"), "")
+        return normalized.contains("STCBANK") || normalized == "STC" || normalized == "STCPAY"
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // "Amount: 3 SAR" or "Amount:3 SAR" or "Amount: 3.50 SAR"
+        val amountPattern = Regex(
+            """Amount\s*:?\s*([0-9,]+(?:\.\d{1,2})?)\s*SAR""",
+            RegexOption.IGNORE_CASE
+        )
+        amountPattern.find(message)?.let { match ->
+            return try {
+                BigDecimal(match.groupValues[1].replace(",", ""))
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+
+        // "SAR 3.00" fallback
+        val sarFirstPattern = Regex(
+            """SAR\s+([0-9,]+(?:\.\d{1,2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        sarFirstPattern.find(message)?.let { match ->
+            return try {
+                BigDecimal(match.groupValues[1].replace(",", ""))
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+
+        return null
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lower = message.lowercase()
+        return when {
+            lower.contains("purchase") -> TransactionType.EXPENSE
+            lower.contains("withdrawal") || lower.contains("withdraw") -> TransactionType.EXPENSE
+            lower.contains("payment") -> TransactionType.EXPENSE
+            lower.contains("debit") -> TransactionType.EXPENSE
+            lower.contains("transfer out") || lower.contains("sent to") -> TransactionType.EXPENSE
+            lower.contains("refund") -> TransactionType.INCOME
+            lower.contains("deposit") -> TransactionType.INCOME
+            lower.contains("credit") && !lower.contains("credit card") -> TransactionType.INCOME
+            lower.contains("received") -> TransactionType.INCOME
+            else -> null
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // "From: MERCHANT NAME" — merchant for Purchase, sender for incoming
+        val fromPattern = Regex(
+            """From\s*:\s*([^\n]+?)(?:\n|At\s*:|$)""",
+            RegexOption.IGNORE_CASE
+        )
+        fromPattern.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(merchant)) {
+                return merchant
+            }
+        }
+
+        // "To: RECIPIENT NAME" — recipient for outgoing transfers
+        val toPattern = Regex(
+            """To\s*:\s*([^\n]+?)(?:\n|At\s*:|$)""",
+            RegexOption.IGNORE_CASE
+        )
+        toPattern.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(merchant)) {
+                return merchant
+            }
+        }
+
+        return null
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        // "**4561 Purchase" / "*4561 Purchase"
+        val starPattern = Regex("""\*+(\d{4})\b""")
+        starPattern.find(message)?.let { return extractLast4Digits(it.groupValues[1]) }
+
+        // "Via:4561" / "Via: 4561"
+        val viaPattern = Regex("""Via\s*:\s*(\d{4})""", RegexOption.IGNORE_CASE)
+        viaPattern.find(message)?.let { return extractLast4Digits(it.groupValues[1]) }
+
+        return super.extractAccountLast4(message)
+    }
+
+    override fun detectIsCard(message: String): Boolean {
+        // Presence of masked card (**XXXX) or Via:XXXX indicates card transaction
+        if (Regex("""\*+\d{4}""").containsMatchIn(message)) return true
+        if (Regex("""Via\s*:\s*\d{4}""", RegexOption.IGNORE_CASE).containsMatchIn(message)) return true
+        return super.detectIsCard(message)
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+
+        if (lower.contains("otp") || lower.contains("verification code") ||
+            lower.contains("one time password")
+        ) {
+            return false
+        }
+
+        val keywords = listOf(
+            "purchase",
+            "amount",
+            "withdraw",
+            "transfer",
+            "payment",
+            "refund",
+            "deposit",
+            "debit",
+            "credit",
+            "sar"
+        )
+        return keywords.any { lower.contains(it) }
+    }
+}

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SNBAlAhliBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SNBAlAhliBankParserTest.kt
@@ -1,0 +1,62 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import com.pennywiseai.parser.core.test.SimpleTestCase
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class SNBAlAhliBankParserTest {
+
+    private val parser = SNBAlAhliBankParser()
+
+    @TestFactory
+    fun `snb alahli parser handles key paths`(): List<DynamicTest> {
+        val cases = listOf(
+            ParserTestCase(
+                name = "POS purchase with Samsung Pay (Mada)",
+                message = "شراء نقاط بيع SamsungPay\nبـSAR 19.45\nمن filwah al\nمدى *2342\nفي 07:53 03/04/26",
+                sender = "SNB-AlAhli",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("19.45"),
+                    currency = "SAR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "filwah al",
+                    accountLast4 = "2342",
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "OTP message is ignored",
+                message = "رمز التحقق الخاص بك هو 123456. لا تشاركه مع أحد.",
+                sender = "SNB-AlAhli",
+                shouldParse = false
+            )
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases)
+    }
+
+    @TestFactory
+    fun `factory resolves snb alahli`(): List<DynamicTest> {
+        val cases = listOf(
+            SimpleTestCase(
+                bankName = "Saudi National Bank",
+                sender = "SNB-AlAhli",
+                currency = "SAR",
+                message = "شراء نقاط بيع SamsungPay\nبـSAR 19.45\nمن filwah al\nمدى *2342\nفي 07:53 03/04/26",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("19.45"),
+                    currency = "SAR",
+                    type = TransactionType.EXPENSE
+                ),
+                shouldHandle = true
+            )
+        )
+
+        return ParserTestUtils.runFactoryTestSuite(cases, "Factory smoke tests")
+    }
+}

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/STCBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/STCBankParserTest.kt
@@ -1,0 +1,87 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import com.pennywiseai.parser.core.test.SimpleTestCase
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class STCBankParserTest {
+
+    private val parser = STCBankParser()
+
+    @TestFactory
+    fun `stc bank parser handles key paths`(): List<DynamicTest> {
+        val cases = listOf(
+            ParserTestCase(
+                name = "Card purchase from screenshot",
+                message = "**4561 Purchase\nVia:4561\nAmount: 3 SAR\nFrom: ABDULLAH SALEM MUEEN\nAt: 26/07/25 21:58",
+                sender = "STC Bank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("3"),
+                    currency = "SAR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "ABDULLAH SALEM MUEEN",
+                    accountLast4 = "4561",
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "Card purchase with decimal amount",
+                message = "**9876 Purchase\nVia:9876\nAmount: 125.50 SAR\nFrom: LULU HYPERMARKET\nAt: 14/05/26 18:23",
+                sender = "STCBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("125.50"),
+                    currency = "SAR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "LULU HYPERMARKET",
+                    accountLast4 = "9876",
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "OTP message is ignored",
+                message = "Your STC Bank verification code is 123456. Do not share it.",
+                sender = "STC Bank",
+                shouldParse = false
+            )
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases)
+    }
+
+    @TestFactory
+    fun `factory resolves stc bank`(): List<DynamicTest> {
+        val cases = listOf(
+            SimpleTestCase(
+                bankName = "STC Bank",
+                sender = "STC Bank",
+                currency = "SAR",
+                message = "**4561 Purchase\nVia:4561\nAmount: 3 SAR\nFrom: ABDULLAH SALEM MUEEN\nAt: 26/07/25 21:58",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("3"),
+                    currency = "SAR",
+                    type = TransactionType.EXPENSE
+                ),
+                shouldHandle = true
+            ),
+            SimpleTestCase(
+                bankName = "STC Bank",
+                sender = "STCBank",
+                currency = "SAR",
+                message = "**9876 Purchase\nVia:9876\nAmount: 125.50 SAR\nFrom: LULU HYPERMARKET\nAt: 14/05/26 18:23",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("125.50"),
+                    currency = "SAR",
+                    type = TransactionType.EXPENSE
+                ),
+                shouldHandle = true
+            )
+        )
+
+        return ParserTestUtils.runFactoryTestSuite(cases, "Factory smoke tests")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds **Saudi National Bank / Al Ahli (SNB-AlAhli)** parser for Arabic POS SMS (`شراء نقاط بيع` / `بـSAR` / `من` / `مدى *XXXX`), including Samsung Pay / Apple Pay / Mada card detection.
- Adds **STC Bank** parser for English purchase SMS (`**XXXX Purchase` / `Via:XXXX` / `Amount: X SAR` / `From: …`), with card detection via `**XXXX` and `Via:XXXX`.
- Registers both parsers in `BankParserFactory` and bumps the supported-banks count in `CLAUDE.md` to 53.

## Test plan
- [x] `./gradlew :parser-core:jvmTest` — all new dynamic tests pass
- [x] `SNBAlAhliBankParserTest`: POS purchase from screenshot (amount/merchant/card last4/isFromCard), OTP rejection, factory resolution
- [x] `STCBankParserTest`: card purchase from screenshot, decimal-amount variant, OTP rejection, factory resolution for `STC Bank` and `STCBank`