### PR TITLE
fix: exclude categorised Refunds from totalIncome and use shared aggregator on home carousel

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
@@ -326,11 +326,17 @@ class BudgetGroupRepository @Inject constructor(
         currency: String,
         daysInMonth: Int = 30
     ): BudgetOverallSummary {
-        val incomeTransactions = allTransactions.filter {
-            it.transaction.transactionType == TransactionType.INCOME
-        }
-        val totalIncome = incomeTransactions.fold(BigDecimal.ZERO) { acc, tx ->
-            acc + tx.transaction.amount
+        // Exclude a Refund from totalIncome only when it's also being subtracted
+        // from a category by aggregateBudgetCategorySpending (i.e. budgetCategory
+        // is set). An orphaned DEDUCT_SPENT with no category isn't subtracted
+        // from spend, so dropping it from income too would understate netSavings.
+        val totalIncome = allTransactions.fold(BigDecimal.ZERO) { acc, txWithSplits ->
+            val tx = txWithSplits.transaction
+            if (tx.transactionType != TransactionType.INCOME) acc
+            else if (tx.budgetImpactType == BudgetImpactType.DEDUCT_SPENT &&
+                tx.budgetCategory != null
+            ) acc
+            else acc + tx.amount
         }
 
         // Single-currency: amounts are already in the requested currency, so the

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
@@ -113,13 +113,20 @@ class BudgetGroupsViewModel @Inject constructor(
         displayCurrency: String,
         baseCurrency: String
     ): BudgetOverallSummary {
-        val incomeTransactions = raw.allTransactions.filter {
-            it.transaction.transactionType == TransactionType.INCOME
-        }
+        // Exclude a Refund from totalIncome only when it's also being subtracted
+        // from a category by aggregateBudgetCategorySpending (categorised refund);
+        // orphaned DEDUCT_SPENT income stays in the total so netSavings doesn't
+        // understate. Matches the same guard used in BudgetGroupRepository and the
+        // widget.
         var totalIncome = BigDecimal.ZERO
-        for (tx in incomeTransactions) {
+        for (txWithSplits in raw.allTransactions) {
+            val tx = txWithSplits.transaction
+            if (tx.transactionType != TransactionType.INCOME) continue
+            if (tx.budgetImpactType == BudgetImpactType.DEDUCT_SPENT &&
+                tx.budgetCategory != null
+            ) continue
             totalIncome = totalIncome.add(
-                currencyConversionService.convertAmount(tx.transaction.amount, tx.transaction.currency, displayCurrency)
+                currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
             )
         }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -29,6 +29,7 @@ import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.database.entity.BudgetGroupType
 import com.pennywiseai.tracker.data.repository.BudgetCategorySpending
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository
+import com.pennywiseai.tracker.data.repository.BudgetGroupRepository.Companion.aggregateBudgetCategorySpending
 import com.pennywiseai.tracker.data.repository.BudgetGroupSpending
 import com.pennywiseai.tracker.data.repository.BudgetGroupSpendingRaw
 import com.pennywiseai.tracker.data.repository.BudgetOverallSummary
@@ -1340,43 +1341,50 @@ class HomeViewModel @Inject constructor(
         displayCurrency: String,
         baseCurrency: String
     ): BudgetOverallSummary {
-        val incomeTransactions = raw.allTransactions.filter {
-            it.transaction.transactionType == TransactionType.INCOME
-        }
+        // Exclude a Refund from totalIncome only when it's also being subtracted
+        // from a category by aggregateBudgetCategorySpending (categorised refund);
+        // orphaned DEDUCT_SPENT income stays in the total so netSavings doesn't
+        // understate.
         var totalIncome = BigDecimal.ZERO
-        for (tx in incomeTransactions) {
+        for (txWithSplits in raw.allTransactions) {
+            val tx = txWithSplits.transaction
+            if (tx.transactionType != TransactionType.INCOME) continue
+            if (tx.budgetImpactType == BudgetImpactType.DEDUCT_SPENT &&
+                tx.budgetCategory != null
+            ) continue
             totalIncome = totalIncome.add(
-                currencyConversionService.convertAmount(tx.transaction.amount, tx.transaction.currency, displayCurrency)
+                currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
             )
         }
 
-        val categoryAmounts = mutableMapOf<String, BigDecimal>()
-        raw.allTransactions.forEach { txWithSplits ->
-            if (txWithSplits.transaction.transactionType != TransactionType.INCOME &&
-                txWithSplits.transaction.transactionType != TransactionType.TRANSFER &&
-                txWithSplits.transaction.transactionType != TransactionType.INVESTMENT) {
-                val fromCurrency = txWithSplits.transaction.currency
-                txWithSplits.getAmountByCategory().forEach { (category, amount) ->
-                    val converted = currencyConversionService.convertAmount(amount, fromCurrency, displayCurrency)
-                    val categoryName = category.ifEmpty { "Others" }
-                    categoryAmounts[categoryName] = (categoryAmounts[categoryName] ?: BigDecimal.ZERO) + converted
-                }
+        // Route through the shared aggregator so Refund (DEDUCT_SPENT) and
+        // Extra budget (ADD_TO_LIMIT) take effect on the home carousel the same
+        // way they do on the Budgets screen and the widget.
+        val (categoryAmounts, categoryLimitBoosts) = aggregateBudgetCategorySpending(
+            transactions = raw.allTransactions,
+            convertSplit = { fromCurrency, amount ->
+                currencyConversionService.convertAmount(amount, fromCurrency, displayCurrency)
+            },
+            convertIncome = { tx ->
+                currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
             }
-        }
+        )
 
         val groupSpendingList = raw.budgetsWithCategories.map { group ->
             val catSpending = group.categories.map { cat ->
                 val actual = categoryAmounts[cat.categoryName] ?: BigDecimal.ZERO
                 val convertedBudget = currencyConversionService.convertAmount(cat.budgetAmount, baseCurrency, displayCurrency)
-                val pctUsed = if (convertedBudget > BigDecimal.ZERO) {
-                    (actual.toFloat() / convertedBudget.toFloat() * 100f).coerceAtLeast(0f)
+                val effectiveBudget = convertedBudget +
+                    (categoryLimitBoosts[cat.categoryName] ?: BigDecimal.ZERO)
+                val pctUsed = if (effectiveBudget > BigDecimal.ZERO) {
+                    (actual.toFloat() / effectiveBudget.toFloat() * 100f).coerceAtLeast(0f)
                 } else 0f
                 val dailySpend = if (raw.daysElapsed > 0 && actual > BigDecimal.ZERO) {
                     actual.divide(BigDecimal(raw.daysElapsed), 0, RoundingMode.HALF_UP)
                 } else BigDecimal.ZERO
                 BudgetCategorySpending(
                     categoryName = cat.categoryName,
-                    budgetAmount = convertedBudget,
+                    budgetAmount = effectiveBudget,
                     actualAmount = actual,
                     percentageUsed = pctUsed,
                     dailySpend = dailySpend


### PR DESCRIPTION
## Summary
Closes the last surface in the Refund-handling cleanup. `BudgetOverallSummary.totalIncome` is built in three places, all of which summed every INCOME without checking `budgetImpactType`:

1. `BudgetGroupRepository.buildSummary` (single-currency Budgets / non-unified widget)
2. `BudgetGroupsViewModel.convertRawToSummary` (unified Budgets)
3. `HomeViewModel.mapRawToConvertedSummary` (home budget carousel)

A categorised Refund (`DEDUCT_SPENT + budgetCategory != null`) is now excluded from `totalIncome` in all three sites, matching `aggregateBudgetCategorySpending`'s spend-reduction guard (same orphaned-refund treatment introduced for the widget in #320). Orphaned `DEDUCT_SPENT` rows stay in income so `netSavings` / `savingsRate` don't understate.

`mapRawToConvertedSummary` also duplicated the per-category aggregation that `aggregateBudgetCategorySpending` was introduced to centralise — so it ignored `DEDUCT_SPENT` deductions and `ADD_TO_LIMIT` boosts on the home carousel. Route it through the same helper as the Budgets screen and widget, and add the per-category boost to the displayed budget.

Fixes #321.

## Test plan
- [x] `./gradlew :app:compileStandardDebugKotlin` — builds clean.
- [ ] Manual, home budget carousel:
  - [ ] Refund → category drops "actual" by the refund amount.
  - [ ] Extra budget → category's displayed budget rises.
  - [ ] `netSavings` / `savingsRate` no longer inflated by Refunds.
- [ ] Manual, Budgets screen single-currency: `totalIncome` no longer counts Refunds.
- [ ] Manual, non-unified widget: `totalIncome` / `netSavings` no longer inflated by Refunds.
- [ ] Regression: orphaned `DEDUCT_SPENT` (no `budgetCategory`) is still counted in income (test legacy/imported data).