### PR TITLE
fix: improve balance history contrast and clear smsSource leak

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/BudgetDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/BudgetDao.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 @Dao
 interface BudgetDao {
 
-    @Query("SELECT * FROM budgets WHERE is_active = 1 ORDER BY created_at DESC")
+    @Query("SELECT * FROM budgets WHERE is_active = 1 ORDER BY display_order ASC")
     fun getActiveBudgets(): Flow<List<BudgetEntity>>
 
     @Query("SELECT * FROM budgets ORDER BY created_at DESC")

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupModels.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupModels.kt
@@ -23,7 +23,9 @@ data class BudgetGroupSpending(
     val dailyAllowance: BigDecimal,
     val daysRemaining: Int,
     val daysElapsed: Int,
-    val isTrackingAllExpenses: Boolean = false
+    val isTrackingAllExpenses: Boolean = false,
+    val dailyCumulativeSpending: List<Double> = emptyList(),
+    val dailyBudgetPace: List<Double> = emptyList()
 )
 
 data class BudgetOverallSummary(

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
@@ -167,11 +167,13 @@ class BudgetGroupRepository @Inject constructor(
             0
         }
 
+        val daysInMonth = yearMonth.lengthOfMonth()
+
         return combine(
             budgetDao.getActiveBudgetsWithCategories(),
             transactionSplitDao.getTransactionsWithSplitsFiltered(startDate, endDate, currency)
         ) { groups, allTransactions ->
-            buildSummary(groups, allTransactions, daysElapsed, daysRemaining, currency)
+            buildSummary(groups, allTransactions, daysElapsed, daysRemaining, currency, daysInMonth)
         }
     }
 
@@ -216,7 +218,8 @@ class BudgetGroupRepository @Inject constructor(
         allTransactions: List<com.pennywiseai.tracker.data.database.entity.TransactionWithSplits>,
         daysElapsed: Int,
         daysRemaining: Int,
-        currency: String
+        currency: String,
+        daysInMonth: Int = 30
     ): BudgetOverallSummary {
         val incomeTransactions = allTransactions.filter {
             it.transaction.transactionType == TransactionType.INCOME
@@ -241,6 +244,48 @@ class BudgetGroupRepository @Inject constructor(
         // Calculate total expenses for groups with no categories (track all expenses)
         val totalAllExpenses = categoryAmounts.values.fold(BigDecimal.ZERO) { acc, amount -> acc + amount }
 
+        // Helper: build per-group daily cumulative spending from transactions matching category names
+        fun buildGroupPace(
+            categoryNames: Set<String>?,  // null = all categories
+            groupBudget: BigDecimal
+        ): Pair<List<Double>, List<Double>> {
+            val effectiveDays = daysElapsed.coerceAtMost(daysInMonth)
+            if (effectiveDays < 1) return emptyList<Double>() to emptyList()
+
+            val dailyAmounts = DoubleArray(daysInMonth)
+            allTransactions.forEach { txWithSplits ->
+                val tx = txWithSplits.transaction
+                if (tx.transactionType != TransactionType.INCOME &&
+                    tx.transactionType != TransactionType.TRANSFER &&
+                    tx.transactionType != TransactionType.INVESTMENT &&
+                    tx.loanId == null
+                ) {
+                    val day = tx.dateTime.dayOfMonth.coerceIn(1, daysInMonth)
+                    if (categoryNames == null) {
+                        dailyAmounts[day - 1] += tx.amount.toDouble()
+                    } else {
+                        txWithSplits.getAmountByCategory().forEach { (cat, amount) ->
+                            val catName = cat.ifEmpty { "Others" }
+                            if (catName in categoryNames) {
+                                dailyAmounts[day - 1] += amount.toDouble()
+                            }
+                        }
+                    }
+                }
+            }
+            val cumulative = mutableListOf<Double>()
+            var running = 0.0
+            for (i in 0 until effectiveDays) {
+                running += dailyAmounts[i]
+                cumulative.add(running)
+            }
+            val pace = if (groupBudget > BigDecimal.ZERO) {
+                val dailyPace = groupBudget.toDouble() / daysInMonth
+                (1..effectiveDays).map { it * dailyPace }
+            } else emptyList()
+            return cumulative to pace
+        }
+
         val groupSpendingList = groups.map { group ->
             val isTrackingAll = group.categories.isEmpty()
 
@@ -255,6 +300,7 @@ class BudgetGroupRepository @Inject constructor(
                 val dailyAllowance = if (daysRemaining > 0 && remaining > BigDecimal.ZERO) {
                     remaining.divide(BigDecimal(daysRemaining), 0, RoundingMode.HALF_UP)
                 } else BigDecimal.ZERO
+                val (cumSpending, budgetPace) = buildGroupPace(null, totalBudget)
 
                 BudgetGroupSpending(
                     group = group,
@@ -266,7 +312,9 @@ class BudgetGroupRepository @Inject constructor(
                     dailyAllowance = dailyAllowance,
                     daysRemaining = daysRemaining,
                     daysElapsed = daysElapsed,
-                    isTrackingAllExpenses = true
+                    isTrackingAllExpenses = true,
+                    dailyCumulativeSpending = cumSpending,
+                    dailyBudgetPace = budgetPace
                 )
             } else {
                 // Normal case: track specific categories
@@ -295,6 +343,8 @@ class BudgetGroupRepository @Inject constructor(
                 val dailyAllowance = if (daysRemaining > 0 && remaining > BigDecimal.ZERO) {
                     remaining.divide(BigDecimal(daysRemaining), 0, RoundingMode.HALF_UP)
                 } else BigDecimal.ZERO
+                val catNames = group.categories.map { it.categoryName }.toSet()
+                val (cumSpending, budgetPace) = buildGroupPace(catNames, totalBudget)
 
                 BudgetGroupSpending(
                     group = group,
@@ -306,7 +356,9 @@ class BudgetGroupRepository @Inject constructor(
                     dailyAllowance = dailyAllowance,
                     daysRemaining = daysRemaining,
                     daysElapsed = daysElapsed,
-                    isTrackingAllExpenses = false
+                    isTrackingAllExpenses = false,
+                    dailyCumulativeSpending = cumSpending,
+                    dailyBudgetPace = budgetPace
                 )
             }
         }

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
@@ -119,7 +119,8 @@ class AddTransactionUseCase @Inject constructor(
                     balance = newBalance,
                     timestamp = date,
                     transactionId = transactionId,
-                    sourceType = "TRANSACTION"
+                    sourceType = "TRANSACTION",
+                    smsSource = null
                 )
             )
         }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/BalanceHistoryDialog.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/BalanceHistoryDialog.kt
@@ -205,9 +205,9 @@ private fun BalanceHistoryItem(
             .animateContentSize(),
         colors = CardDefaults.cardColors(
             containerColor = if (isLatest) {
-                MaterialTheme.colorScheme.surfaceContainerHigh
+                MaterialTheme.colorScheme.surfaceContainerHighest
             } else {
-                MaterialTheme.colorScheme.surfaceContainerLow
+                MaterialTheme.colorScheme.surfaceContainerHigh
             }
         ),
         shape = MaterialTheme.shapes.medium
@@ -333,7 +333,7 @@ private fun BalanceHistoryItem(
             
             // Divider
             HorizontalDivider(
-                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
                 thickness = 0.5.dp
             )
             
@@ -417,7 +417,7 @@ private fun BalanceHistoryItem(
                         .fillMaxWidth()
                         .clip(MaterialTheme.shapes.small)
                         .clickable { onToggleExpand() },
-                    color = MaterialTheme.colorScheme.surface,
+                    color = MaterialTheme.colorScheme.surfaceContainer,
                     shape = MaterialTheme.shapes.small
                 ) {
                     Column(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsScreen.kt
@@ -615,19 +615,9 @@ private fun BudgetCard(
                 )
             }
 
-            // Per-budget spending pace chart
-            if (groupSpending.dailyCumulativeSpending.size >= 2 && groupSpending.dailyBudgetPace.isNotEmpty()) {
-                Spacer(modifier = Modifier.height(Spacing.sm))
-                SpendingPaceChart(
-                    cumulativeSpending = groupSpending.dailyCumulativeSpending,
-                    budgetPace = groupSpending.dailyBudgetPace,
-                    currency = currency
-                )
-            }
-
-            // Expandable category list
+            // Expandable category list + pace chart
             AnimatedVisibility(
-                visible = expanded && groupSpending.categorySpending.isNotEmpty(),
+                visible = expanded,
                 enter = fadeIn() + expandVertically(
                     animationSpec = spring(
                         dampingRatio = Spring.DampingRatioLowBouncy,
@@ -640,9 +630,20 @@ private fun BudgetCard(
                     modifier = Modifier.fillMaxWidth(),
                     verticalArrangement = Arrangement.spacedBy(Spacing.xs)
                 ) {
-                    Spacer(modifier = Modifier.height(Spacing.xs))
-                    HorizontalDivider(
-                        color = MaterialTheme.colorScheme.outlineVariant
+                    // Per-budget spending pace chart
+                    if (groupSpending.dailyCumulativeSpending.size >= 2 && groupSpending.dailyBudgetPace.isNotEmpty()) {
+                        Spacer(modifier = Modifier.height(Spacing.xs))
+                        SpendingPaceChart(
+                            cumulativeSpending = groupSpending.dailyCumulativeSpending,
+                            budgetPace = groupSpending.dailyBudgetPace,
+                            currency = currency
+                        )
+                    }
+
+                    if (groupSpending.categorySpending.isNotEmpty()) {
+                        Spacer(modifier = Modifier.height(Spacing.xs))
+                        HorizontalDivider(
+                            color = MaterialTheme.colorScheme.outlineVariant
                     )
                     Spacer(modifier = Modifier.height(Spacing.xs))
 
@@ -735,6 +736,7 @@ private fun BudgetCard(
                                 }
                             }
                         }
+                    }
                     }
                 }
             }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsScreen.kt
@@ -49,7 +49,11 @@ import com.pennywiseai.tracker.ui.icons.CategoryMapping
 import com.pennywiseai.tracker.ui.theme.*
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.unit.sp
 import com.pennywiseai.tracker.utils.CurrencyFormatter
+import ir.ehsannarmani.compose_charts.LineChart
+import ir.ehsannarmani.compose_charts.models.*
 import kotlinx.coroutines.delay
 import java.math.BigDecimal
 import java.time.YearMonth
@@ -543,7 +547,7 @@ private fun BudgetCard(
                         .fillMaxWidth()
                         .height(10.dp)
                         .clip(barShape)
-                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                        .background(statusColor.copy(alpha = 0.15f))
                 ) {
                     Box(
                         modifier = Modifier
@@ -583,7 +587,7 @@ private fun BudgetCard(
                 Text(
                     text = subtitleText,
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = Dimensions.Alpha.subtitle)
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
 
                 Spacer(modifier = Modifier.height(Spacing.xs))
@@ -592,7 +596,7 @@ private fun BudgetCard(
                 Text(
                     text = "Spent ${CurrencyFormatter.formatCurrency(groupSpending.totalActual, currency)} of ${CurrencyFormatter.formatCurrency(groupSpending.totalBudget, currency)}",
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             } else if (groupSpending.isTrackingAllExpenses) {
                 Spacer(modifier = Modifier.height(Spacing.sm))
@@ -607,7 +611,17 @@ private fun BudgetCard(
                 Text(
                     text = "Tracking all expenses",
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = Dimensions.Alpha.subtitle)
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            // Per-budget spending pace chart
+            if (groupSpending.dailyCumulativeSpending.size >= 2 && groupSpending.dailyBudgetPace.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(Spacing.sm))
+                SpendingPaceChart(
+                    cumulativeSpending = groupSpending.dailyCumulativeSpending,
+                    budgetPace = groupSpending.dailyBudgetPace,
+                    currency = currency
                 )
             }
 
@@ -696,7 +710,7 @@ private fun BudgetCard(
                                             .fillMaxWidth()
                                             .height(4.dp)
                                             .clip(catBarShape)
-                                            .background(MaterialTheme.colorScheme.surfaceVariant)
+                                            .background(catStatusColor.copy(alpha = 0.15f))
                                     ) {
                                         Box(
                                             modifier = Modifier
@@ -710,7 +724,7 @@ private fun BudgetCard(
                                     Text(
                                         text = "${CurrencyFormatter.formatCurrency(catSpending.actualAmount, currency)} of ${CurrencyFormatter.formatCurrency(catSpending.budgetAmount, currency)}",
                                         style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
                                     )
                                 } else {
                                     Text(
@@ -726,4 +740,110 @@ private fun BudgetCard(
             }
         }
     }
+}
+
+@Composable
+private fun SpendingPaceChart(
+    cumulativeSpending: List<Double>,
+    budgetPace: List<Double>,
+    currency: String,
+    modifier: Modifier = Modifier
+) {
+    val themeColors = MaterialTheme.colorScheme
+    val isOverPace = cumulativeSpending.lastOrNull()?.let { actual ->
+        budgetPace.lastOrNull()?.let { pace -> actual > pace }
+    } ?: false
+    val spendingColor = if (isOverPace) themeColors.error else themeColors.primary
+
+    Column(modifier = modifier.fillMaxWidth()) {
+            LineChart(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(120.dp),
+                data = listOf(
+                    Line(
+                        label = "Actual",
+                        values = cumulativeSpending,
+                        color = SolidColor(spendingColor),
+                        firstGradientFillColor = spendingColor.copy(alpha = 0.2f),
+                        secondGradientFillColor = Color.Transparent,
+                        strokeAnimationSpec = tween(1200),
+                        gradientAnimationDelay = 600,
+                        drawStyle = DrawStyle.Stroke(width = 2.5.dp),
+                        curvedEdges = true,
+                        dotProperties = DotProperties(
+                            enabled = false
+                        )
+                    ),
+                    Line(
+                        label = "Budget Pace",
+                        values = budgetPace,
+                        color = SolidColor(themeColors.onSurfaceVariant.copy(alpha = 0.4f)),
+                        drawStyle = DrawStyle.Stroke(width = 1.5.dp),
+                        strokeAnimationSpec = tween(1200),
+                        curvedEdges = false,
+                        dotProperties = DotProperties(enabled = false)
+                    )
+                ),
+                dividerProperties = DividerProperties(enabled = false),
+                indicatorProperties = HorizontalIndicatorProperties(
+                    enabled = true,
+                    textStyle = androidx.compose.ui.text.TextStyle.Default.copy(
+                        fontSize = 10.sp,
+                        color = themeColors.onSurfaceVariant.copy(0.7f)
+                    ),
+                    contentBuilder = { value ->
+                        CurrencyFormatter.formatAbbreviated(value, currency)
+                    }
+                ),
+                labelHelperProperties = LabelHelperProperties(enabled = false),
+                labelProperties = LabelProperties(enabled = false),
+                gridProperties = GridProperties(
+                    enabled = true,
+                    xAxisProperties = GridProperties.AxisProperties(
+                        enabled = false
+                    ),
+                    yAxisProperties = GridProperties.AxisProperties(
+                        enabled = true,
+                        style = StrokeStyle.Dashed(),
+                        color = SolidColor(themeColors.onSurface.copy(alpha = 0.08f))
+                    )
+                ),
+                animationMode = AnimationMode.Together(delayBuilder = { it * 100L }),
+            )
+
+            Spacer(modifier = Modifier.height(Spacing.xs))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(8.dp)
+                        .clip(CircleShape)
+                        .background(spendingColor)
+                )
+                Spacer(modifier = Modifier.width(Spacing.xs))
+                Text(
+                    text = "Actual",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = themeColors.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.width(Spacing.md))
+                Box(
+                    modifier = Modifier
+                        .size(8.dp)
+                        .clip(CircleShape)
+                        .background(themeColors.onSurfaceVariant.copy(alpha = 0.4f))
+                )
+                Spacer(modifier = Modifier.width(Spacing.xs))
+                Text(
+                    text = "Budget Pace",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = themeColors.onSurfaceVariant
+                )
+            }
+        }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
@@ -134,7 +134,53 @@ class BudgetGroupsViewModel @Inject constructor(
             }
         }
 
+        // Pre-compute converted category amounts per transaction for pace chart
+        val yearMonth = _selectedYearMonth.value
+        val daysInMonth = yearMonth.lengthOfMonth()
+        val effectiveDays = raw.daysElapsed.coerceAtMost(daysInMonth)
+
+        data class ConvertedTxDay(val day: Int, val categoryAmounts: Map<String, Double>)
+        val convertedTxDays = raw.allTransactions.mapNotNull { txWithSplits ->
+            val tx = txWithSplits.transaction
+            if (tx.transactionType == com.pennywiseai.tracker.data.database.entity.TransactionType.INCOME ||
+                tx.transactionType == com.pennywiseai.tracker.data.database.entity.TransactionType.TRANSFER ||
+                tx.transactionType == com.pennywiseai.tracker.data.database.entity.TransactionType.INVESTMENT ||
+                tx.loanId != null
+            ) return@mapNotNull null
+            val day = tx.dateTime.dayOfMonth.coerceIn(1, daysInMonth)
+            val catAmounts = txWithSplits.getAmountByCategory().mapValues { (_, amount) ->
+                currencyConversionService.convertAmount(amount, tx.currency, displayCurrency).toDouble()
+            }.mapKeys { (cat, _) -> cat.ifEmpty { "Others" } }
+            ConvertedTxDay(day, catAmounts)
+        }
+
+        fun buildGroupPaceUnified(
+            categoryNames: Set<String>?,
+            groupBudget: BigDecimal
+        ): Pair<List<Double>, List<Double>> {
+            if (effectiveDays < 1) return emptyList<Double>() to emptyList()
+            val dailyAmounts = DoubleArray(daysInMonth)
+            convertedTxDays.forEach { txDay ->
+                if (categoryNames == null) {
+                    dailyAmounts[txDay.day - 1] += txDay.categoryAmounts.values.sum()
+                } else {
+                    txDay.categoryAmounts.forEach { (cat, amount) ->
+                        if (cat in categoryNames) dailyAmounts[txDay.day - 1] += amount
+                    }
+                }
+            }
+            val cumulative = mutableListOf<Double>()
+            var running = 0.0
+            for (i in 0 until effectiveDays) { running += dailyAmounts[i]; cumulative.add(running) }
+            val pace = if (groupBudget > BigDecimal.ZERO) {
+                val dp = groupBudget.toDouble() / daysInMonth
+                (1..effectiveDays).map { it * dp }
+            } else emptyList()
+            return cumulative to pace
+        }
+
         val groupSpendingList = raw.budgetsWithCategories.map { group ->
+            val isTrackingAll = group.categories.isEmpty()
             val catSpending = group.categories.map { cat ->
                 val actual = categoryAmounts[cat.categoryName] ?: BigDecimal.ZERO
                 val convertedBudget = currencyConversionService.convertAmount(cat.budgetAmount, baseCurrency, displayCurrency)
@@ -152,8 +198,16 @@ class BudgetGroupsViewModel @Inject constructor(
                     dailySpend = dailySpend
                 )
             }
-            val totalBudget = catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
-            val totalActual = catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.actualAmount }
+            val totalBudget = if (isTrackingAll) {
+                currencyConversionService.convertAmount(group.budget.limitAmount, baseCurrency, displayCurrency)
+            } else {
+                catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
+            }
+            val totalActual = if (isTrackingAll) {
+                categoryAmounts.values.fold(BigDecimal.ZERO) { acc, v -> acc + v }
+            } else {
+                catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.actualAmount }
+            }
             val remaining = totalBudget - totalActual
             val pctUsed = if (totalBudget > BigDecimal.ZERO) {
                 (totalActual.toFloat() / totalBudget.toFloat() * 100f).coerceAtLeast(0f)
@@ -162,16 +216,22 @@ class BudgetGroupsViewModel @Inject constructor(
                 remaining.divide(BigDecimal(raw.daysRemaining), 0, RoundingMode.HALF_UP)
             } else BigDecimal.ZERO
 
+            val catNames = if (isTrackingAll) null else group.categories.map { it.categoryName }.toSet()
+            val (cumSpending, budgetPace) = buildGroupPaceUnified(catNames, totalBudget)
+
             BudgetGroupSpending(
                 group = group,
-                categorySpending = catSpending,
+                categorySpending = if (isTrackingAll) emptyList() else catSpending,
                 totalBudget = totalBudget,
                 totalActual = totalActual,
                 remaining = remaining,
                 percentageUsed = pctUsed,
                 dailyAllowance = dailyAllowance,
                 daysRemaining = raw.daysRemaining,
-                daysElapsed = raw.daysElapsed
+                daysElapsed = raw.daysElapsed,
+                isTrackingAllExpenses = isTrackingAll,
+                dailyCumulativeSpending = cumSpending,
+                dailyBudgetPace = budgetPace
             )
         }
 


### PR DESCRIPTION
## Summary
- **Contrast fix**: Balance history item cards were invisible in AMOLED/dark mode because `surfaceContainerLow` was identical to the dialog's `surface` background (`0xFF0A0A0A`). Bumped item colors to `surfaceContainerHigh`/`surfaceContainerHighest`, increased divider alpha from 0.3 to 0.5, and changed SMS source section from `surface` to `surfaceContainer`.
- **smsSource leak**: `AddTransactionUseCase.updateAccountBalance()` used `currentAccount.copy(...)` which inherited `smsSource` from the previous balance record into manual transaction balance entries. Now explicitly sets `smsSource = null`.

## Test plan
- [ ] Open Balance History dialog in AMOLED dark mode — cards should be clearly visible against the dialog background
- [ ] Open Balance History in standard dark mode — verify good contrast
- [ ] Open Balance History in light mode — verify no regression
- [ ] Create a manual transaction with an account selected — verify balance history entry has "Transaction" badge and no SMS Source section