### PR TITLE
fix: budget sort order, colors, and per-budget spending pace chart

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/BudgetDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/BudgetDao.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 @Dao
 interface BudgetDao {
 
-    @Query("SELECT * FROM budgets WHERE is_active = 1 ORDER BY created_at DESC")
+    @Query("SELECT * FROM budgets WHERE is_active = 1 ORDER BY display_order ASC")
     fun getActiveBudgets(): Flow<List<BudgetEntity>>
 
     @Query("SELECT * FROM budgets ORDER BY created_at DESC")


### PR DESCRIPTION
## Summary
- **Fix budget move up/down** — `BudgetDao.getActiveBudgets()` was sorting by `created_at DESC` instead of `display_order ASC`, making the reorder logic from PR #247 swap against a wrong-ordered list
- **Color polish** — progress bar tracks use status-color tint (green/amber/red at 15% alpha) instead of flat grey; supporting text uses `onSurfaceVariant` instead of manually halved `onSurface` alpha
- **Per-budget spending pace chart** — each budget card shows a two-line chart (actual cumulative spending vs ideal budget pace) when expanded, filtered to only that budget's categories. Spending line turns red when over pace. Works in both single-currency and unified modes. Excludes loan repayments.

## Files changed
- `BudgetDao.kt` — sort order fix
- `BudgetGroupModels.kt` — add `dailyCumulativeSpending` + `dailyBudgetPace` to `BudgetGroupSpending`
- `BudgetGroupRepository.kt` — per-group pace computation in `buildSummary()`
- `BudgetGroupsViewModel.kt` — per-group pace computation for unified-currency mode
- `BudgetGroupsScreen.kt` — color fixes, `SpendingPaceChart` composable, shown on expand

## Test plan
- [x] `./gradlew :app:compileStandardDebugKotlin` — builds clean
- [ ] Manual: open Budgets, verify move up/down reorders correctly
- [ ] Manual: expand a budget card, verify pace chart renders with correct category-filtered data
- [ ] Manual: verify colors look good in both light and dark themes