### PR TITLE
fix: apply Refund / Extra Budget on Budgets screen in unified-currency mode

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.data.currency.CurrencyConversionService
 import com.pennywiseai.tracker.data.database.entity.BudgetGroupType
+import com.pennywiseai.tracker.data.database.entity.BudgetImpactType
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.repository.BudgetCategorySpending
@@ -134,6 +135,29 @@ class BudgetGroupsViewModel @Inject constructor(
             }
         }
 
+        // Apply INCOME transactions tagged with a budget impact, mirroring
+        // BudgetGroupRepository.buildSummary. Refunds (DEDUCT_SPENT) shrink the
+        // category's spent total; Extra Budget (ADD_TO_LIMIT) raises the category's
+        // effective budget below.
+        val categoryLimitBoosts = mutableMapOf<String, BigDecimal>()
+        raw.allTransactions.forEach { txWithSplits ->
+            val tx = txWithSplits.transaction
+            if (tx.transactionType == TransactionType.INCOME && tx.budgetCategory != null) {
+                val converted = currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                when (tx.budgetImpactType) {
+                    BudgetImpactType.DEDUCT_SPENT -> {
+                        val current = categoryAmounts[tx.budgetCategory] ?: BigDecimal.ZERO
+                        categoryAmounts[tx.budgetCategory] = (current - converted).coerceAtLeast(BigDecimal.ZERO)
+                    }
+                    BudgetImpactType.ADD_TO_LIMIT -> {
+                        categoryLimitBoosts[tx.budgetCategory] =
+                            (categoryLimitBoosts[tx.budgetCategory] ?: BigDecimal.ZERO) + converted
+                    }
+                    null -> {}
+                }
+            }
+        }
+
         // Pre-compute converted category amounts per transaction for pace chart
         val yearMonth = _selectedYearMonth.value
         val daysInMonth = yearMonth.lengthOfMonth()
@@ -184,15 +208,16 @@ class BudgetGroupsViewModel @Inject constructor(
             val catSpending = group.categories.map { cat ->
                 val actual = categoryAmounts[cat.categoryName] ?: BigDecimal.ZERO
                 val convertedBudget = currencyConversionService.convertAmount(cat.budgetAmount, baseCurrency, displayCurrency)
-                val pctUsed = if (convertedBudget > BigDecimal.ZERO) {
-                    (actual.toFloat() / convertedBudget.toFloat() * 100f).coerceAtLeast(0f)
+                val effectiveBudget = convertedBudget + (categoryLimitBoosts[cat.categoryName] ?: BigDecimal.ZERO)
+                val pctUsed = if (effectiveBudget > BigDecimal.ZERO) {
+                    (actual.toFloat() / effectiveBudget.toFloat() * 100f).coerceAtLeast(0f)
                 } else 0f
                 val dailySpend = if (raw.daysElapsed > 0 && actual > BigDecimal.ZERO) {
                     actual.divide(BigDecimal(raw.daysElapsed), 0, RoundingMode.HALF_UP)
                 } else BigDecimal.ZERO
                 BudgetCategorySpending(
                     categoryName = cat.categoryName,
-                    budgetAmount = convertedBudget,
+                    budgetAmount = effectiveBudget,
                     actualAmount = actual,
                     percentageUsed = pctUsed,
                     dailySpend = dailySpend


### PR DESCRIPTION
## Summary
- The unified-currency Budgets path (`BudgetGroupsViewModel.convertRawToSummary`) was missing the budget-impact reducer that lives in `BudgetGroupRepository.buildSummary` (single-currency path). INCOME transactions tagged with **Refund** (`DEDUCT_SPENT`) had no effect on the linked category's spent total, and **Extra budget** (`ADD_TO_LIMIT`) never raised the displayed budget.
- This commit mirrors the same loop: walk `INCOME` transactions with `budgetCategory != null`, convert each amount to the display currency, then either subtract it from `categoryAmounts` (floored at zero) or accumulate it into a `categoryLimitBoosts` map that is added to the rendered budget.

Fixes #312.

## Test plan
- [x] `./gradlew :app:compileStandardDebugKotlin` — builds clean.
- [ ] Manual on-device check, unified-currency mode ON:
  - [ ] Spend in a category, then mark an INCOME transaction as **Refund → that category**; verify the category's spent amount drops by the refund (floored at 0) and "Spent / Budget" updates accordingly.
  - [ ] Mark an INCOME transaction as **Extra budget → that category**; verify the category's budget limit raises by that amount.
  - [ ] Regression: single-currency mode still works the same.
  - [ ] Regression: INCOME with no budget impact, or impact pointing at a non-existent category, doesn't affect any totals.

## Notes
- This PR is intentionally scoped to the budget-impact reducer. The unified path still includes TRANSFER/INVESTMENT in `categoryAmounts` whereas the single-currency path excludes them — pre-existing inconsistency, not addressed here.
- Issue #308 is a related-but-separate gap on the home screen "Spent this month" stat and will be its own PR.