### PR TITLE
docs: add TRADEMARKS.md

### DIFF
--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,43 @@
+# Trademark Notice
+
+"**PennyWise**", "**PennyWise AI**", the PennyWise logo, and the PennyWise
+banner artwork are unregistered trademarks of Sarim Ahmed
+(<sarimahmed3520@gmail.com>), the original author and project lead of the
+PennyWise AI project (<https://github.com/sarim2000/pennywiseai-tracker>).
+
+## Scope of the AGPL-3.0 license
+
+The source code in this repository is licensed under the GNU Affero General
+Public License v3.0 (see [`LICENSE`](LICENSE)). The AGPL license grants rights
+in the **source code only**. It does **not** grant any rights, license, or
+permission to use the PennyWise name, logo, banner, or other brand assets.
+
+## Forks and derivative works
+
+You are free to fork, modify, and redistribute the source code, subject to
+the AGPL-3.0 terms (including the source-availability and "same license"
+requirements). However, when you do:
+
+1. You **must not** use the names "PennyWise", "PennyWise AI", or any
+   confusingly similar variant as the name of your fork, app, or service.
+2. You **must not** use the PennyWise logo, banner, or other brand assets in
+   your fork's branding, store listings (Google Play, F-Droid, App Store), or
+   marketing.
+3. You **must** comply with AGPL § 5 by prominently stating that you modified
+   the work and the date of modification, and you **must** preserve all
+   copyright and attribution notices in the source files.
+4. You **must** distribute your derivative work under the **AGPL-3.0** (the
+   same license). You may not relicense it under a more permissive license
+   such as GPL-3.0, LGPL, MIT, Apache-2.0, or BSD.
+
+## Permitted nominative use
+
+You may refer to "PennyWise" in factual, descriptive statements such as
+"this project is a derivative of PennyWise AI" or "based on the PennyWise
+`parser-core` module". You may not imply endorsement, affiliation, or
+sponsorship by the PennyWise project or its author.
+
+## Reporting violations
+
+Suspected trademark or license violations may be reported to
+<sarimahmed3520@gmail.com>.


### PR DESCRIPTION
## Summary
- Adds `TRADEMARKS.md` declaring "PennyWise" / "PennyWise AI" and the banner artwork as unregistered trademarks of the author, separate from the AGPL-3.0 source license.
- Documents what forks/derivatives need to do under AGPL: keep AGPL-3.0 (no relicensing to plain GPL or more permissive licenses), state modifications per § 5, preserve attribution, and don't reuse the PennyWise name or brand assets.

## Why
AGPL-3.0 grants rights in the source code only — it does not grant trademark rights. Spelling this out explicitly makes the project's brand boundaries clear for downstream forks, and gives a separate, license-independent basis to push back if a fork misuses the PennyWise name or banner.

## Test plan
- [ ] Renders correctly on GitHub
- [ ] No code changes — no build/test impact