### PR TITLE
feat: add Sparkasse Rhein-Maas (Germany) SMS parser

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -104,6 +104,7 @@ object BankParserFactory {
         SNBAlAhliBankParser(),  // Saudi National Bank / Al Ahli Bank (Saudi Arabia)
         STCBankParser(),  // STC Bank (Saudi Arabia)
         MBankCZParser(),  // mBank CZ (Czech Republic)
+        SparkasseRheinMaasParser(),  // Sparkasse Rhein-Maas (Germany)
         BankMuscatParser(),  // Bank Muscat (Oman)
         GreaterBankParser()  // Greater Bank (India)
         // Add more bank parsers here as we implement them

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SparkasseRheinMaasParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SparkasseRheinMaasParser.kt
@@ -1,0 +1,171 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Sparkasse Rhein-Maas (Germany) SMS notifications.
+ *
+ * Sender: "Sparkasse"
+ * Currency: EUR
+ *
+ * Supported message types ("Wecker" = alarm / push notification):
+ *  - Kartenwecker      -> card purchase (EXPENSE), signed negative amount.
+ *      Kartenwecker:
+ *      1 neuer Kartenumsatz auf dem Konto *NNNN:
+ *      MERCHANT: -70,85 EUR
+ *      Neuer Saldo: 991,84 EUR
+ *      Ihre Sparkasse
+ *
+ *  - Gehaltswecker     -> salary credit (INCOME), unsigned amount.
+ *      Gehaltswecker:
+ *      Gehalt ist auf Konto *NNNN eingegangen:
+ *      SOURCE: 1.415,62 EUR
+ *      Neuer Saldo: 1.415,67 EUR
+ *      Ihre Sparkasse
+ *
+ *  - Kontostandswecker -> pure balance notification, no transaction amount/merchant.
+ *      Rejected via isTransactionMessage so the base parse() returns null.
+ *
+ * Notes on number formatting (German locale):
+ *  - `.` is the thousands separator, `,` is the decimal separator.
+ *  - Strip `.` and replace `,` with `.` before constructing BigDecimal.
+ */
+class SparkasseRheinMaasParser : BankParser() {
+
+    override fun getBankName() = "Sparkasse Rhein-Maas"
+
+    override fun getCurrency() = "EUR"
+
+    override fun canHandle(sender: String): Boolean {
+        return sender.uppercase().contains("SPARKASSE")
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+
+        // Skip OTP / verification codes if they ever appear.
+        if (lower.contains("otp") ||
+            lower.contains("tan") && lower.contains("code") ||
+            lower.contains("verifizierungscode")
+        ) {
+            return false
+        }
+
+        // Kontostandswecker = balance-only push, no parseable transaction.
+        if (lower.contains("kontostandswecker")) {
+            return false
+        }
+
+        // Must be one of the known transaction "Wecker" variants.
+        return lower.contains("kartenwecker") || lower.contains("gehaltswecker")
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // Find the first transaction line of the form "<label>: [+/-]<number> EUR"
+        // and explicitly skip the "Neuer Saldo:" balance line.
+        val transactionLine = findTransactionLine(message) ?: return null
+        val amountMatch = TRANSACTION_AMOUNT_REGEX.find(transactionLine) ?: return null
+        val raw = amountMatch.groupValues[2]
+        return parseGermanNumber(raw)
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lower = message.lowercase()
+        if (lower.contains("gehaltswecker")) {
+            return TransactionType.INCOME
+        }
+
+        // Fall back to the sign on the amount line.
+        val transactionLine = findTransactionLine(message)
+        if (transactionLine != null) {
+            val signMatch = TRANSACTION_AMOUNT_REGEX.find(transactionLine)
+            val sign = signMatch?.groupValues?.get(1)
+            if (sign == "+") return TransactionType.INCOME
+            if (sign == "-") return TransactionType.EXPENSE
+        }
+
+        if (lower.contains("kartenwecker")) {
+            return TransactionType.EXPENSE
+        }
+        return null
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        val transactionLine = findTransactionLine(message) ?: return null
+        // Merchant is everything before the colon on the transaction line.
+        val colonIdx = transactionLine.indexOf(':')
+        if (colonIdx <= 0) return null
+        val candidate = transactionLine.substring(0, colonIdx).trim()
+        val cleaned = cleanMerchantName(candidate)
+        return if (isValidMerchantName(cleaned)) cleaned else null
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        // Pattern: "Konto *1832"
+        ACCOUNT_REGEX.find(message)?.let { match ->
+            return extractLast4Digits(match.groupValues[1])
+        }
+        return super.extractAccountLast4(message)
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        BALANCE_REGEX.find(message)?.let { match ->
+            return parseGermanNumber(match.groupValues[1])
+        }
+        return null
+    }
+
+    override fun detectIsCard(message: String): Boolean {
+        return message.lowercase().contains("kartenwecker") ||
+                message.lowercase().contains("kartenumsatz")
+    }
+
+    /**
+     * Returns the first non-balance line that contains a `<label>: <amount> EUR` payload.
+     */
+    private fun findTransactionLine(message: String): String? {
+        for (rawLine in message.lines()) {
+            val line = rawLine.trim()
+            if (line.isEmpty()) continue
+            if (line.lowercase().startsWith("neuer saldo")) continue
+            if (TRANSACTION_AMOUNT_REGEX.containsMatchIn(line)) {
+                return line
+            }
+        }
+        return null
+    }
+
+    private fun parseGermanNumber(raw: String): BigDecimal? {
+        // German format: "1.415,62" -> "1415.62"; "70,85" -> "70.85"
+        val normalized = raw
+            .replace(".", "")
+            .replace(",", ".")
+        return try {
+            BigDecimal(normalized)
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    companion object {
+        // Matches "[+/-]<german-number> EUR" anywhere on the line.
+        // Group 1: optional sign. Group 2: the numeric body (with German separators).
+        private val TRANSACTION_AMOUNT_REGEX = Regex(
+            """([+-])?\s*(\d{1,3}(?:\.\d{3})*(?:,\d{1,2})?|\d+(?:,\d{1,2})?)\s*EUR""",
+            RegexOption.IGNORE_CASE
+        )
+
+        // "Neuer Saldo: 991,84 EUR" or "Neuer Saldo 991,84 EUR"
+        private val BALANCE_REGEX = Regex(
+            """Neuer\s+Saldo:?\s*([+-]?\d{1,3}(?:\.\d{3})*(?:,\d{1,2})?|\d+(?:,\d{1,2})?)\s*EUR""",
+            RegexOption.IGNORE_CASE
+        )
+
+        // "Konto *1832" - capture the digits after the asterisk.
+        private val ACCOUNT_REGEX = Regex(
+            """Konto\s*\*+\s*(\d{3,})""",
+            RegexOption.IGNORE_CASE
+        )
+    }
+}

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SparkasseRheinMaasParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SparkasseRheinMaasParserTest.kt
@@ -1,0 +1,85 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class SparkasseRheinMaasParserTest {
+
+    private val parser = SparkasseRheinMaasParser()
+
+    @TestFactory
+    fun `sparkasse rhein-maas parser handles common cases`(): List<DynamicTest> {
+        val cases = listOf(
+            ParserTestCase(
+                name = "Kartenwecker - card purchase",
+                message = """
+                    Kartenwecker:
+                    1 neuer Kartenumsatz auf dem Konto *1832:
+                    KAUFLAND: -70,85 EUR
+                    Neuer Saldo: 991,84 EUR
+                    Ihre Sparkasse
+                """.trimIndent(),
+                sender = "Sparkasse",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("70.85"),
+                    currency = "EUR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "KAUFLAND",
+                    accountLast4 = "1832",
+                    balance = BigDecimal("991.84"),
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "Gehaltswecker - salary credit with thousands separator",
+                message = """
+                    Gehaltswecker:
+                    Gehalt ist auf Konto *1832 eingegangen:
+                    Action De.: 1.415,62 EUR
+                    Neuer Saldo: 1.415,67 EUR
+                    Ihre Sparkasse
+                """.trimIndent(),
+                sender = "Sparkasse",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1415.62"),
+                    currency = "EUR",
+                    type = TransactionType.INCOME,
+                    merchant = "Action De.",
+                    accountLast4 = "1832",
+                    balance = BigDecimal("1415.67"),
+                    isFromCard = false
+                )
+            ),
+            ParserTestCase(
+                name = "Kontostandswecker - balance-only push is rejected",
+                message = """
+                    Kontostandswecker:
+                    Konto *1832
+                    Neuer Saldo: 1.246,69 EUR
+                    Neue Umsaetze: 4
+                    Ihre Sparkasse
+                """.trimIndent(),
+                sender = "Sparkasse",
+                shouldParse = false
+            )
+        )
+
+        val handleChecks = listOf(
+            "Sparkasse" to true,
+            "SPARKASSE" to true,
+            "UNKNOWN" to false
+        )
+
+        return ParserTestUtils.runTestSuite(
+            parser,
+            cases,
+            handleChecks,
+            "Sparkasse Rhein-Maas Parser"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
First European parser for the Sparkasse **Wecker** push notification family. Covers the three sample formats in #300:

- `Kartenwecker` — card purchase, signed EUR debit, merchant + `Neuer Saldo`.
- `Gehaltswecker` — salary credit, EUR with thousands separator + `Neuer Saldo`.
- `Kontostandswecker` — balance-only notification, no transaction amount; parsed to `null` via `isTransactionMessage`.

Currency is **EUR**. `canHandle` matches any sender whose uppercased form contains `SPARKASSE`. Registered after `MBankCZParser()` in `BankParserFactory`.

German number handling: strips thousands `.` and converts decimal `,` to `.` before constructing `BigDecimal`. Merchant is the line immediately preceding the signed amount.

Authored end-to-end by the new `parser-author` subagent.

Fixes #300.

## Test plan
- [x] `./gradlew :parser-core:jvmTest --tests "SparkasseRheinMaasParserTest"` — **6/6 pass**.

## Known limitation — framework gap (acknowledged, not closed here)

Greptile (3/5) flagged that this parser's broad `canHandle` (any sender containing `SPARKASSE`) combined with the narrow `isTransactionMessage` whitelist (only `Kartenwecker` / `Gehaltswecker`) creates a transaction-loss path: a Sparkasse user receiving a Wecker variant we haven't added (wire transfer, standing order, etc.) will have that message claimed by this parser, returned as `null` from `parse()`, and **silently dropped** — `SmsTransactionProcessor` does not route null-parsed messages to the unrecognized-SMS pipeline (`SmsTransactionProcessor.kt:78-80`).

This is **not unique to Sparkasse** — every parser in `BankParserFactory` has the same shape (claim sender, return null on unhandled body, dropped). Sparkasse just exposes it earlier because German Sparkasse banks send more notification types than any one PR can preemptively cover.

The proper fix is a one-block change in `SmsTransactionProcessor` to insert null-parsed SMS into the unrecognized-SMS pipeline so the user can report unhandled formats. That benefits every parser and will be tracked / shipped separately. The Sparkasse parser correctly handles the 3 documented formats today; new Wecker types will be added as samples arrive.

## Observations
- `Gehaltswecker` merchant comes out as `Action De.` (label includes the trailing period — SMS artefact, not parser bug). Clean-up is a downstream tweak.
- Substring match on `SPARKASSE` is intentionally broad to cover regional Sparkasse variants (`Sparkasse Köln`, `Sparkasse RM`, etc.). If a region-specific parser is added later, place it before this one in `BankParserFactory` or tighten this one's `canHandle`.