### PR TITLE
feat: complete loan tracking — Lent stat + settlement losses in Spent

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/LoanDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/LoanDao.kt
@@ -6,6 +6,7 @@ import com.pennywiseai.tracker.data.database.entity.LoanStatus
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import kotlinx.coroutines.flow.Flow
 import java.math.BigDecimal
+import java.time.LocalDateTime
 
 @Dao
 interface LoanDao {
@@ -58,6 +59,25 @@ interface LoanDao {
 
     @Query("SELECT COALESCE(SUM(remaining_amount), 0) FROM loans WHERE direction = 'BORROWED' AND status = 'ACTIVE'")
     fun getTotalBorrowedRemaining(): Flow<BigDecimal>
+
+    /**
+     * Returns the source EXPENSE transactions of LENT-direction loans whose date_time falls in
+     * the given window. Summing these gives the principal lent during the period (used to
+     * surface "Lent this month" on the home screen, separate from "Spent this month").
+     */
+    @Query("""
+        SELECT t.* FROM transactions t
+        INNER JOIN loans l ON t.loan_id = l.id
+        WHERE l.direction = 'LENT'
+          AND t.transaction_type = 'EXPENSE'
+          AND t.is_deleted = 0
+          AND t.date_time BETWEEN :startDate AND :endDate
+        ORDER BY t.date_time DESC
+    """)
+    fun getLentTransactionsInPeriod(
+        startDate: LocalDateTime,
+        endDate: LocalDateTime
+    ): Flow<List<TransactionEntity>>
 
     @Query("UPDATE transactions SET loan_id = NULL WHERE id = :transactionId")
     suspend fun unlinkTransaction(transactionId: Long)

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/LoanDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/LoanDao.kt
@@ -61,23 +61,40 @@ interface LoanDao {
     fun getTotalBorrowedRemaining(): Flow<BigDecimal>
 
     /**
-     * Returns the source EXPENSE transactions of LENT-direction loans whose date_time falls in
-     * the given window. Summing these gives the principal lent during the period (used to
-     * surface "Lent this month" on the home screen, separate from "Spent this month").
+     * Source EXPENSE transactions of currently-ACTIVE LENT loans whose date_time falls in the
+     * given window. Drives "Lent this month" on the home screen — settled loans are excluded
+     * because their principal is reflected in "Spent this month" (as a settlement loss) or has
+     * been recovered as INCOME repayments.
      */
     @Query("""
         SELECT t.* FROM transactions t
         INNER JOIN loans l ON t.loan_id = l.id
         WHERE l.direction = 'LENT'
+          AND l.status = 'ACTIVE'
           AND t.transaction_type = 'EXPENSE'
           AND t.is_deleted = 0
           AND t.date_time BETWEEN :startDate AND :endDate
         ORDER BY t.date_time DESC
     """)
-    fun getLentTransactionsInPeriod(
+    fun getActiveLentTransactionsInPeriod(
         startDate: LocalDateTime,
         endDate: LocalDateTime
     ): Flow<List<TransactionEntity>>
+
+    /**
+     * LENT loans settled within the period. Used to compute settlement losses
+     * (originalAmount - totalRepaid) which are folded into "Spent this month".
+     */
+    @Query("""
+        SELECT * FROM loans
+        WHERE direction = 'LENT'
+          AND status = 'SETTLED'
+          AND settled_at BETWEEN :startDate AND :endDate
+    """)
+    fun getLentLoansSettledInPeriod(
+        startDate: LocalDateTime,
+        endDate: LocalDateTime
+    ): Flow<List<LoanEntity>>
 
     @Query("UPDATE transactions SET loan_id = NULL WHERE id = :transactionId")
     suspend fun unlinkTransaction(transactionId: Long)

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/LoanRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/LoanRepository.kt
@@ -29,10 +29,25 @@ class LoanRepository @Inject constructor(
 
     fun getTotalBorrowedRemaining(): Flow<BigDecimal> = loanDao.getTotalBorrowedRemaining()
 
-    fun getLentTransactionsInPeriod(
+    fun getActiveLentTransactionsInPeriod(
         startDate: LocalDateTime,
         endDate: LocalDateTime
-    ): Flow<List<TransactionEntity>> = loanDao.getLentTransactionsInPeriod(startDate, endDate)
+    ): Flow<List<TransactionEntity>> = loanDao.getActiveLentTransactionsInPeriod(startDate, endDate)
+
+    fun getLentLoansSettledInPeriod(
+        startDate: LocalDateTime,
+        endDate: LocalDateTime
+    ): Flow<List<LoanEntity>> = loanDao.getLentLoansSettledInPeriod(startDate, endDate)
+
+    /**
+     * Net loss on a settled LENT loan: principal minus what came back as INCOME repayments.
+     * Returns zero if the loan was repaid in full (or over).
+     */
+    suspend fun getSettlementLoss(loan: LoanEntity): BigDecimal {
+        if (loan.direction != LoanDirection.LENT) return BigDecimal.ZERO
+        val repaid = loanDao.getTotalRepaidByType(loan.id, "INCOME")
+        return (loan.originalAmount - repaid).coerceAtLeast(BigDecimal.ZERO)
+    }
 
     fun getTransactionsForLoan(loanId: Long): Flow<List<TransactionEntity>> =
         loanDao.getTransactionsForLoan(loanId)

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/LoanRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/LoanRepository.kt
@@ -61,6 +61,9 @@ class LoanRepository @Inject constructor(
 
     suspend fun getLoanById(loanId: Long): LoanEntity? = loanDao.getLoanById(loanId)
 
+    suspend fun getOriginalTransactionForLoan(loanId: Long): TransactionEntity? =
+        loanDao.getOriginalTransactionForLoan(loanId)
+
     suspend fun findActiveLoanForPerson(personName: String, direction: LoanDirection): LoanEntity? =
         loanDao.getActiveLoanByPersonAndDirection(personName, direction.name)
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/LoanRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/LoanRepository.kt
@@ -29,6 +29,11 @@ class LoanRepository @Inject constructor(
 
     fun getTotalBorrowedRemaining(): Flow<BigDecimal> = loanDao.getTotalBorrowedRemaining()
 
+    fun getLentTransactionsInPeriod(
+        startDate: LocalDateTime,
+        endDate: LocalDateTime
+    ): Flow<List<TransactionEntity>> = loanDao.getLentTransactionsInPeriod(startDate, endDate)
+
     fun getTransactionsForLoan(loanId: Long): Flow<List<TransactionEntity>> =
         loanDao.getTransactionsForLoan(loanId)
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
@@ -377,6 +377,7 @@ fun HomeScreen(
                             currency = uiState.selectedCurrency,
                             currentMonthIncome = uiState.currentMonthIncome,
                             currentMonthExpenses = uiState.currentMonthExpenses,
+                            currentMonthLent = uiState.currentMonthLent,
                             currentMonthTotal = uiState.currentMonthTotal,
                             balanceHistory = uiState.balanceHistory,
                             spendingHistory = uiState.spendingHistory,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -89,6 +89,10 @@ class HomeViewModel @Inject constructor(
     private var currentMonthBreakdownMap: Map<String, TransactionRepository.MonthlyBreakdown> = emptyMap()
     private var lastMonthBreakdownMap: Map<String, TransactionRepository.MonthlyBreakdown> = emptyMap()
 
+    // Per-currency total loss from LENT loans settled this month. Folded into the displayed
+    // currentMonthExpenses so a settlement loss shows up as money the user actually lost.
+    private var currentMonthLoanLossByCurrency: Map<String, BigDecimal> = emptyMap()
+
     // Track if user has manually selected a currency to prevent auto-reset
     private var hasUserSelectedCurrency = false
 
@@ -242,7 +246,9 @@ class HomeViewModel @Inject constructor(
 
     private fun loadHomeData() {
         viewModelScope.launch {
-            // Load current month breakdown by currency (filtered by business/personal)
+            // Load current month breakdown by currency (filtered by business/personal).
+            // Loan-linked transactions are excluded — loan principal is shown separately
+            // as "Lent this month", and settlement losses are folded into expenses below.
             val now = LocalDate.now()
             val startOfMonth = now.withDayOfMonth(1)
             combine(
@@ -250,7 +256,9 @@ class HomeViewModel @Inject constructor(
                 userPreferencesRepository.selectedProfileId,
                 _cachedAccountBalances.filterNotNull()
             ) { transactions, profileId, balances ->
-                computeBreakdownByCurrency(filterTransactionsByProfile(transactions, profileId, buildProfileAccountKeys(balances)))
+                val nonLoan = filterTransactionsByProfile(transactions, profileId, buildProfileAccountKeys(balances))
+                    .filter { it.loanId == null }
+                computeBreakdownByCurrency(nonLoan)
             }.collect { breakdownByCurrency ->
                 updateBreakdownForSelectedCurrency(breakdownByCurrency, isCurrentMonth = true)
             }
@@ -384,7 +392,7 @@ class HomeViewModel @Inject constructor(
             val endOfMonth = now.withDayOfMonth(now.lengthOfMonth()).atTime(23, 59, 59)
 
             combine(
-                loanRepository.getLentTransactionsInPeriod(startOfMonth, endOfMonth),
+                loanRepository.getActiveLentTransactionsInPeriod(startOfMonth, endOfMonth),
                 userPreferencesRepository.selectedProfileId,
                 _cachedAccountBalances.filterNotNull(),
                 userPreferencesRepository.unifiedCurrencyMode,
@@ -413,6 +421,28 @@ class HomeViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
+            // Track losses on LENT loans settled this month. Each loss feeds back into the
+            // displayed "Spent this month" via updateUIStateForCurrency.
+            val now = LocalDate.now()
+            val startOfMonth = now.withDayOfMonth(1).atStartOfDay()
+            val endOfMonth = now.withDayOfMonth(now.lengthOfMonth()).atTime(23, 59, 59)
+
+            loanRepository.getLentLoansSettledInPeriod(startOfMonth, endOfMonth)
+                .collect { settledLoans ->
+                    val byCurrency = mutableMapOf<String, BigDecimal>()
+                    for (loan in settledLoans) {
+                        val loss = loanRepository.getSettlementLoss(loan)
+                        if (loss > BigDecimal.ZERO) {
+                            byCurrency.merge(loan.currency, loss) { a, b -> a + b }
+                        }
+                    }
+                    currentMonthLoanLossByCurrency = byCurrency
+                    // Trigger redisplay so spent reflects the new loss
+                    updateUIStateForCurrency(_uiState.value.selectedCurrency, _uiState.value.availableCurrencies)
+                }
+        }
+
+        viewModelScope.launch {
             // Load last month breakdown by currency (filtered by business/personal)
             val now = LocalDate.now()
             val dayOfMonth = now.dayOfMonth
@@ -425,7 +455,9 @@ class HomeViewModel @Inject constructor(
                 userPreferencesRepository.selectedProfileId,
                 _cachedAccountBalances.filterNotNull()
             ) { transactions, profileId, balances ->
-                computeBreakdownByCurrency(filterTransactionsByProfile(transactions, profileId, buildProfileAccountKeys(balances)))
+                val nonLoan = filterTransactionsByProfile(transactions, profileId, buildProfileAccountKeys(balances))
+                    .filter { it.loanId == null }
+                computeBreakdownByCurrency(nonLoan)
             }.collect { breakdownByCurrency ->
                 updateBreakdownForSelectedCurrency(breakdownByCurrency, isCurrentMonth = false)
             }
@@ -1144,11 +1176,12 @@ class HomeViewModel @Inject constructor(
             viewModelScope.launch {
                 val currentBreakdown = aggregateBreakdowns(currentMonthBreakdownMap, selectedCurrency)
                 val lastBreakdown = aggregateBreakdowns(lastMonthBreakdownMap, selectedCurrency)
+                val loanLoss = aggregateLoanLoss(currentMonthLoanLossByCurrency, selectedCurrency, isUnified = true)
 
                 _uiState.value = _uiState.value.copy(
-                    currentMonthTotal = currentBreakdown.total,
+                    currentMonthTotal = currentBreakdown.total - loanLoss,
                     currentMonthIncome = currentBreakdown.income,
-                    currentMonthExpenses = currentBreakdown.expenses,
+                    currentMonthExpenses = currentBreakdown.expenses + loanLoss,
                     lastMonthTotal = lastBreakdown.total,
                     lastMonthIncome = lastBreakdown.income,
                     lastMonthExpenses = lastBreakdown.expenses,
@@ -1171,10 +1204,12 @@ class HomeViewModel @Inject constructor(
                 expenses = BigDecimal.ZERO
             )
 
+            val loanLoss = currentMonthLoanLossByCurrency[selectedCurrency] ?: BigDecimal.ZERO
+
             _uiState.value = _uiState.value.copy(
-                currentMonthTotal = currentBreakdown.total,
+                currentMonthTotal = currentBreakdown.total - loanLoss,
                 currentMonthIncome = currentBreakdown.income,
-                currentMonthExpenses = currentBreakdown.expenses,
+                currentMonthExpenses = currentBreakdown.expenses + loanLoss,
                 lastMonthTotal = lastBreakdown.total,
                 lastMonthIncome = lastBreakdown.income,
                 lastMonthExpenses = lastBreakdown.expenses,
@@ -1183,6 +1218,21 @@ class HomeViewModel @Inject constructor(
             )
             calculateMonthlyChange()
         }
+    }
+
+    private suspend fun aggregateLoanLoss(
+        byCurrency: Map<String, BigDecimal>,
+        selectedCurrency: String,
+        isUnified: Boolean
+    ): BigDecimal {
+        if (byCurrency.isEmpty()) return BigDecimal.ZERO
+        if (!isUnified) return byCurrency[selectedCurrency] ?: BigDecimal.ZERO
+        var total = BigDecimal.ZERO
+        for ((currency, amount) in byCurrency) {
+            total += if (currency == selectedCurrency) amount
+            else currencyConversionService.convertAmount(amount, currency, selectedCurrency)
+        }
+        return total
     }
 
     private suspend fun aggregateBreakdowns(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -434,7 +434,11 @@ class HomeViewModel @Inject constructor(
                 val byCurrency = mutableMapOf<String, BigDecimal>()
                 for (loan in settledLoans) {
                     val sourceTx = loanRepository.getOriginalTransactionForLoan(loan.id)
-                    val belongsToProfile = sourceTx == null ||
+                    // Null sourceTx means the loan has no live linked transaction (all were
+                    // unlinked or deleted). Skip entirely — without a transaction we can't
+                    // attribute the loss to any profile, and treating null as "include
+                    // everywhere" would double-count it for users with multiple profiles.
+                    val belongsToProfile = sourceTx != null &&
                         filterTransactionsByProfile(listOf(sourceTx), profileId, keys).isNotEmpty()
                     if (!belongsToProfile) continue
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -377,6 +377,42 @@ class HomeViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
+            // Track principal lent during the current month — surfaced separately from
+            // "Spent this month" so loan outflows don't masquerade as everyday spending.
+            val now = LocalDate.now()
+            val startOfMonth = now.withDayOfMonth(1).atStartOfDay()
+            val endOfMonth = now.withDayOfMonth(now.lengthOfMonth()).atTime(23, 59, 59)
+
+            combine(
+                loanRepository.getLentTransactionsInPeriod(startOfMonth, endOfMonth),
+                userPreferencesRepository.selectedProfileId,
+                _cachedAccountBalances.filterNotNull(),
+                userPreferencesRepository.unifiedCurrencyMode,
+                userPreferencesRepository.displayCurrency
+            ) { lentTxns, profileId, balances, isUnified, displayCurrency ->
+                val keys = buildProfileAccountKeys(balances)
+                val filtered = filterTransactionsByProfile(lentTxns, profileId, keys)
+                val selectedCurrency = if (isUnified) displayCurrency else _uiState.value.selectedCurrency
+                isUnified to filtered to selectedCurrency
+            }.collect { (pair, selectedCurrency) ->
+                val (isUnified, filtered) = pair
+                val total = if (isUnified) {
+                    var sum = BigDecimal.ZERO
+                    for (tx in filtered) {
+                        sum += if (tx.currency == selectedCurrency) tx.amount
+                        else currencyConversionService.convertAmount(tx.amount, tx.currency, selectedCurrency)
+                    }
+                    sum
+                } else {
+                    filtered
+                        .filter { it.currency == selectedCurrency }
+                        .fold(BigDecimal.ZERO) { acc, tx -> acc + tx.amount }
+                }
+                _uiState.value = _uiState.value.copy(currentMonthLent = total)
+            }
+        }
+
+        viewModelScope.launch {
             // Load last month breakdown by currency (filtered by business/personal)
             val now = LocalDate.now()
             val dayOfMonth = now.dayOfMonth
@@ -1323,6 +1359,7 @@ data class HomeUiState(
     val currentMonthTotal: BigDecimal = BigDecimal.ZERO,
     val currentMonthIncome: BigDecimal = BigDecimal.ZERO,
     val currentMonthExpenses: BigDecimal = BigDecimal.ZERO,
+    val currentMonthLent: BigDecimal = BigDecimal.ZERO,
     val currentMonthCreditCard: BigDecimal = BigDecimal.ZERO,
     val currentMonthTransfer: BigDecimal = BigDecimal.ZERO,
     val currentMonthInvestment: BigDecimal = BigDecimal.ZERO,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -93,6 +93,11 @@ class HomeViewModel @Inject constructor(
     // currentMonthExpenses so a settlement loss shows up as money the user actually lost.
     private var currentMonthLoanLossByCurrency: Map<String, BigDecimal> = emptyMap()
 
+    // Per-currency principal lent during this month for currently-active LENT loans.
+    // Resolved against the selected/display currency in updateUIStateForCurrency so the
+    // Lent pill stays in sync when the user switches currency tabs.
+    private var currentMonthLentByCurrency: Map<String, BigDecimal> = emptyMap()
+
     // Track if user has manually selected a currency to prevent auto-reset
     private var hasUserSelectedCurrency = false
 
@@ -387,59 +392,60 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             // Track principal lent during the current month — surfaced separately from
             // "Spent this month" so loan outflows don't masquerade as everyday spending.
+            // Stored per-currency so updateUIStateForCurrency can resolve the right value
+            // whenever the user switches currency tabs or unified mode toggles.
             val now = LocalDate.now()
             val startOfMonth = now.withDayOfMonth(1).atStartOfDay()
-            val endOfMonth = now.withDayOfMonth(now.lengthOfMonth()).atTime(23, 59, 59)
+            val endOfMonth = now.withDayOfMonth(now.lengthOfMonth()).atTime(java.time.LocalTime.MAX)
 
             combine(
                 loanRepository.getActiveLentTransactionsInPeriod(startOfMonth, endOfMonth),
                 userPreferencesRepository.selectedProfileId,
-                _cachedAccountBalances.filterNotNull(),
-                userPreferencesRepository.unifiedCurrencyMode,
-                userPreferencesRepository.displayCurrency
-            ) { lentTxns, profileId, balances, isUnified, displayCurrency ->
+                _cachedAccountBalances.filterNotNull()
+            ) { lentTxns, profileId, balances ->
                 val keys = buildProfileAccountKeys(balances)
-                val filtered = filterTransactionsByProfile(lentTxns, profileId, keys)
-                val selectedCurrency = if (isUnified) displayCurrency else _uiState.value.selectedCurrency
-                isUnified to filtered to selectedCurrency
-            }.collect { (pair, selectedCurrency) ->
-                val (isUnified, filtered) = pair
-                val total = if (isUnified) {
-                    var sum = BigDecimal.ZERO
-                    for (tx in filtered) {
-                        sum += if (tx.currency == selectedCurrency) tx.amount
-                        else currencyConversionService.convertAmount(tx.amount, tx.currency, selectedCurrency)
-                    }
-                    sum
-                } else {
-                    filtered
-                        .filter { it.currency == selectedCurrency }
-                        .fold(BigDecimal.ZERO) { acc, tx -> acc + tx.amount }
+                filterTransactionsByProfile(lentTxns, profileId, keys)
+            }.collect { filtered ->
+                currentMonthLentByCurrency = filtered.groupBy { it.currency }.mapValues { (_, txs) ->
+                    txs.fold(BigDecimal.ZERO) { acc, tx -> acc + tx.amount }
                 }
-                _uiState.value = _uiState.value.copy(currentMonthLent = total)
+                updateUIStateForCurrency(_uiState.value.selectedCurrency, _uiState.value.availableCurrencies)
             }
         }
 
         viewModelScope.launch {
             // Track losses on LENT loans settled this month. Each loss feeds back into the
             // displayed "Spent this month" via updateUIStateForCurrency.
+            //
+            // LoanEntity has no profile column, so the profile filter is applied via the
+            // source EXPENSE transaction (same bank+account → same profile).
             val now = LocalDate.now()
             val startOfMonth = now.withDayOfMonth(1).atStartOfDay()
-            val endOfMonth = now.withDayOfMonth(now.lengthOfMonth()).atTime(23, 59, 59)
+            val endOfMonth = now.withDayOfMonth(now.lengthOfMonth()).atTime(java.time.LocalTime.MAX)
 
-            loanRepository.getLentLoansSettledInPeriod(startOfMonth, endOfMonth)
-                .collect { settledLoans ->
-                    val byCurrency = mutableMapOf<String, BigDecimal>()
-                    for (loan in settledLoans) {
-                        val loss = loanRepository.getSettlementLoss(loan)
-                        if (loss > BigDecimal.ZERO) {
-                            byCurrency.merge(loan.currency, loss) { a, b -> a + b }
-                        }
+            combine(
+                loanRepository.getLentLoansSettledInPeriod(startOfMonth, endOfMonth),
+                userPreferencesRepository.selectedProfileId,
+                _cachedAccountBalances.filterNotNull()
+            ) { settledLoans, profileId, balances ->
+                Triple(settledLoans, profileId, balances)
+            }.collect { (settledLoans, profileId, balances) ->
+                val keys = buildProfileAccountKeys(balances)
+                val byCurrency = mutableMapOf<String, BigDecimal>()
+                for (loan in settledLoans) {
+                    val sourceTx = loanRepository.getOriginalTransactionForLoan(loan.id)
+                    val belongsToProfile = sourceTx == null ||
+                        filterTransactionsByProfile(listOf(sourceTx), profileId, keys).isNotEmpty()
+                    if (!belongsToProfile) continue
+
+                    val loss = loanRepository.getSettlementLoss(loan)
+                    if (loss > BigDecimal.ZERO) {
+                        byCurrency.merge(loan.currency, loss) { a, b -> a + b }
                     }
-                    currentMonthLoanLossByCurrency = byCurrency
-                    // Trigger redisplay so spent reflects the new loss
-                    updateUIStateForCurrency(_uiState.value.selectedCurrency, _uiState.value.availableCurrencies)
                 }
+                currentMonthLoanLossByCurrency = byCurrency
+                updateUIStateForCurrency(_uiState.value.selectedCurrency, _uiState.value.availableCurrencies)
+            }
         }
 
         viewModelScope.launch {
@@ -1176,12 +1182,14 @@ class HomeViewModel @Inject constructor(
             viewModelScope.launch {
                 val currentBreakdown = aggregateBreakdowns(currentMonthBreakdownMap, selectedCurrency)
                 val lastBreakdown = aggregateBreakdowns(lastMonthBreakdownMap, selectedCurrency)
-                val loanLoss = aggregateLoanLoss(currentMonthLoanLossByCurrency, selectedCurrency, isUnified = true)
+                val loanLoss = aggregateAcrossCurrencies(currentMonthLoanLossByCurrency, selectedCurrency, isUnified = true)
+                val lent = aggregateAcrossCurrencies(currentMonthLentByCurrency, selectedCurrency, isUnified = true)
 
                 _uiState.value = _uiState.value.copy(
                     currentMonthTotal = currentBreakdown.total - loanLoss,
                     currentMonthIncome = currentBreakdown.income,
                     currentMonthExpenses = currentBreakdown.expenses + loanLoss,
+                    currentMonthLent = lent,
                     lastMonthTotal = lastBreakdown.total,
                     lastMonthIncome = lastBreakdown.income,
                     lastMonthExpenses = lastBreakdown.expenses,
@@ -1205,11 +1213,13 @@ class HomeViewModel @Inject constructor(
             )
 
             val loanLoss = currentMonthLoanLossByCurrency[selectedCurrency] ?: BigDecimal.ZERO
+            val lent = currentMonthLentByCurrency[selectedCurrency] ?: BigDecimal.ZERO
 
             _uiState.value = _uiState.value.copy(
                 currentMonthTotal = currentBreakdown.total - loanLoss,
                 currentMonthIncome = currentBreakdown.income,
                 currentMonthExpenses = currentBreakdown.expenses + loanLoss,
+                currentMonthLent = lent,
                 lastMonthTotal = lastBreakdown.total,
                 lastMonthIncome = lastBreakdown.income,
                 lastMonthExpenses = lastBreakdown.expenses,
@@ -1220,7 +1230,7 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private suspend fun aggregateLoanLoss(
+    private suspend fun aggregateAcrossCurrencies(
         byCurrency: Map<String, BigDecimal>,
         selectedCurrency: String,
         isUnified: Boolean

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceCard.kt
@@ -70,6 +70,7 @@ fun BalanceCard(
     currency: String,
     currentMonthIncome: BigDecimal,
     currentMonthExpenses: BigDecimal,
+    currentMonthLent: BigDecimal = BigDecimal.ZERO,
     currentMonthTotal: BigDecimal,
     balanceHistory: List<BigDecimal>,
     spendingHistory: List<BigDecimal> = emptyList(),
@@ -468,6 +469,13 @@ fun BalanceCard(
                                 value = if (isBalanceHidden) "••••" else CurrencyFormatter.formatCurrency(currentMonthExpenses, currency),
                                 accentColor = expenseColor
                             )
+                            if (currentMonthLent > BigDecimal.ZERO) {
+                                SummaryItem(
+                                    label = "Lent",
+                                    value = if (isBalanceHidden) "••••" else CurrencyFormatter.formatCurrency(currentMonthLent, currency),
+                                    accentColor = MaterialTheme.colorScheme.tertiary
+                                )
+                            }
                             SummaryItem(
                                 label = "Saved",
                                 value = if (isBalanceHidden) "••••" else CurrencyFormatter.formatCurrency(currentMonthTotal, currency),


### PR DESCRIPTION
## Summary
Closes #280 in full.

**Part 1 — new "Lent this month" pill** in the BalanceCard expanded summary row, alongside Income / Expenses / Saved. Hidden when zero so users without loan activity don't see an extra column. Counts the source EXPENSE of currently-ACTIVE LENT loans whose date falls in the month.

**Part 2 — loan flows now decoupled from Spent/Income**
- Loan-linked transactions (both source EXPENSEs and INCOME repayments) are filtered out of the home Income/Expenses breakdown for current and last month.
- Losses on LENT loans settled this month (`originalAmount − totalRepaid`) are folded into "Spent this month" and netted out of the Saved total.
- The Lent pill counts only ACTIVE loans, so a loan that's lent + settled with loss in the same month moves out of Lent and into Spent — exactly the case the issue describes (lent 2000, got 1000 back, settled → Spent +1000, Lent 0).

Respects the active Personal/Business profile filter and works in both per-currency and unified-currency modes.

## Test plan
- [x] App builds clean (`assembleStandardDebug`)
- [ ] No loans this month → Income / Expenses / Saved unchanged from before this PR
- [ ] Lend money via Mark as Loan → Lent pill appears with the principal; Spent does *not* go up
- [ ] Receive a partial repayment → Income does *not* go up (it's tracked as a loan repayment, not free income)
- [ ] Settle that loan with money still owed → Lent goes to 0, Spent goes up by the unrecovered amount
- [ ] Settle a loan fully → no change to Spent, Lent goes to 0
- [ ] Switch profiles + currency / toggle unified mode → all stats refresh correctly