### PR TITLE
fix: restyle Smart Rules quick-template chips

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
@@ -241,7 +241,7 @@ fun CreateRuleScreen(
                         modifier = Modifier.fillMaxWidth()
                     ) {
                         commonPresets.forEach { (label, action) ->
-                            AssistChip(
+                            ElevatedAssistChip(
                                 onClick = action,
                                 label = { Text(label, style = MaterialTheme.typography.bodySmall) }
                             )
@@ -583,7 +583,7 @@ fun CreateRuleScreen(
                                 modifier = Modifier.fillMaxWidth()
                             ) {
                                 commonMerchants.forEach { merchant ->
-                                    AssistChip(
+                                    ElevatedAssistChip(
                                         onClick = { actionValue = merchant },
                                         label = { Text(merchant, style = MaterialTheme.typography.bodySmall) }
                                     )


### PR DESCRIPTION
## Summary
- Swap the outlined `AssistChip` used for Quick Templates and common-merchant suggestions in `CreateRuleScreen` for `ElevatedAssistChip`
- Drop-in M3 replacement: same API, but renders with a filled `surface` container and subtle elevation instead of transparent + border-only
- Inside the primaryContainer Card the chips now read as floating tonal pills; inside the default Card they get visual separation from elevation

Closes #277

## Test plan
- [x] App compiles clean
- [ ] Open Settings → Smart Rules → Create Rule → Quick Templates section: chips have filled background & elevation
- [ ] Set a rule action to Merchant: common-merchant suggestion chips have the same treatment
- [ ] Verified in light + dark themes