### PR TITLE
fix: backup loans, transaction groups, profiles, and budget snapshots

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
@@ -74,6 +74,11 @@ class BackupExporter @Inject constructor(
         val budgetCategories = database.budgetDao().getAllBudgetCategories().first()
         val transactionSplits = database.transactionSplitDao().getAllSplits().first()
         val bankNotifications = database.bankNotificationDao().getAllNotifications().first()
+        val loans = database.loanDao().getAllLoans().first()
+        val transactionGroups = database.transactionGroupDao().getAllGroups().first()
+        val profiles = database.profileDao().getAllProfiles()
+        val budgetMonthSnapshots = database.budgetSnapshotDao().getAllGroupSnapshots()
+        val budgetCategoryMonthSnapshots = database.budgetSnapshotDao().getAllCategorySnapshots()
         
         // Get preferences from repository
         val prefs = userPreferencesRepository.userPreferences.first()
@@ -117,6 +122,15 @@ class BackupExporter @Inject constructor(
         val exportedTransactionSplits = if (privacy == ExportPrivacy.FULL) transactionSplits else emptyList()
         val exportedBankNotifications = if (privacy == ExportPrivacy.FULL) bankNotifications else emptyList()
         val exportedRuleApplications = if (privacy == ExportPrivacy.FULL) ruleApplications else emptyList()
+        // Loans / groups / profiles / budget snapshots: kept on FULL only, like
+        // every other relational table; in MASKED/ANONYMOUS the transaction
+        // references are stripped to "Merchant" anyway so re-attaching them is
+        // not useful.
+        val exportedLoans = if (privacy == ExportPrivacy.FULL) loans else emptyList()
+        val exportedTransactionGroups = if (privacy == ExportPrivacy.FULL) transactionGroups else emptyList()
+        val exportedProfiles = if (privacy == ExportPrivacy.FULL) profiles else emptyList()
+        val exportedBudgetMonthSnapshots = if (privacy == ExportPrivacy.FULL) budgetMonthSnapshots else emptyList()
+        val exportedBudgetCategoryMonthSnapshots = if (privacy == ExportPrivacy.FULL) budgetCategoryMonthSnapshots else emptyList()
         
         return PennyWiseBackup(
             metadata = BackupMetadata(
@@ -137,6 +151,11 @@ class BackupExporter @Inject constructor(
                     totalBudgetCategories = exportedBudgetCategories.size,
                     totalTransactionSplits = exportedTransactionSplits.size,
                     totalBankNotifications = exportedBankNotifications.size,
+                    totalLoans = exportedLoans.size,
+                    totalTransactionGroups = exportedTransactionGroups.size,
+                    totalProfiles = exportedProfiles.size,
+                    totalBudgetMonthSnapshots = exportedBudgetMonthSnapshots.size,
+                    totalBudgetCategoryMonthSnapshots = exportedBudgetCategoryMonthSnapshots.size,
                     dateRange = dateRange
                 )
             ),
@@ -155,7 +174,12 @@ class BackupExporter @Inject constructor(
                 budgets = exportedBudgets,
                 budgetCategories = exportedBudgetCategories,
                 transactionSplits = exportedTransactionSplits,
-                bankNotifications = exportedBankNotifications
+                bankNotifications = exportedBankNotifications,
+                loans = exportedLoans,
+                transactionGroups = exportedTransactionGroups,
+                profiles = exportedProfiles,
+                budgetMonthSnapshots = exportedBudgetMonthSnapshots,
+                budgetCategoryMonthSnapshots = exportedBudgetCategoryMonthSnapshots
             ),
             preferences = PreferencesSnapshot(
                 theme = ThemePreferences(

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
@@ -264,14 +264,35 @@ class BackupImporter @Inject constructor(
                 // refs on transactions get stripped to NULL — preventing the
                 // ghost-link bug where an old loan_id silently collides with
                 // a future auto-generated loan ID.
+                //
+                // Dedup by an immutable composite key so a repeat MERGE of the
+                // same backup maps each backup row to its already-imported
+                // local row instead of inserting a ghost duplicate. We avoid
+                // mutable fields (amount, note, status) so user edits between
+                // imports don't break the match.
+                val existingLoans = database.loanDao().getAllLoans().first()
+                val existingLoanKeyToId = existingLoans.associate {
+                    Triple(it.personName, it.direction, it.createdAt) to it.id
+                }
                 val oldToNewLoanIdMap = mutableMapOf<Long, Long>()
                 backup.database.loans.forEach { loan ->
-                    val newId = database.loanDao().insertLoan(loan.copy(id = 0))
+                    val key = Triple(loan.personName, loan.direction, loan.createdAt)
+                    val existingId = existingLoanKeyToId[key]
+                    val newId = existingId
+                        ?: database.loanDao().insertLoan(loan.copy(id = 0))
                     if (loan.id != 0L) oldToNewLoanIdMap[loan.id] = newId
+                }
+
+                val existingGroups = database.transactionGroupDao().getAllGroups().first()
+                val existingGroupKeyToId = existingGroups.associate {
+                    (it.name to it.createdAt) to it.id
                 }
                 val oldToNewGroupIdMap = mutableMapOf<Long, Long>()
                 backup.database.transactionGroups.forEach { group ->
-                    val newId = database.transactionGroupDao().insertGroup(group.copy(id = 0))
+                    val key = group.name to group.createdAt
+                    val existingId = existingGroupKeyToId[key]
+                    val newId = existingId
+                        ?: database.transactionGroupDao().insertGroup(group.copy(id = 0))
                     if (group.id != 0L) oldToNewGroupIdMap[group.id] = newId
                 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
@@ -89,20 +89,6 @@ class BackupImporter @Inject constructor(
         var importedTransactions = 0
         var importedCategories = 0
 
-        // Older backups (pre-v1.1) didn't serialize loans / transaction_groups.
-        // The transactions inside such backups still carry loan_id / group_id
-        // values that point at entities we never restored — and when the user
-        // later creates a new loan/group, Room auto-assigns an ID starting at 1
-        // and silently collides with those orphaned pointers (ghost-linking
-        // unrelated transactions). Strip the orphan refs at import time so
-        // those columns are NULL by the time anything new is inserted.
-        val backupLoanIds = backup.database.loans.map { it.id }.toSet()
-        val backupGroupIds = backup.database.transactionGroups.map { it.id }.toSet()
-        fun cleanTransaction(tx: TransactionEntity): TransactionEntity = tx.copy(
-            loanId = tx.loanId?.takeIf { it in backupLoanIds },
-            groupId = tx.groupId?.takeIf { it in backupGroupIds }
-        )
-
         return database.withTransaction {
             try {
                 // Clear existing data
@@ -127,16 +113,49 @@ class BackupImporter @Inject constructor(
                 // Profiles deliberately preserved — defaults (Personal=1, Business=2)
                 // are seeded on first launch and we don't want to wipe them.
 
-                // Import loans / groups BEFORE transactions so the foreign-key
-                // references on TransactionEntity.loan_id / group_id resolve.
-                // Both DAOs respect the explicit `id` field on @Insert when it
-                // is non-zero, so the backup's original IDs are preserved.
+                // Import loans / groups / profiles BEFORE transactions and
+                // account balances so the foreign-key references on those
+                // children (loan_id, group_id, profile_id) resolve.
+                //
+                // Loans & groups: both DAOs respect the explicit `id` field on
+                // @Insert when non-zero, so backup IDs are preserved.
+                // Profiles: explicit primary key, but local defaults (1, 2)
+                // already exist — importProfilesAndBuildMap dedups by name and
+                // returns a backup-id → final-local-id map so callers can
+                // remap each entity's profileId field.
                 backup.database.loans.forEach { loan ->
                     database.loanDao().insertLoan(loan)
                 }
                 backup.database.transactionGroups.forEach { group ->
                     database.transactionGroupDao().insertGroup(group)
                 }
+                val profileIdMap = importProfilesAndBuildMap(backup.database.profiles)
+
+                // Older backups (pre-v1.1) didn't serialize loans / groups,
+                // and profiles were never in v1.0 either. The transactions
+                // inside such backups still carry loan_id / group_id /
+                // profile_id values that point at entities we never restored.
+                // When the user later creates a new loan/group/profile, Room
+                // auto-assigns an ID that may silently collide with the
+                // orphan pointer (ghost-linking unrelated transactions).
+                // Strip orphan refs at import so those columns are NULL by
+                // the time anything new is inserted; for profile_id we keep
+                // refs that still point at a surviving local profile.
+                val backupLoanIds = backup.database.loans.map { it.id }.toSet()
+                val backupGroupIds = backup.database.transactionGroups.map { it.id }.toSet()
+                val survivingProfileIds = database.profileDao().getAllProfiles()
+                    .map { it.id }.toSet()
+                fun resolveProfileId(oldId: Long?): Long? = when {
+                    oldId == null -> null
+                    profileIdMap.containsKey(oldId) -> profileIdMap[oldId]
+                    oldId in survivingProfileIds -> oldId
+                    else -> null
+                }
+                fun cleanTransaction(tx: TransactionEntity): TransactionEntity = tx.copy(
+                    loanId = tx.loanId?.takeIf { it in backupLoanIds },
+                    groupId = tx.groupId?.takeIf { it in backupGroupIds },
+                    profileId = resolveProfileId(tx.profileId)
+                )
 
                 // Import all data
                 backup.database.categories.forEach { category ->
@@ -148,13 +167,20 @@ class BackupImporter @Inject constructor(
                     database.transactionDao().insertTransaction(cleanTransaction(transaction))
                     importedTransactions++
                 }
-                
+
                 backup.database.cards.forEach { card ->
                     database.cardDao().insertCard(card)
                 }
-                
+
                 backup.database.accountBalances.forEach { balance ->
-                    database.accountBalanceDao().insertBalance(balance)
+                    // Remap profile_id the same way as transactions; fall back
+                    // to PERSONAL when the source profile didn't survive (the
+                    // column is non-null with a default of 1).
+                    val mappedProfileId = resolveProfileId(balance.profileId)
+                        ?: ProfileEntity.PERSONAL_ID
+                    database.accountBalanceDao().insertBalance(
+                        balance.copy(profileId = mappedProfileId)
+                    )
                 }
                 
                 backup.database.subscriptions.forEach { subscription ->
@@ -196,17 +222,8 @@ class BackupImporter @Inject constructor(
                     database.bankNotificationDao().insertOrReplace(notification)
                 }
 
-                // Profiles: insert only ones we don't already have (preserves
-                // the default Personal=1 / Business=2 rows and any custom
-                // profiles the user has set up locally).
-                if (backup.database.profiles.isNotEmpty()) {
-                    val existingProfileIds = database.profileDao().getAllProfiles()
-                        .map { it.id }.toSet()
-                    backup.database.profiles
-                        .filter { it.id !in existingProfileIds }
-                        .takeIf { it.isNotEmpty() }
-                        ?.let { database.profileDao().insertAll(it) }
-                }
+                // Profiles were already imported earlier (before transactions /
+                // account balances) so foreign-key remapping could happen.
 
                 database.budgetSnapshotDao().insertGroupSnapshots(backup.database.budgetMonthSnapshots)
                 database.budgetSnapshotDao().insertCategorySnapshots(backup.database.budgetCategoryMonthSnapshots)
@@ -296,6 +313,20 @@ class BackupImporter @Inject constructor(
                     if (group.id != 0L) oldToNewGroupIdMap[group.id] = newId
                 }
 
+                // Build profile id map up-front so transactions and account
+                // balances can remap profile_id during insert (same hazard as
+                // loans/groups — a stale backup profile_id can collide with a
+                // future user-created profile and ghost-link transactions).
+                val profileIdMap = importProfilesAndBuildMap(backup.database.profiles)
+                val survivingProfileIds = database.profileDao().getAllProfiles()
+                    .map { it.id }.toSet()
+                fun resolveProfileId(oldId: Long?): Long? = when {
+                    oldId == null -> null
+                    profileIdMap.containsKey(oldId) -> profileIdMap[oldId]
+                    oldId in survivingProfileIds -> oldId
+                    else -> null
+                }
+
                 // Import transactions (skip duplicates by hash)
                 // Build mapping from old transaction IDs to new IDs for split/application imports
                 val oldToNewTransactionIdMap = mutableMapOf<Long, Long>()
@@ -306,7 +337,8 @@ class BackupImporter @Inject constructor(
                         val newTransaction = transaction.copy(
                             id = 0,
                             loanId = transaction.loanId?.let { oldToNewLoanIdMap[it] },
-                            groupId = transaction.groupId?.let { oldToNewGroupIdMap[it] }
+                            groupId = transaction.groupId?.let { oldToNewGroupIdMap[it] },
+                            profileId = resolveProfileId(transaction.profileId)
                         )
                         val newId = database.transactionDao().insertTransaction(newTransaction)
                         // Track old ID -> new ID mapping directly from insert result
@@ -326,7 +358,7 @@ class BackupImporter @Inject constructor(
                 
                 // Import other entities with duplicate checking
                 importCardsWithMerge(backup.database.cards)
-                importAccountBalancesWithMerge(backup.database.accountBalances)
+                importAccountBalancesWithMerge(backup.database.accountBalances) { resolveProfileId(it) }
                 importSubscriptionsWithMerge(backup.database.subscriptions)
                 importMerchantMappingsWithMerge(backup.database.merchantMappings)
                 
@@ -378,17 +410,8 @@ class BackupImporter @Inject constructor(
                     database.bankNotificationDao().insertOrReplace(notification)
                 }
 
-                // Profiles: insert ones we don't have locally yet so custom
-                // profiles from the backup come along, but the user's existing
-                // defaults / customisations are preserved.
-                if (backup.database.profiles.isNotEmpty()) {
-                    val existingProfileIds = database.profileDao().getAllProfiles()
-                        .map { it.id }.toSet()
-                    backup.database.profiles
-                        .filter { it.id !in existingProfileIds }
-                        .takeIf { it.isNotEmpty() }
-                        ?.let { database.profileDao().insertAll(it) }
-                }
+                // Profiles were already imported earlier (before transactions /
+                // account balances) so foreign-key remapping could happen.
 
                 // Budget month snapshots: merge by (year, month) pair —
                 // backup wins for any month the local DB also has so a stale
@@ -444,12 +467,20 @@ class BackupImporter @Inject constructor(
     }
     
     /**
-     * Import account balances with duplicate checking
+     * Import account balances with duplicate checking.
+     * @param resolveProfileId remaps the source profile_id to its final local
+     *   id (handles name-based dedup + orphan stripping). Caller passes a
+     *   closure that already knows about the current profile map.
      */
-    private suspend fun importAccountBalancesWithMerge(balances: List<AccountBalanceEntity>) {
+    private suspend fun importAccountBalancesWithMerge(
+        balances: List<AccountBalanceEntity>,
+        resolveProfileId: (Long?) -> Long?
+    ) {
         // For balances, we'll import all as they represent historical data
         balances.forEach { balance ->
-            val newBalance = balance.copy(id = 0)
+            val mappedProfileId = resolveProfileId(balance.profileId)
+                ?: ProfileEntity.PERSONAL_ID
+            val newBalance = balance.copy(id = 0, profileId = mappedProfileId)
             database.accountBalanceDao().insertBalance(newBalance)
         }
     }
@@ -513,6 +544,57 @@ class BackupImporter @Inject constructor(
         }
     }
     
+    /**
+     * Insert backup profiles and return a `backup-id → local-id` map so other
+     * tables (transactions, account balances) can rewrite their profile_id
+     * column to point at the surviving local profile.
+     *
+     * Dedup priority:
+     *  1. Match by `name` — if a local profile with the same name already
+     *     exists, the backup profile is treated as the same logical profile
+     *     and we map to its local id (no insert).
+     *  2. No name match, original id unused locally — insert with the
+     *     backup's original id.
+     *  3. No name match, original id collides with a different local
+     *     profile — insert under a fresh id (max existing + 1) so we don't
+     *     overwrite the local row of a different identity.
+     *
+     * This keeps default profiles (Personal=1, Business=2) stable across
+     * imports because they match by name; only genuine new custom profiles
+     * get inserted.
+     */
+    private suspend fun importProfilesAndBuildMap(
+        profiles: List<ProfileEntity>
+    ): Map<Long, Long> {
+        if (profiles.isEmpty()) return emptyMap()
+
+        val existing = database.profileDao().getAllProfiles()
+        val existingByName = existing.associateBy { it.name }
+        val takenIds = existing.map { it.id }.toMutableSet()
+        var nextId = (takenIds.maxOrNull() ?: 0L) + 1
+
+        val map = mutableMapOf<Long, Long>()
+        for (profile in profiles) {
+            val matched = existingByName[profile.name]
+            val finalId = when {
+                matched != null -> matched.id
+                profile.id !in takenIds -> {
+                    database.profileDao().insert(profile)
+                    takenIds.add(profile.id)
+                    profile.id
+                }
+                else -> {
+                    val newId = nextId++
+                    database.profileDao().insert(profile.copy(id = newId))
+                    takenIds.add(newId)
+                    newId
+                }
+            }
+            map[profile.id] = finalId
+        }
+        return map
+    }
+
     /**
      * Import user preferences
      */

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
@@ -88,7 +88,21 @@ class BackupImporter @Inject constructor(
     private suspend fun replaceAllData(backup: PennyWiseBackup): ImportResult {
         var importedTransactions = 0
         var importedCategories = 0
-        
+
+        // Older backups (pre-v1.1) didn't serialize loans / transaction_groups.
+        // The transactions inside such backups still carry loan_id / group_id
+        // values that point at entities we never restored — and when the user
+        // later creates a new loan/group, Room auto-assigns an ID starting at 1
+        // and silently collides with those orphaned pointers (ghost-linking
+        // unrelated transactions). Strip the orphan refs at import time so
+        // those columns are NULL by the time anything new is inserted.
+        val backupLoanIds = backup.database.loans.map { it.id }.toSet()
+        val backupGroupIds = backup.database.transactionGroups.map { it.id }.toSet()
+        fun cleanTransaction(tx: TransactionEntity): TransactionEntity = tx.copy(
+            loanId = tx.loanId?.takeIf { it in backupLoanIds },
+            groupId = tx.groupId?.takeIf { it in backupGroupIds }
+        )
+
         return database.withTransaction {
             try {
                 // Clear existing data
@@ -105,16 +119,33 @@ class BackupImporter @Inject constructor(
                 database.budgetDao().deleteAllBudgets()
                 database.exchangeRateDao().deleteAllRates()
                 database.bankNotificationDao().deleteAllNotifications()
+                database.loanDao().deleteAllLoans()
+                database.transactionGroupDao().deleteAllGroups()
+                database.budgetSnapshotDao().deleteAllGroupSnapshots()
+                database.budgetSnapshotDao().deleteAllCategorySnapshots()
                 // Note: budget categories and transaction splits are deleted via cascade (budget categories via budget deletion, transaction splits via transaction deletion)
-                
+                // Profiles deliberately preserved — defaults (Personal=1, Business=2)
+                // are seeded on first launch and we don't want to wipe them.
+
+                // Import loans / groups BEFORE transactions so the foreign-key
+                // references on TransactionEntity.loan_id / group_id resolve.
+                // Both DAOs respect the explicit `id` field on @Insert when it
+                // is non-zero, so the backup's original IDs are preserved.
+                backup.database.loans.forEach { loan ->
+                    database.loanDao().insertLoan(loan)
+                }
+                backup.database.transactionGroups.forEach { group ->
+                    database.transactionGroupDao().insertGroup(group)
+                }
+
                 // Import all data
                 backup.database.categories.forEach { category ->
                     database.categoryDao().insertCategory(category)
                     importedCategories++
                 }
-                
+
                 backup.database.transactions.forEach { transaction ->
-                    database.transactionDao().insertTransaction(transaction)
+                    database.transactionDao().insertTransaction(cleanTransaction(transaction))
                     importedTransactions++
                 }
                 
@@ -164,10 +195,25 @@ class BackupImporter @Inject constructor(
                 backup.database.bankNotifications.forEach { notification ->
                     database.bankNotificationDao().insertOrReplace(notification)
                 }
-                
+
+                // Profiles: insert only ones we don't already have (preserves
+                // the default Personal=1 / Business=2 rows and any custom
+                // profiles the user has set up locally).
+                if (backup.database.profiles.isNotEmpty()) {
+                    val existingProfileIds = database.profileDao().getAllProfiles()
+                        .map { it.id }.toSet()
+                    backup.database.profiles
+                        .filter { it.id !in existingProfileIds }
+                        .takeIf { it.isNotEmpty() }
+                        ?.let { database.profileDao().insertAll(it) }
+                }
+
+                database.budgetSnapshotDao().insertGroupSnapshots(backup.database.budgetMonthSnapshots)
+                database.budgetSnapshotDao().insertCategorySnapshots(backup.database.budgetCategoryMonthSnapshots)
+
                 // Import preferences
                 importPreferences(backup.preferences)
-                
+
                 ImportResult.Success(
                     importedTransactions = importedTransactions,
                     importedCategories = importedCategories,
@@ -186,7 +232,7 @@ class BackupImporter @Inject constructor(
         var importedTransactions = 0
         var importedCategories = 0
         var skippedDuplicates = 0
-        
+
         return database.withTransaction {
             try {
                 // Get existing data for duplicate checking
@@ -194,12 +240,12 @@ class BackupImporter @Inject constructor(
                     .getAllTransactions().first()
                 val existingTransactionHashes = existingTransactions.map { it.transactionHash }.toSet()
                 val existingHashToIdMap = existingTransactions.associateBy({ it.transactionHash }, { it.id })
-                
+
                 val existingCategories = database.categoryDao()
                     .getAllCategories().first()
                     .map { it.name }
                     .toSet()
-                
+
                 // Import categories (merge by name)
                 backup.database.categories.forEach { category ->
                     if (!existingCategories.contains(category.name)) {
@@ -209,15 +255,38 @@ class BackupImporter @Inject constructor(
                         importedCategories++
                     }
                 }
-                
+
+                // Import loans / groups BEFORE transactions so we can remap
+                // TransactionEntity.loan_id and group_id to the new local IDs
+                // (Room hands us fresh IDs because we insert with id = 0 in
+                // merge mode). For older backups that don't carry these
+                // entities at all, the maps stay empty and the corresponding
+                // refs on transactions get stripped to NULL — preventing the
+                // ghost-link bug where an old loan_id silently collides with
+                // a future auto-generated loan ID.
+                val oldToNewLoanIdMap = mutableMapOf<Long, Long>()
+                backup.database.loans.forEach { loan ->
+                    val newId = database.loanDao().insertLoan(loan.copy(id = 0))
+                    if (loan.id != 0L) oldToNewLoanIdMap[loan.id] = newId
+                }
+                val oldToNewGroupIdMap = mutableMapOf<Long, Long>()
+                backup.database.transactionGroups.forEach { group ->
+                    val newId = database.transactionGroupDao().insertGroup(group.copy(id = 0))
+                    if (group.id != 0L) oldToNewGroupIdMap[group.id] = newId
+                }
+
                 // Import transactions (skip duplicates by hash)
                 // Build mapping from old transaction IDs to new IDs for split/application imports
                 val oldToNewTransactionIdMap = mutableMapOf<Long, Long>()
-                
+
                 backup.database.transactions.forEach { transaction ->
                     if (!existingTransactionHashes.contains(transaction.transactionHash)) {
                         val oldId = transaction.id
-                        val newTransaction = transaction.copy(id = 0)
+                        val newTransaction = transaction.copy(
+                            id = 0,
+                            loanId = transaction.loanId?.let { oldToNewLoanIdMap[it] },
+                            groupId = transaction.groupId?.let { oldToNewGroupIdMap[it] }
+                        )
                         val newId = database.transactionDao().insertTransaction(newTransaction)
                         // Track old ID -> new ID mapping directly from insert result
                         if (oldId != 0L) {
@@ -287,7 +356,42 @@ class BackupImporter @Inject constructor(
                 backup.database.bankNotifications.forEach { notification ->
                     database.bankNotificationDao().insertOrReplace(notification)
                 }
-                
+
+                // Profiles: insert ones we don't have locally yet so custom
+                // profiles from the backup come along, but the user's existing
+                // defaults / customisations are preserved.
+                if (backup.database.profiles.isNotEmpty()) {
+                    val existingProfileIds = database.profileDao().getAllProfiles()
+                        .map { it.id }.toSet()
+                    backup.database.profiles
+                        .filter { it.id !in existingProfileIds }
+                        .takeIf { it.isNotEmpty() }
+                        ?.let { database.profileDao().insertAll(it) }
+                }
+
+                // Budget month snapshots: merge by (year, month) pair —
+                // backup wins for any month the local DB also has so a stale
+                // local snapshot doesn't double up with the imported one.
+                if (backup.database.budgetMonthSnapshots.isNotEmpty() ||
+                    backup.database.budgetCategoryMonthSnapshots.isNotEmpty()
+                ) {
+                    val groupByMonth = backup.database.budgetMonthSnapshots
+                        .groupBy { it.year to it.month }
+                    val catByMonth = backup.database.budgetCategoryMonthSnapshots
+                        .groupBy { it.year to it.month }
+                    val allMonths = (groupByMonth.keys + catByMonth.keys)
+                    allMonths.forEach { (year, month) ->
+                        database.budgetSnapshotDao().replaceMonthSnapshots(
+                            year = year,
+                            month = month,
+                            groupSnapshots = (groupByMonth[year to month] ?: emptyList())
+                                .map { it.copy(id = 0) },
+                            categorySnapshots = (catByMonth[year to month] ?: emptyList())
+                                .map { it.copy(id = 0) }
+                        )
+                    }
+                }
+
                 // Import preferences (merge with existing)
                 importPreferences(backup.preferences)
                 

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
@@ -584,6 +584,11 @@ class BackupImporter @Inject constructor(
                     profile.id
                 }
                 else -> {
+                    // Advance past any ids that case 2 above has inserted
+                    // during this same loop, otherwise `nextId` might already
+                    // belong to a freshly-imported profile and trip the
+                    // UNIQUE PK constraint on insert.
+                    while (nextId in takenIds) nextId++
                     val newId = nextId++
                     database.profileDao().insert(profile.copy(id = newId))
                     takenIds.add(newId)

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
@@ -9,7 +9,7 @@ import java.time.LocalDateTime
  */
 data class PennyWiseBackup(
     @SerializedName("_format")
-    val format: String = "PennyWise Backup v1.0",
+    val format: String = "PennyWise Backup v1.1",
     
     @SerializedName("_warning")
     val warning: String = "Contains sensitive financial data. Keep this file secure.",
@@ -86,7 +86,22 @@ data class BackupStatistics(
     
     @SerializedName("total_bank_notifications")
     val totalBankNotifications: Int = 0,
-    
+
+    @SerializedName("total_loans")
+    val totalLoans: Int = 0,
+
+    @SerializedName("total_transaction_groups")
+    val totalTransactionGroups: Int = 0,
+
+    @SerializedName("total_profiles")
+    val totalProfiles: Int = 0,
+
+    @SerializedName("total_budget_month_snapshots")
+    val totalBudgetMonthSnapshots: Int = 0,
+
+    @SerializedName("total_budget_category_month_snapshots")
+    val totalBudgetCategoryMonthSnapshots: Int = 0,
+
     @SerializedName("date_range")
     val dateRange: DateRange?
 )
@@ -149,7 +164,22 @@ data class DatabaseSnapshot(
     val transactionSplits: List<TransactionSplitEntity> = emptyList(),
     
     @SerializedName("bank_notifications")
-    val bankNotifications: List<BankNotificationEntity> = emptyList()
+    val bankNotifications: List<BankNotificationEntity> = emptyList(),
+
+    @SerializedName("loans")
+    val loans: List<LoanEntity> = emptyList(),
+
+    @SerializedName("transaction_groups")
+    val transactionGroups: List<TransactionGroupEntity> = emptyList(),
+
+    @SerializedName("profiles")
+    val profiles: List<ProfileEntity> = emptyList(),
+
+    @SerializedName("budget_month_snapshots")
+    val budgetMonthSnapshots: List<BudgetMonthSnapshotEntity> = emptyList(),
+
+    @SerializedName("budget_category_month_snapshots")
+    val budgetCategoryMonthSnapshots: List<BudgetCategoryMonthSnapshotEntity> = emptyList()
 )
 
 /**

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/BudgetSnapshotDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/BudgetSnapshotDao.kt
@@ -40,4 +40,17 @@ interface BudgetSnapshotDao {
 
     @Query("SELECT * FROM budget_category_month_snapshots WHERE year = :year AND month = :month")
     suspend fun getCategorySnapshots(year: Int, month: Int): List<BudgetCategoryMonthSnapshotEntity>
+
+    // Full-table reads used by backup export.
+    @Query("SELECT * FROM budget_month_snapshots")
+    suspend fun getAllGroupSnapshots(): List<BudgetMonthSnapshotEntity>
+
+    @Query("SELECT * FROM budget_category_month_snapshots")
+    suspend fun getAllCategorySnapshots(): List<BudgetCategoryMonthSnapshotEntity>
+
+    @Query("DELETE FROM budget_month_snapshots")
+    suspend fun deleteAllGroupSnapshots()
+
+    @Query("DELETE FROM budget_category_month_snapshots")
+    suspend fun deleteAllCategorySnapshots()
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/LoanDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/LoanDao.kt
@@ -113,4 +113,8 @@ interface LoanDao {
         LIMIT :limit
     """)
     fun getRecentUnlinkedTransactionsByType(type: String, limit: Int = 20): Flow<List<TransactionEntity>>
+
+    // Used by BackupImporter.replaceAllData to clear loans before re-import.
+    @Query("DELETE FROM loans")
+    suspend fun deleteAllLoans()
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionGroupDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionGroupDao.kt
@@ -67,4 +67,8 @@ interface TransactionGroupDao {
         LIMIT :limit
     """)
     fun searchUngroupedTransactions(query: String, limit: Int = 50): Flow<List<TransactionEntity>>
+
+    // Used by BackupImporter.replaceAllData to clear groups before re-import.
+    @Query("DELETE FROM transaction_groups")
+    suspend fun deleteAllGroups()
 }


### PR DESCRIPTION
## Summary
Tester reported that after fresh-install + import, the Loans section and transaction groups disappear, and "Mark as loan" on a random transaction ghost-links 6 unrelated transactions to the new loan.

**Root cause:** the backup snapshot serialised `TransactionEntity` (with its `loan_id` / `group_id` FK columns) but never serialised the `LoanEntity` / `TransactionGroupEntity` rows themselves. On import, transactions came back with stale `loan_id` values pointing at nothing; when the user created a new loan, Room auto-assigned id=1 and silently collided with the orphan refs.

## Changes
- **BackupModels** — bump format to `v1.1`; add `loans`, `transactionGroups`, `profiles`, `budgetMonthSnapshots`, `budgetCategoryMonthSnapshots` to `DatabaseSnapshot` (default `emptyList()` so v1.0 backups still parse). Mirror counts in `BackupStatistics`.
- **BackupExporter** — read from the new DAOs, populate snapshot + stats.
- **BackupImporter**
  - REPLACE_ALL: clear the new tables; insert loans/groups with original IDs so transactions resolve. Profiles preserved (defaults seeded on first launch); only add profiles whose IDs aren't already present.
  - MERGE: insert loans/groups with `id=0`, build `oldToNewLoanIdMap` / `oldToNewGroupIdMap`, remap each transaction's `loanId` / `groupId` during insert.
  - Snapshots merge by `(year, month)` via existing `replaceMonthSnapshots`.
  - **Defensive null-out for v1.0 backups**: strip `transaction.loanId` / `groupId` to NULL when the referenced entity isn't in the snapshot. Prevents the ghost-link bug on existing backups.
- **DAOs** — add bulk `deleteAll*()` queries on LoanDao / TransactionGroupDao / BudgetSnapshotDao, plus full-table reads on BudgetSnapshotDao. Existing single-entity `insert*` methods already respect explicit IDs.

## Test plan
- [x] `./gradlew :app:compileStandardDebugKotlin` clean (only pre-existing warnings)
- [x] `BackupModelsTest` still passes
- [ ] Manual: backup with active loans → import on a fresh install → loans appear with correct math
- [ ] Manual: backup with transaction groups → import → groups intact, transactions still linked
- [ ] Manual: backup with multiple profiles (Personal + Business + custom) → import → all profiles present, transactions partitioned correctly
- [ ] Manual: backup with budget month snapshots → import → historical Budgets screen renders past months
- [ ] Manual: import an OLD (v1.0) backup that has `loan_id` set on transactions → loan section is empty, transactions have no "Lent to X" tag, "Mark as loan" on one transaction creates an isolated loan (no ghost-link)
- [ ] Manual: cross-currency profiles still work after import

## Tester caveat
For the tester's already-broken state from an existing v1.0 backup: the defensive null-out stops the ghost-link, but the historical loan rows (and what was repaid) **cannot be recovered** — they were never serialised. They'll need to rebuild loans manually from here forward.