### PR TITLE
fix: GPay PDF parser assigns correct date to every row (#250)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -144,6 +144,14 @@ android {
     buildFeatures {
         compose = true
     }
+
+    testOptions {
+        unitTests {
+            // Allow JVM unit tests to exercise code that touches android.util.Log
+            // and other Android framework stubs without Robolectric.
+            isReturnDefaultValues = true
+        }
+    }
 }
 
 kotlin {

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/GPayPdfParser.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/GPayPdfParser.kt
@@ -22,7 +22,6 @@ class GPayPdfParser : PdfStatementParser {
     companion object {
         private const val TAG                 = "GPayPdfParser"
         private const val DATE_FORMAT_PATTERN = "dd MMM, yyyy hh:mm a"
-        private const val DATE_BUFFER_SIZE    = 8   // lines buffered before anchor
     }
 
     private val IST = TimeZone.getTimeZone("Asia/Kolkata")
@@ -83,41 +82,61 @@ class GPayPdfParser : PdfStatementParser {
     /**
      * Splits raw PDF text into one string per transaction.
      *
-     * The challenge: date lines appear on the 3 lines BEFORE the transaction
-     * anchor. We keep a rolling buffer of recent pre-anchor lines and prepend
-     * them to the block when an anchor is detected.
+     * The challenge: date lines (`"01 Sep,"`, `"2025"`, `"03:02 PM"`) appear on
+     * the lines BEFORE the transaction anchor in GPay exports. We keep a rolling
+     * "pending" triplet of the most-recent date/year/time lines seen, and each
+     * time a new anchor arrives we prepend that triplet to the new block before
+     * consuming it. Date-pattern lines are never appended to the *current* block
+     * because they belong to the *next* transaction — otherwise N+1's date lines
+     * would bleed into N's block and confuse `extractTimestamp`.
      *
-     * An anchor is "Paid to <X>" where X does NOT end with 4 digits, or
+     * An anchor is "Paid to <X>" where X is not a bank account line, or
      * "Received from <X>". This excludes "Paid to South Indian Bank 1234"
-     * (the account line in income transactions) from being treated as anchors.
+     * (the account line in income transactions) from being treated as an anchor.
      */
     private fun splitIntoBlocks(text: String): List<String> {
-        val blocks  = mutableListOf<String>()
-        val buffer  = ArrayDeque<String>()   // pre-anchor lines (date, year, time)
+        val blocks = mutableListOf<String>()
         val current = StringBuilder()
+        var pendingDate: String? = null
+        var pendingYear: String? = null
+        var pendingTime: String? = null
         var inBlock = false
 
         for (rawLine in text.lines()) {
             val line = rawLine.trim()
             if (line.isEmpty()) continue
 
+            val isDate = dateLineRegex.matches(line)
+            val isYear = yearLineRegex.matches(line)
+            val isTime = timeLineRegex.matches(line)
+
             if (isTransactionAnchor(line)) {
                 if (inBlock && current.isNotEmpty()) {
                     blocks.add(current.toString().trim())
                     current.clear()
                 }
-                // Prepend buffered date lines so extractTimestamp has context
-                buffer.forEach { current.appendLine(it) }
-                buffer.clear()
+                // Prepend the most-recent pending date triplet so this block
+                // owns its own dates — then clear pending so the next transaction
+                // starts fresh.
+                pendingDate?.let { current.appendLine(it) }
+                pendingYear?.let { current.appendLine(it) }
+                pendingTime?.let { current.appendLine(it) }
+                pendingDate = null
+                pendingYear = null
+                pendingTime = null
+                current.appendLine(line)
                 inBlock = true
+                continue
             }
 
-            if (inBlock) {
-                current.appendLine(line)
-            } else {
-                buffer.addLast(line)
-                if (buffer.size > DATE_BUFFER_SIZE) buffer.removeFirst()
-            }
+            // Date-pattern lines are NEVER appended to the current block — they
+            // always belong to the next anchor's transaction. Track the most
+            // recent triplet so the next anchor can consume it.
+            if (isDate) { pendingDate = line; continue }
+            if (isYear) { pendingYear = line; continue }
+            if (isTime) { pendingTime = line; continue }
+
+            if (inBlock) current.appendLine(line)
         }
 
         if (current.isNotEmpty()) blocks.add(current.toString().trim())

--- a/app/src/test/java/com/pennywiseai/tracker/data/statement/GPayPdfParserTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/statement/GPayPdfParserTest.kt
@@ -1,0 +1,135 @@
+package com.pennywiseai.tracker.data.statement
+
+import com.pennywiseai.parser.core.TransactionType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.math.BigDecimal
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Regression tests for [GPayPdfParser], particularly issue #250 — all
+ * transactions after the first were falling back to `System.currentTimeMillis()`
+ * because the pre-anchor date buffer was only populated once at the start of
+ * the document and never refilled.
+ */
+class GPayPdfParserTest {
+
+    private val parser = GPayPdfParser()
+
+    private val ist = TimeZone.getTimeZone("Asia/Kolkata")
+    private val dateFormat = SimpleDateFormat("dd MMM, yyyy hh:mm a", Locale.ENGLISH).apply {
+        timeZone = ist
+    }
+
+    private fun epochForIstDate(text: String): Long = dateFormat.parse(text)!!.time
+
+    /**
+     * Fixture modelled after real GPay PDF exports: each transaction is preceded
+     * by a "date / year / time" triplet on its own lines, then the anchor line
+     * (`"Paid to …"` / `"Received from …"`), then amount, UPI id, and account
+     * line. This is the shape the parser's docstrings describe.
+     */
+    private val statementText = """
+        Google Pay Statement
+        01 Sep,
+        2025
+        03:02 PM
+        Paid to Starbucks
+        ₹450
+        UPI Transaction ID: 123456789012
+        Paid by HDFC Bank 1234
+        02 Sep,
+        2025
+        11:30 AM
+        Received from Alice
+        ₹2,000
+        UPI Transaction ID: 223456789012
+        Paid to HDFC Bank 1234
+        03 Sep,
+        2025
+        07:45 PM
+        Paid to Amazon
+        ₹1,250.50
+        UPI Transaction ID: 323456789012
+        Paid by HDFC Bank 1234
+    """.trimIndent()
+
+    @Test
+    fun `parser handles the fixture`() {
+        assertTrue("canHandle should recognise the GPay statement", parser.canHandle(statementText))
+    }
+
+    @Test
+    fun `parses all three transactions`() {
+        val txs = parser.parse(statementText)
+        assertEquals(3, txs.size)
+    }
+
+    @Test
+    fun `each transaction gets its own correct timestamp - issue 250 regression`() {
+        val txs = parser.parse(statementText)
+        assertEquals(3, txs.size)
+
+        val expected1 = epochForIstDate("01 Sep, 2025 03:02 PM")
+        val expected2 = epochForIstDate("02 Sep, 2025 11:30 AM")
+        val expected3 = epochForIstDate("03 Sep, 2025 07:45 PM")
+
+        assertEquals("txn1 should parse to 01 Sep 2025 03:02 PM IST", expected1, txs[0].timestamp)
+        assertEquals("txn2 should parse to 02 Sep 2025 11:30 AM IST", expected2, txs[1].timestamp)
+        assertEquals("txn3 should parse to 03 Sep 2025 07:45 PM IST", expected3, txs[2].timestamp)
+    }
+
+    @Test
+    fun `last transaction does not fall back to current time`() {
+        // Before the fix, the last transaction in the statement had no "next"
+        // transaction's date lines to pollute its block, so extractTimestamp
+        // returned null and the parser fell back to System.currentTimeMillis().
+        // A fresh parse should land nowhere near "now".
+        val txs = parser.parse(statementText)
+        val lastTimestamp = txs.last().timestamp
+        val now = System.currentTimeMillis()
+        val diff = Math.abs(now - lastTimestamp)
+        assertTrue(
+            "Last timestamp ($lastTimestamp) looks like current time ($now) — fallback regression",
+            diff > 24L * 60 * 60 * 1000 // more than 1 day away from now
+        )
+    }
+
+    @Test
+    fun `merchant type and account are extracted correctly`() {
+        val txs = parser.parse(statementText)
+
+        assertEquals("Starbucks", txs[0].merchant)
+        assertEquals(TransactionType.EXPENSE, txs[0].type)
+        assertEquals(BigDecimal("450"), txs[0].amount)
+        assertEquals("1234", txs[0].accountLast4)
+
+        assertEquals("Alice", txs[1].merchant)
+        assertEquals(TransactionType.INCOME, txs[1].type)
+        assertEquals(BigDecimal("2000"), txs[1].amount)
+
+        assertEquals("Amazon", txs[2].merchant)
+        assertEquals(TransactionType.EXPENSE, txs[2].type)
+        assertEquals(BigDecimal("1250.50"), txs[2].amount)
+    }
+
+    @Test
+    fun `middle transactions do not borrow next transaction's date`() {
+        // Before the fix, block 2's date lines (02 Sep) were being appended to
+        // block 1's content because splitIntoBlocks kept adding every non-anchor
+        // line to the current block. extractTimestamp then picked block 2's
+        // "02 Sep" for block 1, producing wildly wrong timestamps. Assert the
+        // middle transaction specifically gets its OWN date, not the next one.
+        val txs = parser.parse(statementText)
+        val txn2 = txs[1]
+        val expected = epochForIstDate("02 Sep, 2025 11:30 AM")
+        val notExpected = epochForIstDate("03 Sep, 2025 07:45 PM")
+        assertEquals(expected, txn2.timestamp)
+        assertNotEquals(notExpected, txn2.timestamp)
+    }
+}


### PR DESCRIPTION
Closes #250.

## Summary
- Replace the one-shot pre-anchor date buffer in `GPayPdfParser.splitIntoBlocks` with a rolling pending `date / year / time` triplet that is always updated as new date-pattern lines are scanned and consumed when the next transaction anchor is hit.
- Date-pattern lines are no longer appended to the current block — they always belong to the *next* anchor, so appending them was polluting the in-progress block and confusing `extractTimestamp`.
- Adds a JUnit unit test with a three-transaction fixture and an explicit "last row doesn't fall back to current time" regression guard.
- Enables `testOptions.unitTests.isReturnDefaultValues` so pure-JVM tests can exercise code that touches `android.util.Log` without Robolectric.

## Root cause
In the old `splitIntoBlocks`, once the first anchor set `inBlock = true`, the pre-anchor `buffer` was never refilled, because only the `else` branch fed it. As a result:
- **Txn 1** got its dates correctly from the initial buffer.
- **Txns 2..N-1** got the *following* transaction's date lines (because non-anchor lines — including date/year/time lines for the next txn — were being appended to the current block; `extractTimestamp` then picked them up).
- **Txn N** (last row) had no "next" date lines to borrow, so `extractTimestamp` returned `null` and the parser fell back to `System.currentTimeMillis()` via `timestamp ?: System.currentTimeMillis()` on the old line 188.

The fix: keep a `pendingDate / pendingYear / pendingTime` triplet at the top level of `splitIntoBlocks` that is updated on *every* date-pattern line regardless of `inBlock` state, and consumed (prepended to the new block) at every transaction anchor. Date-pattern lines stop being appended to the current block, so there's no more pollution into earlier transactions either.

## Test plan
- [x] `./gradlew :app:testStandardDebugUnitTest --tests "com.pennywiseai.tracker.data.statement.GPayPdfParserTest"` — 6 / 6 pass
- [x] **Verified the tests actually catch the bug:** stashed the parser fix, reran the same suite, saw 3 / 6 fail with the exact pollution pattern described above (txn2 got txn3's date; last row fell back to epoch now). Restored the fix and all 6 pass again.
- [x] `./gradlew :app:testStandardDebugUnitTest` — full app unit test suite: 12 / 12 pass (no regression from `isReturnDefaultValues`).
- [ ] Manual end-to-end test with a real GPay PDF export — not done locally; requires a real statement PDF.

## Not in scope
- The shared KMP `GPaySharedStatementParser` (`shared/src/commonMain/...`) has a separate issue: it has no date extraction at all and always returns `fallbackTimestamp()`. That path is iOS-only and not reachable from the Android import flow (`PdfParserFactory` uses `GPayPdfParser` directly), so I left it alone. Worth its own follow-up.
- Issue #251 (GPay statement enrichment of existing SMS rows by UTR) — unrelated code path, leaving it for a separate PR once akshaynexus/#248 lands.