### PR TITLE
fix: exclude Refunds from Transactions filter header income / expenses

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -3,6 +3,7 @@ package com.pennywiseai.tracker.presentation.transactions
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.data.database.dao.TransactionSplitDao
+import com.pennywiseai.tracker.data.database.entity.BudgetImpactType
 import com.pennywiseai.tracker.data.database.entity.CategoryEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
@@ -901,15 +902,31 @@ class TransactionsViewModel @Inject constructor(
         val transactionsByCurrency = transactions.groupBy { it.currency }
 
         val totalsByCurrency = transactionsByCurrency.mapValues { (currency, currencyTransactions) ->
-            val income = currencyTransactions
-                .filter { it.transactionType == TransactionType.INCOME }
+            // A "Refund" (INCOME + DEDUCT_SPENT) is the reversal of a previous
+            // expense, so it shrinks "Expenses" (floored at zero) and does not
+            // appear in "Income". "Extra budget" (ADD_TO_LIMIT) is real money in
+            // and stays in income — same treatment as HomeViewModel.
+            val refundTotal = currencyTransactions
+                .filter {
+                    it.transactionType == TransactionType.INCOME &&
+                        it.budgetImpactType == BudgetImpactType.DEDUCT_SPENT
+                }
                 .sumOf { it.amount.toDouble() }
                 .toBigDecimal()
 
-            val expenses = currencyTransactions
+            val income = currencyTransactions
+                .filter {
+                    it.transactionType == TransactionType.INCOME &&
+                        it.budgetImpactType != BudgetImpactType.DEDUCT_SPENT
+                }
+                .sumOf { it.amount.toDouble() }
+                .toBigDecimal()
+
+            val rawExpenses = currencyTransactions
                 .filter { it.transactionType == TransactionType.EXPENSE }
                 .sumOf { it.amount.toDouble() }
                 .toBigDecimal()
+            val expenses = (rawExpenses - refundTotal).coerceAtLeast(BigDecimal.ZERO)
 
             val credit = currencyTransactions
                 .filter { it.transactionType == TransactionType.CREDIT }


### PR DESCRIPTION
## Summary
`TransactionsViewModel.calculateCurrencyGroupedTotals` summed every INCOME / EXPENSE row into the per-currency filter header without considering the **Budget impact** tag. A **Refund** (`INCOME + DEDUCT_SPENT`) now shrinks "Expenses" (floored at zero) and is excluded from "Income"; **Extra budget** (`ADD_TO_LIMIT`) stays in "Income". Mirrors what landed for `HomeViewModel.computeBreakdownByCurrency` in #317 and `aggregateBudgetCategorySpending` in #314.

Fixes #315.

## Test plan
- [x] `./gradlew :app:compileStandardDebugKotlin` — builds clean.
- [ ] Manual:
  - [ ] Open the Transactions list with no filter applied. Mark an INCOME txn as **Refund**; the filter header's `income` drops by that amount and `expenses` drops by that amount (floored at zero).
  - [ ] Mark an INCOME as **Extra budget**; filter header `income` is unchanged from raw INCOME total.
  - [ ] Regression: applying a date / type filter still sums correctly.