### PR TITLE
fix: budget shows 'Spent X of ₹0' when per-category limits left blank

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
@@ -457,7 +457,14 @@ class BudgetGroupRepository @Inject constructor(
                         dailySpend = dailySpend
                     )
                 }
-                val totalBudget = catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
+                // "Category Limits" are optional — the group-level limit is the
+                // source of truth when set, with the per-cat sum as a fallback
+                // for budgets that only define per-cat amounts.
+                val totalBudget = if (group.budget.limitAmount > BigDecimal.ZERO) {
+                    group.budget.limitAmount
+                } else {
+                    catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
+                }
                 val totalActual = catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.actualAmount }
                 val remaining = totalBudget - totalActual
                 val pctUsed = if (totalBudget > BigDecimal.ZERO) {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
@@ -233,10 +233,16 @@ class BudgetGroupsViewModel @Inject constructor(
                     dailySpend = dailySpend
                 )
             }
-            val totalBudget = if (isTrackingAll) {
-                currencyConversionService.convertAmount(group.budget.limitAmount, baseCurrency, displayCurrency)
-            } else {
-                catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
+            val convertedGroupLimit = currencyConversionService.convertAmount(
+                group.budget.limitAmount, baseCurrency, displayCurrency
+            )
+            val totalBudget = when {
+                isTrackingAll -> convertedGroupLimit
+                // "Category Limits" are optional — the group-level limit is
+                // the source of truth when set, with the per-cat sum as a
+                // fallback for budgets that only define per-cat amounts.
+                convertedGroupLimit > BigDecimal.ZERO -> convertedGroupLimit
+                else -> catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
             }
             val totalActual = if (isTrackingAll) {
                 categoryAmounts.values.fold(BigDecimal.ZERO) { acc, v -> acc + v }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
@@ -236,13 +236,14 @@ class BudgetGroupsViewModel @Inject constructor(
             val convertedGroupLimit = currencyConversionService.convertAmount(
                 group.budget.limitAmount, baseCurrency, displayCurrency
             )
-            val totalBudget = when {
-                isTrackingAll -> convertedGroupLimit
-                // "Category Limits" are optional — the group-level limit is
-                // the source of truth when set, with the per-cat sum as a
-                // fallback for budgets that only define per-cat amounts.
-                convertedGroupLimit > BigDecimal.ZERO -> convertedGroupLimit
-                else -> catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
+            // "Category Limits" are optional — the group-level limit is the
+            // source of truth when set (including when isTrackingAll), with
+            // the per-cat sum as a fallback for budgets that only define
+            // per-cat amounts.
+            val totalBudget = if (convertedGroupLimit > BigDecimal.ZERO) {
+                convertedGroupLimit
+            } else {
+                catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
             }
             val totalActual = if (isTrackingAll) {
                 categoryAmounts.values.fold(BigDecimal.ZERO) { acc, v -> acc + v }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -1375,6 +1375,7 @@ class HomeViewModel @Inject constructor(
         )
 
         val groupSpendingList = raw.budgetsWithCategories.map { group ->
+            val isTrackingAll = group.categories.isEmpty()
             val catSpending = group.categories.map { cat ->
                 val actual = categoryAmounts[cat.categoryName] ?: BigDecimal.ZERO
                 val convertedBudget = currencyConversionService.convertAmount(cat.budgetAmount, baseCurrency, displayCurrency)
@@ -1394,8 +1395,22 @@ class HomeViewModel @Inject constructor(
                     dailySpend = dailySpend
                 )
             }
-            val totalBudget = catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
-            val totalActual = catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.actualAmount }
+            val convertedGroupLimit = currencyConversionService.convertAmount(
+                group.budget.limitAmount, baseCurrency, displayCurrency
+            )
+            val totalBudget = when {
+                isTrackingAll -> convertedGroupLimit
+                // "Category Limits" are optional — the group-level limit is
+                // the source of truth when set, with the per-cat sum as a
+                // fallback for budgets that only define per-cat amounts.
+                convertedGroupLimit > BigDecimal.ZERO -> convertedGroupLimit
+                else -> catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
+            }
+            val totalActual = if (isTrackingAll) {
+                categoryAmounts.values.fold(BigDecimal.ZERO) { acc, v -> acc + v }
+            } else {
+                catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.actualAmount }
+            }
             val remaining = totalBudget - totalActual
             val pctUsed = if (totalBudget > BigDecimal.ZERO) {
                 (totalActual.toFloat() / totalBudget.toFloat() * 100f).coerceAtLeast(0f)
@@ -1405,14 +1420,15 @@ class HomeViewModel @Inject constructor(
             } else BigDecimal.ZERO
             BudgetGroupSpending(
                 group = group,
-                categorySpending = catSpending,
+                categorySpending = if (isTrackingAll) emptyList() else catSpending,
                 totalBudget = totalBudget,
                 totalActual = totalActual,
                 remaining = remaining,
                 percentageUsed = pctUsed,
                 dailyAllowance = dailyAllowance,
                 daysRemaining = raw.daysRemaining,
-                daysElapsed = raw.daysElapsed
+                daysElapsed = raw.daysElapsed,
+                isTrackingAllExpenses = isTrackingAll
             )
         }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -1398,13 +1398,14 @@ class HomeViewModel @Inject constructor(
             val convertedGroupLimit = currencyConversionService.convertAmount(
                 group.budget.limitAmount, baseCurrency, displayCurrency
             )
-            val totalBudget = when {
-                isTrackingAll -> convertedGroupLimit
-                // "Category Limits" are optional — the group-level limit is
-                // the source of truth when set, with the per-cat sum as a
-                // fallback for budgets that only define per-cat amounts.
-                convertedGroupLimit > BigDecimal.ZERO -> convertedGroupLimit
-                else -> catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
+            // "Category Limits" are optional — the group-level limit is the
+            // source of truth when set (including when isTrackingAll), with
+            // the per-cat sum as a fallback for budgets that only define
+            // per-cat amounts.
+            val totalBudget = if (convertedGroupLimit > BigDecimal.ZERO) {
+                convertedGroupLimit
+            } else {
+                catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
             }
             val totalActual = if (isTrackingAll) {
                 categoryAmounts.values.fold(BigDecimal.ZERO) { acc, v -> acc + v }

--- a/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
@@ -111,6 +111,7 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
                 }
 
                 val groupSpendingList = raw.budgetsWithCategories.map { group ->
+                    val isTrackingAll = group.categories.isEmpty()
                     val catSpending = group.categories.map { cat ->
                         val actual = categoryAmounts[cat.categoryName] ?: BigDecimal.ZERO
                         val convertedBudget = currencyConversionService.convertAmount(cat.budgetAmount, baseCurrency, displayCurrency)
@@ -118,9 +119,34 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
                             (categoryLimitBoosts[cat.categoryName] ?: BigDecimal.ZERO)
                         BudgetCategorySpending(cat.categoryName, effectiveBudget, actual, 0f, BigDecimal.ZERO)
                     }
-                    val totalBudget = catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
-                    val totalActual = catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.actualAmount }
-                    BudgetGroupSpending(group, catSpending, totalBudget, totalActual, totalBudget - totalActual, 0f, BigDecimal.ZERO, raw.daysRemaining, raw.daysElapsed)
+                    val convertedGroupLimit = currencyConversionService.convertAmount(
+                        group.budget.limitAmount, baseCurrency, displayCurrency
+                    )
+                    val totalBudget = when {
+                        isTrackingAll -> convertedGroupLimit
+                        // "Category Limits" are optional — the group-level limit
+                        // is the source of truth when set, with the per-cat sum
+                        // as a fallback for budgets that only define per-cat amounts.
+                        convertedGroupLimit > BigDecimal.ZERO -> convertedGroupLimit
+                        else -> catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
+                    }
+                    val totalActual = if (isTrackingAll) {
+                        categoryAmounts.values.fold(BigDecimal.ZERO) { acc, v -> acc + v }
+                    } else {
+                        catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.actualAmount }
+                    }
+                    BudgetGroupSpending(
+                        group,
+                        if (isTrackingAll) emptyList() else catSpending,
+                        totalBudget,
+                        totalActual,
+                        totalBudget - totalActual,
+                        0f,
+                        BigDecimal.ZERO,
+                        raw.daysRemaining,
+                        raw.daysElapsed,
+                        isTrackingAllExpenses = isTrackingAll
+                    )
                 }
 
                 val limitGroups = groupSpendingList.filter { it.group.budget.groupType == BudgetGroupType.LIMIT }

--- a/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
@@ -122,13 +122,14 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
                     val convertedGroupLimit = currencyConversionService.convertAmount(
                         group.budget.limitAmount, baseCurrency, displayCurrency
                     )
-                    val totalBudget = when {
-                        isTrackingAll -> convertedGroupLimit
-                        // "Category Limits" are optional — the group-level limit
-                        // is the source of truth when set, with the per-cat sum
-                        // as a fallback for budgets that only define per-cat amounts.
-                        convertedGroupLimit > BigDecimal.ZERO -> convertedGroupLimit
-                        else -> catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
+                    // "Category Limits" are optional — the group-level limit
+                    // is the source of truth when set (including when
+                    // isTrackingAll), with the per-cat sum as a fallback for
+                    // budgets that only define per-cat amounts.
+                    val totalBudget = if (convertedGroupLimit > BigDecimal.ZERO) {
+                        convertedGroupLimit
+                    } else {
+                        catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
                     }
                     val totalActual = if (isTrackingAll) {
                         categoryAmounts.values.fold(BigDecimal.ZERO) { acc, v -> acc + v }


### PR DESCRIPTION
## Summary
- Tester reported the Home budget carousel showing "Spent ₹53,345.99 of ₹0 — over by ₹53,345.99" for a group with a ₹40,000 limit but blank per-category limits.
- Root cause: `totalBudget` was computed as `sum(per-cat limits)` across 4 sites (Budgets screen single + unified, Home carousel, Widget). When categories were listed but their limits left blank, the sum was 0 and the group limit was silently ignored.
- Fix: switch all 4 sites to "group limit wins if set; per-cat sum is the fallback" — matches the "Category Limits (optional)" labelling in Edit Budget.
- Home carousel + Widget were also missing the `isTrackingAllExpenses` branch the Budgets screen already had, so groups with zero categories also showed `of ₹0` there. Added that branch in both.

## Behaviour change worth flagging
For users with **both** a group limit and non-zero per-cat limits, the group limit now wins (Budgets screen previously summed the cats). This matches the UI label and is the more intuitive behaviour, but it is a slight change for anyone in that configuration.

## Test plan
- [x] `./gradlew :app:compileStandardDebugKotlin` — clean (only pre-existing warnings).
- [ ] Manual: group with budget set and blank per-cat limits — Home card, Budgets screen (single + unified), Widget all show "of ₹40,000".
- [ ] Manual: group with per-cat limits only, no group limit — still shows the per-cat sum.
- [ ] Manual: group with zero categories — Home + Widget now also use the group limit instead of ₹0.
- [ ] Manual: cross-currency (budget in INR, display in USD) — group limit converts correctly.