### PR TITLE
feat: add Altana Federal Credit Union (USA) SMS parser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,10 +87,11 @@ Bank parsers are now in the `parser-core` module for reusability across platform
 - Use `com.pennywiseai.tracker.data.mapper.toEntity()` to convert ParsedTransaction to TransactionEntity
 - The mapper handles type conversions between modules
 
-## Supported Banks (54 parsers)
+## Supported Banks (55 parsers)
 - Airtel Payments Bank
 - **Al Rajhi Bank (Saudi Arabia)** - Arabic SMS support
 - **Alinma Bank (Saudi Arabia)** - Arabic SMS support
+- **Altana Federal Credit Union (USA)**
 - American Express (AMEX)
 - Axis Bank
 - Bank of Baroda

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/AltanaFCUParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/AltanaFCUParser.kt
@@ -1,0 +1,100 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Altana Federal Credit Union (USA)
+ *
+ * Supported format:
+ * - Debit card pending charge:
+ *   "Pending charge for $43.92 on 04/24 20:39 CDT at MERCHANT, CITY, STATE for Debit Consumer card ending in 1234."
+ *
+ * Common senders: "Altana FCU", or the toll-free number (877) 590-5546.
+ */
+class AltanaFCUParser : BankParser() {
+
+    override fun getBankName() = "Altana Federal Credit Union"
+
+    override fun getCurrency() = "USD"
+
+    override fun canHandle(sender: String): Boolean {
+        val upper = sender.uppercase()
+        if (upper.contains("ALTANA")) return true
+
+        // Match the toll-free number across common formats: "(877) 590-5546", "877-590-5546",
+        // "8775905546", "+18775905546" (and digit-only variants).
+        val digits = sender.filter { it.isDigit() }
+        return digits == "8775905546" || digits == "18775905546"
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // "charge for $43.92 on" — captures both pending and posted charge variants.
+        val pattern = Regex(
+            """charge\s+for\s+\$([0-9,]+(?:\.\d{2})?)\s+on""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            val amount = match.groupValues[1].replace(",", "")
+            return try {
+                BigDecimal(amount)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+        return super.extractAmount(message)
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lower = message.lowercase()
+        return when {
+            lower.contains("charge for") -> TransactionType.EXPENSE
+            else -> super.extractTransactionType(message)
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // " at MERCHANT, CITY, STATE for Debit Consumer card "
+        val pattern = Regex(
+            """\bat\s+(.+?)\s+for\s+(?:Debit|Credit)\s+Consumer""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim().trimEnd(','))
+            if (isValidMerchantName(merchant)) {
+                return merchant
+            }
+        }
+        return super.extractMerchant(message, sender)
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        super.extractAccountLast4(message)?.let { return it }
+        // "card ending in 1234"
+        val pattern = Regex(
+            """ending\s+in\s+(\d{4})""",
+            RegexOption.IGNORE_CASE
+        )
+        return pattern.find(message)?.groupValues?.get(1)
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+        if (lower.contains("charge for") &&
+            lower.contains("ending in") &&
+            lower.contains("card")
+        ) {
+            return true
+        }
+        return super.isTransactionMessage(message)
+    }
+
+    override fun detectIsCard(message: String): Boolean {
+        val lower = message.lowercase()
+        return when {
+            lower.contains("debit consumer card") -> true
+            lower.contains("credit consumer card") -> true
+            else -> super.detectIsCard(message)
+        }
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -58,6 +58,7 @@ object BankParserFactory {
         OldHickoryParser(),  // Old Hickory Credit Union (USA)
         LaxmiBankParser(),  // Laxmi Sunrise Bank (Nepal)
         CBEBankParser(),  // Commercial Bank of Ethiopia
+        AltanaFCUParser(),  // Altana Federal Credit Union (USA) — must precede EverestBank, which greedily claims numeric senders
         EverestBankParser(),  // Everest Bank (Nepal)
         BancolombiaParser(),  // Bancolombia (Colombia)
         MashreqBankParser(),  // Mashreq Bank (UAE)

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/AltanaFCUParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/AltanaFCUParserTest.kt
@@ -1,0 +1,93 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import com.pennywiseai.parser.core.test.SimpleTestCase
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class AltanaFCUParserTest {
+
+    private val parser = AltanaFCUParser()
+
+    @TestFactory
+    fun `altana fcu parser handles key paths`(): List<DynamicTest> {
+        val cases = listOf(
+            ParserTestCase(
+                name = "Pending debit card charge",
+                message = "Pending charge for \$43.92 on 04/24 20:39 CDT at MERCHANT NAME, CITY, ST for Debit Consumer card ending in 1234.",
+                sender = "Altana FCU",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("43.92"),
+                    currency = "USD",
+                    type = TransactionType.EXPENSE,
+                    merchant = "MERCHANT NAME, CITY, ST",
+                    accountLast4 = "1234",
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "Pending charge with comma in amount",
+                message = "Pending charge for \$1,250.00 on 05/01 12:34 CDT at HOME GOODS STORE, AUSTIN, TX for Debit Consumer card ending in 5678.",
+                sender = "8775905546",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1250.00"),
+                    currency = "USD",
+                    type = TransactionType.EXPENSE,
+                    merchant = "HOME GOODS STORE, AUSTIN, TX",
+                    accountLast4 = "5678",
+                    isFromCard = true
+                )
+            )
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases)
+    }
+
+    @TestFactory
+    fun `factory resolves altana fcu`(): List<DynamicTest> {
+        val cases = listOf(
+            SimpleTestCase(
+                bankName = "Altana Federal Credit Union",
+                sender = "Altana FCU",
+                currency = "USD",
+                message = "Pending charge for \$43.92 on 04/24 20:39 CDT at MERCHANT NAME, CITY, ST for Debit Consumer card ending in 1234.",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("43.92"),
+                    currency = "USD",
+                    type = TransactionType.EXPENSE
+                ),
+                shouldHandle = true
+            ),
+            SimpleTestCase(
+                bankName = "Altana Federal Credit Union",
+                sender = "8775905546",
+                currency = "USD",
+                message = "Pending charge for \$10.00 on 04/24 20:39 CDT at MERCHANT, CITY, ST for Debit Consumer card ending in 1234.",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("10.00"),
+                    currency = "USD",
+                    type = TransactionType.EXPENSE
+                ),
+                shouldHandle = true
+            ),
+            SimpleTestCase(
+                bankName = "Altana Federal Credit Union",
+                sender = "(877) 590-5546",
+                currency = "USD",
+                message = "Pending charge for \$10.00 on 04/24 20:39 CDT at MERCHANT, CITY, ST for Debit Consumer card ending in 1234.",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("10.00"),
+                    currency = "USD",
+                    type = TransactionType.EXPENSE
+                ),
+                shouldHandle = true
+            )
+        )
+
+        return ParserTestUtils.runFactoryTestSuite(cases, "Factory smoke tests")
+    }
+}


### PR DESCRIPTION
## Summary
- New `AltanaFCUParser` for Altana Federal Credit Union pending-charge alerts
- Parses amount, merchant + location, last 4 of card, and treats the alert as an EXPENSE / card-from transaction
- Resolves on sender name "Altana FCU" and on the toll-free number 877-590-5546 in any common format

## Notes
Registered ahead of `EverestBankParser`, which greedily claims any 7-10 digit numeric sender. Without this ordering Altana's toll-free number would be intercepted by Everest.

Closes #283

## Test plan
- [x] `./gradlew :parser-core:test` — 5 new tests pass (2 parser cases + 3 factory smoke tests)
- [x] `./gradlew :app:assembleStandardDebug` — app builds clean
- [ ] Smoke test on a real device with an Altana SMS once a contributor with the bank confirms