### PR TITLE
fix: deduct Refund from home Spent this month + sparkline

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -10,6 +10,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkInfo
 import androidx.work.workDataOf
 import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
+import com.pennywiseai.tracker.data.database.entity.BudgetImpactType
 import com.pennywiseai.tracker.data.database.entity.ProfileEntity
 import com.pennywiseai.tracker.data.database.entity.SubscriptionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
@@ -216,16 +217,68 @@ class HomeViewModel @Inject constructor(
         transactions: List<TransactionEntity>
     ): Map<String, TransactionRepository.MonthlyBreakdown> {
         return transactions.groupBy { it.currency }.mapValues { (_, txs) ->
-            val income = txs.filter { it.transactionType == TransactionType.INCOME }
+            // A "Refund" (INCOME + DEDUCT_SPENT) is the reversal of a previous
+            // expense, so it should shrink "Spent this month" and not appear as
+            // new income. "Extra budget" (ADD_TO_LIMIT) is real money in — leave
+            // it in the income total.
+            val refundTotal = txs
+                .filter {
+                    it.transactionType == TransactionType.INCOME &&
+                        it.budgetImpactType == BudgetImpactType.DEDUCT_SPENT
+                }
                 .fold(BigDecimal.ZERO) { acc, tx -> acc + tx.amount }
-            val expenses = txs.filter { it.transactionType == TransactionType.EXPENSE }
+            val income = txs
+                .filter {
+                    it.transactionType == TransactionType.INCOME &&
+                        it.budgetImpactType != BudgetImpactType.DEDUCT_SPENT
+                }
                 .fold(BigDecimal.ZERO) { acc, tx -> acc + tx.amount }
+            val rawExpenses = txs
+                .filter { it.transactionType == TransactionType.EXPENSE }
+                .fold(BigDecimal.ZERO) { acc, tx -> acc + tx.amount }
+            val expenses = (rawExpenses - refundTotal).coerceAtLeast(BigDecimal.ZERO)
             TransactionRepository.MonthlyBreakdown(
                 total = income - expenses,
                 income = income,
                 expenses = expenses
             )
         }
+    }
+
+    /**
+     * Net daily expense map for the sparkline: EXPENSE adds, Refund (INCOME +
+     * DEDUCT_SPENT) subtracts. Loan-linked transactions are excluded. Amounts are
+     * converted into [selectedCurrency] when [isUnified] is true and the txn's
+     * native currency differs; otherwise only txns already in [selectedCurrency]
+     * are considered. The caller is responsible for clamping the cumulative at
+     * zero so refunds don't make the running total go negative.
+     */
+    private suspend fun buildDailyNetExpense(
+        transactions: List<TransactionEntity>,
+        isUnified: Boolean,
+        selectedCurrency: String
+    ): Map<LocalDate, BigDecimal> {
+        val daily = mutableMapOf<LocalDate, BigDecimal>()
+        for (tx in transactions) {
+            if (tx.loanId != null) continue
+            if (!isUnified && tx.currency != selectedCurrency) continue
+
+            val sign = when {
+                tx.transactionType == TransactionType.EXPENSE -> BigDecimal.ONE
+                tx.transactionType == TransactionType.INCOME &&
+                    tx.budgetImpactType == BudgetImpactType.DEDUCT_SPENT -> BigDecimal.ONE.negate()
+                else -> continue
+            }
+
+            val amount = if (isUnified && tx.currency != selectedCurrency) {
+                currencyConversionService.convertAmount(tx.amount, tx.currency, selectedCurrency)
+            } else {
+                tx.amount
+            }
+            val day = tx.dateTime.toLocalDate()
+            daily[day] = (daily[day] ?: BigDecimal.ZERO) + amount.multiply(sign)
+        }
+        return daily
     }
 
     private fun loadUnifiedModePreferences() {
@@ -499,55 +552,20 @@ class HomeViewModel @Inject constructor(
                     d >= lastMonthStart && d < firstOfMonth
                 }
 
-                // Filter to EXPENSE only (excluding loans), respect currency/unified mode
-                val currentExpenses = if (isUnified) {
-                    currentMonthTxs.filter { it.transactionType == TransactionType.EXPENSE && it.loanId == null }
-                } else {
-                    currentMonthTxs.filter {
-                        it.transactionType == TransactionType.EXPENSE && it.currency == selectedCurrency && it.loanId == null
-                    }
-                }
+                // Net daily expense (EXPENSE adds, Refund subtracts) for both
+                // months, then cumulative below clamps at zero so refunds pull the
+                // sparkline endpoint in lockstep with the displayed "Spent" stat.
+                val dailySums = buildDailyNetExpense(currentMonthTxs, isUnified, selectedCurrency)
+                val lastMonthDailySums = buildDailyNetExpense(lastMonthTxs, isUnified, selectedCurrency)
 
-                // Group by day and sum amounts (convert if unified mode)
-                val dailySums = mutableMapOf<LocalDate, BigDecimal>()
-                for (tx in currentExpenses) {
-                    val day = tx.dateTime.toLocalDate()
-                    val amount = if (isUnified && tx.currency != selectedCurrency) {
-                        currencyConversionService.convertAmount(tx.amount, tx.currency, selectedCurrency)
-                    } else {
-                        tx.amount
-                    }
-                    dailySums[day] = (dailySums[day] ?: BigDecimal.ZERO) + amount
-                }
-
-                // Build cumulative list: one entry per day from 1st to today
                 val cumulativeList = mutableListOf<BigDecimal>()
                 var cumulative = BigDecimal.ZERO
                 var day = firstOfMonth
                 while (!day.isAfter(now)) {
-                    cumulative += (dailySums[day] ?: BigDecimal.ZERO)
+                    cumulative = (cumulative + (dailySums[day] ?: BigDecimal.ZERO))
+                        .coerceAtLeast(BigDecimal.ZERO)
                     cumulativeList.add(cumulative)
                     day = day.plusDays(1)
-                }
-
-                // Build last month's cumulative spending (same day count for comparison)
-                val lastMonthExpenses = if (isUnified) {
-                    lastMonthTxs.filter { it.transactionType == TransactionType.EXPENSE && it.loanId == null }
-                } else {
-                    lastMonthTxs.filter {
-                        it.transactionType == TransactionType.EXPENSE && it.currency == selectedCurrency && it.loanId == null
-                    }
-                }
-
-                val lastMonthDailySums = mutableMapOf<LocalDate, BigDecimal>()
-                for (tx in lastMonthExpenses) {
-                    val txDay = tx.dateTime.toLocalDate()
-                    val amount = if (isUnified && tx.currency != selectedCurrency) {
-                        currencyConversionService.convertAmount(tx.amount, tx.currency, selectedCurrency)
-                    } else {
-                        tx.amount
-                    }
-                    lastMonthDailySums[txDay] = (lastMonthDailySums[txDay] ?: BigDecimal.ZERO) + amount
                 }
 
                 val daysToInclude = now.dayOfMonth
@@ -556,7 +574,8 @@ class HomeViewModel @Inject constructor(
                 var lastDay = lastMonthStart
                 var dayCount = 0
                 while (dayCount < daysToInclude && lastDay < firstOfMonth) {
-                    lastCum += (lastMonthDailySums[lastDay] ?: BigDecimal.ZERO)
+                    lastCum = (lastCum + (lastMonthDailySums[lastDay] ?: BigDecimal.ZERO))
+                        .coerceAtLeast(BigDecimal.ZERO)
                     lastMonthCumulative.add(lastCum)
                     lastDay = lastDay.plusDays(1)
                     dayCount++

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -558,25 +558,27 @@ class HomeViewModel @Inject constructor(
                 val dailySums = buildDailyNetExpense(currentMonthTxs, isUnified, selectedCurrency)
                 val lastMonthDailySums = buildDailyNetExpense(lastMonthTxs, isUnified, selectedCurrency)
 
+                // Carry the running total forward unclamped (so a refund dated
+                // before the first expense still counts) and only clamp the value
+                // we display, so the chart endpoint matches the month-level floor
+                // applied to "Spent this month" in computeBreakdownByCurrency.
                 val cumulativeList = mutableListOf<BigDecimal>()
-                var cumulative = BigDecimal.ZERO
+                var runningNet = BigDecimal.ZERO
                 var day = firstOfMonth
                 while (!day.isAfter(now)) {
-                    cumulative = (cumulative + (dailySums[day] ?: BigDecimal.ZERO))
-                        .coerceAtLeast(BigDecimal.ZERO)
-                    cumulativeList.add(cumulative)
+                    runningNet += (dailySums[day] ?: BigDecimal.ZERO)
+                    cumulativeList.add(runningNet.coerceAtLeast(BigDecimal.ZERO))
                     day = day.plusDays(1)
                 }
 
                 val daysToInclude = now.dayOfMonth
                 val lastMonthCumulative = mutableListOf<BigDecimal>()
-                var lastCum = BigDecimal.ZERO
+                var lastRunningNet = BigDecimal.ZERO
                 var lastDay = lastMonthStart
                 var dayCount = 0
                 while (dayCount < daysToInclude && lastDay < firstOfMonth) {
-                    lastCum = (lastCum + (lastMonthDailySums[lastDay] ?: BigDecimal.ZERO))
-                        .coerceAtLeast(BigDecimal.ZERO)
-                    lastMonthCumulative.add(lastCum)
+                    lastRunningNet += (lastMonthDailySums[lastDay] ?: BigDecimal.ZERO)
+                    lastMonthCumulative.add(lastRunningNet.coerceAtLeast(BigDecimal.ZERO))
                     lastDay = lastDay.plusDays(1)
                     dayCount++
                 }


### PR DESCRIPTION
## Summary
- `HomeViewModel.computeBreakdownByCurrency` summed every INCOME into "Income this month" and every EXPENSE into "Spent this month", ignoring the **Budget impact** tag on a transaction. A **Refund** (`INCOME + DEDUCT_SPENT`) is the reversal of a previous expense, so it now shrinks "Spent" (floored at zero) and is excluded from "Income". **Extra budget** (`ADD_TO_LIMIT`) is real money in and continues to count as income — matches the issue's "only add a condition on Refund" guidance.
- The cumulative-spending sparkline had the same gap, and the current-month / last-month blocks were near-duplicate. Replace both with one suspend helper `buildDailyNetExpense` that adds EXPENSE amounts and subtracts Refund amounts on the day they occurred. Cumulative loops now clamp at zero so the chart endpoint tracks the (now-correct) "Spent" stat after a refund.

Fixes #308.

## Test plan
- [x] `./gradlew :app:compileStandardDebugKotlin` — builds clean.
- [ ] Manual, current-month, **single-currency**:
  - [ ] Mark an INCOME as **Refund** → home "Spent this month" drops by that amount (floored at 0), "Income this month" does NOT include it.
  - [ ] Mark an INCOME as **Extra budget** → home "Spent this month" unchanged, "Income this month" still includes it.
  - [ ] Sparkline endpoint after a refund matches the displayed "Spent" stat.
- [ ] Manual, **unified-currency** mode: same as above with a refund in a different native currency — the converted amount is used.
- [ ] Regression: a normal INCOME (no budget impact) still counts as income, sparkline unchanged.
- [ ] Regression: last-month sparkline comparison still renders correctly.

## Related
- #312 (Budgets screen + pace chart, PR #314) — already covered.
- #315 (Transactions filter header) and #316 (Budget widget unified mode) — same conceptual gap on other surfaces, filed separately.