### PR TITLE
fix: pace-chart endpoint diverges when refund precedes expenses

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
@@ -385,14 +385,15 @@ class BudgetGroupRepository @Inject constructor(
                 val day = tx.dateTime.dayOfMonth.coerceIn(1, daysInMonth)
                 dailyAmounts[day - 1] -= tx.amount.toDouble()
             }
+            // Carry the running total forward unclamped so a refund dated before
+            // the first expense still nets out against later expenses; only the
+            // emitted value is clamped, so the chart endpoint matches the
+            // per-category floor used in aggregateBudgetCategorySpending.
             val cumulative = mutableListOf<Double>()
-            var running = 0.0
+            var runningNet = 0.0
             for (i in 0 until effectiveDays) {
-                // Clamp at zero to mirror the per-category floor in
-                // aggregateBudgetCategorySpending; a refund larger than spend-to-date
-                // visually pulls the line back to zero rather than going negative.
-                running = (running + dailyAmounts[i]).coerceAtLeast(0.0)
-                cumulative.add(running)
+                runningNet += dailyAmounts[i]
+                cumulative.add(runningNet.coerceAtLeast(0.0))
             }
             val pace = if (groupBudget > BigDecimal.ZERO) {
                 val dailyPace = groupBudget.toDouble() / daysInMonth

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
@@ -190,13 +190,14 @@ class BudgetGroupsViewModel @Inject constructor(
                     dailyAmounts[refundDay.day - 1] -= refundDay.amount
                 }
             }
+            // Carry the running total forward unclamped so a refund dated before
+            // the first expense still nets out; only the emitted value is clamped
+            // so the endpoint matches aggregateBudgetCategorySpending's floor.
             val cumulative = mutableListOf<Double>()
-            var running = 0.0
+            var runningNet = 0.0
             for (i in 0 until effectiveDays) {
-                // Clamp at zero to mirror the per-category floor in
-                // aggregateBudgetCategorySpending.
-                running = (running + dailyAmounts[i]).coerceAtLeast(0.0)
-                cumulative.add(running)
+                runningNet += dailyAmounts[i]
+                cumulative.add(runningNet.coerceAtLeast(0.0))
             }
             val pace = if (groupBudget > BigDecimal.ZERO) {
                 val dp = groupBudget.toDouble() / daysInMonth


### PR DESCRIPTION
## Summary
Follow-up to #314. Both `buildGroupPace` (single-currency) and `buildGroupPaceUnified` (unified) clamped the cumulative running total to zero **per day**:

```kotlin
running = (running + dailyAmounts[i]).coerceAtLeast(0.0)
cumulative.add(running)
```

If a Refund is dated before any expense in the month, the day-1 clamp zeroes the running total and the refund's negative contribution is silently lost. The next expense starts from zero again, so the chart endpoint over-reports vs the displayed "actual" (which uses a single per-category floor in `aggregateBudgetCategorySpending`).

Fix: carry the running total forward unclamped; clamp only the value pushed to the cumulative list. Endpoint now matches the floor regardless of refund-vs-expense ordering.

Spotted by Greptile on the parallel fix in #317 (`HomeViewModel` sparkline had the same bug).

## Test plan
- [x] `./gradlew :app:compileStandardDebugKotlin` — builds clean.
- [ ] Manual: in a category with budget set, record a Refund on day 1 and an expense on day 5; verify the pace chart endpoint on day 5 equals the displayed "actual" (i.e. `expense − refund`, floored at 0).
- [ ] Regression: refund-after-expense ordering still matches the displayed actual.
- [ ] Regression: months with no refunds render identically to before.