### PR TITLE
fix: exclude loan repayments from budget and analytics totals

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetRepository.kt
@@ -150,8 +150,8 @@ class BudgetRepository @Inject constructor(
             endDate = budget.endDate.atTime(23, 59, 59),
             currency = budget.currency
         ).map { allTransactions ->
-            // Filter to only include EXPENSE transactions
-            allTransactions.filter { it.transaction.transactionType == TransactionType.EXPENSE }
+            // Filter to only include EXPENSE transactions, excluding loan repayments
+            allTransactions.filter { it.transaction.transactionType == TransactionType.EXPENSE && it.transaction.loanId == null }
         }
 
         val categoriesFlow = if (budget.includeAllCategories) {

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -176,11 +176,12 @@ class AnalyticsViewModel @Inject constructor(
                 }
             }.mapLatest { (allTransactionsWithSplits, transactionTypeFilter, isUnified) ->
                 // Filter by transaction type in memory (splits are already loaded)
-                val filteredTransactionsWithSplits = if (transactionTypeFilter != null) {
+                // Exclude loan repayments — they are fixed obligations, not discretionary spending
+                val filteredTransactionsWithSplits = (if (transactionTypeFilter != null) {
                     allTransactionsWithSplits.filter { it.transaction.transactionType == transactionTypeFilter }
                 } else {
                     allTransactionsWithSplits
-                }
+                }).filter { it.transaction.loanId == null }
 
                 // Compute available categories BEFORE applying category filter
                 val allCategoryNames = filteredTransactionsWithSplits


### PR DESCRIPTION
## Summary
- Exclude loan repayments (`loanId != null`) from budget spending calculations in `BudgetRepository.kt:154`
- Exclude loan repayments from analytics category breakdowns in `AnalyticsViewModel.kt:179`
- Follows the existing pattern already used in `HomeViewModel` (lines 323, 326, 354, 357) and `TransactionRepository` (lines 173, 204, 231, 259)

Loan repayments are stored as regular `EXPENSE` transactions with a non-null `loanId`. Without this filter, EMI/loan payments inflate budget "spent" totals and leak into category pie charts, making budgets useless for tracking actual discretionary spending.

## Test plan
- [x] `./gradlew :app:compileStandardDebugKotlin` — builds clean
- [ ] Manual: create a loan, record a repayment, verify it no longer appears in budget spending or analytics category breakdown