### PR TITLE
fix: parse Kotak short-SMS UPI format and KOTAKD sender

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KotakBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KotakBankParser.kt
@@ -17,8 +17,8 @@ class KotakBankParser : BankParser() {
     override fun canHandle(sender: String): Boolean {
         val normalizedSender = sender.uppercase()
 
-        // DLT patterns for Kotak Bank
-        return normalizedSender.matches(Regex("^[A-Z]{2}-KOTAKB-[ST]$"))
+        // DLT patterns for Kotak Bank — covers KOTAKB, KOTAKD, and similar variants
+        return normalizedSender.matches(Regex("^[A-Z]{2}-KOTAK[A-Z]-[ST]$"))
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
@@ -202,9 +202,9 @@ class KotakBankParser : BankParser() {
         }
 
         return when {
-            // Kotak specific: "Sent Rs.X from Kotak Bank" - money going OUT (EXPENSE)
-            // This indicates the user sent money from their Kotak account to someone else
-            lowerMessage.contains("sent") && lowerMessage.contains("from kotak") -> TransactionType.EXPENSE
+            // Kotak specific: "Sent Rs.X from ..." - money going OUT (EXPENSE)
+            // Covers both "Sent Rs.X from Kotak Bank AC..." and "Sent Rs.X from XXXXXX1234 to..."
+            lowerMessage.contains("sent") -> TransactionType.EXPENSE
 
             // Standard expense keywords
             lowerMessage.contains("debited") -> TransactionType.EXPENSE
@@ -226,10 +226,16 @@ class KotakBankParser : BankParser() {
     }
 
     override fun extractReference(message: String): String? {
-        // Kotak specific UPI reference pattern
-        val upiRefPattern = Regex("UPI\\s+Ref\\s+([0-9]+)", RegexOption.IGNORE_CASE)
-        upiRefPattern.find(message)?.let { match ->
-            return match.groupValues[1].trim()
+        // Kotak specific UPI reference patterns
+        val upiRefPatterns = listOf(
+            Regex("""UPI\s+Ref\s+([0-9]+)""", RegexOption.IGNORE_CASE),
+            // New short-SMS format: "UPI ref no. 648604626824"
+            Regex("""UPI\s+ref\s+no\.?\s+([0-9]+)""", RegexOption.IGNORE_CASE)
+        )
+        for (pattern in upiRefPatterns) {
+            pattern.find(message)?.let { match ->
+                return match.groupValues[1].trim()
+            }
         }
 
         // Fall back to generic extraction
@@ -251,6 +257,15 @@ class KotakBankParser : BankParser() {
         val kotakAccountPattern =
             Regex("AC\\s+[X*]*([0-9]{4})(?:\\s|,|\\.)", RegexOption.IGNORE_CASE)
         kotakAccountPattern.find(message)?.let { match ->
+            return match.groupValues[1]
+        }
+
+        // Short-SMS format: "Sent Rs.X from XXXXXX9722 to ..."
+        val kotakMaskedAccountPattern = Regex(
+            """from\s+[xX*]{2,}(\d{4})\b""",
+            RegexOption.IGNORE_CASE
+        )
+        kotakMaskedAccountPattern.find(message)?.let { match ->
             return match.groupValues[1]
         }
 

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KotakBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KotakBankParser.kt
@@ -202,9 +202,11 @@ class KotakBankParser : BankParser() {
         }
 
         return when {
-            // Kotak specific: "Sent Rs.X from ..." - money going OUT (EXPENSE)
-            // Covers both "Sent Rs.X from Kotak Bank AC..." and "Sent Rs.X from XXXXXX1234 to..."
-            lowerMessage.contains("sent") -> TransactionType.EXPENSE
+            // Kotak specific: "Sent Rs.X ..." - money going OUT (EXPENSE)
+            // Anchored on "sent rs" so unrelated uses of the word "sent" (e.g. a
+            // refund/cashback notification reading "...has been sent to your A/c...")
+            // don't get misclassified as expense before the INCOME branches run.
+            lowerMessage.contains("sent rs") -> TransactionType.EXPENSE
 
             // Standard expense keywords
             lowerMessage.contains("debited") -> TransactionType.EXPENSE

--- a/parser-core/src/test/kotlin/TestKotakBankParser.kt
+++ b/parser-core/src/test/kotlin/TestKotakBankParser.kt
@@ -135,6 +135,21 @@ class KotakBankParserTest {
                     reference = "648724676562",
                     accountLast4 = "9722"
                 )
+            ),
+            // Negative case: a credit/refund-style message that contains the word
+            // "sent" (e.g. "...has been sent to your A/c...") must still be parsed
+            // as INCOME — the parser should anchor on "sent rs", not bare "sent".
+            ParserTestCase(
+                name = "Credit message containing the word 'sent' stays INCOME",
+                message = "Cashback of Rs.50.00 has been sent to your Kotak Bank A/c x5555. Credited on 14-10-25. UPI Ref 9999999999",
+                sender = "JD-KOTAKB-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("50.00"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    reference = "9999999999",
+                    accountLast4 = "5555"
+                )
             )
         )
 

--- a/parser-core/src/test/kotlin/TestKotakBankParser.kt
+++ b/parser-core/src/test/kotlin/TestKotakBankParser.kt
@@ -109,12 +109,39 @@ class KotakBankParserTest {
                     isFromCard = true,
                     creditLimit = BigDecimal("73733.02")
                 )
+            ),
+            ParserTestCase(
+                name = "Short-SMS UPI to person (KOTAKD sender)",
+                message = "Sent Rs.51.00 from XXXXXX9722 to DINESHBHAI RAMJIBHAI on 30/04/2026. UPI ref no. 648604626824. Not you? Tap https://kotk.in/KOTAKD/Eg9Cu0 to report -Kotak",
+                sender = "VM-KOTAKD-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("51.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "DINESHBHAI RAMJIBHAI",
+                    reference = "648604626824",
+                    accountLast4 = "9722"
+                )
+            ),
+            ParserTestCase(
+                name = "Short-SMS UPI smaller amount",
+                message = "Sent Rs.10.00 from XXXXXX9722 to Makavana Mahipatbhai on 01/05/2026. UPI ref no. 648724676562. Not you? Tap https://kotk.in/KOTAKD/EhkUKk to report -Kotak",
+                sender = "VM-KOTAKD-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("10.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Makavana Mahipatbhai",
+                    reference = "648724676562",
+                    accountLast4 = "9722"
+                )
             )
         )
 
         val handleChecks = listOf(
             "JD-KOTAKB-S" to true,
             "JD-KOTAKB-T" to true,
+            "VM-KOTAKD-S" to true,
             "VM-KOTAKB" to false,
             "UNKNOWN" to false
         )


### PR DESCRIPTION
## Summary
- Widened `KotakBankParser.canHandle` regex from `KOTAKB` → `KOTAK[A-Z]` so SMS from `KOTAKD` DLT senders (e.g. `VM-KOTAKD-S`) are recognised.
- Handled the short-SMS format `Sent Rs.X from XXXXXX1234 to <Name> on DD/MM/YYYY. UPI ref no. <ref>`: added masked-account pattern (`from XXXXXX1234`) and `UPI ref no.` reference pattern (existing regex broke on the period after `no`).
- Simplified the "sent" → EXPENSE rule; it no longer requires the literal `from Kotak` substring since the new format doesn't include it.

Fixes #297.

## Test plan
- [x] `./gradlew :parser-core:jvmTest --tests "KotakBankParserTest"` — 9 parse cases + 5 handle-checks, all pass (including 2 new cases for the short-SMS format and the `VM-KOTAKD-S` sender).
- [ ] Spot-check on a build that pre-existing KOTAKB UPI / credit-card / IMPS messages still parse correctly (covered by existing test cases).