### PR TITLE
feat: add quick Add Transaction home-screen widget (#253)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -126,6 +126,19 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/recent_transactions_widget_info" />
         </receiver>
+
+        <!-- Add Transaction Quick Widget -->
+        <receiver
+            android:name=".widget.AddTransactionWidgetReceiver"
+            android:exported="true"
+            android:label="@string/widget_name_add_transaction">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/add_transaction_widget_info" />
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/pennywiseai/tracker/widget/AddTransactionWidget.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/AddTransactionWidget.kt
@@ -1,0 +1,115 @@
+package com.pennywiseai.tracker.widget
+
+import android.content.Context
+import android.os.Build
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.SizeMode
+import androidx.glance.appwidget.action.actionRunCallback
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.action.clickable
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.size
+import androidx.glance.layout.width
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import com.pennywiseai.tracker.R
+
+class AddTransactionWidget : GlanceAppWidget() {
+
+    override val sizeMode: SizeMode = SizeMode.Responsive(
+        setOf(
+            DpSize(80.dp, 80.dp),
+            DpSize(160.dp, 80.dp)
+        )
+    )
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        provideContent {
+            GlanceTheme(
+                colors = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+                    GlanceTheme.colors
+                else
+                    PennyWiseWidgetTheme.colors
+            ) {
+                AddTransactionContent()
+            }
+        }
+    }
+
+    @Composable
+    private fun AddTransactionContent() {
+        Box(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .padding(8.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Box(
+                modifier = GlanceModifier
+                    .fillMaxSize()
+                    .cornerRadius(20.dp)
+                    .background(GlanceTheme.colors.primaryContainer)
+                    .clickable(actionRunCallback<OpenAddTransactionAction>())
+                    .padding(horizontal = 12.dp, vertical = 10.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Box(
+                        modifier = GlanceModifier
+                            .size(36.dp)
+                            .cornerRadius(18.dp)
+                            .background(GlanceTheme.colors.primary),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Image(
+                            provider = ImageProvider(R.drawable.ic_widget_add),
+                            contentDescription = "Add transaction",
+                            modifier = GlanceModifier.size(20.dp)
+                        )
+                    }
+                    Spacer(modifier = GlanceModifier.width(10.dp))
+                    Column {
+                        Text(
+                            text = "Add",
+                            style = TextStyle(
+                                color = GlanceTheme.colors.onPrimaryContainer,
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                        )
+                        Spacer(modifier = GlanceModifier.height(1.dp))
+                        Text(
+                            text = "Transaction",
+                            style = TextStyle(
+                                color = GlanceTheme.colors.onPrimaryContainer,
+                                fontSize = 11.sp
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/widget/AddTransactionWidgetReceiver.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/AddTransactionWidgetReceiver.kt
@@ -1,0 +1,9 @@
+package com.pennywiseai.tracker.widget
+
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+class AddTransactionWidgetReceiver : GlanceAppWidgetReceiver() {
+
+    override val glanceAppWidget: GlanceAppWidget = AddTransactionWidget()
+}

--- a/app/src/main/res/layout/add_transaction_widget_preview.xml
+++ b/app/src/main/res/layout/add_transaction_widget_preview.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    android:gravity="center"
+    android:padding="12dp"
+    android:theme="@android:style/Theme.DeviceDefault.DayNight"
+    android:background="?android:attr/colorBackground">
+
+    <ImageView
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:padding="8dp"
+        android:src="@drawable/ic_widget_add" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Add"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:textColor="?android:attr/textColorPrimary" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Transaction"
+            android:textSize="11sp"
+            android:textColor="?android:attr/textColorSecondary" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,6 @@
     <string name="widget_loading">Loading widget…</string>
     <string name="widget_name_recent">Recent Transactions</string>
     <string name="widget_description_recent">View your monthly spend and latest transactions at a glance.</string>
+    <string name="widget_name_add_transaction">Add Transaction</string>
+    <string name="widget_description_add_transaction">Tap to quickly add a manual transaction without opening the app.</string>
 </resources>

--- a/app/src/main/res/xml/add_transaction_widget_info.xml
+++ b/app/src/main/res/xml/add_transaction_widget_info.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:initialLayout="@layout/add_transaction_widget_preview"
+    android:minWidth="80dp"
+    android:minHeight="80dp"
+    android:targetCellWidth="2"
+    android:targetCellHeight="1"
+    android:maxResizeWidth="250dp"
+    android:maxResizeHeight="120dp"
+    android:minResizeWidth="80dp"
+    android:minResizeHeight="80dp"
+    android:resizeMode="horizontal"
+    android:previewLayout="@layout/add_transaction_widget_preview"
+    android:description="@string/widget_description_add_transaction"
+    android:widgetCategory="home_screen" />


### PR DESCRIPTION
Single-tap Glance widget that launches the in-app manual entry flow via the existing OpenAddTransactionAction → MainActivity deep link, so users can add a transaction without first opening the app.

## Summary

<!-- Briefly explain the change and why it’s needed. Keep it focused. -->

## Type of change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Code improvement (no behavior change)
- [ ] perf: Performance improvement
- [ ] style: Formatting (no behavior change)
- [ ] test: Add/update tests
- [ ] chore/ci: Build or CI changes

## Screenshots/Recordings (optional)

<!-- Add images or videos for UI changes. -->

## How to test

<!-- Steps for reviewers to verify the change locally. -->
1. 
2. 
3. 

## Breaking changes

- [ ] No breaking changes
- [ ] Yes (describe): 

## Related issues

<!-- e.g., Closes #123, Fixes #456 -->

## Checklist

- [ ] Focused PR (single purpose)
- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [ ] `./gradlew test` passes locally
- [ ] `./gradlew lint` passes locally
- [ ] Follows existing code style and patterns


