### PR TITLE
feat: user-defined custom SMS parsers with token-tagging UI

### DIFF
--- a/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/47.json
+++ b/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/47.json
@@ -1,0 +1,1831 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 47,
+    "identityHash": "d3ae746ea54899f0bf89cd162d07d8d1",
+    "entities": [
+      {
+        "tableName": "transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` TEXT NOT NULL, `merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `transaction_type` TEXT NOT NULL, `date_time` TEXT NOT NULL, `description` TEXT, `sms_body` TEXT, `bank_name` TEXT, `sms_sender` TEXT, `account_number` TEXT, `balance_after` TEXT, `transaction_hash` TEXT NOT NULL DEFAULT '', `is_recurring` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `from_account` TEXT, `to_account` TEXT, `reference` TEXT, `loan_id` INTEGER DEFAULT NULL, `receipt_path` TEXT DEFAULT NULL, `budget_category` TEXT DEFAULT NULL, `budget_impact_type` TEXT DEFAULT NULL, `group_id` INTEGER DEFAULT NULL, `profile_id` INTEGER DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionType",
+            "columnName": "transaction_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateTime",
+            "columnName": "date_time",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsSender",
+            "columnName": "sms_sender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountNumber",
+            "columnName": "account_number",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "balanceAfter",
+            "columnName": "balance_after",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "transactionHash",
+            "columnName": "transaction_hash",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isRecurring",
+            "columnName": "is_recurring",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "fromAccount",
+            "columnName": "from_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toAccount",
+            "columnName": "to_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "loanId",
+            "columnName": "loan_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "receiptPath",
+            "columnName": "receipt_path",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetCategory",
+            "columnName": "budget_category",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetImpactType",
+            "columnName": "budget_impact_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "group_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transactions_transaction_hash",
+            "unique": true,
+            "columnNames": [
+              "transaction_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_transactions_transaction_hash` ON `${TABLE_NAME}` (`transaction_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `merchant_name` TEXT NOT NULL, `amount` TEXT NOT NULL, `next_payment_date` TEXT, `state` TEXT NOT NULL, `bank_name` TEXT, `umn` TEXT, `category` TEXT, `sms_body` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextPaymentDate",
+            "columnName": "next_payment_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umn",
+            "columnName": "umn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `message` TEXT NOT NULL, `isUser` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `isSystemPrompt` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUser",
+            "columnName": "isUser",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemPrompt",
+            "columnName": "isSystemPrompt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "merchant_mappings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`merchant_name`))",
+        "fields": [
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "merchant_name"
+          ]
+        }
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `color` TEXT NOT NULL, `is_system` INTEGER NOT NULL, `is_income` INTEGER NOT NULL, `display_order` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIncome",
+            "columnName": "is_income",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_categories_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_categories_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "account_balances",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT NOT NULL, `balance` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `transaction_id` INTEGER, `credit_limit` TEXT, `is_credit_card` INTEGER NOT NULL DEFAULT 0, `sms_source` TEXT, `source_type` TEXT, `account_type` TEXT, `created_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `statement_day` INTEGER DEFAULT NULL, `profile_id` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "creditLimit",
+            "columnName": "credit_limit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isCreditCard",
+            "columnName": "is_credit_card",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "smsSource",
+            "columnName": "sms_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "source_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountType",
+            "columnName": "account_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "statementDay",
+            "columnName": "statement_day",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_account_balances_bank_name_account_last4_timestamp",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "account_last4",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4_timestamp` ON `${TABLE_NAME}` (`bank_name`, `account_last4`, `timestamp`)"
+          },
+          {
+            "name": "index_account_balances_bank_name_account_last4",
+            "unique": false,
+            "columnNames": [
+              "bank_name",
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4` ON `${TABLE_NAME}` (`bank_name`, `account_last4`)"
+          },
+          {
+            "name": "index_account_balances_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "unrecognized_sms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sender` TEXT NOT NULL, `sms_body` TEXT NOT NULL, `received_at` TEXT NOT NULL, `reported` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receivedAt",
+            "columnName": "received_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reported",
+            "columnName": "reported",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_unrecognized_sms_sender_sms_body",
+            "unique": true,
+            "columnNames": [
+              "sender",
+              "sms_body"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_unrecognized_sms_sender_sms_body` ON `${TABLE_NAME}` (`sender`, `sms_body`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `card_last4` TEXT NOT NULL, `card_type` TEXT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT, `nickname` TEXT, `is_active` INTEGER NOT NULL DEFAULT 1, `last_balance` TEXT, `last_balance_source` TEXT, `last_balance_date` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardLast4",
+            "columnName": "card_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardType",
+            "columnName": "card_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastBalance",
+            "columnName": "last_balance",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceSource",
+            "columnName": "last_balance_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceDate",
+            "columnName": "last_balance_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cards_bank_name_card_last4",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cards_bank_name_card_last4` ON `${TABLE_NAME}` (`bank_name`, `card_last4`)"
+          },
+          {
+            "name": "index_cards_card_last4",
+            "unique": false,
+            "columnNames": [
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_card_last4` ON `${TABLE_NAME}` (`card_last4`)"
+          },
+          {
+            "name": "index_cards_account_last4",
+            "unique": false,
+            "columnNames": [
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_account_last4` ON `${TABLE_NAME}` (`account_last4`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `conditions` TEXT NOT NULL, `actions` TEXT NOT NULL, `is_active` INTEGER NOT NULL, `is_system_template` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conditions",
+            "columnName": "conditions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actions",
+            "columnName": "actions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemTemplate",
+            "columnName": "is_system_template",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_rules_priority_is_active",
+            "unique": false,
+            "columnNames": [
+              "priority",
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_priority_is_active` ON `${TABLE_NAME}` (`priority`, `is_active`)"
+          },
+          {
+            "name": "index_transaction_rules_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "rule_applications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `rule_id` TEXT NOT NULL, `rule_name` TEXT NOT NULL, `transaction_id` TEXT NOT NULL, `fields_modified` TEXT NOT NULL, `applied_at` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`rule_id`) REFERENCES `transaction_rules`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "rule_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleName",
+            "columnName": "rule_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fieldsModified",
+            "columnName": "fields_modified",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedAt",
+            "columnName": "applied_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rule_applications_rule_id",
+            "unique": false,
+            "columnNames": [
+              "rule_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_rule_id` ON `${TABLE_NAME}` (`rule_id`)"
+          },
+          {
+            "name": "index_rule_applications_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          },
+          {
+            "name": "index_rule_applications_applied_at",
+            "unique": false,
+            "columnNames": [
+              "applied_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_applied_at` ON `${TABLE_NAME}` (`applied_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transaction_rules",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "rule_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "exchange_rates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `from_currency` TEXT NOT NULL, `to_currency` TEXT NOT NULL, `rate` TEXT NOT NULL, `provider` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `updated_at_unix` INTEGER NOT NULL DEFAULT 0, `expires_at` TEXT NOT NULL, `expires_at_unix` INTEGER NOT NULL DEFAULT 0, `is_custom_rate` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCurrency",
+            "columnName": "from_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCurrency",
+            "columnName": "to_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtUnix",
+            "columnName": "updated_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expires_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAtUnix",
+            "columnName": "expires_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isCustomRate",
+            "columnName": "is_custom_rate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_exchange_rates_from_currency_to_currency",
+            "unique": true,
+            "columnNames": [
+              "from_currency",
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_exchange_rates_from_currency_to_currency` ON `${TABLE_NAME}` (`from_currency`, `to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_from_currency",
+            "unique": false,
+            "columnNames": [
+              "from_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_from_currency` ON `${TABLE_NAME}` (`from_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_to_currency",
+            "unique": false,
+            "columnNames": [
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_to_currency` ON `${TABLE_NAME}` (`to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          },
+          {
+            "name": "index_exchange_rates_expires_at_unix",
+            "unique": false,
+            "columnNames": [
+              "expires_at_unix"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_expires_at_unix` ON `${TABLE_NAME}` (`expires_at_unix`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `period_type` TEXT NOT NULL, `start_date` TEXT NOT NULL, `end_date` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `is_active` INTEGER NOT NULL DEFAULT 1, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "periodType",
+            "columnName": "period_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budgets_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_budgets_is_active",
+            "unique": false,
+            "columnNames": [
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_is_active` ON `${TABLE_NAME}` (`is_active`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budget_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL DEFAULT '0', FOREIGN KEY(`budget_id`) REFERENCES `budgets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budget_categories_budget_id",
+            "unique": false,
+            "columnNames": [
+              "budget_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budget_categories_budget_id` ON `${TABLE_NAME}` (`budget_id`)"
+          },
+          {
+            "name": "index_budget_categories_budget_id_category_name",
+            "unique": true,
+            "columnNames": [
+              "budget_id",
+              "category_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_budget_categories_budget_id_category_name` ON `${TABLE_NAME}` (`budget_id`, `category_name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "budgets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "budget_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "budget_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `budget_name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetName",
+            "columnName": "budget_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "budget_category_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "transaction_splits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `transaction_id` INTEGER NOT NULL, `category` TEXT NOT NULL, `amount` TEXT NOT NULL, `created_at` TEXT NOT NULL, FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_splits_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_splits_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bank_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `package_name` TEXT NOT NULL, `sender_alias` TEXT NOT NULL, `message_body` TEXT NOT NULL, `message_hash` TEXT NOT NULL, `posted_at` TEXT NOT NULL, `processed` INTEGER NOT NULL, `transaction_id` INTEGER, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderAlias",
+            "columnName": "sender_alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageBody",
+            "columnName": "message_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageHash",
+            "columnName": "message_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postedAt",
+            "columnName": "posted_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "processed",
+            "columnName": "processed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bank_notifications_package_name_message_hash",
+            "unique": true,
+            "columnNames": [
+              "package_name",
+              "message_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_bank_notifications_package_name_message_hash` ON `${TABLE_NAME}` (`package_name`, `message_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "loans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `person_name` TEXT NOT NULL, `direction` TEXT NOT NULL, `original_amount` TEXT NOT NULL, `remaining_amount` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `status` TEXT NOT NULL DEFAULT 'ACTIVE', `note` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `settled_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personName",
+            "columnName": "person_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalAmount",
+            "columnName": "original_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remainingAmount",
+            "columnName": "remaining_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'ACTIVE'"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settledAt",
+            "columnName": "settled_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_loans_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_loans_person_name",
+            "unique": false,
+            "columnNames": [
+              "person_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_person_name` ON `${TABLE_NAME}` (`person_name`)"
+          },
+          {
+            "name": "index_loans_created_at",
+            "unique": false,
+            "columnNames": [
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_created_at` ON `${TABLE_NAME}` (`created_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `note` TEXT DEFAULT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_groups_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_groups_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `color_hex` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorHex",
+            "columnName": "color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "custom_parser_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `sender_pattern` TEXT NOT NULL, `sample_sms` TEXT NOT NULL, `amount_regex` TEXT NOT NULL, `merchant_regex` TEXT, `account_regex` TEXT, `expense_keywords` TEXT NOT NULL, `income_keywords` TEXT NOT NULL, `currency` TEXT NOT NULL, `bank_name_display` TEXT NOT NULL, `priority` INTEGER NOT NULL, `is_active` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderPattern",
+            "columnName": "sender_pattern",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sampleSms",
+            "columnName": "sample_sms",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amountRegex",
+            "columnName": "amount_regex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantRegex",
+            "columnName": "merchant_regex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountRegex",
+            "columnName": "account_regex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "expenseKeywords",
+            "columnName": "expense_keywords",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "incomeKeywords",
+            "columnName": "income_keywords",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankNameDisplay",
+            "columnName": "bank_name_display",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_custom_parser_rules_priority_is_active",
+            "unique": false,
+            "columnNames": [
+              "priority",
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_custom_parser_rules_priority_is_active` ON `${TABLE_NAME}` (`priority`, `is_active`)"
+          },
+          {
+            "name": "index_custom_parser_rules_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_custom_parser_rules_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd3ae746ea54899f0bf89cd162d07d8d1')"
+    ]
+  }
+}

--- a/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/48.json
+++ b/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/48.json
@@ -1,0 +1,1836 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 48,
+    "identityHash": "72ddb00bead481ad4e41e3de8b5f2e79",
+    "entities": [
+      {
+        "tableName": "transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` TEXT NOT NULL, `merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `transaction_type` TEXT NOT NULL, `date_time` TEXT NOT NULL, `description` TEXT, `sms_body` TEXT, `bank_name` TEXT, `sms_sender` TEXT, `account_number` TEXT, `balance_after` TEXT, `transaction_hash` TEXT NOT NULL DEFAULT '', `is_recurring` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `from_account` TEXT, `to_account` TEXT, `reference` TEXT, `loan_id` INTEGER DEFAULT NULL, `receipt_path` TEXT DEFAULT NULL, `budget_category` TEXT DEFAULT NULL, `budget_impact_type` TEXT DEFAULT NULL, `group_id` INTEGER DEFAULT NULL, `profile_id` INTEGER DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionType",
+            "columnName": "transaction_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateTime",
+            "columnName": "date_time",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsSender",
+            "columnName": "sms_sender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountNumber",
+            "columnName": "account_number",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "balanceAfter",
+            "columnName": "balance_after",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "transactionHash",
+            "columnName": "transaction_hash",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isRecurring",
+            "columnName": "is_recurring",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "fromAccount",
+            "columnName": "from_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toAccount",
+            "columnName": "to_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "loanId",
+            "columnName": "loan_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "receiptPath",
+            "columnName": "receipt_path",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetCategory",
+            "columnName": "budget_category",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetImpactType",
+            "columnName": "budget_impact_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "group_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transactions_transaction_hash",
+            "unique": true,
+            "columnNames": [
+              "transaction_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_transactions_transaction_hash` ON `${TABLE_NAME}` (`transaction_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `merchant_name` TEXT NOT NULL, `amount` TEXT NOT NULL, `next_payment_date` TEXT, `state` TEXT NOT NULL, `bank_name` TEXT, `umn` TEXT, `category` TEXT, `sms_body` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextPaymentDate",
+            "columnName": "next_payment_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umn",
+            "columnName": "umn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `message` TEXT NOT NULL, `isUser` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `isSystemPrompt` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUser",
+            "columnName": "isUser",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemPrompt",
+            "columnName": "isSystemPrompt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "merchant_mappings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`merchant_name`))",
+        "fields": [
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "merchant_name"
+          ]
+        }
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `color` TEXT NOT NULL, `is_system` INTEGER NOT NULL, `is_income` INTEGER NOT NULL, `display_order` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIncome",
+            "columnName": "is_income",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_categories_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_categories_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "account_balances",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT NOT NULL, `balance` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `transaction_id` INTEGER, `credit_limit` TEXT, `is_credit_card` INTEGER NOT NULL DEFAULT 0, `sms_source` TEXT, `source_type` TEXT, `account_type` TEXT, `created_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `statement_day` INTEGER DEFAULT NULL, `profile_id` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "creditLimit",
+            "columnName": "credit_limit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isCreditCard",
+            "columnName": "is_credit_card",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "smsSource",
+            "columnName": "sms_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "source_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountType",
+            "columnName": "account_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "statementDay",
+            "columnName": "statement_day",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_account_balances_bank_name_account_last4_timestamp",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "account_last4",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4_timestamp` ON `${TABLE_NAME}` (`bank_name`, `account_last4`, `timestamp`)"
+          },
+          {
+            "name": "index_account_balances_bank_name_account_last4",
+            "unique": false,
+            "columnNames": [
+              "bank_name",
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4` ON `${TABLE_NAME}` (`bank_name`, `account_last4`)"
+          },
+          {
+            "name": "index_account_balances_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "unrecognized_sms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sender` TEXT NOT NULL, `sms_body` TEXT NOT NULL, `received_at` TEXT NOT NULL, `reported` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receivedAt",
+            "columnName": "received_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reported",
+            "columnName": "reported",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_unrecognized_sms_sender_sms_body",
+            "unique": true,
+            "columnNames": [
+              "sender",
+              "sms_body"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_unrecognized_sms_sender_sms_body` ON `${TABLE_NAME}` (`sender`, `sms_body`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `card_last4` TEXT NOT NULL, `card_type` TEXT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT, `nickname` TEXT, `is_active` INTEGER NOT NULL DEFAULT 1, `last_balance` TEXT, `last_balance_source` TEXT, `last_balance_date` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardLast4",
+            "columnName": "card_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardType",
+            "columnName": "card_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastBalance",
+            "columnName": "last_balance",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceSource",
+            "columnName": "last_balance_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceDate",
+            "columnName": "last_balance_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cards_bank_name_card_last4",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cards_bank_name_card_last4` ON `${TABLE_NAME}` (`bank_name`, `card_last4`)"
+          },
+          {
+            "name": "index_cards_card_last4",
+            "unique": false,
+            "columnNames": [
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_card_last4` ON `${TABLE_NAME}` (`card_last4`)"
+          },
+          {
+            "name": "index_cards_account_last4",
+            "unique": false,
+            "columnNames": [
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_account_last4` ON `${TABLE_NAME}` (`account_last4`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `conditions` TEXT NOT NULL, `actions` TEXT NOT NULL, `is_active` INTEGER NOT NULL, `is_system_template` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conditions",
+            "columnName": "conditions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actions",
+            "columnName": "actions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemTemplate",
+            "columnName": "is_system_template",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_rules_priority_is_active",
+            "unique": false,
+            "columnNames": [
+              "priority",
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_priority_is_active` ON `${TABLE_NAME}` (`priority`, `is_active`)"
+          },
+          {
+            "name": "index_transaction_rules_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "rule_applications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `rule_id` TEXT NOT NULL, `rule_name` TEXT NOT NULL, `transaction_id` TEXT NOT NULL, `fields_modified` TEXT NOT NULL, `applied_at` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`rule_id`) REFERENCES `transaction_rules`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "rule_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleName",
+            "columnName": "rule_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fieldsModified",
+            "columnName": "fields_modified",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedAt",
+            "columnName": "applied_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rule_applications_rule_id",
+            "unique": false,
+            "columnNames": [
+              "rule_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_rule_id` ON `${TABLE_NAME}` (`rule_id`)"
+          },
+          {
+            "name": "index_rule_applications_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          },
+          {
+            "name": "index_rule_applications_applied_at",
+            "unique": false,
+            "columnNames": [
+              "applied_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_applied_at` ON `${TABLE_NAME}` (`applied_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transaction_rules",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "rule_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "exchange_rates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `from_currency` TEXT NOT NULL, `to_currency` TEXT NOT NULL, `rate` TEXT NOT NULL, `provider` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `updated_at_unix` INTEGER NOT NULL DEFAULT 0, `expires_at` TEXT NOT NULL, `expires_at_unix` INTEGER NOT NULL DEFAULT 0, `is_custom_rate` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCurrency",
+            "columnName": "from_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCurrency",
+            "columnName": "to_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtUnix",
+            "columnName": "updated_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expires_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAtUnix",
+            "columnName": "expires_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isCustomRate",
+            "columnName": "is_custom_rate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_exchange_rates_from_currency_to_currency",
+            "unique": true,
+            "columnNames": [
+              "from_currency",
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_exchange_rates_from_currency_to_currency` ON `${TABLE_NAME}` (`from_currency`, `to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_from_currency",
+            "unique": false,
+            "columnNames": [
+              "from_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_from_currency` ON `${TABLE_NAME}` (`from_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_to_currency",
+            "unique": false,
+            "columnNames": [
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_to_currency` ON `${TABLE_NAME}` (`to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          },
+          {
+            "name": "index_exchange_rates_expires_at_unix",
+            "unique": false,
+            "columnNames": [
+              "expires_at_unix"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_expires_at_unix` ON `${TABLE_NAME}` (`expires_at_unix`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `period_type` TEXT NOT NULL, `start_date` TEXT NOT NULL, `end_date` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `is_active` INTEGER NOT NULL DEFAULT 1, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "periodType",
+            "columnName": "period_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budgets_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_budgets_is_active",
+            "unique": false,
+            "columnNames": [
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_is_active` ON `${TABLE_NAME}` (`is_active`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budget_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL DEFAULT '0', FOREIGN KEY(`budget_id`) REFERENCES `budgets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budget_categories_budget_id",
+            "unique": false,
+            "columnNames": [
+              "budget_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budget_categories_budget_id` ON `${TABLE_NAME}` (`budget_id`)"
+          },
+          {
+            "name": "index_budget_categories_budget_id_category_name",
+            "unique": true,
+            "columnNames": [
+              "budget_id",
+              "category_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_budget_categories_budget_id_category_name` ON `${TABLE_NAME}` (`budget_id`, `category_name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "budgets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "budget_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "budget_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `budget_name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetName",
+            "columnName": "budget_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "budget_category_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "transaction_splits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `transaction_id` INTEGER NOT NULL, `category` TEXT NOT NULL, `amount` TEXT NOT NULL, `created_at` TEXT NOT NULL, FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_splits_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_splits_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bank_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `package_name` TEXT NOT NULL, `sender_alias` TEXT NOT NULL, `message_body` TEXT NOT NULL, `message_hash` TEXT NOT NULL, `posted_at` TEXT NOT NULL, `processed` INTEGER NOT NULL, `transaction_id` INTEGER, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderAlias",
+            "columnName": "sender_alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageBody",
+            "columnName": "message_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageHash",
+            "columnName": "message_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postedAt",
+            "columnName": "posted_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "processed",
+            "columnName": "processed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bank_notifications_package_name_message_hash",
+            "unique": true,
+            "columnNames": [
+              "package_name",
+              "message_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_bank_notifications_package_name_message_hash` ON `${TABLE_NAME}` (`package_name`, `message_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "loans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `person_name` TEXT NOT NULL, `direction` TEXT NOT NULL, `original_amount` TEXT NOT NULL, `remaining_amount` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `status` TEXT NOT NULL DEFAULT 'ACTIVE', `note` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `settled_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personName",
+            "columnName": "person_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalAmount",
+            "columnName": "original_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remainingAmount",
+            "columnName": "remaining_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'ACTIVE'"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settledAt",
+            "columnName": "settled_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_loans_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_loans_person_name",
+            "unique": false,
+            "columnNames": [
+              "person_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_person_name` ON `${TABLE_NAME}` (`person_name`)"
+          },
+          {
+            "name": "index_loans_created_at",
+            "unique": false,
+            "columnNames": [
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_created_at` ON `${TABLE_NAME}` (`created_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `note` TEXT DEFAULT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_groups_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_groups_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `color_hex` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorHex",
+            "columnName": "color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "custom_parser_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `sender_pattern` TEXT NOT NULL, `sample_sms` TEXT NOT NULL, `amount_regex` TEXT NOT NULL, `merchant_regex` TEXT, `account_regex` TEXT, `expense_keywords` TEXT NOT NULL, `income_keywords` TEXT NOT NULL, `currency` TEXT NOT NULL, `bank_name_display` TEXT NOT NULL, `tags_json` TEXT, `priority` INTEGER NOT NULL, `is_active` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderPattern",
+            "columnName": "sender_pattern",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sampleSms",
+            "columnName": "sample_sms",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amountRegex",
+            "columnName": "amount_regex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantRegex",
+            "columnName": "merchant_regex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountRegex",
+            "columnName": "account_regex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "expenseKeywords",
+            "columnName": "expense_keywords",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "incomeKeywords",
+            "columnName": "income_keywords",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankNameDisplay",
+            "columnName": "bank_name_display",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagsJson",
+            "columnName": "tags_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_custom_parser_rules_priority_is_active",
+            "unique": false,
+            "columnNames": [
+              "priority",
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_custom_parser_rules_priority_is_active` ON `${TABLE_NAME}` (`priority`, `is_active`)"
+          },
+          {
+            "name": "index_custom_parser_rules_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_custom_parser_rules_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '72ddb00bead481ad4e41e3de8b5f2e79')"
+    ]
+  }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
@@ -17,6 +17,7 @@ import com.pennywiseai.tracker.data.database.dao.BudgetDao
 import com.pennywiseai.tracker.data.database.dao.CardDao
 import com.pennywiseai.tracker.data.database.dao.CategoryDao
 import com.pennywiseai.tracker.data.database.dao.ChatDao
+import com.pennywiseai.tracker.data.database.dao.CustomParserRuleDao
 import com.pennywiseai.tracker.data.database.dao.ExchangeRateDao
 import com.pennywiseai.tracker.data.database.dao.LoanDao
 import com.pennywiseai.tracker.data.database.dao.MerchantMappingDao
@@ -38,6 +39,7 @@ import com.pennywiseai.tracker.data.database.entity.BudgetMonthSnapshotEntity
 import com.pennywiseai.tracker.data.database.entity.CardEntity
 import com.pennywiseai.tracker.data.database.entity.CategoryEntity
 import com.pennywiseai.tracker.data.database.entity.ChatMessage
+import com.pennywiseai.tracker.data.database.entity.CustomParserRuleEntity
 import com.pennywiseai.tracker.data.database.entity.ExchangeRateEntity
 import com.pennywiseai.tracker.data.database.entity.LoanEntity
 import com.pennywiseai.tracker.data.database.entity.MerchantMappingEntity
@@ -60,8 +62,8 @@ import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
  * @property autoMigrations List of automatic migrations between versions.
  */
 @Database(
-    entities = [TransactionEntity::class, SubscriptionEntity::class, ChatMessage::class, MerchantMappingEntity::class, CategoryEntity::class, AccountBalanceEntity::class, UnrecognizedSmsEntity::class, CardEntity::class, RuleEntity::class, RuleApplicationEntity::class, ExchangeRateEntity::class, BudgetEntity::class, BudgetCategoryEntity::class, BudgetMonthSnapshotEntity::class, BudgetCategoryMonthSnapshotEntity::class, TransactionSplitEntity::class, BankNotificationEntity::class, LoanEntity::class, TransactionGroupEntity::class, ProfileEntity::class],
-    version = 46,
+    entities = [TransactionEntity::class, SubscriptionEntity::class, ChatMessage::class, MerchantMappingEntity::class, CategoryEntity::class, AccountBalanceEntity::class, UnrecognizedSmsEntity::class, CardEntity::class, RuleEntity::class, RuleApplicationEntity::class, ExchangeRateEntity::class, BudgetEntity::class, BudgetCategoryEntity::class, BudgetMonthSnapshotEntity::class, BudgetCategoryMonthSnapshotEntity::class, TransactionSplitEntity::class, BankNotificationEntity::class, LoanEntity::class, TransactionGroupEntity::class, ProfileEntity::class, CustomParserRuleEntity::class],
+    version = 47,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
@@ -105,6 +107,7 @@ import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
         AutoMigration(from = 42, to = 43),
         AutoMigration(from = 43, to = 44, spec = Migration43To44::class)
         // 44→45 and 45→46 are manual migrations registered in DatabaseModule (add profile_id columns)
+        // 46→47 is a manual migration registered in DatabaseModule (custom_parser_rules table)
     ]
 )
 @TypeConverters(Converters::class)
@@ -127,6 +130,7 @@ abstract class PennyWiseDatabase : RoomDatabase() {
     abstract fun transactionGroupDao(): TransactionGroupDao
     abstract fun budgetSnapshotDao(): BudgetSnapshotDao
     abstract fun profileDao(): ProfileDao
+    abstract fun customParserRuleDao(): CustomParserRuleDao
 
     companion object {
         const val DATABASE_NAME = "pennywise_database"
@@ -432,6 +436,32 @@ abstract class PennyWiseDatabase : RoomDatabase() {
         val MIGRATION_45_46 = object : Migration(45, 46) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE `transactions` ADD COLUMN `profile_id` INTEGER DEFAULT NULL")
+            }
+        }
+
+        val MIGRATION_46_47 = object : Migration(46, 47) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS `custom_parser_rules` (
+                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        `name` TEXT NOT NULL,
+                        `sender_pattern` TEXT NOT NULL,
+                        `sample_sms` TEXT NOT NULL,
+                        `amount_regex` TEXT NOT NULL,
+                        `merchant_regex` TEXT,
+                        `account_regex` TEXT,
+                        `expense_keywords` TEXT NOT NULL,
+                        `income_keywords` TEXT NOT NULL,
+                        `currency` TEXT NOT NULL,
+                        `bank_name_display` TEXT NOT NULL,
+                        `priority` INTEGER NOT NULL,
+                        `is_active` INTEGER NOT NULL,
+                        `created_at` TEXT NOT NULL,
+                        `updated_at` TEXT NOT NULL
+                    )
+                """.trimIndent())
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_custom_parser_rules_priority_is_active` ON `custom_parser_rules` (`priority`, `is_active`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_custom_parser_rules_name` ON `custom_parser_rules` (`name`)")
             }
         }
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
@@ -63,7 +63,7 @@ import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
  */
 @Database(
     entities = [TransactionEntity::class, SubscriptionEntity::class, ChatMessage::class, MerchantMappingEntity::class, CategoryEntity::class, AccountBalanceEntity::class, UnrecognizedSmsEntity::class, CardEntity::class, RuleEntity::class, RuleApplicationEntity::class, ExchangeRateEntity::class, BudgetEntity::class, BudgetCategoryEntity::class, BudgetMonthSnapshotEntity::class, BudgetCategoryMonthSnapshotEntity::class, TransactionSplitEntity::class, BankNotificationEntity::class, LoanEntity::class, TransactionGroupEntity::class, ProfileEntity::class, CustomParserRuleEntity::class],
-    version = 47,
+    version = 48,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
@@ -105,7 +105,8 @@ import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
         AutoMigration(from = 40, to = 41),
         AutoMigration(from = 41, to = 42),
         AutoMigration(from = 42, to = 43),
-        AutoMigration(from = 43, to = 44, spec = Migration43To44::class)
+        AutoMigration(from = 43, to = 44, spec = Migration43To44::class),
+        AutoMigration(from = 47, to = 48)
         // 44→45 and 45→46 are manual migrations registered in DatabaseModule (add profile_id columns)
         // 46→47 is a manual migration registered in DatabaseModule (custom_parser_rules table)
     ]

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/CustomParserRuleDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/CustomParserRuleDao.kt
@@ -1,0 +1,38 @@
+package com.pennywiseai.tracker.data.database.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.pennywiseai.tracker.data.database.entity.CustomParserRuleEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CustomParserRuleDao {
+
+    @Query("SELECT * FROM custom_parser_rules ORDER BY priority ASC, name ASC")
+    fun getAllRules(): Flow<List<CustomParserRuleEntity>>
+
+    @Query("SELECT * FROM custom_parser_rules WHERE is_active = 1 ORDER BY priority ASC")
+    suspend fun getActiveRules(): List<CustomParserRuleEntity>
+
+    @Query("SELECT * FROM custom_parser_rules WHERE id = :id")
+    suspend fun getRuleById(id: Long): CustomParserRuleEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertRule(rule: CustomParserRuleEntity): Long
+
+    @Update
+    suspend fun updateRule(rule: CustomParserRuleEntity)
+
+    @Query("UPDATE custom_parser_rules SET is_active = :isActive, updated_at = :updatedAt WHERE id = :id")
+    suspend fun setActive(id: Long, isActive: Boolean, updatedAt: java.time.LocalDateTime = java.time.LocalDateTime.now())
+
+    @Delete
+    suspend fun deleteRule(rule: CustomParserRuleEntity)
+
+    @Query("DELETE FROM custom_parser_rules WHERE id = :id")
+    suspend fun deleteRuleById(id: Long)
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/UnrecognizedSmsDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/UnrecognizedSmsDao.kt
@@ -21,6 +21,9 @@ interface UnrecognizedSmsDao {
     
     @Query("SELECT * FROM unrecognized_sms WHERE is_deleted = 0 ORDER BY received_at DESC")
     fun getAllVisible(): Flow<List<UnrecognizedSmsEntity>>
+
+    @Query("SELECT * FROM unrecognized_sms WHERE is_deleted = 0 ORDER BY received_at DESC")
+    suspend fun getAllVisibleSnapshot(): List<UnrecognizedSmsEntity>
     
     @Query("SELECT * FROM unrecognized_sms ORDER BY received_at DESC")
     fun getAllUnrecognizedSms(): Flow<List<UnrecognizedSmsEntity>>

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/CustomParserRuleEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/CustomParserRuleEntity.kt
@@ -47,6 +47,9 @@ data class CustomParserRuleEntity(
     @ColumnInfo(name = "bank_name_display")
     val bankNameDisplay: String,
 
+    @ColumnInfo(name = "tags_json")
+    val tagsJson: String? = null,
+
     @ColumnInfo(name = "priority")
     val priority: Int = 100,
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/CustomParserRuleEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/CustomParserRuleEntity.kt
@@ -1,0 +1,61 @@
+package com.pennywiseai.tracker.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.time.LocalDateTime
+
+@Entity(
+    tableName = "custom_parser_rules",
+    indices = [
+        Index(value = ["priority", "is_active"]),
+        Index(value = ["name"])
+    ]
+)
+data class CustomParserRuleEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+
+    @ColumnInfo(name = "name")
+    val name: String,
+
+    @ColumnInfo(name = "sender_pattern")
+    val senderPattern: String,
+
+    @ColumnInfo(name = "sample_sms")
+    val sampleSms: String,
+
+    @ColumnInfo(name = "amount_regex")
+    val amountRegex: String,
+
+    @ColumnInfo(name = "merchant_regex")
+    val merchantRegex: String?,
+
+    @ColumnInfo(name = "account_regex")
+    val accountRegex: String?,
+
+    @ColumnInfo(name = "expense_keywords")
+    val expenseKeywords: String,
+
+    @ColumnInfo(name = "income_keywords")
+    val incomeKeywords: String,
+
+    @ColumnInfo(name = "currency")
+    val currency: String,
+
+    @ColumnInfo(name = "bank_name_display")
+    val bankNameDisplay: String,
+
+    @ColumnInfo(name = "priority")
+    val priority: Int = 100,
+
+    @ColumnInfo(name = "is_active")
+    val isActive: Boolean = true,
+
+    @ColumnInfo(name = "created_at")
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @ColumnInfo(name = "updated_at")
+    val updatedAt: LocalDateTime = LocalDateTime.now()
+)

--- a/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsTransactionProcessor.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsTransactionProcessor.kt
@@ -72,8 +72,12 @@ class SmsTransactionProcessor @Inject constructor(
             // Get the appropriate parser for this sender. Built-in parsers always
             // win; user-defined custom rules only run as a fallback.
             val parser = BankParserFactory.getParser(sender)
-            val parsedTransaction = parser?.parse(body, sender, timestamp)
-                ?: customParserService.tryParse(sender, body, timestamp)
+            val builtInParsed = parser?.parse(body, sender, timestamp)
+            val parsedTransaction = builtInParsed
+                ?: run {
+                    Log.d(TAG, "Built-in parser ${parser?.let { "'${it.getBankName()}' produced null" } ?: "missing"}, trying custom rules for sender='$sender'")
+                    customParserService.tryParse(sender, body, timestamp)
+                }
 
             if (parsedTransaction == null) {
                 val reason = if (parser == null) {
@@ -84,7 +88,8 @@ class SmsTransactionProcessor @Inject constructor(
                 return ProcessingResult(false, reason = reason)
             }
 
-            Log.d(TAG, "Parsed transaction: ${parsedTransaction.amount} from ${parsedTransaction.bankName}")
+            val source = if (builtInParsed != null) "built-in" else "custom"
+            Log.d(TAG, "Parsed transaction ($source): ${parsedTransaction.amount} from ${parsedTransaction.bankName}")
 
             // Save the transaction
             return saveParsedTransaction(parsedTransaction, body)

--- a/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsTransactionProcessor.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsTransactionProcessor.kt
@@ -16,6 +16,7 @@ import com.pennywiseai.tracker.data.repository.MerchantMappingRepository
 import com.pennywiseai.tracker.data.repository.SubscriptionRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import com.pennywiseai.tracker.domain.repository.RuleRepository
+import com.pennywiseai.tracker.domain.service.CustomParserService
 import com.pennywiseai.tracker.domain.service.RuleEngine
 import java.math.BigDecimal
 import java.time.Instant
@@ -38,7 +39,8 @@ class SmsTransactionProcessor @Inject constructor(
     private val merchantMappingRepository: MerchantMappingRepository,
     private val subscriptionRepository: SubscriptionRepository,
     private val ruleRepository: RuleRepository,
-    private val ruleEngine: RuleEngine
+    private val ruleEngine: RuleEngine,
+    private val customParserService: CustomParserService
 ) {
     companion object {
         private const val TAG = "SmsTransactionProcessor"
@@ -67,16 +69,19 @@ class SmsTransactionProcessor @Inject constructor(
         timestamp: Long
     ): ProcessingResult {
         try {
-            // Get the appropriate parser for this sender
+            // Get the appropriate parser for this sender. Built-in parsers always
+            // win; user-defined custom rules only run as a fallback.
             val parser = BankParserFactory.getParser(sender)
-            if (parser == null) {
-                return ProcessingResult(false, reason = "No parser found for sender: $sender")
-            }
+            val parsedTransaction = parser?.parse(body, sender, timestamp)
+                ?: customParserService.tryParse(sender, body, timestamp)
 
-            // Parse the SMS
-            val parsedTransaction = parser.parse(body, sender, timestamp)
             if (parsedTransaction == null) {
-                return ProcessingResult(false, reason = "Could not parse transaction from SMS")
+                val reason = if (parser == null) {
+                    "No parser found for sender: $sender"
+                } else {
+                    "Could not parse transaction from SMS"
+                }
+                return ProcessingResult(false, reason = reason)
             }
 
             Log.d(TAG, "Parsed transaction: ${parsedTransaction.amount} from ${parsedTransaction.bankName}")

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/CustomParserRuleRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/CustomParserRuleRepository.kt
@@ -1,0 +1,31 @@
+package com.pennywiseai.tracker.data.repository
+
+import com.pennywiseai.tracker.data.database.dao.CustomParserRuleDao
+import com.pennywiseai.tracker.data.database.entity.CustomParserRuleEntity
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDateTime
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CustomParserRuleRepository @Inject constructor(
+    private val dao: CustomParserRuleDao
+) {
+    fun getAllRules(): Flow<List<CustomParserRuleEntity>> = dao.getAllRules()
+
+    suspend fun getActiveRules(): List<CustomParserRuleEntity> = dao.getActiveRules()
+
+    suspend fun getRuleById(id: Long): CustomParserRuleEntity? = dao.getRuleById(id)
+
+    suspend fun insertRule(rule: CustomParserRuleEntity): Long = dao.insertRule(rule)
+
+    suspend fun updateRule(rule: CustomParserRuleEntity) {
+        dao.updateRule(rule.copy(updatedAt = LocalDateTime.now()))
+    }
+
+    suspend fun setActive(id: Long, isActive: Boolean) {
+        dao.setActive(id, isActive)
+    }
+
+    suspend fun deleteRuleById(id: Long) = dao.deleteRuleById(id)
+}

--- a/app/src/main/java/com/pennywiseai/tracker/di/DatabaseModule.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/di/DatabaseModule.kt
@@ -13,6 +13,7 @@ import com.pennywiseai.tracker.data.database.dao.BudgetSnapshotDao
 import com.pennywiseai.tracker.data.database.dao.CardDao
 import com.pennywiseai.tracker.data.database.dao.CategoryDao
 import com.pennywiseai.tracker.data.database.dao.ChatDao
+import com.pennywiseai.tracker.data.database.dao.CustomParserRuleDao
 import com.pennywiseai.tracker.data.database.dao.ExchangeRateDao
 import com.pennywiseai.tracker.data.database.dao.LoanDao
 import com.pennywiseai.tracker.data.database.dao.TransactionGroupDao
@@ -66,7 +67,8 @@ object DatabaseModule {
                 PennyWiseDatabase.MIGRATION_22_23,
                 PennyWiseDatabase.MIGRATION_38_39,
                 PennyWiseDatabase.MIGRATION_44_45,
-                PennyWiseDatabase.MIGRATION_45_46
+                PennyWiseDatabase.MIGRATION_45_46,
+                PennyWiseDatabase.MIGRATION_46_47
             )
 
             // Enable auto-migrations
@@ -267,6 +269,12 @@ object DatabaseModule {
     @Singleton
     fun provideProfileDao(database: PennyWiseDatabase): ProfileDao {
         return database.profileDao()
+    }
+
+    @Provides
+    @Singleton
+    fun provideCustomParserRuleDao(database: PennyWiseDatabase): CustomParserRuleDao {
+        return database.customParserRuleDao()
     }
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/domain/service/CustomParserRuleBuilder.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/service/CustomParserRuleBuilder.kt
@@ -1,5 +1,6 @@
 package com.pennywiseai.tracker.domain.service
 
+import kotlinx.serialization.Serializable
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -13,6 +14,7 @@ import javax.inject.Singleton
 @Singleton
 class CustomParserRuleBuilder @Inject constructor() {
 
+    @Serializable
     enum class TokenTag {
         AMOUNT,
         MERCHANT,
@@ -21,6 +23,7 @@ class CustomParserRuleBuilder @Inject constructor() {
         INCOME_KEYWORD
     }
 
+    @Serializable
     data class TaggedToken(val tokenIndex: Int, val tag: TokenTag)
 
     data class BuiltPatterns(
@@ -40,9 +43,9 @@ class CustomParserRuleBuilder @Inject constructor() {
             return BuiltPatterns(null, null, null, emptyList(), emptyList())
         }
 
-        val amountTag = tags.firstOrNull { it.tag == TokenTag.AMOUNT }
-        val merchantTag = tags.firstOrNull { it.tag == TokenTag.MERCHANT }
-        val accountTag = tags.firstOrNull { it.tag == TokenTag.ACCOUNT }
+        val amountIndices = tags.filter { it.tag == TokenTag.AMOUNT }.map { it.tokenIndex }
+        val merchantIndices = tags.filter { it.tag == TokenTag.MERCHANT }.map { it.tokenIndex }
+        val accountIndices = tags.filter { it.tag == TokenTag.ACCOUNT }.map { it.tokenIndex }
 
         val expenseKeywords = tags
             .filter { it.tag == TokenTag.EXPENSE_KEYWORD }
@@ -57,9 +60,9 @@ class CustomParserRuleBuilder @Inject constructor() {
             .distinct()
 
         return BuiltPatterns(
-            amountRegex = amountTag?.let { buildAnchoredPattern(tokens, it.tokenIndex, AMOUNT_VALUE) },
-            merchantRegex = merchantTag?.let { buildAnchoredPattern(tokens, it.tokenIndex, MERCHANT_VALUE) },
-            accountRegex = accountTag?.let { buildAnchoredPattern(tokens, it.tokenIndex, ACCOUNT_VALUE) },
+            amountRegex = buildSpannedPattern(tokens, amountIndices, AMOUNT_VALUE),
+            merchantRegex = buildSpannedPattern(tokens, merchantIndices, MERCHANT_VALUE),
+            accountRegex = buildSpannedPattern(tokens, accountIndices, ACCOUNT_VALUE),
             expenseKeywords = expenseKeywords,
             incomeKeywords = incomeKeywords
         )
@@ -72,13 +75,22 @@ class CustomParserRuleBuilder @Inject constructor() {
      */
     fun buildSenderPattern(sender: String): String = Regex.escape(sender.trim())
 
-    private fun buildAnchoredPattern(
+    /**
+     * Builds an anchored pattern that brackets the leftmost-to-rightmost
+     * tagged token. Lets a multi-token field like a merchant name span more
+     * than one token; the captured value pattern stretches from the token
+     * before the first to the token after the last.
+     */
+    private fun buildSpannedPattern(
         tokens: List<String>,
-        targetIndex: Int,
+        indices: List<Int>,
         valuePattern: String
-    ): String {
-        val anchorBefore = tokens.getOrNull(targetIndex - 1)?.let(::escapeAnchor)
-        val anchorAfter = tokens.getOrNull(targetIndex + 1)?.let(::escapeAnchor)
+    ): String? {
+        if (indices.isEmpty()) return null
+        val first = indices.min()
+        val last = indices.max()
+        val anchorBefore = tokens.getOrNull(first - 1)?.let(::escapeAnchor)
+        val anchorAfter = tokens.getOrNull(last + 1)?.let(::escapeAnchor)
 
         return buildString {
             if (anchorBefore != null) {

--- a/app/src/main/java/com/pennywiseai/tracker/domain/service/CustomParserRuleBuilder.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/service/CustomParserRuleBuilder.kt
@@ -1,0 +1,122 @@
+package com.pennywiseai.tracker.domain.service
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Generates regex patterns from a sample SMS plus token-level field tags
+ * produced by the add/edit screen. Each "tag" is the index of a whitespace-
+ * delimited token in the sample plus the field it identifies; the builder
+ * picks neighboring tokens as anchors and synthesizes a regex that locates
+ * the same field in future SMS with the same surrounding shape.
+ */
+@Singleton
+class CustomParserRuleBuilder @Inject constructor() {
+
+    enum class TokenTag {
+        AMOUNT,
+        MERCHANT,
+        ACCOUNT,
+        EXPENSE_KEYWORD,
+        INCOME_KEYWORD
+    }
+
+    data class TaggedToken(val tokenIndex: Int, val tag: TokenTag)
+
+    data class BuiltPatterns(
+        val amountRegex: String?,
+        val merchantRegex: String?,
+        val accountRegex: String?,
+        val expenseKeywords: List<String>,
+        val incomeKeywords: List<String>
+    )
+
+    fun tokenize(sms: String): List<String> =
+        sms.split(WHITESPACE).filter { it.isNotEmpty() }
+
+    fun build(sample: String, tags: List<TaggedToken>): BuiltPatterns {
+        val tokens = tokenize(sample)
+        if (tokens.isEmpty()) {
+            return BuiltPatterns(null, null, null, emptyList(), emptyList())
+        }
+
+        val amountTag = tags.firstOrNull { it.tag == TokenTag.AMOUNT }
+        val merchantTag = tags.firstOrNull { it.tag == TokenTag.MERCHANT }
+        val accountTag = tags.firstOrNull { it.tag == TokenTag.ACCOUNT }
+
+        val expenseKeywords = tags
+            .filter { it.tag == TokenTag.EXPENSE_KEYWORD }
+            .mapNotNull { tokens.getOrNull(it.tokenIndex)?.let(::stripTrailingPunct) }
+            .filter { it.isNotEmpty() }
+            .distinct()
+
+        val incomeKeywords = tags
+            .filter { it.tag == TokenTag.INCOME_KEYWORD }
+            .mapNotNull { tokens.getOrNull(it.tokenIndex)?.let(::stripTrailingPunct) }
+            .filter { it.isNotEmpty() }
+            .distinct()
+
+        return BuiltPatterns(
+            amountRegex = amountTag?.let { buildAnchoredPattern(tokens, it.tokenIndex, AMOUNT_VALUE) },
+            merchantRegex = merchantTag?.let { buildAnchoredPattern(tokens, it.tokenIndex, MERCHANT_VALUE) },
+            accountRegex = accountTag?.let { buildAnchoredPattern(tokens, it.tokenIndex, ACCOUNT_VALUE) },
+            expenseKeywords = expenseKeywords,
+            incomeKeywords = incomeKeywords
+        )
+    }
+
+    /**
+     * Produces a sender pattern from the SMS sender. We keep alphabetic prefixes
+     * verbatim and treat numeric runs (likely DLT codes / phone numbers) as
+     * literal — this matches Cashew's behavior of locking sender exactly.
+     */
+    fun buildSenderPattern(sender: String): String = Regex.escape(sender.trim())
+
+    private fun buildAnchoredPattern(
+        tokens: List<String>,
+        targetIndex: Int,
+        valuePattern: String
+    ): String {
+        val anchorBefore = tokens.getOrNull(targetIndex - 1)?.let(::escapeAnchor)
+        val anchorAfter = tokens.getOrNull(targetIndex + 1)?.let(::escapeAnchor)
+
+        return buildString {
+            if (anchorBefore != null) {
+                append(anchorBefore)
+                append("""\s+""")
+            }
+            append("(")
+            append(valuePattern)
+            append(")")
+            if (anchorAfter != null) {
+                append("""\s+""")
+                append(anchorAfter)
+            }
+        }
+    }
+
+    /**
+     * Escape a token for use as a regex anchor. We strip surrounding
+     * punctuation that's likely incidental (".", ",", ":") so that minor
+     * SMS variations don't break the anchor.
+     */
+    private fun escapeAnchor(token: String): String =
+        Regex.escape(stripTrailingPunct(token))
+
+    private fun stripTrailingPunct(token: String): String =
+        token.trim().trim { ch -> ch in ",.;:!?" }
+
+    companion object {
+        private val WHITESPACE = Regex("""\s+""")
+
+        // Numeric value with optional thousand separators and decimals.
+        private const val AMOUNT_VALUE = """[\d,]+(?:\.\d{1,2})?"""
+
+        // Merchant: greedy across letters/digits/space and a few separators,
+        // bounded by the surrounding anchors in the synthesized pattern.
+        private const val MERCHANT_VALUE = """[A-Za-z0-9 ._&'/-]+?"""
+
+        // Account / card last 4: at least 4 digits, possibly preceded by Xs.
+        private const val ACCOUNT_VALUE = """[X\d]{4,20}"""
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/domain/service/CustomParserService.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/service/CustomParserService.kt
@@ -29,12 +29,18 @@ class CustomParserService @Inject constructor(
 
     suspend fun tryParse(sender: String, smsBody: String, timestamp: Long): ParsedTransaction? {
         val rules = repository.getActiveRules()
+        Log.d(TAG, "tryParse sender='$sender' activeRules=${rules.size}")
+        if (rules.isEmpty()) return null
         for (rule in rules) {
             val parsed = runCatching { applyRule(rule, sender, smsBody, timestamp) }
-                .onFailure { Log.w(TAG, "Rule '${rule.name}' threw while parsing: ${it.message}") }
+                .onFailure { Log.w(TAG, "Rule '${rule.name}' (id=${rule.id}) threw while parsing: ${it.message}") }
                 .getOrNull()
-            if (parsed != null) return parsed
+            if (parsed != null) {
+                Log.d(TAG, "Rule '${rule.name}' (id=${rule.id}) matched: amount=${parsed.amount} type=${parsed.type} merchant=${parsed.merchant}")
+                return parsed
+            }
         }
+        Log.d(TAG, "No custom rule matched sender='$sender'")
         return null
     }
 
@@ -44,10 +50,21 @@ class CustomParserService @Inject constructor(
         smsBody: String,
         timestamp: Long
     ): ParsedTransaction? {
-        if (!matchesSender(rule, sender)) return null
+        if (!matchesSender(rule, sender)) {
+            Log.v(TAG, "Rule '${rule.name}' skipped — sender '$sender' doesn't match pattern '${rule.senderPattern}'")
+            return null
+        }
 
-        val amount = extractAmount(rule, smsBody) ?: return null
-        val type = detectType(rule, smsBody) ?: return null
+        val amount = extractAmount(rule, smsBody)
+        if (amount == null) {
+            Log.v(TAG, "Rule '${rule.name}' rejected — amount regex /${rule.amountRegex}/ didn't match")
+            return null
+        }
+        val type = detectType(rule, smsBody)
+        if (type == null) {
+            Log.v(TAG, "Rule '${rule.name}' rejected — no expense/income keyword found in body")
+            return null
+        }
 
         return ParsedTransaction(
             amount = amount,
@@ -129,6 +146,7 @@ class CustomParserService @Inject constructor(
      */
     suspend fun dryRunOnPastSms(rule: CustomParserRuleEntity, sampleLimit: Int = 5): DryRunResult {
         val unrecognized = unrecognizedSmsDao.getAllVisibleSnapshot()
+        Log.d(TAG, "dryRunOnPastSms rule='${rule.name}' (id=${rule.id}) scanning ${unrecognized.size} unrecognised SMS")
         val matches = unrecognized.mapNotNull { sms ->
             val timestamp = sms.receivedAt
                 .atZone(ZoneId.systemDefault())
@@ -139,6 +157,7 @@ class CustomParserService @Inject constructor(
                 .getOrNull()
             parsed?.let { DryRunMatch(sms, it) }
         }
+        Log.d(TAG, "dryRunOnPastSms rule='${rule.name}' matched ${matches.size}/${unrecognized.size}")
         return DryRunResult(
             totalScanned = unrecognized.size,
             totalMatched = matches.size,

--- a/app/src/main/java/com/pennywiseai/tracker/domain/service/CustomParserService.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/service/CustomParserService.kt
@@ -3,9 +3,12 @@ package com.pennywiseai.tracker.domain.service
 import android.util.Log
 import com.pennywiseai.parser.core.ParsedTransaction
 import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.tracker.data.database.dao.UnrecognizedSmsDao
 import com.pennywiseai.tracker.data.database.entity.CustomParserRuleEntity
+import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
 import com.pennywiseai.tracker.data.repository.CustomParserRuleRepository
 import java.math.BigDecimal
+import java.time.ZoneId
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -17,7 +20,8 @@ import javax.inject.Singleton
  */
 @Singleton
 class CustomParserService @Inject constructor(
-    private val repository: CustomParserRuleRepository
+    private val repository: CustomParserRuleRepository,
+    private val unrecognizedSmsDao: UnrecognizedSmsDao
 ) {
     companion object {
         private const val TAG = "CustomParserService"
@@ -117,4 +121,41 @@ class CustomParserService @Inject constructor(
     ) {
         val isComplete: Boolean get() = amount != null && type != null
     }
+
+    /**
+     * Apply a rule to every unrecognised SMS already on disk and return the
+     * matches without persisting anything. Used by the editor's post-save
+     * preview to show the user what would happen before they commit.
+     */
+    suspend fun dryRunOnPastSms(rule: CustomParserRuleEntity, sampleLimit: Int = 5): DryRunResult {
+        val unrecognized = unrecognizedSmsDao.getAllVisibleSnapshot()
+        val matches = unrecognized.mapNotNull { sms ->
+            val timestamp = sms.receivedAt
+                .atZone(ZoneId.systemDefault())
+                .toInstant()
+                .toEpochMilli()
+            val parsed = runCatching { applyRule(rule, sms.sender, sms.smsBody, timestamp) }
+                .onFailure { Log.w(TAG, "Dry-run threw on SMS ${sms.id}: ${it.message}") }
+                .getOrNull()
+            parsed?.let { DryRunMatch(sms, it) }
+        }
+        return DryRunResult(
+            totalScanned = unrecognized.size,
+            totalMatched = matches.size,
+            samples = matches.take(sampleLimit),
+            allMatches = matches
+        )
+    }
+
+    data class DryRunMatch(
+        val sms: UnrecognizedSmsEntity,
+        val parsed: ParsedTransaction
+    )
+
+    data class DryRunResult(
+        val totalScanned: Int,
+        val totalMatched: Int,
+        val samples: List<DryRunMatch>,
+        val allMatches: List<DryRunMatch>
+    )
 }

--- a/app/src/main/java/com/pennywiseai/tracker/domain/service/CustomParserService.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/service/CustomParserService.kt
@@ -1,0 +1,120 @@
+package com.pennywiseai.tracker.domain.service
+
+import android.util.Log
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.tracker.data.database.entity.CustomParserRuleEntity
+import com.pennywiseai.tracker.data.repository.CustomParserRuleRepository
+import java.math.BigDecimal
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Runs user-defined parsing rules as a fallback when no built-in BankParser
+ * claims an SMS sender. Each rule stores regex patterns generated from the
+ * token-tagging UI; this service loads active rules and tries them in priority
+ * order, returning the first successful match.
+ */
+@Singleton
+class CustomParserService @Inject constructor(
+    private val repository: CustomParserRuleRepository
+) {
+    companion object {
+        private const val TAG = "CustomParserService"
+    }
+
+    suspend fun tryParse(sender: String, smsBody: String, timestamp: Long): ParsedTransaction? {
+        val rules = repository.getActiveRules()
+        for (rule in rules) {
+            val parsed = runCatching { applyRule(rule, sender, smsBody, timestamp) }
+                .onFailure { Log.w(TAG, "Rule '${rule.name}' threw while parsing: ${it.message}") }
+                .getOrNull()
+            if (parsed != null) return parsed
+        }
+        return null
+    }
+
+    fun applyRule(
+        rule: CustomParserRuleEntity,
+        sender: String,
+        smsBody: String,
+        timestamp: Long
+    ): ParsedTransaction? {
+        if (!matchesSender(rule, sender)) return null
+
+        val amount = extractAmount(rule, smsBody) ?: return null
+        val type = detectType(rule, smsBody) ?: return null
+
+        return ParsedTransaction(
+            amount = amount,
+            type = type,
+            merchant = extractFirstGroup(rule.merchantRegex, smsBody)?.trim(),
+            reference = null,
+            accountLast4 = extractFirstGroup(rule.accountRegex, smsBody)?.takeLast(4),
+            balance = null,
+            creditLimit = null,
+            smsBody = smsBody,
+            sender = sender,
+            timestamp = timestamp,
+            bankName = rule.bankNameDisplay,
+            isFromCard = false,
+            currency = rule.currency
+        )
+    }
+
+    /**
+     * Convenience for the editor preview: extract values without requiring
+     * the sender to match. Used by the add/edit screen's live preview pane.
+     */
+    fun extractPreview(rule: CustomParserRuleEntity, smsBody: String): PreviewResult {
+        val amount = extractAmount(rule, smsBody)
+        val type = detectType(rule, smsBody)
+        val merchant = extractFirstGroup(rule.merchantRegex, smsBody)?.trim()
+        val account = extractFirstGroup(rule.accountRegex, smsBody)?.takeLast(4)
+        return PreviewResult(amount = amount, type = type, merchant = merchant, accountLast4 = account)
+    }
+
+    private fun matchesSender(rule: CustomParserRuleEntity, sender: String): Boolean {
+        val pattern = rule.senderPattern.trim()
+        if (pattern.isEmpty()) return false
+        val regex = runCatching { Regex(pattern, RegexOption.IGNORE_CASE) }.getOrNull()
+            ?: return sender.contains(pattern, ignoreCase = true)
+        return regex.containsMatchIn(sender)
+    }
+
+    private fun extractAmount(rule: CustomParserRuleEntity, smsBody: String): BigDecimal? {
+        val raw = extractFirstGroup(rule.amountRegex, smsBody) ?: return null
+        // Strip thousand separators; keep decimal point.
+        val cleaned = raw.replace(",", "").trim()
+        return runCatching { BigDecimal(cleaned) }.getOrNull()
+    }
+
+    private fun detectType(rule: CustomParserRuleEntity, smsBody: String): TransactionType? {
+        val lower = smsBody.lowercase()
+        val expense = splitKeywords(rule.expenseKeywords)
+        if (expense.any { lower.contains(it.lowercase()) }) return TransactionType.EXPENSE
+        val income = splitKeywords(rule.incomeKeywords)
+        if (income.any { lower.contains(it.lowercase()) }) return TransactionType.INCOME
+        return null
+    }
+
+    private fun splitKeywords(raw: String): List<String> =
+        raw.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+
+    private fun extractFirstGroup(pattern: String?, text: String): String? {
+        if (pattern.isNullOrBlank()) return null
+        val regex = runCatching { Regex(pattern, RegexOption.IGNORE_CASE) }.getOrNull() ?: return null
+        val match = regex.find(text) ?: return null
+        return match.groupValues.getOrNull(1)?.takeIf { it.isNotBlank() }
+            ?: match.value.takeIf { it.isNotBlank() }
+    }
+
+    data class PreviewResult(
+        val amount: BigDecimal?,
+        val type: TransactionType?,
+        val merchant: String?,
+        val accountLast4: String?
+    ) {
+        val isComplete: Boolean get() = amount != null && type != null
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseDestinations.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseDestinations.kt
@@ -52,6 +52,12 @@ object Rules
 data class CreateRule(val ruleId: String? = null)
 
 @Serializable
+object CustomParsers
+
+@Serializable
+data class CustomParserEdit(val ruleId: Long = -1L)
+
+@Serializable
 object ExchangeRates
 
 @Serializable

--- a/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseNavHost.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseNavHost.kt
@@ -133,7 +133,40 @@ fun PennyWiseNavHost(
                 },
                 onNavigateToTransactionGroups = {
                     navController.navigate(TransactionGroups) { launchSingleTop = true }
+                },
+                onNavigateToCustomParsers = {
+                    navController.navigate(CustomParsers) { launchSingleTop = true }
                 }
+            )
+        }
+
+        composable<CustomParsers>(
+            enterTransition = { fadeIn(tween(300)) + slideInVertically { it / 4 } },
+            exitTransition = { fadeOut(tween(200)) },
+            popEnterTransition = { fadeIn(tween(300)) },
+            popExitTransition = { fadeOut(tween(200)) + slideOutVertically { it / 4 } }
+        ) {
+            com.pennywiseai.tracker.presentation.customparser.CustomParsersScreen(
+                onNavigateBack = { navController.safePopBackStack() },
+                onAdd = {
+                    navController.navigate(CustomParserEdit()) { launchSingleTop = true }
+                },
+                onEdit = { id ->
+                    navController.navigate(CustomParserEdit(id)) { launchSingleTop = true }
+                }
+            )
+        }
+
+        composable<CustomParserEdit>(
+            enterTransition = { fadeIn(tween(300)) + slideInVertically { it / 4 } },
+            exitTransition = { fadeOut(tween(200)) },
+            popEnterTransition = { fadeIn(tween(300)) },
+            popExitTransition = { fadeOut(tween(200)) + slideOutVertically { it / 4 } }
+        ) { backStackEntry ->
+            val args = backStackEntry.toRoute<CustomParserEdit>()
+            com.pennywiseai.tracker.presentation.customparser.CustomParserEditScreen(
+                ruleId = args.ruleId,
+                onNavigateBack = { navController.safePopBackStack() }
             )
         }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserEditScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserEditScreen.kt
@@ -9,18 +9,26 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Inbox
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -49,6 +57,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
 import com.pennywiseai.tracker.domain.service.CustomParserRuleBuilder
 import com.pennywiseai.tracker.ui.components.PennyWiseScaffold
 import com.pennywiseai.tracker.ui.components.cards.PennyWiseCardV2
@@ -64,10 +73,14 @@ fun CustomParserEditScreen(
 ) {
     LaunchedEffect(ruleId) { viewModel.loadForEdit(ruleId) }
     val state by viewModel.editorState.collectAsStateWithLifecycle()
+    val pickerCandidates by viewModel.pickerCandidates.collectAsStateWithLifecycle()
+    val pickerQuery by viewModel.smsPickerQuery.collectAsStateWithLifecycle()
     val scope = rememberCoroutineScope()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val pickerSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     var sheetTokenIndex by remember { mutableStateOf<Int?>(null) }
+    var showPicker by remember { mutableStateOf(false) }
 
     PennyWiseScaffold(
         title = if (ruleId > 0) "Edit Custom Parser" else "New Custom Parser",
@@ -129,14 +142,21 @@ fun CustomParserEditScreen(
                 fontWeight = FontWeight.Medium
             )
             Text(
-                text = "Paste a real SMS from this sender. Tap each highlighted token to label it.",
+                text = "Pick from your inbox or paste a real SMS. Tap each highlighted token to label it.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+            OutlinedButton(
+                onClick = { showPicker = true },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(Icons.Default.Inbox, contentDescription = null)
+                Text("  Pick from your SMS")
+            }
             OutlinedTextField(
                 value = state.sampleSms,
                 onValueChange = viewModel::updateSample,
-                placeholder = { Text("Paste sample SMS here") },
+                placeholder = { Text("…or paste a sample SMS here") },
                 modifier = Modifier
                     .fillMaxWidth()
                     .wrapContentHeight(),
@@ -166,6 +186,29 @@ fun CustomParserEditScreen(
             ) {
                 Icon(Icons.Default.Check, contentDescription = null)
                 Text("  Save", fontWeight = FontWeight.Medium)
+            }
+        }
+
+        if (showPicker) {
+            ModalBottomSheet(
+                onDismissRequest = {
+                    showPicker = false
+                    viewModel.updatePickerQuery("")
+                },
+                sheetState = pickerSheetState
+            ) {
+                SmsPickerSheet(
+                    candidates = pickerCandidates,
+                    query = pickerQuery,
+                    onQueryChange = viewModel::updatePickerQuery,
+                    onPick = { sms ->
+                        viewModel.pickSms(sms)
+                        scope.launch { pickerSheetState.hide() }.invokeOnCompletion {
+                            showPicker = false
+                            viewModel.updatePickerQuery("")
+                        }
+                    }
+                )
             }
         }
 
@@ -432,6 +475,97 @@ private fun TagOption(
                 )
             }
             if (selected) Icon(Icons.Default.Check, contentDescription = null)
+        }
+    }
+}
+
+@Composable
+private fun SmsPickerSheet(
+    candidates: List<UnrecognizedSmsEntity>,
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onPick: (UnrecognizedSmsEntity) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.md)
+            .padding(bottom = Spacing.md),
+        verticalArrangement = Arrangement.spacedBy(Spacing.sm)
+    ) {
+        Text(
+            text = "Pick a sample SMS",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Medium
+        )
+        Text(
+            text = "These are SMS that no built-in parser recognised. Pick one to seed your rule.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        OutlinedTextField(
+            value = query,
+            onValueChange = onQueryChange,
+            placeholder = { Text("Search sender or body") },
+            leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+        if (candidates.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 120.dp)
+                    .padding(vertical = Spacing.lg),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = if (query.isBlank())
+                        "No unrecognised SMS yet. Once an SMS arrives that no built-in parser handles, it'll show up here."
+                    else
+                        "No SMS match \"$query\".",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 480.dp),
+                verticalArrangement = Arrangement.spacedBy(Spacing.xs)
+            ) {
+                items(candidates, key = { it.id }) { sms ->
+                    SmsPickerRow(sms = sms, onClick = { onPick(sms) })
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(Spacing.sm))
+    }
+}
+
+@Composable
+private fun SmsPickerRow(sms: UnrecognizedSmsEntity, onClick: () -> Unit) {
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm)
+        ) {
+            Text(
+                text = sms.sender,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = sms.smsBody,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 3
+            )
         }
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserEditScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserEditScreen.kt
@@ -434,7 +434,7 @@ private fun TagPickerSheet(
         )
 
         TagOption("Amount", "The transaction amount", CustomParserRuleBuilder.TokenTag.AMOUNT, currentTag, onPick)
-        TagOption("Merchant", "Who got paid / who paid you", CustomParserRuleBuilder.TokenTag.MERCHANT, currentTag, onPick)
+        TagOption("Merchant", "Who got paid / who paid you. Tap each word if the name spans multiple tokens.", CustomParserRuleBuilder.TokenTag.MERCHANT, currentTag, onPick)
         TagOption("Account number", "Last 4 digits of account / card", CustomParserRuleBuilder.TokenTag.ACCOUNT, currentTag, onPick)
         TagOption("Expense keyword", "Word that means money went out (e.g. \"debited\")", CustomParserRuleBuilder.TokenTag.EXPENSE_KEYWORD, currentTag, onPick)
         TagOption("Income keyword", "Word that means money came in (e.g. \"credited\")", CustomParserRuleBuilder.TokenTag.INCOME_KEYWORD, currentTag, onPick)

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserEditScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserEditScreen.kt
@@ -1,0 +1,437 @@
+package com.pennywiseai.tracker.presentation.customparser
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.tracker.domain.service.CustomParserRuleBuilder
+import com.pennywiseai.tracker.ui.components.PennyWiseScaffold
+import com.pennywiseai.tracker.ui.components.cards.PennyWiseCardV2
+import com.pennywiseai.tracker.ui.theme.Spacing
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun CustomParserEditScreen(
+    ruleId: Long,
+    onNavigateBack: () -> Unit,
+    viewModel: CustomParserViewModel = hiltViewModel()
+) {
+    LaunchedEffect(ruleId) { viewModel.loadForEdit(ruleId) }
+    val state by viewModel.editorState.collectAsStateWithLifecycle()
+    val scope = rememberCoroutineScope()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    var sheetTokenIndex by remember { mutableStateOf<Int?>(null) }
+
+    PennyWiseScaffold(
+        title = if (ruleId > 0) "Edit Custom Parser" else "New Custom Parser",
+        navigationIcon = {
+            IconButton(onClick = onNavigateBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = Spacing.md, vertical = Spacing.md),
+            verticalArrangement = Arrangement.spacedBy(Spacing.md)
+        ) {
+            OutlinedTextField(
+                value = state.name,
+                onValueChange = viewModel::updateName,
+                label = { Text("Rule name") },
+                placeholder = { Text("e.g. My credit union") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            OutlinedTextField(
+                value = state.senderPattern,
+                onValueChange = viewModel::updateSenderPattern,
+                label = { Text("SMS sender (or pattern)") },
+                placeholder = { Text("e.g. AD-MYBANK or 8775905546") },
+                singleLine = true,
+                supportingText = { Text("Substring or regex matched against the sender.") },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                OutlinedTextField(
+                    value = state.bankNameDisplay,
+                    onValueChange = viewModel::updateBankName,
+                    label = { Text("Display name") },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f)
+                )
+                OutlinedTextField(
+                    value = state.currency,
+                    onValueChange = viewModel::updateCurrency,
+                    label = { Text("Currency") },
+                    singleLine = true,
+                    modifier = Modifier.weight(0.6f)
+                )
+            }
+
+            HorizontalDivider()
+
+            Text(
+                text = "Sample SMS",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = "Paste a real SMS from this sender. Tap each highlighted token to label it.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            OutlinedTextField(
+                value = state.sampleSms,
+                onValueChange = viewModel::updateSample,
+                placeholder = { Text("Paste sample SMS here") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight(),
+                minLines = 3,
+                maxLines = 6
+            )
+
+            if (state.sampleSms.isNotBlank()) {
+                TokenGrid(
+                    sample = state.sampleSms,
+                    tags = state.tags,
+                    onTokenTap = { tokenIndex -> sheetTokenIndex = tokenIndex }
+                )
+                LegendRow()
+            }
+
+            HorizontalDivider()
+
+            PreviewPanel(state = state)
+
+            Button(
+                onClick = {
+                    viewModel.save { onNavigateBack() }
+                },
+                enabled = state.isValid,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(Icons.Default.Check, contentDescription = null)
+                Text("  Save", fontWeight = FontWeight.Medium)
+            }
+        }
+
+        val tokenIndex = sheetTokenIndex
+        if (tokenIndex != null) {
+            val tokens = remember(state.sampleSms) {
+                state.sampleSms.split(Regex("""\s+""")).filter { it.isNotEmpty() }
+            }
+            val token = tokens.getOrNull(tokenIndex) ?: ""
+            val currentTag = state.tags.firstOrNull { it.tokenIndex == tokenIndex }?.tag
+
+            ModalBottomSheet(
+                onDismissRequest = { sheetTokenIndex = null },
+                sheetState = sheetState
+            ) {
+                TagPickerSheet(
+                    token = token,
+                    currentTag = currentTag,
+                    onPick = { newTag ->
+                        viewModel.setTag(tokenIndex, newTag)
+                        scope.launch { sheetState.hide() }.invokeOnCompletion {
+                            sheetTokenIndex = null
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun TokenGrid(
+    sample: String,
+    tags: List<CustomParserRuleBuilder.TaggedToken>,
+    onTokenTap: (Int) -> Unit
+) {
+    val tokens = remember(sample) {
+        sample.split(Regex("""\s+""")).filter { it.isNotEmpty() }
+    }
+    val tagByIndex = tags.associateBy { it.tokenIndex }
+
+    FlowRow(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs)
+    ) {
+        tokens.forEachIndexed { index, token ->
+            TokenChip(
+                text = token,
+                tag = tagByIndex[index]?.tag,
+                onClick = { onTokenTap(index) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun TokenChip(
+    text: String,
+    tag: CustomParserRuleBuilder.TokenTag?,
+    onClick: () -> Unit
+) {
+    val (bg, fg) = tagColors(tag)
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(8.dp),
+        color = bg,
+        contentColor = fg
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(horizontal = Spacing.sm, vertical = 6.dp)
+        )
+    }
+}
+
+@Composable
+private fun tagColors(tag: CustomParserRuleBuilder.TokenTag?): Pair<Color, Color> {
+    return when (tag) {
+        CustomParserRuleBuilder.TokenTag.AMOUNT ->
+            MaterialTheme.colorScheme.primary to MaterialTheme.colorScheme.onPrimary
+        CustomParserRuleBuilder.TokenTag.MERCHANT ->
+            MaterialTheme.colorScheme.tertiary to MaterialTheme.colorScheme.onTertiary
+        CustomParserRuleBuilder.TokenTag.ACCOUNT ->
+            MaterialTheme.colorScheme.secondary to MaterialTheme.colorScheme.onSecondary
+        CustomParserRuleBuilder.TokenTag.EXPENSE_KEYWORD ->
+            MaterialTheme.colorScheme.errorContainer to MaterialTheme.colorScheme.onErrorContainer
+        CustomParserRuleBuilder.TokenTag.INCOME_KEYWORD ->
+            MaterialTheme.colorScheme.primaryContainer to MaterialTheme.colorScheme.onPrimaryContainer
+        null ->
+            MaterialTheme.colorScheme.surfaceVariant to MaterialTheme.colorScheme.onSurfaceVariant
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun LegendRow() {
+    val items = listOf(
+        CustomParserRuleBuilder.TokenTag.AMOUNT to "Amount",
+        CustomParserRuleBuilder.TokenTag.MERCHANT to "Merchant",
+        CustomParserRuleBuilder.TokenTag.ACCOUNT to "Account",
+        CustomParserRuleBuilder.TokenTag.EXPENSE_KEYWORD to "Expense word",
+        CustomParserRuleBuilder.TokenTag.INCOME_KEYWORD to "Income word"
+    )
+    FlowRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = Spacing.xs),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs)
+    ) {
+        items.forEach { (tag, label) ->
+            val (bg, _) = tagColors(tag)
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    modifier = Modifier
+                        .size(10.dp)
+                        .clip(RoundedCornerShape(2.dp))
+                        .background(bg)
+                )
+                Text(
+                    text = "  $label",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreviewPanel(state: CustomParserViewModel.EditorState) {
+    PennyWiseCardV2(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "Live preview",
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Medium
+        )
+        if (state.sampleSms.isBlank()) {
+            Text(
+                text = "Paste a sample SMS and tag tokens to see what gets extracted.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = Spacing.xs)
+            )
+            return@PennyWiseCardV2
+        }
+        Column(modifier = Modifier.padding(top = Spacing.xs)) {
+            PreviewRow("Amount", state.preview.amount?.toPlainString() ?: "—")
+            PreviewRow("Type", state.preview.type?.toDisplay() ?: "—")
+            PreviewRow("Merchant", state.preview.merchant ?: "—")
+            PreviewRow("Account", state.preview.accountLast4 ?: "—")
+        }
+    }
+}
+
+private fun TransactionType.toDisplay(): String = when (this) {
+    TransactionType.INCOME -> "Income"
+    TransactionType.EXPENSE -> "Expense"
+    TransactionType.TRANSFER -> "Transfer"
+    TransactionType.INVESTMENT -> "Investment"
+    TransactionType.CREDIT -> "Credit (card)"
+    TransactionType.BALANCE_UPDATE -> "Balance update"
+}
+
+@Composable
+private fun PreviewRow(label: String, value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp)
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(0.4f)
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(0.6f)
+        )
+    }
+}
+
+@Composable
+private fun TagPickerSheet(
+    token: String,
+    currentTag: CustomParserRuleBuilder.TokenTag?,
+    onPick: (CustomParserRuleBuilder.TokenTag?) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.md, vertical = Spacing.md),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs)
+    ) {
+        Text(
+            text = "What is \"$token\"?",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Medium
+        )
+        Text(
+            text = "PennyWise will use the surrounding tokens as anchors to find this in future SMS.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = Spacing.sm)
+        )
+
+        TagOption("Amount", "The transaction amount", CustomParserRuleBuilder.TokenTag.AMOUNT, currentTag, onPick)
+        TagOption("Merchant", "Who got paid / who paid you", CustomParserRuleBuilder.TokenTag.MERCHANT, currentTag, onPick)
+        TagOption("Account number", "Last 4 digits of account / card", CustomParserRuleBuilder.TokenTag.ACCOUNT, currentTag, onPick)
+        TagOption("Expense keyword", "Word that means money went out (e.g. \"debited\")", CustomParserRuleBuilder.TokenTag.EXPENSE_KEYWORD, currentTag, onPick)
+        TagOption("Income keyword", "Word that means money came in (e.g. \"credited\")", CustomParserRuleBuilder.TokenTag.INCOME_KEYWORD, currentTag, onPick)
+
+        TextButton(
+            onClick = { onPick(null) },
+            colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.onSurfaceVariant),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = Spacing.sm)
+        ) {
+            Text(if (currentTag == null) "Skip" else "Clear tag")
+        }
+    }
+}
+
+@Composable
+private fun TagOption(
+    title: String,
+    description: String,
+    tag: CustomParserRuleBuilder.TokenTag,
+    currentTag: CustomParserRuleBuilder.TokenTag?,
+    onPick: (CustomParserRuleBuilder.TokenTag) -> Unit
+) {
+    val selected = currentTag == tag
+    val (bg, fg) = tagColors(tag)
+    Surface(
+        onClick = { onPick(tag) },
+        shape = RoundedCornerShape(12.dp),
+        color = if (selected) bg else MaterialTheme.colorScheme.surfaceContainerLow,
+        contentColor = if (selected) fg else MaterialTheme.colorScheme.onSurface,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(12.dp)
+                    .clip(RoundedCornerShape(2.dp))
+                    .background(bg)
+            )
+            Column(modifier = Modifier.padding(start = Spacing.sm).weight(1f)) {
+                Text(text = title, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Medium)
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (selected) fg else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            if (selected) Icon(Icons.Default.Check, contentDescription = null)
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserEditScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserEditScreen.kt
@@ -27,9 +27,11 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Inbox
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -75,6 +77,7 @@ fun CustomParserEditScreen(
     val state by viewModel.editorState.collectAsStateWithLifecycle()
     val pickerCandidates by viewModel.pickerCandidates.collectAsStateWithLifecycle()
     val pickerQuery by viewModel.smsPickerQuery.collectAsStateWithLifecycle()
+    val backfillState by viewModel.backfillState.collectAsStateWithLifecycle()
     val scope = rememberCoroutineScope()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val pickerSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -181,13 +184,22 @@ fun CustomParserEditScreen(
                 onClick = {
                     viewModel.save { onNavigateBack() }
                 },
-                enabled = state.isValid,
+                enabled = state.isValid && backfillState == CustomParserViewModel.BackfillState.Idle,
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Icon(Icons.Default.Check, contentDescription = null)
                 Text("  Save", fontWeight = FontWeight.Medium)
             }
         }
+
+        BackfillDialog(
+            state = backfillState,
+            onDismiss = {
+                viewModel.dismissBackfill()
+                onNavigateBack()
+            },
+            onApply = { viewModel.applyBackfill() }
+        )
 
         if (showPicker) {
             ModalBottomSheet(
@@ -475,6 +487,146 @@ private fun TagOption(
                 )
             }
             if (selected) Icon(Icons.Default.Check, contentDescription = null)
+        }
+    }
+}
+
+@Composable
+private fun BackfillDialog(
+    state: CustomParserViewModel.BackfillState,
+    onDismiss: () -> Unit,
+    onApply: () -> Unit
+) {
+    if (state == CustomParserViewModel.BackfillState.Idle) return
+
+    val title = when (state) {
+        CustomParserViewModel.BackfillState.DryRunning -> "Scanning past SMS…"
+        is CustomParserViewModel.BackfillState.Preview -> "Apply to past SMS?"
+        is CustomParserViewModel.BackfillState.Applying -> "Applying…"
+        is CustomParserViewModel.BackfillState.Done -> "Done"
+        CustomParserViewModel.BackfillState.Idle -> ""
+    }
+
+    AlertDialog(
+        onDismissRequest = {
+            // Don't let user dismiss while we're working.
+            if (state is CustomParserViewModel.BackfillState.Preview ||
+                state is CustomParserViewModel.BackfillState.Done) {
+                onDismiss()
+            }
+        },
+        title = { Text(title) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                when (state) {
+                    CustomParserViewModel.BackfillState.DryRunning -> {
+                        LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                        Text(
+                            "Checking which past SMS this rule would parse.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    is CustomParserViewModel.BackfillState.Preview -> {
+                        Text(
+                            text = "Scanned ${state.dryRun.totalScanned} unrecognised SMS:",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            text = "${state.dryRun.totalMatched} would be parsed as transactions",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                            fontWeight = FontWeight.Medium
+                        )
+                        if (state.dryRun.samples.isNotEmpty()) {
+                            HorizontalDivider(modifier = Modifier.padding(vertical = Spacing.xs))
+                            Text(
+                                text = "Sample:",
+                                style = MaterialTheme.typography.labelMedium,
+                                fontWeight = FontWeight.Medium
+                            )
+                            state.dryRun.samples.forEach { sample ->
+                                BackfillSampleRow(sample)
+                            }
+                            if (state.dryRun.totalMatched > state.dryRun.samples.size) {
+                                Text(
+                                    text = "…and ${state.dryRun.totalMatched - state.dryRun.samples.size} more.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                    is CustomParserViewModel.BackfillState.Applying -> {
+                        LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                        Text(
+                            "Saving ${state.processed} of ${state.dryRun.totalMatched}…",
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                    is CustomParserViewModel.BackfillState.Done -> {
+                        Text(
+                            text = "Parsed ${state.saved} past SMS as transactions.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                            fontWeight = FontWeight.Medium
+                        )
+                        Text(
+                            text = "You can review them in the Transactions screen.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    CustomParserViewModel.BackfillState.Idle -> {}
+                }
+            }
+        },
+        confirmButton = {
+            when (state) {
+                is CustomParserViewModel.BackfillState.Preview -> {
+                    TextButton(onClick = onApply) { Text("Apply") }
+                }
+                is CustomParserViewModel.BackfillState.Done -> {
+                    TextButton(onClick = onDismiss) { Text("Close") }
+                }
+                else -> {}
+            }
+        },
+        dismissButton = {
+            if (state is CustomParserViewModel.BackfillState.Preview) {
+                TextButton(
+                    onClick = onDismiss,
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                ) { Text("Skip") }
+            }
+        }
+    )
+}
+
+@Composable
+private fun BackfillSampleRow(sample: com.pennywiseai.tracker.domain.service.CustomParserService.DryRunMatch) {
+    Surface(
+        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(horizontal = Spacing.sm, vertical = 6.dp)) {
+            Text(
+                text = sample.sms.sender,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Medium
+            )
+            val parsed = sample.parsed
+            Text(
+                text = "${parsed.type.name.lowercase().replaceFirstChar { it.uppercase() }} · ${parsed.currency} ${parsed.amount.toPlainString()}" +
+                    (parsed.merchant?.let { " · $it" } ?: ""),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2
+            )
         }
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.data.database.dao.UnrecognizedSmsDao
 import com.pennywiseai.tracker.data.database.entity.CustomParserRuleEntity
 import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
+import com.pennywiseai.tracker.data.manager.SmsTransactionProcessor
 import com.pennywiseai.tracker.data.repository.CustomParserRuleRepository
 import com.pennywiseai.tracker.domain.service.CustomParserRuleBuilder
 import com.pennywiseai.tracker.domain.service.CustomParserService
@@ -23,7 +24,8 @@ class CustomParserViewModel @Inject constructor(
     private val repository: CustomParserRuleRepository,
     private val builder: CustomParserRuleBuilder,
     private val parserService: CustomParserService,
-    private val unrecognizedSmsDao: UnrecognizedSmsDao
+    private val unrecognizedSmsDao: UnrecognizedSmsDao,
+    private val smsTransactionProcessor: SmsTransactionProcessor
 ) : ViewModel() {
 
     val rules: StateFlow<List<CustomParserRuleEntity>> = repository.getAllRules()
@@ -55,6 +57,9 @@ class CustomParserViewModel @Inject constructor(
     fun updatePickerQuery(value: String) {
         _smsPickerQuery.value = value
     }
+
+    private val _backfillState = MutableStateFlow<BackfillState>(BackfillState.Idle)
+    val backfillState: StateFlow<BackfillState> = _backfillState.asStateFlow()
 
     fun pickSms(sms: UnrecognizedSmsEntity) {
         // Filling both sender and sample at once keeps the editor in a consistent
@@ -162,8 +167,53 @@ class CustomParserViewModel @Inject constructor(
             } else {
                 repository.insertRule(entity)
             }
-            onDone(saved)
+            // Trigger a dry-run against past unrecognised SMS so the editor can
+            // show the user what would be parsed before they commit. Skip when
+            // editing — those SMS would already be in the table only if they
+            // failed under the older version of the rule, but the UX scope is
+            // "post-create preview".
+            _backfillState.value = BackfillState.DryRunning
+            val rule = repository.getRuleById(saved) ?: run {
+                _backfillState.value = BackfillState.Idle
+                onDone(saved); return@launch
+            }
+            val dryRun = parserService.dryRunOnPastSms(rule)
+            _backfillState.value = if (dryRun.totalMatched == 0) {
+                BackfillState.Idle
+            } else {
+                BackfillState.Preview(rule, dryRun)
+            }
+            if (dryRun.totalMatched == 0) onDone(saved)
         }
+    }
+
+    fun applyBackfill() {
+        val current = _backfillState.value as? BackfillState.Preview ?: return
+        val matches = current.dryRun.allMatches
+        viewModelScope.launch {
+            _backfillState.value = BackfillState.Applying(current.rule, current.dryRun, processed = 0)
+            var saved = 0
+            for ((index, match) in matches.withIndex()) {
+                val timestamp = match.parsed.timestamp
+                val result = smsTransactionProcessor.processAndSaveTransaction(
+                    sender = match.sms.sender,
+                    body = match.sms.smsBody,
+                    timestamp = timestamp
+                )
+                if (result.success) {
+                    saved++
+                    unrecognizedSmsDao.softDeleteById(match.sms.id)
+                }
+                _backfillState.value = BackfillState.Applying(
+                    current.rule, current.dryRun, processed = index + 1
+                )
+            }
+            _backfillState.value = BackfillState.Done(saved = saved, scanned = current.dryRun.totalScanned)
+        }
+    }
+
+    fun dismissBackfill() {
+        _backfillState.value = BackfillState.Idle
     }
 
     fun setActive(id: Long, isActive: Boolean) {
@@ -210,6 +260,21 @@ class CustomParserViewModel @Inject constructor(
             incomeKeywords = patterns.incomeKeywords,
             preview = preview
         )
+    }
+
+    sealed class BackfillState {
+        object Idle : BackfillState()
+        object DryRunning : BackfillState()
+        data class Preview(
+            val rule: CustomParserRuleEntity,
+            val dryRun: CustomParserService.DryRunResult
+        ) : BackfillState()
+        data class Applying(
+            val rule: CustomParserRuleEntity,
+            val dryRun: CustomParserService.DryRunResult,
+            val processed: Int
+        ) : BackfillState()
+        data class Done(val saved: Int, val scanned: Int) : BackfillState()
     }
 
     data class EditorState(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserViewModel.kt
@@ -1,0 +1,203 @@
+package com.pennywiseai.tracker.presentation.customparser
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.pennywiseai.tracker.data.database.entity.CustomParserRuleEntity
+import com.pennywiseai.tracker.data.repository.CustomParserRuleRepository
+import com.pennywiseai.tracker.domain.service.CustomParserRuleBuilder
+import com.pennywiseai.tracker.domain.service.CustomParserService
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class CustomParserViewModel @Inject constructor(
+    private val repository: CustomParserRuleRepository,
+    private val builder: CustomParserRuleBuilder,
+    private val parserService: CustomParserService
+) : ViewModel() {
+
+    val rules: StateFlow<List<CustomParserRuleEntity>> = repository.getAllRules()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = emptyList()
+        )
+
+    private val _editorState = MutableStateFlow(EditorState())
+    val editorState: StateFlow<EditorState> = _editorState.asStateFlow()
+
+    fun loadForEdit(ruleId: Long) {
+        if (ruleId <= 0) {
+            _editorState.value = EditorState()
+            return
+        }
+        viewModelScope.launch {
+            val existing = repository.getRuleById(ruleId) ?: return@launch
+            _editorState.value = EditorState(
+                editingId = existing.id,
+                name = existing.name,
+                senderPattern = existing.senderPattern,
+                sampleSms = existing.sampleSms,
+                bankNameDisplay = existing.bankNameDisplay,
+                currency = existing.currency,
+                tags = emptyList(),
+                amountRegex = existing.amountRegex,
+                merchantRegex = existing.merchantRegex,
+                accountRegex = existing.accountRegex,
+                expenseKeywords = existing.expenseKeywords.split(",")
+                    .map { it.trim() }.filter { it.isNotEmpty() },
+                incomeKeywords = existing.incomeKeywords.split(",")
+                    .map { it.trim() }.filter { it.isNotEmpty() }
+            )
+        }
+    }
+
+    fun updateName(name: String) {
+        _editorState.value = _editorState.value.copy(name = name)
+    }
+
+    fun updateSenderPattern(value: String) {
+        _editorState.value = _editorState.value.copy(senderPattern = value)
+    }
+
+    fun updateBankName(value: String) {
+        _editorState.value = _editorState.value.copy(bankNameDisplay = value)
+    }
+
+    fun updateCurrency(value: String) {
+        _editorState.value = _editorState.value.copy(currency = value)
+    }
+
+    fun updateSample(sample: String) {
+        // Resetting tags when the sample changes — token indices would otherwise
+        // refer to a different tokenization.
+        _editorState.value = _editorState.value.copy(
+            sampleSms = sample,
+            tags = emptyList()
+        ).recompute()
+    }
+
+    fun setTag(tokenIndex: Int, tag: CustomParserRuleBuilder.TokenTag?) {
+        val state = _editorState.value
+        // Each field tag (Amount/Merchant/Account) can only point to one token.
+        // Multiple keyword tokens are allowed.
+        val cleaned = state.tags.filterNot { it.tokenIndex == tokenIndex }
+        val isUnique = tag == CustomParserRuleBuilder.TokenTag.AMOUNT ||
+            tag == CustomParserRuleBuilder.TokenTag.MERCHANT ||
+            tag == CustomParserRuleBuilder.TokenTag.ACCOUNT
+        val deduped = if (isUnique) cleaned.filterNot { it.tag == tag } else cleaned
+
+        val updated = if (tag == null) deduped else
+            deduped + CustomParserRuleBuilder.TaggedToken(tokenIndex, tag)
+
+        _editorState.value = state.copy(tags = updated).recompute()
+    }
+
+    fun save(onDone: (Long) -> Unit) {
+        val state = _editorState.value
+        if (!state.isValid) return
+        viewModelScope.launch {
+            val now = java.time.LocalDateTime.now()
+            val entity = CustomParserRuleEntity(
+                id = state.editingId ?: 0,
+                name = state.name.trim(),
+                senderPattern = state.senderPattern.trim(),
+                sampleSms = state.sampleSms,
+                amountRegex = state.amountRegex ?: "",
+                merchantRegex = state.merchantRegex,
+                accountRegex = state.accountRegex,
+                expenseKeywords = state.expenseKeywords.joinToString(","),
+                incomeKeywords = state.incomeKeywords.joinToString(","),
+                currency = state.currency.trim().ifEmpty { "INR" },
+                bankNameDisplay = state.bankNameDisplay.trim(),
+                priority = 100,
+                isActive = true,
+                createdAt = now,
+                updatedAt = now
+            )
+            val saved = if (state.editingId != null) {
+                repository.updateRule(entity)
+                state.editingId
+            } else {
+                repository.insertRule(entity)
+            }
+            onDone(saved)
+        }
+    }
+
+    fun setActive(id: Long, isActive: Boolean) {
+        viewModelScope.launch { repository.setActive(id, isActive) }
+    }
+
+    fun delete(id: Long) {
+        viewModelScope.launch { repository.deleteRuleById(id) }
+    }
+
+    private fun EditorState.recompute(): EditorState {
+        if (sampleSms.isBlank()) {
+            return copy(
+                amountRegex = null,
+                merchantRegex = null,
+                accountRegex = null,
+                expenseKeywords = emptyList(),
+                incomeKeywords = emptyList(),
+                preview = CustomParserService.PreviewResult(null, null, null, null)
+            )
+        }
+        val patterns = builder.build(sampleSms, tags)
+        val tentative = CustomParserRuleEntity(
+            id = editingId ?: 0,
+            name = name,
+            senderPattern = senderPattern,
+            sampleSms = sampleSms,
+            amountRegex = patterns.amountRegex ?: "",
+            merchantRegex = patterns.merchantRegex,
+            accountRegex = patterns.accountRegex,
+            expenseKeywords = patterns.expenseKeywords.joinToString(","),
+            incomeKeywords = patterns.incomeKeywords.joinToString(","),
+            currency = currency,
+            bankNameDisplay = bankNameDisplay,
+            priority = 100,
+            isActive = true
+        )
+        val preview = parserService.extractPreview(tentative, sampleSms)
+        return copy(
+            amountRegex = patterns.amountRegex,
+            merchantRegex = patterns.merchantRegex,
+            accountRegex = patterns.accountRegex,
+            expenseKeywords = patterns.expenseKeywords,
+            incomeKeywords = patterns.incomeKeywords,
+            preview = preview
+        )
+    }
+
+    data class EditorState(
+        val editingId: Long? = null,
+        val name: String = "",
+        val senderPattern: String = "",
+        val sampleSms: String = "",
+        val bankNameDisplay: String = "",
+        val currency: String = "INR",
+        val tags: List<CustomParserRuleBuilder.TaggedToken> = emptyList(),
+        val amountRegex: String? = null,
+        val merchantRegex: String? = null,
+        val accountRegex: String? = null,
+        val expenseKeywords: List<String> = emptyList(),
+        val incomeKeywords: List<String> = emptyList(),
+        val preview: CustomParserService.PreviewResult =
+            CustomParserService.PreviewResult(null, null, null, null)
+    ) {
+        val isValid: Boolean get() =
+            name.isNotBlank() &&
+            senderPattern.isNotBlank() &&
+            bankNameDisplay.isNotBlank() &&
+            !amountRegex.isNullOrBlank() &&
+            (expenseKeywords.isNotEmpty() || incomeKeywords.isNotEmpty())
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserViewModel.kt
@@ -1,5 +1,6 @@
 package com.pennywiseai.tracker.presentation.customparser
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.data.database.dao.UnrecognizedSmsDao
@@ -30,6 +31,10 @@ class CustomParserViewModel @Inject constructor(
     private val unrecognizedSmsDao: UnrecognizedSmsDao,
     private val smsTransactionProcessor: SmsTransactionProcessor
 ) : ViewModel() {
+
+    companion object {
+        private const val TAG = "CustomParserVM"
+    }
 
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -180,6 +185,7 @@ class CustomParserViewModel @Inject constructor(
             } else {
                 repository.insertRule(entity)
             }
+            Log.d(TAG, "Saved custom rule id=$saved name='${entity.name}' senderPattern='${entity.senderPattern}' amountRegex='${entity.amountRegex}' merchantRegex='${entity.merchantRegex}'")
             // Trigger a dry-run against past unrecognised SMS so the editor can
             // show the user what would be parsed before they commit. Skip when
             // editing — those SMS would already be in the table only if they
@@ -204,6 +210,7 @@ class CustomParserViewModel @Inject constructor(
         val current = _backfillState.value as? BackfillState.Preview ?: return
         val matches = current.dryRun.allMatches
         viewModelScope.launch {
+            Log.d(TAG, "applyBackfill rule='${current.rule.name}' (id=${current.rule.id}) matches=${matches.size}")
             _backfillState.value = BackfillState.Applying(current.rule, current.dryRun, processed = 0)
             var saved = 0
             for ((index, match) in matches.withIndex()) {
@@ -216,11 +223,14 @@ class CustomParserViewModel @Inject constructor(
                 if (result.success) {
                     saved++
                     unrecognizedSmsDao.softDeleteById(match.sms.id)
+                } else {
+                    Log.w(TAG, "Backfill skipped SMS id=${match.sms.id} sender='${match.sms.sender}' reason=${result.reason}")
                 }
                 _backfillState.value = BackfillState.Applying(
                     current.rule, current.dryRun, processed = index + 1
                 )
             }
+            Log.d(TAG, "applyBackfill done saved=$saved/${matches.size}")
             _backfillState.value = BackfillState.Done(saved = saved, scanned = current.dryRun.totalScanned)
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserViewModel.kt
@@ -17,6 +17,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
 @HiltViewModel
@@ -27,6 +30,8 @@ class CustomParserViewModel @Inject constructor(
     private val unrecognizedSmsDao: UnrecognizedSmsDao,
     private val smsTransactionProcessor: SmsTransactionProcessor
 ) : ViewModel() {
+
+    private val json = Json { ignoreUnknownKeys = true }
 
     val rules: StateFlow<List<CustomParserRuleEntity>> = repository.getAllRules()
         .stateIn(
@@ -79,6 +84,12 @@ class CustomParserViewModel @Inject constructor(
         }
         viewModelScope.launch {
             val existing = repository.getRuleById(ruleId) ?: return@launch
+            val savedTags: List<CustomParserRuleBuilder.TaggedToken> = existing.tagsJson
+                ?.let { raw ->
+                    runCatching { json.decodeFromString<List<CustomParserRuleBuilder.TaggedToken>>(raw) }
+                        .getOrNull()
+                }
+                .orEmpty()
             _editorState.value = EditorState(
                 editingId = existing.id,
                 name = existing.name,
@@ -86,7 +97,7 @@ class CustomParserViewModel @Inject constructor(
                 sampleSms = existing.sampleSms,
                 bankNameDisplay = existing.bankNameDisplay,
                 currency = existing.currency,
-                tags = emptyList(),
+                tags = savedTags,
                 amountRegex = existing.amountRegex,
                 merchantRegex = existing.merchantRegex,
                 accountRegex = existing.accountRegex,
@@ -94,7 +105,7 @@ class CustomParserViewModel @Inject constructor(
                     .map { it.trim() }.filter { it.isNotEmpty() },
                 incomeKeywords = existing.incomeKeywords.split(",")
                     .map { it.trim() }.filter { it.isNotEmpty() }
-            )
+            ).recompute()
         }
     }
 
@@ -125,13 +136,13 @@ class CustomParserViewModel @Inject constructor(
 
     fun setTag(tokenIndex: Int, tag: CustomParserRuleBuilder.TokenTag?) {
         val state = _editorState.value
-        // Each field tag (Amount/Merchant/Account) can only point to one token.
-        // Multiple keyword tokens are allowed.
         val cleaned = state.tags.filterNot { it.tokenIndex == tokenIndex }
-        val isUnique = tag == CustomParserRuleBuilder.TokenTag.AMOUNT ||
-            tag == CustomParserRuleBuilder.TokenTag.MERCHANT ||
+        // AMOUNT and ACCOUNT are inherently single-token; only one token can
+        // carry that tag at a time. MERCHANT can span multiple tokens (e.g.
+        // "AMAZON INDIA"), so we don't dedupe it. Keywords can repeat freely.
+        val isSingleton = tag == CustomParserRuleBuilder.TokenTag.AMOUNT ||
             tag == CustomParserRuleBuilder.TokenTag.ACCOUNT
-        val deduped = if (isUnique) cleaned.filterNot { it.tag == tag } else cleaned
+        val deduped = if (isSingleton) cleaned.filterNot { it.tag == tag } else cleaned
 
         val updated = if (tag == null) deduped else
             deduped + CustomParserRuleBuilder.TaggedToken(tokenIndex, tag)
@@ -156,6 +167,8 @@ class CustomParserViewModel @Inject constructor(
                 incomeKeywords = state.incomeKeywords.joinToString(","),
                 currency = state.currency.trim().ifEmpty { "INR" },
                 bankNameDisplay = state.bankNameDisplay.trim(),
+                tagsJson = if (state.tags.isEmpty()) null
+                    else json.encodeToString(state.tags),
                 priority = 100,
                 isActive = true,
                 createdAt = now,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParserViewModel.kt
@@ -2,7 +2,9 @@ package com.pennywiseai.tracker.presentation.customparser
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.pennywiseai.tracker.data.database.dao.UnrecognizedSmsDao
 import com.pennywiseai.tracker.data.database.entity.CustomParserRuleEntity
+import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
 import com.pennywiseai.tracker.data.repository.CustomParserRuleRepository
 import com.pennywiseai.tracker.domain.service.CustomParserRuleBuilder
 import com.pennywiseai.tracker.domain.service.CustomParserService
@@ -11,6 +13,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -19,7 +22,8 @@ import javax.inject.Inject
 class CustomParserViewModel @Inject constructor(
     private val repository: CustomParserRuleRepository,
     private val builder: CustomParserRuleBuilder,
-    private val parserService: CustomParserService
+    private val parserService: CustomParserService,
+    private val unrecognizedSmsDao: UnrecognizedSmsDao
 ) : ViewModel() {
 
     val rules: StateFlow<List<CustomParserRuleEntity>> = repository.getAllRules()
@@ -31,6 +35,37 @@ class CustomParserViewModel @Inject constructor(
 
     private val _editorState = MutableStateFlow(EditorState())
     val editorState: StateFlow<EditorState> = _editorState.asStateFlow()
+
+    private val _smsPickerQuery = MutableStateFlow("")
+    val smsPickerQuery: StateFlow<String> = _smsPickerQuery.asStateFlow()
+
+    val pickerCandidates: StateFlow<List<UnrecognizedSmsEntity>> =
+        combine(unrecognizedSmsDao.getAllVisible(), _smsPickerQuery) { all, query ->
+            if (query.isBlank()) all
+            else all.filter { sms ->
+                sms.sender.contains(query, ignoreCase = true) ||
+                    sms.smsBody.contains(query, ignoreCase = true)
+            }
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = emptyList()
+        )
+
+    fun updatePickerQuery(value: String) {
+        _smsPickerQuery.value = value
+    }
+
+    fun pickSms(sms: UnrecognizedSmsEntity) {
+        // Filling both sender and sample at once keeps the editor in a consistent
+        // state — picking is essentially "use this SMS as the seed".
+        val state = _editorState.value
+        _editorState.value = state.copy(
+            sampleSms = sms.smsBody,
+            senderPattern = sms.sender,
+            tags = emptyList()
+        ).recompute()
+    }
 
     fun loadForEdit(ruleId: Long) {
         if (ruleId <= 0) {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParsersScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParsersScreen.kt
@@ -88,12 +88,19 @@ fun CustomParsersScreen(
                 verticalArrangement = Arrangement.spacedBy(Spacing.sm)
             ) {
                 item {
-                    Text(
-                        text = "Custom parsers run only when no built-in bank parser matches the sender. Built-in parsers always take priority.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(bottom = Spacing.sm)
-                    )
+                    Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+                        Text(
+                            text = "Custom parsers run only when no built-in bank parser matches the sender. Built-in parsers always take priority.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            text = "Need to fix a wrong merchant or category on SMS that PennyWise already detects? Use Smart Rules instead.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(bottom = Spacing.sm)
+                        )
+                    }
                 }
                 items(rules, key = { it.id }) { rule ->
                     CustomParserRow(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParsersScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/customparser/CustomParsersScreen.kt
@@ -1,0 +1,228 @@
+package com.pennywiseai.tracker.presentation.customparser
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.pennywiseai.tracker.data.database.entity.CustomParserRuleEntity
+import com.pennywiseai.tracker.ui.components.PennyWiseScaffold
+import com.pennywiseai.tracker.ui.components.cards.PennyWiseCardV2
+import com.pennywiseai.tracker.ui.theme.Spacing
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CustomParsersScreen(
+    onNavigateBack: () -> Unit,
+    onAdd: () -> Unit,
+    onEdit: (Long) -> Unit,
+    viewModel: CustomParserViewModel = hiltViewModel()
+) {
+    val rules by viewModel.rules.collectAsStateWithLifecycle()
+
+    PennyWiseScaffold(
+        title = "Custom Parsers",
+        navigationIcon = {
+            IconButton(onClick = onNavigateBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = onAdd) {
+                Icon(Icons.Default.Add, contentDescription = "Add custom parser")
+            }
+        }
+    ) { padding ->
+        if (rules.isEmpty()) {
+            EmptyState(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(horizontal = Spacing.lg),
+                onAdd = onAdd
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentPadding = PaddingValues(
+                    horizontal = Spacing.md,
+                    vertical = Spacing.md
+                ),
+                verticalArrangement = Arrangement.spacedBy(Spacing.sm)
+            ) {
+                item {
+                    Text(
+                        text = "Custom parsers run only when no built-in bank parser matches the sender. Built-in parsers always take priority.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(bottom = Spacing.sm)
+                    )
+                }
+                items(rules, key = { it.id }) { rule ->
+                    CustomParserRow(
+                        rule = rule,
+                        onClick = { onEdit(rule.id) },
+                        onToggle = { viewModel.setActive(rule.id, it) },
+                        onDelete = { viewModel.delete(rule.id) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CustomParserRow(
+    rule: CustomParserRuleEntity,
+    onClick: () -> Unit,
+    onToggle: (Boolean) -> Unit,
+    onDelete: () -> Unit
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+    var confirmDelete by remember { mutableStateOf(false) }
+
+    PennyWiseCardV2(
+        modifier = Modifier.fillMaxWidth(),
+        onClick = onClick
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm)
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = rule.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    text = "${rule.bankNameDisplay} · ${rule.currency}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = "Sender: ${rule.senderPattern}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Switch(checked = rule.isActive, onCheckedChange = onToggle)
+            Box {
+                IconButton(onClick = { menuOpen = true }) {
+                    Icon(Icons.Default.MoreVert, contentDescription = "More")
+                }
+                DropdownMenu(
+                    expanded = menuOpen,
+                    onDismissRequest = { menuOpen = false }
+                ) {
+                    DropdownMenuItem(
+                        text = { Text("Edit") },
+                        leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
+                        onClick = {
+                            menuOpen = false
+                            onClick()
+                        }
+                    )
+                    DropdownMenuItem(
+                        text = { Text("Delete") },
+                        leadingIcon = {
+                            Icon(
+                                Icons.Default.Delete,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.error
+                            )
+                        },
+                        onClick = {
+                            menuOpen = false
+                            confirmDelete = true
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    if (confirmDelete) {
+        AlertDialog(
+            onDismissRequest = { confirmDelete = false },
+            title = { Text("Delete custom parser?") },
+            text = { Text("\"${rule.name}\" will be removed. SMS from this sender will no longer be parsed.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        confirmDelete = false
+                        onDelete()
+                    },
+                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
+                ) { Text("Delete") }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmDelete = false }) { Text("Cancel") }
+            }
+        )
+    }
+}
+
+@Composable
+private fun EmptyState(modifier: Modifier = Modifier, onAdd: () -> Unit) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "No custom parsers yet",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Medium,
+            textAlign = TextAlign.Center
+        )
+        Text(
+            text = "Teach PennyWise to read SMS from senders we don't support out of the box.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = Spacing.sm, bottom = Spacing.md)
+        )
+        TextButton(onClick = onAdd) {
+            Icon(Icons.Default.Add, contentDescription = null)
+            Text(" Add custom parser", modifier = Modifier.padding(start = Spacing.xs))
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
@@ -410,6 +410,11 @@ fun MainScreen(
                         rootNavController?.navigate(
                             com.pennywiseai.tracker.navigation.TransactionGroups
                         ) { launchSingleTop = true }
+                    },
+                    onNavigateToCustomParsers = {
+                        rootNavController?.navigate(
+                            com.pennywiseai.tracker.navigation.CustomParsers
+                        ) { launchSingleTop = true }
                     }
                 )
             }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -81,6 +81,7 @@ fun SettingsScreen(
     onNavigateToManageAccounts: () -> Unit = {},
     onNavigateToFaq: () -> Unit = {},
     onNavigateToRules: () -> Unit = {},
+    onNavigateToCustomParsers: () -> Unit = {},
     onNavigateToBudgets: () -> Unit = {},
     onNavigateToLoans: () -> Unit = {},
     onNavigateToTransactionGroups: () -> Unit = {},
@@ -316,6 +317,15 @@ fun SettingsScreen(
                     title = "Smart Rules",
                     subtitle = "Automatic transaction categorization",
                     onClick = onNavigateToRules,
+                    position = ItemPosition.MIDDLE
+                )
+                SettingsNavItem(
+                    icon = Icons.Default.Code,
+                    iconBgColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    iconTint = MaterialTheme.colorScheme.onTertiaryContainer,
+                    title = "Custom Parsers",
+                    subtitle = "Teach PennyWise to read SMS from new senders",
+                    onClick = onNavigateToCustomParsers,
                     position = ItemPosition.MIDDLE
                 )
                 SettingsNavItem(


### PR DESCRIPTION
## Summary

Closes #279.

Lets users teach PennyWise to read SMS from senders that no built-in bank parser supports — without having to hand-write regex.

**How it works**

- **Settings → Custom Parsers** lists user-defined rules with toggle / edit / delete.
- The **add / edit** screen takes a sample SMS, tokenizes it on whitespace into tappable chips, and pops a sheet when you tap one: *Amount / Merchant / Account # / Expense keyword / Income keyword / Skip*.
- Behind the scenes the editor takes the 1 token before and 1 token after the tagged token as anchors and synthesizes a regex for that field. A live preview shows what the rule would extract from the sample as you tag.
- Built-in `BankParserFactory` parsers still run first — custom rules only fire as a fallback when no built-in parser claims the sender. Existing bank support is unaffected.
- Schema bumped 46 → 47 with a manual migration that creates `custom_parser_rules`. No changes to existing tables.

**Out of scope (deliberately) for this PR**

- Multi-sample-SMS training — one sample per rule.
- Currency auto-detect — user picks (default INR).
- Balance / mandate / subscription extraction.

## Test plan

- [ ] Settings → Custom Parsers opens.
- [ ] Empty state shows "Add custom parser" CTA.
- [ ] FAB opens new-rule editor.
- [ ] Pasting a sample SMS renders chips.
- [ ] Tapping a chip opens the bottom sheet; selecting a tag colors the chip and updates the live preview.
- [ ] Save is disabled until name + sender + display name + amount tag + at least one expense/income keyword are present.
- [ ] After saving, the rule appears in the list.
- [ ] Toggling active off / on persists across screen rotation.
- [ ] An SMS from a sender that **does** match a built-in bank parser still routes to that built-in (custom never shadows real banks).
- [ ] An SMS from a sender that **does not** match any built-in parser, but matches a custom rule's sender pattern, gets parsed using the rule's regex.
- [ ] Edit existing rule loads name / sender / display / currency back into the editor (note: tag chips do not re-hydrate from a saved rule — only the regex does).
- [ ] Delete confirmation dialog removes the rule.