### PR TITLE
feat: add Enpara (Turkey) push-notification parser

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/receiver/BankNotificationConfig.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/receiver/BankNotificationConfig.kt
@@ -12,7 +12,10 @@ object BankNotificationConfig {
 
     private val allowedPackages: Map<String, String> = mapOf(
         // Faysal Bank (Pakistan) – alias must match FaysalBankParser.canHandle()
-        "com.avanza.ambitwizfbl" to "FaysalBank"
+        "com.avanza.ambitwizfbl" to "FaysalBank",
+        // Enpara (Turkey) – alias must match EnparaBankParser.canHandle()
+        "finansbank.enpara" to "Enpara",      // Enpara.com Cep Şubesi (personal, older brand)
+        "com.enparabank.retail" to "Enpara"   // Enpara Bank Cep Şube (personal, post-rebrand)
     )
 
     fun isAllowed(packageName: String): Boolean =

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -105,6 +105,7 @@ object BankParserFactory {
         STCBankParser(),  // STC Bank (Saudi Arabia)
         SabbBankParser(),  // SABB - Saudi Awwal Bank (Saudi Arabia)
         MBankCZParser(),  // mBank CZ (Czech Republic)
+        EnparaBankParser(),  // Enpara (Turkey) — push notifications
         BankMuscatParser(),  // Bank Muscat (Oman)
         GreaterBankParser()  // Greater Bank (India)
         // Add more bank parsers here as we implement them

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/EnparaBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/EnparaBankParser.kt
@@ -1,0 +1,212 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Enpara (digital bank by QNB Finansbank / Enpara Bank, Turkey).
+ *
+ * Source: push notifications from the Enpara Android app (not SMS).
+ * Sender alias supplied by BankNotificationConfig: "Enpara".
+ * Currency: TRY (Turkish Lira; appears in notifications as "TL").
+ *
+ * Number formatting (Turkish locale):
+ *  - `.` is the thousands separator, `,` is the decimal separator (e.g. "1.175,28 TL").
+ *  - Strip `.` and replace `,` with `.` before constructing BigDecimal.
+ *
+ * Supported notification shapes:
+ *
+ *  1) Card spend (Encard) -> EXPENSE, isFromCard = true.
+ *     "Vadesiz TL hesabınıza bağlı 2589 ile biten Encard'ınızla 10/05/2026 tarihinde
+ *      105100000024364-OBILET ISTANBUL TR firmasında 520,00 TL tutarında harcama yapıldı."
+ *     - accountLast4: 4 digits between "bağlı" and "ile biten Encard".
+ *     - merchant: the segment after the leading numeric reference and before " firmasında",
+ *       with the trailing " TR" stripped.
+ *     - balanceAfter: not present in this notification shape.
+ *
+ *  2) Outgoing FAST transfer -> EXPENSE.
+ *     "13/05/2026 tarihinde vadesiz TL hesabınızdan <RECIPIENT> adlı alıcıya 500,00 TL
+ *      tutarında para transferi (FAST) yapıldı. İşlem sonrası hesap bakiyesi: 1.175,28 TL"
+ *     - merchant: recipient name between "hesabınızdan" and "adlı alıcıya".
+ *     - balance: number after "İşlem sonrası hesap bakiyesi:".
+ *
+ *  3) Incoming FAST transfer -> INCOME.
+ *     "Vadesiz TL hesabınıza 11/05/2026 tarihinde <SENDER> tarafından yapılan para transferi
+ *      (FAST) sonucunda 200,00 TL giriş oldu. İşlem sonrası hesap bakiyesi: 3.231,27 TL"
+ *     - merchant: sender name between the date and "tarafından".
+ *     - balance: number after "İşlem sonrası hesap bakiyesi:".
+ */
+class EnparaBankParser : BankParser() {
+
+    override fun getBankName() = "Enpara"
+
+    override fun getCurrency() = "TRY"
+
+    override fun canHandle(sender: String): Boolean {
+        return sender.equals("Enpara", ignoreCase = true)
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+
+        // Skip OTP / verification codes if they ever appear in notifications.
+        if (lower.contains("otp") ||
+            lower.contains("doğrulama kodu") ||
+            lower.contains("tek kullanımlık şifre") ||
+            lower.contains("şifreniz")
+        ) {
+            return false
+        }
+
+        // Must look like one of the three known transaction notification shapes.
+        return lower.contains("harcama yapıldı") ||
+                lower.contains("para transferi") ||
+                lower.contains("giriş oldu")
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // Card spend: "... 520,00 TL tutarında harcama yapıldı."
+        CARD_AMOUNT_REGEX.find(message)?.let {
+            return parseTurkishNumber(it.groupValues[1])
+        }
+
+        // Outgoing transfer: "... 500,00 TL tutarında para transferi (FAST) yapıldı."
+        OUTGOING_AMOUNT_REGEX.find(message)?.let {
+            return parseTurkishNumber(it.groupValues[1])
+        }
+
+        // Incoming transfer: "... sonucunda 200,00 TL giriş oldu."
+        INCOMING_AMOUNT_REGEX.find(message)?.let {
+            return parseTurkishNumber(it.groupValues[1])
+        }
+
+        return null
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lower = message.lowercase()
+        return when {
+            lower.contains("giriş oldu") -> TransactionType.INCOME
+            lower.contains("harcama yapıldı") -> TransactionType.EXPENSE
+            lower.contains("para transferi") && lower.contains("yapıldı") -> TransactionType.EXPENSE
+            else -> null
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // Card spend: merchant lives between the leading numeric reference and " firmasında".
+        CARD_MERCHANT_REGEX.find(message)?.let { match ->
+            val raw = match.groupValues[1].trim()
+            val stripped = stripTrailingCountryCode(raw)
+            val cleaned = cleanMerchantName(stripped)
+            if (isValidMerchantName(cleaned)) return cleaned
+        }
+
+        // Outgoing transfer: recipient between "hesabınızdan" and "adlı alıcıya".
+        OUTGOING_RECIPIENT_REGEX.find(message)?.let { match ->
+            val cleaned = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(cleaned)) return cleaned
+        }
+
+        // Incoming transfer: sender between "tarihinde" and "tarafından".
+        INCOMING_SENDER_REGEX.find(message)?.let { match ->
+            val cleaned = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(cleaned)) return cleaned
+        }
+
+        return null
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        // "bağlı 2589 ile biten Encard" — 4 digits between "bağlı" and "ile biten Encard".
+        CARD_LAST4_REGEX.find(message)?.let { match ->
+            return extractLast4Digits(match.groupValues[1])
+        }
+        return null
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        // "İşlem sonrası hesap bakiyesi: 1.175,28 TL"
+        BALANCE_REGEX.find(message)?.let { match ->
+            return parseTurkishNumber(match.groupValues[1])
+        }
+        return null
+    }
+
+    override fun detectIsCard(message: String): Boolean {
+        // Card spend notifications mention "Encard".
+        return message.contains("Encard", ignoreCase = true)
+    }
+
+    /**
+     * Removes a trailing standalone " TR" (country code) from a card-spend merchant
+     * candidate. We intentionally leave the city token (e.g. "ISTANBUL", "KIRIKKALE")
+     * intact since the issue allows it.
+     */
+    private fun stripTrailingCountryCode(raw: String): String {
+        return raw.trimEnd().removeSuffix(" TR").trimEnd()
+    }
+
+    private fun parseTurkishNumber(raw: String): BigDecimal? {
+        // Turkish format: "1.175,28" -> "1175.28"; "520,00" -> "520.00"
+        val normalized = raw
+            .replace(".", "")
+            .replace(",", ".")
+        return try {
+            BigDecimal(normalized)
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    companion object {
+        // Card spend amount: "<number> TL tutarında harcama yapıldı"
+        private val CARD_AMOUNT_REGEX = Regex(
+            """([0-9.,]+)\s*TL\s+tutarında\s+harcama\s+yapıldı""",
+            RegexOption.IGNORE_CASE
+        )
+
+        // Outgoing transfer amount: "<number> TL tutarında para transferi"
+        private val OUTGOING_AMOUNT_REGEX = Regex(
+            """([0-9.,]+)\s*TL\s+tutarında\s+para\s+transferi""",
+            RegexOption.IGNORE_CASE
+        )
+
+        // Incoming transfer amount: "sonucunda <number> TL giriş oldu"
+        private val INCOMING_AMOUNT_REGEX = Regex(
+            """sonucunda\s+([0-9.,]+)\s*TL\s+giriş\s+oldu""",
+            RegexOption.IGNORE_CASE
+        )
+
+        // Card spend merchant: after "tarihinde", optional leading numeric reference
+        // (e.g. "105100000024364-" or "2288088 -"), up to " firmasında".
+        private val CARD_MERCHANT_REGEX = Regex(
+            """tarihinde\s+\d+\s*-\s*(.+?)\s+firmasında""",
+            RegexOption.IGNORE_CASE
+        )
+
+        // Outgoing recipient: between "hesabınızdan" and "adlı alıcıya".
+        private val OUTGOING_RECIPIENT_REGEX = Regex(
+            """hesabınızdan\s+(.+?)\s+adlı\s+alıcıya""",
+            RegexOption.IGNORE_CASE
+        )
+
+        // Incoming sender: between "tarihinde" and "tarafından".
+        private val INCOMING_SENDER_REGEX = Regex(
+            """tarihinde\s+(.+?)\s+tarafından""",
+            RegexOption.IGNORE_CASE
+        )
+
+        // Card last 4: digits between "bağlı" and "ile biten Encard".
+        private val CARD_LAST4_REGEX = Regex(
+            """bağlı\s+(\d{4})\s+ile\s+biten\s+Encard""",
+            RegexOption.IGNORE_CASE
+        )
+
+        // Post-transaction balance: "İşlem sonrası hesap bakiyesi: <number> TL"
+        private val BALANCE_REGEX = Regex(
+            """İşlem\s+sonrası\s+hesap\s+bakiyesi:?\s*([0-9.,]+)\s*TL""",
+            RegexOption.IGNORE_CASE
+        )
+    }
+}

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/EnparaBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/EnparaBankParserTest.kt
@@ -1,0 +1,122 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class EnparaBankParserTest {
+
+    private val parser = EnparaBankParser()
+
+    @TestFactory
+    fun `enpara parser handles common cases`(): List<DynamicTest> {
+        val cases = listOf(
+            ParserTestCase(
+                name = "Card spend (Encard) - simple merchant",
+                message = "Vadesiz TL hesabınıza bağlı 2589 ile biten Encard'ınızla " +
+                        "10/05/2026 tarihinde 105100000024364-OBILET ISTANBUL TR " +
+                        "firmasında 520,00 TL tutarında harcama yapıldı.",
+                sender = "Enpara",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("520.00"),
+                    currency = "TRY",
+                    type = TransactionType.EXPENSE,
+                    merchant = "OBILET ISTANBUL",
+                    accountLast4 = "2589",
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "Card spend (Encard) - hyphenated merchant",
+                message = "Vadesiz TL hesabınıza bağlı 2589 ile biten Encard'ınızla " +
+                        "11/05/2026 tarihinde 105100000248567-Trendyol - Yemek ISTANBUL TR " +
+                        "firmasında 350,00 TL tutarında harcama yapıldı.",
+                sender = "Enpara",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("350.00"),
+                    currency = "TRY",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Trendyol - Yemek ISTANBUL",
+                    accountLast4 = "2589",
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "Card spend (Encard) - space before dash in reference",
+                message = "Vadesiz TL hesabınıza bağlı 2589 ile biten Encard'ınızla " +
+                        "11/05/2026 tarihinde 2288088 -SBUX KRK KIRIKKALE PODIU KIRIKKALE TR " +
+                        "firmasında 465,00 TL tutarında harcama yapıldı.",
+                sender = "Enpara",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("465.00"),
+                    currency = "TRY",
+                    type = TransactionType.EXPENSE,
+                    merchant = "SBUX KRK KIRIKKALE PODIU KIRIKKALE",
+                    accountLast4 = "2589",
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "Card spend (Encard) - merchant with slash",
+                message = "Vadesiz TL hesabınıza bağlı 2589 ile biten Encard'ınızla " +
+                        "11/05/2026 tarihinde 000000003718799-NKOLAY/DIRK ROSSMANN ISTANBUL TR " +
+                        "firmasında 528,00 TL tutarında harcama yapıldı.",
+                sender = "Enpara",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("528.00"),
+                    currency = "TRY",
+                    type = TransactionType.EXPENSE,
+                    merchant = "NKOLAY/DIRK ROSSMANN ISTANBUL",
+                    accountLast4 = "2589",
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "Outgoing FAST transfer with balanceAfter",
+                message = "13/05/2026 tarihinde vadesiz TL hesabınızdan Hakan G adlı alıcıya " +
+                        "500,00 TL tutarında para transferi (FAST) yapıldı. " +
+                        "İşlem sonrası hesap bakiyesi: 1.175,28 TL",
+                sender = "Enpara",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("500.00"),
+                    currency = "TRY",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Hakan G",
+                    balance = BigDecimal("1175.28"),
+                    isFromCard = false
+                )
+            ),
+            ParserTestCase(
+                name = "Incoming FAST transfer with balanceAfter",
+                message = "Vadesiz TL hesabınıza 11/05/2026 tarihinde Ismail U tarafından " +
+                        "yapılan para transferi (FAST) sonucunda 200,00 TL giriş oldu. " +
+                        "İşlem sonrası hesap bakiyesi: 3.231,27 TL",
+                sender = "Enpara",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("200.00"),
+                    currency = "TRY",
+                    type = TransactionType.INCOME,
+                    merchant = "Ismail U",
+                    balance = BigDecimal("3231.27"),
+                    isFromCard = false
+                )
+            )
+        )
+
+        val handleChecks = listOf(
+            "Enpara" to true,
+            "UNKNOWN" to false
+        )
+
+        return ParserTestUtils.runTestSuite(
+            parser,
+            cases,
+            handleChecks,
+            "Enpara Bank Parser"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
First Turkish parser, and the second integration of the existing **NotificationListener pipeline** (after Faysal Bank). Reads three push-notification shapes from the Enpara Cep Şubesi Android app:

- **Encard card spend** → EXPENSE (with `accountLast4` from `2589 ile biten Encard`, `isFromCard = true`)
- **Outgoing FAST transfer** → EXPENSE (with recipient as merchant, `balanceAfter`)
- **Incoming FAST transfer** → INCOME (with sender as merchant, `balanceAfter`)

Currency is **TRY**. Numbers use comma decimal + dot thousands (e.g. `1.175,28 TL`); parsing mirrors `SparkasseRheinMaasParser`'s German-style logic.

`canHandle` matches the literal sender alias `"Enpara"`. The `NotificationListener` resolves this via `BankNotificationConfig.allowedPackages`, which is updated to include both:
- `finansbank.enpara` — Enpara.com Cep Şubesi (personal, older brand)
- `com.enparabank.retail` — Enpara Bank Cep Şube (personal, post-rebrand)

The corporate packages (`finansbank.enpara.sirketim`, `com.enparabank.corporate`) are intentionally not allow-listed yet — will add when a reporter confirms they need it.

Parser + tests + factory entry authored end-to-end by the `parser-author` subagent. The app-side `BankNotificationConfig` change applied by hand since that file lives outside `parser-core`.

Fixes #329.

## Test plan
- [x] `./gradlew :parser-core:jvmTest --tests "EnparaBankParserTest"` — **8/8 pass** (4 Encard variants + outgoing FAST + incoming FAST + 2 handle-checks).
- [x] `./gradlew :app:compileStandardDebugKotlin` — clean.
- [ ] Manual: install the build on a device with Enpara, grant notification-listener permission, trigger a card spend or transfer, verify it shows up in PennyWise.

## Known limitations / follow-ups
- **Corporate packages not allow-listed** — add when reporters need them.
- **Merchant strings retain city tokens** (e.g. `OBILET ISTANBUL`, `SBUX KRK KIRIKKALE PODIU KIRIKKALE`). Heuristic stripping is risky because compound merchant names embed city words — a per-merchant cleanup map is a separate enhancement.
- **`SparkasseRheinMaasParser` from #328 isn't on this branch yet** — when both merge, you may want Enpara repositioned next to Sparkasse in `BankParserFactory` for grouping. Trivial follow-up.