### PR TITLE
feat: support AND / OR between rule conditions

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/domain/service/RuleEngine.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/service/RuleEngine.kt
@@ -64,13 +64,16 @@ class RuleEngine @Inject constructor() {
         rules: List<TransactionRule>,
         type: TransactionType
     ): Pair<TransactionEntity, List<RuleApplication>> {
-        // Pre-filter rules that apply to this transaction type
+        // Pre-filter rules that apply to this transaction type. This is an optimization
+        // for the common AND-only case; rules that mix in any OR logic are passed through
+        // since a TYPE condition that fails on its own can still let the rule match via
+        // an OR'd sibling.
         val applicableRules = rules.filter { rule ->
             val hasTypeCondition = rule.conditions.any { it.field == TransactionField.TYPE }
-            if (!hasTypeCondition) {
-                true // Rule applies to all transaction types
+            val hasOrLogic = rule.conditions.any { it.logicalOperator == LogicalOperator.OR }
+            if (!hasTypeCondition || hasOrLogic) {
+                true
             } else {
-                // Check if any TYPE condition matches this transaction's type
                 rule.conditions.any { condition ->
                     condition.field == TransactionField.TYPE &&
                     when (condition.operator) {
@@ -125,16 +128,20 @@ class RuleEngine @Inject constructor() {
     ): Boolean {
         if (conditions.isEmpty()) return false
 
-        // KISS: Simply AND all conditions together
-        // Each condition must be true for the rule to apply
-        for (condition in conditions) {
-            val conditionResult = evaluateCondition(transaction, smsText, condition)
-            if (!conditionResult) {
-                return false // If any condition is false, rule doesn't match
+        // Each condition (after the first) carries a logicalOperator describing how it
+        // combines with the running result so far. Evaluation is left-to-right with no
+        // precedence — "A AND B OR C" reads as "(A AND B) OR C" — which matches the
+        // most common user intent of "either these together, or that".
+        var result = evaluateCondition(transaction, smsText, conditions.first())
+        for (i in 1 until conditions.size) {
+            val condition = conditions[i]
+            val condResult = evaluateCondition(transaction, smsText, condition)
+            result = when (condition.logicalOperator) {
+                LogicalOperator.AND -> result && condResult
+                LogicalOperator.OR -> result || condResult
             }
         }
-
-        return true // All conditions matched
+        return result
     }
 
     private fun evaluateCondition(

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
@@ -323,17 +323,28 @@ fun CreateRuleScreen(
                                 modifier = Modifier.padding(Spacing.md),
                                 verticalArrangement = Arrangement.spacedBy(Spacing.sm)
                             ) {
-                                // Header with delete button
+                                // Header with logical-operator toggle and delete button
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
                                     horizontalArrangement = Arrangement.SpaceBetween,
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
-                                    Text(
-                                        text = if (index == 0) "Condition" else "AND Condition ${index + 1}",
-                                        style = MaterialTheme.typography.bodySmall,
-                                        fontWeight = FontWeight.Medium
-                                    )
+                                    if (index == 0) {
+                                        Text(
+                                            text = "Condition",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            fontWeight = FontWeight.Medium
+                                        )
+                                    } else {
+                                        LogicalOperatorToggle(
+                                            selected = condition.logicalOperator,
+                                            onSelect = { newOp ->
+                                                conditions = conditions.toMutableList().apply {
+                                                    set(index, condition.copy(logicalOperator = newOp))
+                                                }
+                                            }
+                                        )
+                                    }
                                     if (conditions.size > 1) {
                                         IconButton(
                                             onClick = {
@@ -1015,6 +1026,31 @@ private fun ConditionFieldSelector(
                 },
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun LogicalOperatorToggle(
+    selected: LogicalOperator,
+    onSelect: (LogicalOperator) -> Unit
+) {
+    val options = listOf(LogicalOperator.AND, LogicalOperator.OR)
+    SingleChoiceSegmentedButtonRow {
+        options.forEachIndexed { index, op ->
+            SegmentedButton(
+                selected = selected == op,
+                onClick = { onSelect(op) },
+                shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
+                label = {
+                    Text(
+                        text = op.name,
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
             )
         }
     }


### PR DESCRIPTION
## Summary
The data model has had a per-condition `LogicalOperator` (defaulting to AND) for a while, but it was inert: the engine always AND'd everything, and the Create Rule UI hardcoded "AND Condition N" in the header. This PR makes the operator real.

- **Engine** — `evaluateConditions` now evaluates left-to-right, combining each condition with the running result via its `logicalOperator`. No precedence — `A AND B OR C` reads as `(A AND B) OR C`, which matches the common "either these together, or that" intent.
- **UI** — Replaces the hardcoded "AND" label on conditions after the first with a Material 3 segmented `AND / OR` toggle. Users can now mix operators per condition.
- **Pre-filter safety** — `evaluateRulesForType` was using a TYPE-condition short-circuit safe only for AND-only rules. Rules that contain any OR are now passed through to full evaluation, since a TYPE condition that fails on its own can still let the rule match via an OR'd sibling.

Existing AND-only rules and system templates are unaffected (the default operator is still AND).

Closes #281

## Test plan
- [x] App builds clean
- [ ] Create a rule with two conditions: `SMS contains "UPI"` AND `SMS contains "received"` → only INCOME-shaped SMS match
- [ ] Edit it: switch the second condition's operator to OR → SMS containing either keyword now match
- [ ] Mix three: `A AND B OR C` → matches when both A & B are true, or when C is true (left-to-right)
- [ ] Single-condition rules behave exactly as before
- [ ] System template rules still work