### PR TITLE
fix: share budget-impact reducer across single- and unified-currency Budgets

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
@@ -11,7 +11,9 @@ import com.pennywiseai.tracker.data.database.entity.BudgetMonthSnapshotEntity
 import com.pennywiseai.tracker.data.database.entity.BudgetPeriodType
 import com.pennywiseai.tracker.data.database.entity.BudgetWithCategories
 import com.pennywiseai.tracker.data.database.entity.BudgetImpactType
+import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
+import com.pennywiseai.tracker.data.database.entity.TransactionWithSplits
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -316,9 +318,9 @@ class BudgetGroupRepository @Inject constructor(
         }
     }
 
-    fun buildSummary(
+    suspend fun buildSummary(
         groups: List<BudgetWithCategories>,
-        allTransactions: List<com.pennywiseai.tracker.data.database.entity.TransactionWithSplits>,
+        allTransactions: List<TransactionWithSplits>,
         daysElapsed: Int,
         daysRemaining: Int,
         currency: String,
@@ -331,36 +333,14 @@ class BudgetGroupRepository @Inject constructor(
             acc + tx.transaction.amount
         }
 
-        // Build category → amount map from all transactions (not just expenses)
-        val categoryAmounts = mutableMapOf<String, BigDecimal>()
-        allTransactions.forEach { txWithSplits ->
-            if (txWithSplits.transaction.transactionType != TransactionType.INCOME &&
-                txWithSplits.transaction.transactionType != TransactionType.TRANSFER &&
-                txWithSplits.transaction.transactionType != TransactionType.INVESTMENT) {
-                txWithSplits.getAmountByCategory().forEach { (category, amount) ->
-                    val categoryName = category.ifEmpty { "Others" }
-                    categoryAmounts[categoryName] = (categoryAmounts[categoryName] ?: BigDecimal.ZERO) + amount
-                }
-            }
-        }
-
-        // Apply income transactions that are linked to budget categories
-        val categoryLimitBoosts = mutableMapOf<String, BigDecimal>()
-        allTransactions.forEach { txWithSplits ->
-            val tx = txWithSplits.transaction
-            if (tx.transactionType == TransactionType.INCOME && tx.budgetCategory != null) {
-                when (tx.budgetImpactType) {
-                    BudgetImpactType.DEDUCT_SPENT -> {
-                        val current = categoryAmounts[tx.budgetCategory] ?: BigDecimal.ZERO
-                        categoryAmounts[tx.budgetCategory] = (current - tx.amount).coerceAtLeast(BigDecimal.ZERO)
-                    }
-                    BudgetImpactType.ADD_TO_LIMIT -> {
-                        categoryLimitBoosts[tx.budgetCategory] = (categoryLimitBoosts[tx.budgetCategory] ?: BigDecimal.ZERO) + tx.amount
-                    }
-                    null -> {}
-                }
-            }
-        }
+        // Single-currency: amounts are already in the requested currency, so the
+        // converter lambdas are identities. The unified-currency caller in
+        // BudgetGroupsViewModel injects real conversion via the same helper.
+        val (categoryAmounts, categoryLimitBoosts) = aggregateBudgetCategorySpending(
+            transactions = allTransactions,
+            convertSplit = { _, amount -> amount },
+            convertIncome = { tx -> tx.amount }
+        )
 
         // Calculate total expenses for groups with no categories (track all expenses)
         val totalAllExpenses = categoryAmounts.values.fold(BigDecimal.ZERO) { acc, amount -> acc + amount }
@@ -603,6 +583,75 @@ class BudgetGroupRepository @Inject constructor(
             val below = groups[index + 1]
             budgetDao.updateBudget(current.copy(displayOrder = below.displayOrder, updatedAt = LocalDateTime.now()))
             budgetDao.updateBudget(below.copy(displayOrder = current.displayOrder, updatedAt = LocalDateTime.now()))
+        }
+    }
+
+    companion object {
+        /**
+         * Per-category spend after applying any INCOME-side budget impacts,
+         * plus the per-category budget bumps contributed by Extra-budget income.
+         */
+        data class CategoryAggregation(
+            val categoryAmounts: Map<String, BigDecimal>,
+            val categoryLimitBoosts: Map<String, BigDecimal>
+        )
+
+        /**
+         * Single source of truth for the per-category aggregation used on the
+         * Budgets screen. Walks `transactions` and:
+         *  - sums non-INCOME / non-TRANSFER / non-INVESTMENT split amounts into
+         *    `categoryAmounts` (key=category name, "Others" when blank);
+         *  - for INCOME txns with a `budgetCategory`, subtracts DEDUCT_SPENT
+         *    (Refund) amounts from `categoryAmounts` (floored at zero) and
+         *    accumulates ADD_TO_LIMIT (Extra budget) amounts into
+         *    `categoryLimitBoosts`.
+         *
+         * `convertSplit` and `convertIncome` let callers project amounts into a
+         * display currency. Same-currency callers pass identity lambdas; the
+         * unified-currency call site supplies `CurrencyConversionService`-backed
+         * suspending converters.
+         */
+        suspend fun aggregateBudgetCategorySpending(
+            transactions: List<TransactionWithSplits>,
+            convertSplit: suspend (fromCurrency: String, amount: BigDecimal) -> BigDecimal,
+            convertIncome: suspend (TransactionEntity) -> BigDecimal
+        ): CategoryAggregation {
+            val categoryAmounts = mutableMapOf<String, BigDecimal>()
+            for (txWithSplits in transactions) {
+                val type = txWithSplits.transaction.transactionType
+                if (type == TransactionType.INCOME ||
+                    type == TransactionType.TRANSFER ||
+                    type == TransactionType.INVESTMENT
+                ) continue
+                val fromCurrency = txWithSplits.transaction.currency
+                for ((category, amount) in txWithSplits.getAmountByCategory()) {
+                    val categoryName = category.ifEmpty { "Others" }
+                    val converted = convertSplit(fromCurrency, amount)
+                    categoryAmounts[categoryName] =
+                        (categoryAmounts[categoryName] ?: BigDecimal.ZERO) + converted
+                }
+            }
+
+            val categoryLimitBoosts = mutableMapOf<String, BigDecimal>()
+            for (txWithSplits in transactions) {
+                val tx = txWithSplits.transaction
+                if (tx.transactionType != TransactionType.INCOME) continue
+                val category = tx.budgetCategory ?: continue
+                val impact = tx.budgetImpactType ?: continue
+                val amount = convertIncome(tx)
+                when (impact) {
+                    BudgetImpactType.DEDUCT_SPENT -> {
+                        val current = categoryAmounts[category] ?: BigDecimal.ZERO
+                        categoryAmounts[category] = (current - amount).coerceAtLeast(BigDecimal.ZERO)
+                    }
+                    BudgetImpactType.ADD_TO_LIMIT -> {
+                        categoryLimitBoosts[category] =
+                            (categoryLimitBoosts[category] ?: BigDecimal.ZERO) + amount
+                    }
+                }
+            }
+
+            return CategoryAggregation(categoryAmounts, categoryLimitBoosts)
         }
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
@@ -374,10 +374,24 @@ class BudgetGroupRepository @Inject constructor(
                     }
                 }
             }
+            // Subtract Refund (DEDUCT_SPENT) income on the day it occurred so the
+            // cumulative endpoint tracks the same "actual" figure shown on the row.
+            allTransactions.forEach { txWithSplits ->
+                val tx = txWithSplits.transaction
+                if (tx.transactionType != TransactionType.INCOME) return@forEach
+                if (tx.budgetImpactType != BudgetImpactType.DEDUCT_SPENT) return@forEach
+                val category = tx.budgetCategory ?: return@forEach
+                if (categoryNames != null && category !in categoryNames) return@forEach
+                val day = tx.dateTime.dayOfMonth.coerceIn(1, daysInMonth)
+                dailyAmounts[day - 1] -= tx.amount.toDouble()
+            }
             val cumulative = mutableListOf<Double>()
             var running = 0.0
             for (i in 0 until effectiveDays) {
-                running += dailyAmounts[i]
+                // Clamp at zero to mirror the per-category floor in
+                // aggregateBudgetCategorySpending; a refund larger than spend-to-date
+                // visually pulls the line back to zero rather than going negative.
+                running = (running + dailyAmounts[i]).coerceAtLeast(0.0)
                 cumulative.add(running)
             }
             val pace = if (groupBudget > BigDecimal.ZERO) {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.data.currency.CurrencyConversionService
 import com.pennywiseai.tracker.data.database.entity.BudgetGroupType
+import com.pennywiseai.tracker.data.database.entity.BudgetImpactType
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository.Companion.aggregateBudgetCategorySpending
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
@@ -144,9 +145,9 @@ class BudgetGroupsViewModel @Inject constructor(
         data class ConvertedTxDay(val day: Int, val categoryAmounts: Map<String, Double>)
         val convertedTxDays = raw.allTransactions.mapNotNull { txWithSplits ->
             val tx = txWithSplits.transaction
-            if (tx.transactionType == com.pennywiseai.tracker.data.database.entity.TransactionType.INCOME ||
-                tx.transactionType == com.pennywiseai.tracker.data.database.entity.TransactionType.TRANSFER ||
-                tx.transactionType == com.pennywiseai.tracker.data.database.entity.TransactionType.INVESTMENT ||
+            if (tx.transactionType == TransactionType.INCOME ||
+                tx.transactionType == TransactionType.TRANSFER ||
+                tx.transactionType == TransactionType.INVESTMENT ||
                 tx.loanId != null
             ) return@mapNotNull null
             val day = tx.dateTime.dayOfMonth.coerceIn(1, daysInMonth)
@@ -154,6 +155,19 @@ class BudgetGroupsViewModel @Inject constructor(
                 currencyConversionService.convertAmount(amount, tx.currency, displayCurrency).toDouble()
             }.mapKeys { (cat, _) -> cat.ifEmpty { "Others" } }
             ConvertedTxDay(day, catAmounts)
+        }
+
+        // Pre-convert Refund (DEDUCT_SPENT) income amounts on the day they occurred
+        // so the pace chart subtracts them in lockstep with the displayed "actual".
+        data class ConvertedRefundDay(val day: Int, val category: String, val amount: Double)
+        val convertedRefundDays = raw.allTransactions.mapNotNull { txWithSplits ->
+            val tx = txWithSplits.transaction
+            if (tx.transactionType != TransactionType.INCOME) return@mapNotNull null
+            if (tx.budgetImpactType != BudgetImpactType.DEDUCT_SPENT) return@mapNotNull null
+            val category = tx.budgetCategory ?: return@mapNotNull null
+            val day = tx.dateTime.dayOfMonth.coerceIn(1, daysInMonth)
+            val amount = currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency).toDouble()
+            ConvertedRefundDay(day, category, amount)
         }
 
         fun buildGroupPaceUnified(
@@ -171,9 +185,19 @@ class BudgetGroupsViewModel @Inject constructor(
                     }
                 }
             }
+            convertedRefundDays.forEach { refundDay ->
+                if (categoryNames == null || refundDay.category in categoryNames) {
+                    dailyAmounts[refundDay.day - 1] -= refundDay.amount
+                }
+            }
             val cumulative = mutableListOf<Double>()
             var running = 0.0
-            for (i in 0 until effectiveDays) { running += dailyAmounts[i]; cumulative.add(running) }
+            for (i in 0 until effectiveDays) {
+                // Clamp at zero to mirror the per-category floor in
+                // aggregateBudgetCategorySpending.
+                running = (running + dailyAmounts[i]).coerceAtLeast(0.0)
+                cumulative.add(running)
+            }
             val pace = if (groupBudget > BigDecimal.ZERO) {
                 val dp = groupBudget.toDouble() / daysInMonth
                 (1..effectiveDays).map { it * dp }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.data.currency.CurrencyConversionService
 import com.pennywiseai.tracker.data.database.entity.BudgetGroupType
 import com.pennywiseai.tracker.data.database.entity.TransactionType
+import com.pennywiseai.tracker.data.repository.BudgetGroupRepository.Companion.aggregateBudgetCategorySpending
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.repository.BudgetCategorySpending
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository
@@ -121,18 +122,19 @@ class BudgetGroupsViewModel @Inject constructor(
             )
         }
 
-        // Build category amounts from all non-income transactions, converting currencies
-        val categoryAmounts = mutableMapOf<String, BigDecimal>()
-        raw.allTransactions.forEach { txWithSplits ->
-            if (txWithSplits.transaction.transactionType != TransactionType.INCOME) {
-                val fromCurrency = txWithSplits.transaction.currency
-                txWithSplits.getAmountByCategory().forEach { (category, amount) ->
-                    val converted = currencyConversionService.convertAmount(amount, fromCurrency, displayCurrency)
-                    val categoryName = category.ifEmpty { "Others" }
-                    categoryAmounts[categoryName] = (categoryAmounts[categoryName] ?: BigDecimal.ZERO) + converted
-                }
+        // Unified-currency: route through the same aggregator used by the
+        // single-currency path so Refund (DEDUCT_SPENT) and Extra budget
+        // (ADD_TO_LIMIT) take effect here too. The converters project each
+        // amount into the display currency before aggregation.
+        val (categoryAmounts, categoryLimitBoosts) = aggregateBudgetCategorySpending(
+            transactions = raw.allTransactions,
+            convertSplit = { fromCurrency, amount ->
+                currencyConversionService.convertAmount(amount, fromCurrency, displayCurrency)
+            },
+            convertIncome = { tx ->
+                currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
             }
-        }
+        )
 
         // Pre-compute converted category amounts per transaction for pace chart
         val yearMonth = _selectedYearMonth.value
@@ -184,15 +186,16 @@ class BudgetGroupsViewModel @Inject constructor(
             val catSpending = group.categories.map { cat ->
                 val actual = categoryAmounts[cat.categoryName] ?: BigDecimal.ZERO
                 val convertedBudget = currencyConversionService.convertAmount(cat.budgetAmount, baseCurrency, displayCurrency)
-                val pctUsed = if (convertedBudget > BigDecimal.ZERO) {
-                    (actual.toFloat() / convertedBudget.toFloat() * 100f).coerceAtLeast(0f)
+                val effectiveBudget = convertedBudget + (categoryLimitBoosts[cat.categoryName] ?: BigDecimal.ZERO)
+                val pctUsed = if (effectiveBudget > BigDecimal.ZERO) {
+                    (actual.toFloat() / effectiveBudget.toFloat() * 100f).coerceAtLeast(0f)
                 } else 0f
                 val dailySpend = if (raw.daysElapsed > 0 && actual > BigDecimal.ZERO) {
                     actual.divide(BigDecimal(raw.daysElapsed), 0, RoundingMode.HALF_UP)
                 } else BigDecimal.ZERO
                 BudgetCategorySpending(
                     categoryName = cat.categoryName,
-                    budgetAmount = convertedBudget,
+                    budgetAmount = effectiveBudget,
                     actualAmount = actual,
                     percentageUsed = pctUsed,
                     dailySpend = dailySpend


### PR DESCRIPTION
## Summary
- #312 was caused by the unified-currency Budgets path (`BudgetGroupsViewModel.convertRawToSummary`) drifting from the single-currency path (`BudgetGroupRepository.buildSummary`): the unified path never applied INCOME-side budget impacts, so **Refund** (`DEDUCT_SPENT`) did not reduce a category's spent total and **Extra budget** (`ADD_TO_LIMIT`) did not raise its displayed budget.
- Rather than mirror the loop again, this PR extracts the aggregation into one shared `suspend` helper — `BudgetGroupRepository.aggregateBudgetCategorySpending` — and routes both call sites through it.
  - **Single-currency** path passes identity converter lambdas.
  - **Unified-currency** path supplies `CurrencyConversionService`-backed converters so each amount is projected into the display currency before aggregation.
- Side effect: the unified path now also excludes `TRANSFER` and `INVESTMENT` transactions from `categoryAmounts`, matching the single-currency behaviour (pre-existing inconsistency in the unified path).
- Follow-up commit fixes the cumulative-spending pace chart: both `buildGroupPace` (single-currency) and `buildGroupPaceUnified` (unified) now subtract converted Refund amounts on the day they occurred, with the running cumulative clamped at zero so the chart endpoint matches the per-category "actual" floor.

Fixes #312.

## Why a shared helper, not a mirror
The original bug existed precisely because the same reducer was implemented in two places and drifted. Mirroring it preserves that risk; centralising it removes it. The helper is a `suspend` function (since the unified converter is `suspend`), and `buildSummary` becomes `suspend` — both existing call sites are already inside `combine { ... }` transforms, which accept suspend.

The pace-chart fix is kept inline in each call site rather than extracted into another shared helper: the two implementations differ in amount-source shape (raw `tx.amount` vs pre-converted `convertedTxDays`), and a single-shot helper would obscure more than it would clarify. The two blocks are deliberately written in parallel so review can spot drift.

## Test plan
- [x] `./gradlew :app:compileStandardDebugKotlin` — builds clean.
- [ ] Manual, **unified-currency mode ON**:
  - [ ] Refund → category: that category's "spent" drops by the refund (floored at 0).
  - [ ] Extra budget → category: that category's displayed budget rises by the income amount.
  - [ ] Mixed currencies: refund in INR with display in USD applies a correctly-converted deduction.
  - [ ] Pace chart endpoint after a refund now matches the displayed "actual".
  - [ ] Regression: TRANSFER/INVESTMENT transactions no longer inflate a category's spend.
- [ ] Manual, **single-currency mode** (regression):
  - [ ] Existing Refund / Extra budget behaviour is unchanged.
  - [ ] Pace chart now also reflects refund on its day.
  - [ ] Pace chart + daily allowance + totals still render as before for refund-less months.

## Out of scope
- Issue #308 (home screen "Spent this month" doesn't deduct refunds) is a different surface and will be its own PR.