### PR TITLE
feat: add Punjab & Sind Bank SMS parser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Bank parsers are now in the `parser-core` module for reusability across platform
 - Use `com.pennywiseai.tracker.data.mapper.toEntity()` to convert ParsedTransaction to TransactionEntity
 - The mapper handles type conversions between modules
 
-## Supported Banks (53 parsers)
+## Supported Banks (54 parsers)
 - Airtel Payments Bank
 - **Al Rajhi Bank (Saudi Arabia)** - Arabic SMS support
 - **Alinma Bank (Saudi Arabia)** - Arabic SMS support
@@ -128,6 +128,7 @@ Bank parsers are now in the `parser-core` module for reusability across platform
 - OneCard
 - **Priorbank (Belarus)** - Russian/Belarusian SMS support
 - Punjab National Bank (PNB)
+- Punjab & Sind Bank (PSB)
 - Saraswat Co-operative Bank
 - **Saudi National Bank / Al Ahli (SNB-AlAhli, Saudi Arabia)** - Arabic SMS support
 - **Siddhartha Bank Limited (Nepal)**

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -25,6 +25,7 @@ object BankParserFactory {
         JupiterBankParser(),
         AxisBankParser(),
         PNBBankParser(),
+        PunjabSindBankParser(),  // Punjab & Sind Bank (India)
         CanaraBankParser(),
         BankOfBarodaParser(),
         BankOfIndiaParser(),

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/PunjabSindBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/PunjabSindBankParser.kt
@@ -1,0 +1,127 @@
+package com.pennywiseai.parser.core.bank
+
+import java.math.BigDecimal
+
+/**
+ * Parser for Punjab & Sind Bank (PSB) SMS messages.
+ *
+ * Expected format:
+ *   A/c No **<last4> Credited|Debited with Rs <amount>--<description> (CLR BAL <bal>CR|DR)(dd-MM-yyyy HH:mm:ss)-Punjab&Sind Bank
+ *
+ * <description> variants:
+ *   - NEFT/<ref>/<sender name>
+ *   - UPI/CR|DR/<utr>/<counterparty>/<bank>/<account>/<suffix>
+ *   - Credit|Debit of <MICR> (cheque clearing)
+ *   - Free text (e.g. generic vendor note)
+ */
+class PunjabSindBankParser : BaseIndianBankParser() {
+
+    override fun getBankName() = "Punjab & Sind Bank"
+
+    override fun canHandle(sender: String): Boolean {
+        val normalizedSender = sender.uppercase()
+        return normalizedSender.contains("PSBANK") ||
+                normalizedSender.contains("PUNJAB&SIND") ||
+                normalizedSender.contains("PUNJAB & SIND")
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        val pattern = Regex(
+            """(?:Credited|Debited)\s+with\s+Rs\.?\s*([0-9,]+(?:\.\d{2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            val amountStr = match.groupValues[1].replace(",", "")
+            return try {
+                BigDecimal(amountStr)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+        return super.extractAmount(message)
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        val pattern = Regex(
+            """A/[Cc]\s+No\s+\*+(\d{2,})""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            return extractLast4Digits(match.groupValues[1])
+        }
+        return super.extractAccountLast4(message)
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        val pattern = Regex(
+            """CLR\s+BAL\s+([0-9,]+(?:\.\d{2})?)\s*(?:CR|DR)?""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            val balanceStr = match.groupValues[1].replace(",", "")
+            return try {
+                BigDecimal(balanceStr)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+        return super.extractBalance(message)
+    }
+
+    override fun extractReference(message: String): String? {
+        val neftRef = Regex("""NEFT/([A-Z0-9]+)/""", RegexOption.IGNORE_CASE)
+        neftRef.find(message)?.let { return it.groupValues[1] }
+
+        val upiRef = Regex("""UPI/(?:CR|DR)/(\d+)/""", RegexOption.IGNORE_CASE)
+        upiRef.find(message)?.let { return it.groupValues[1] }
+
+        val chequeRef = Regex("""(?:Credit|Debit)\s+of\s+(\d+)""", RegexOption.IGNORE_CASE)
+        chequeRef.find(message)?.let { return it.groupValues[1] }
+
+        val psbRef = Regex("""\b(PSB\d{10,})\b""")
+        psbRef.find(message)?.let { return it.groupValues[1] }
+
+        return super.extractReference(message)
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        val upiMerchant = Regex(
+            """UPI/(?:CR|DR)/\d+/([^/]+)/""",
+            RegexOption.IGNORE_CASE
+        )
+        upiMerchant.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(merchant)) return merchant
+        }
+
+        val neftMerchant = Regex(
+            """NEFT/[A-Z0-9]+/([^(\r\n]+?)(?=\s*\(|\s*$)""",
+            RegexOption.IGNORE_CASE
+        )
+        neftMerchant.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(merchant)) return merchant
+        }
+
+        val chequePattern = Regex("""(Credit|Debit)\s+of\s+\d+""", RegexOption.IGNORE_CASE)
+        chequePattern.find(message)?.let { match ->
+            return if (match.groupValues[1].equals("Credit", ignoreCase = true)) {
+                "Cheque Credit"
+            } else {
+                "Cheque Debit"
+            }
+        }
+
+        val descPattern = Regex(
+            """(?:Credited|Debited)\s+with\s+Rs\.?\s*[0-9,]+(?:\.\d{2})?\s*--\s*([^(\r\n]+?)\s*\(CLR\s+BAL""",
+            RegexOption.IGNORE_CASE
+        )
+        descPattern.find(message)?.let { match ->
+            val desc = match.groupValues[1].trim().trimEnd('-').trim()
+            val merchant = cleanMerchantName(desc)
+            if (isValidMerchantName(merchant)) return merchant
+        }
+
+        return super.extractMerchant(message, sender)
+    }
+}

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/PunjabSindBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/PunjabSindBankParserTest.kt
@@ -1,0 +1,98 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import com.pennywiseai.parser.core.test.SimpleTestCase
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class PunjabSindBankParserTest {
+
+    private val parser = PunjabSindBankParser()
+
+    @TestFactory
+    fun `punjab sind bank parser handles key paths`(): List<DynamicTest> {
+        val cases = listOf(
+            ParserTestCase(
+                name = "Generic credit with free-text description",
+                message = "PSB000000000000001\nA/C No **1111 Credited with Rs 500--Vendor Amount (CLR BAL 1250.63CR)(18-03-2026 16:51:51) Punjab&Sind Bank",
+                sender = "VM-PSBANK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("500"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    merchant = "Vendor Amount",
+                    accountLast4 = "1111",
+                    balance = BigDecimal("1250.63")
+                )
+            ),
+            ParserTestCase(
+                name = "NEFT credit extracts sender name and UTR",
+                message = "PSB000000000000002\nA/C No **1111 Credited with Rs 500--NEFT/AXPS260760067935/ACME SCHOOL (CLR BAL 1800.63CR)(19-03-2026 06:51:51) Punjab&Sind Bank",
+                sender = "AX-PSBANK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("500"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    merchant = "ACME SCHOOL",
+                    reference = "AXPS260760067935",
+                    accountLast4 = "1111",
+                    balance = BigDecimal("1800.63")
+                )
+            ),
+            ParserTestCase(
+                name = "UPI credit extracts counterparty name and UTR",
+                message = "PSB000000000000003\nA/c No **2222 Credited with Rs 5500--UPI/CR/121888265852/JOHN/HDFC/00000000000000/U (CLR BAL 30987.99CR)(13-04-2026 17:22:34)-Punjab&Sind Bank",
+                sender = "JD-PSBANK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("5500"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    merchant = "JOHN",
+                    reference = "121888265852",
+                    accountLast4 = "2222",
+                    balance = BigDecimal("30987.99")
+                )
+            ),
+            ParserTestCase(
+                name = "Cheque clearing credit maps to Cheque Credit merchant",
+                message = "PSB000000000000004\nA/c No **3333 Credited with Rs 700--Credit of 045252 (CLR BAL 11064.24CR)(13-04-2026 19:16:15)-Punjab&Sind Bank",
+                sender = "VM-PSBANK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("700"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    merchant = "Cheque Credit",
+                    reference = "045252",
+                    accountLast4 = "3333",
+                    balance = BigDecimal("11064.24")
+                )
+            )
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases)
+    }
+
+    @TestFactory
+    fun `factory resolves punjab sind bank`(): List<DynamicTest> {
+        val cases = listOf(
+            SimpleTestCase(
+                bankName = "Punjab & Sind Bank",
+                sender = "VM-PSBANK-S",
+                currency = "INR",
+                message = "PSB000000000000005\nA/c No **4444 Credited with Rs 100--Test (CLR BAL 200.00CR)(13-04-2026 19:16:15)-Punjab&Sind Bank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("100"),
+                    currency = "INR",
+                    type = TransactionType.INCOME
+                ),
+                shouldHandle = true
+            )
+        )
+
+        return ParserTestUtils.runFactoryTestSuite(cases, "Punjab & Sind Bank factory smoke tests")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `PunjabSindBankParser` to handle Punjab & Sind Bank (PSB) SMS across NEFT, UPI, cheque clearing, and free-text descriptions
- Registers the parser in `BankParserFactory` and updates CLAUDE.md (bank count → 54)
- Closes #266

## Parser coverage
- Account last4 from `A/c No **XXXX`
- Amount from `Credited/Debited with Rs <amt>`
- Balance from `(CLR BAL <bal>CR|DR)`
- Reference: NEFT UTR, UPI UTR, cheque MICR, and the leading `PSB…` txn id as fallback
- Merchant: UPI counterparty (4th field), NEFT sender name (3rd field), `Cheque Credit/Debit` for clearing entries, and the `--<desc>` payload otherwise
- Sender match: `PSBANK`, `PUNJAB&SIND`, `PUNJAB & SIND` (covers `VM-PSBANK-S`, `AX-PSBANK-S`, `JD-PSBANK-S`, etc.)

## Test plan
- [x] `./gradlew :parser-core:test` — all parser-core tests pass, including new `PunjabSindBankParserTest` (4 scenarios + factory smoke test)
- [ ] Manual verification with real PSB SMS once merged