### PR TITLE
fix: show masked mobile as merchant for Kotak IMPS credits

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KotakBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KotakBankParser.kt
@@ -22,6 +22,15 @@ class KotakBankParser : BankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
+        // IMPS credit from mobile: "linked to mobile xNNNN"
+        val mobileLinkedPattern = Regex(
+            """linked\s+to\s+mobile\s+([xX*]+\d{2,})""",
+            RegexOption.IGNORE_CASE
+        )
+        mobileLinkedPattern.find(message)?.let { match ->
+            return match.groupValues[1]
+        }
+
         // Credit card merchant pattern: "on DD-MON-YYYY at MERCHANT. Avl limit"
         val cardMerchantPattern = Regex(
             """on\s+\d{1,2}-\w{3}-\d{2,4}\s+at\s+([^.]+?)(?:\.|\s+Avl|$)""",

--- a/parser-core/src/test/kotlin/TestKotakBankParser.kt
+++ b/parser-core/src/test/kotlin/TestKotakBankParser.kt
@@ -84,6 +84,19 @@ class KotakBankParserTest {
                 )
             ),
             ParserTestCase(
+                name = "IMPS credit surfaces masked mobile as merchant",
+                message = "Received Rs. 329.00 on 15-04-26 in your Kotak Bank A/C x2451 by an A/C linked to mobile x111. IMPS Ref no 610511412340.",
+                sender = "JD-KOTAKB-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("329.00"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    merchant = "x111",
+                    reference = "610511412340",
+                    accountLast4 = "2451"
+                )
+            ),
+            ParserTestCase(
                 name = "Credit card spending with available limit",
                 message = "INR 20 spent on Kotak Credit Card x5236 on 23-JAN-2026 at UPI-638903921672-CORN. Avl limit INR 73733.02 Fraud? https://www.kotak.bank.in/KBANKT/querytxn",
                 sender = "TX-KOTAKB-S",


### PR DESCRIPTION
## Summary
Kotak IMPS credit SMS of the form `...by an A/C linked to mobile xNNN. IMPS Ref no …` had no merchant pattern in `KotakBankParser`, so it fell through to the generic extractor and rendered as **Unknown Merchant**. Added a dedicated pattern that captures the masked mobile (e.g. `x111`) and uses it as the merchant, so users can see *who* sent the money.

## Test plan
- [x] New test case in `TestKotakBankParser.kt` covers the IMPS-from-mobile message
- [x] `./gradlew :parser-core:test` — all Kotak tests pass, including the new case