### PR TITLE
feat: add Cashfree (India) payment-gateway SMS parser

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -14,6 +14,7 @@ object BankParserFactory {
         IndianBankParser(),
         FederalBankParser(),
         JuspayParser(),
+        CashfreeParser(),  // Cashfree payment gateway (India) — grouped with other aggregators
         SliceParser(),
         CredParser(),
         LazyPayParser(),

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CashfreeParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CashfreeParser.kt
@@ -1,0 +1,113 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Cashfree payment gateway confirmations.
+ * Handles DLT-style senders such as JX-CSHfre-S, VK-CSHfre-S, JD-CSHfre-T, etc.
+ *
+ * Cashfree is a payment aggregator (similar in role to Juspay) that delivers
+ * outgoing payment confirmations on behalf of merchants. Messages typically look like:
+ *
+ *   "Payment INR 50.00 (ID:1234567890) confirmed for order #abc_123 on MerchantName.
+ *    Powered by Cashfree"
+ *
+ * The gateway has no concept of balance, account, mandate, or subscription, so this
+ * parser extends [BankParser] directly rather than [BaseIndianBankParser].
+ */
+class CashfreeParser : BankParser() {
+
+    override fun getBankName() = "Cashfree"
+
+    override fun getCurrency() = "INR"
+
+    override fun canHandle(sender: String): Boolean {
+        // Match the CSHfre token case-insensitively. Covers headers like
+        // JX-CSHfre-S, VK-CSHfre-S, JD-CSHfre-T, and plain "CSHFRE".
+        return sender.uppercase().contains("CSHFRE")
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lowerMessage = message.lowercase()
+
+        // Cashfree-specific confirmation phrasing: "Payment ... confirmed for order ..."
+        if (lowerMessage.contains("payment") &&
+            lowerMessage.contains("confirmed for order")
+        ) {
+            return true
+        }
+
+        return super.isTransactionMessage(message)
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // Pattern: "Payment INR 50.00"
+        val paymentPattern = Regex(
+            """Payment\s+INR\s+([0-9,]+(?:\.\d{1,2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        paymentPattern.find(message)?.let { match ->
+            return try {
+                BigDecimal(match.groupValues[1].replace(",", ""))
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+
+        return super.extractAmount(message)
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lowerMessage = message.lowercase()
+
+        // Cashfree messages are outgoing payment confirmations.
+        if (lowerMessage.contains("payment") &&
+            lowerMessage.contains("confirmed for order")
+        ) {
+            return TransactionType.EXPENSE
+        }
+
+        return super.extractTransactionType(message)
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // Pattern: "...confirmed for order #<orderId> on <Merchant>."
+        // Capture the merchant between "on " and the next period/end-of-line.
+        val merchantPattern = Regex(
+            """confirmed\s+for\s+order\s+#\S+\s+on\s+([^.\n\r]+?)(?:\.|$)""",
+            RegexOption.IGNORE_CASE
+        )
+        merchantPattern.find(message)?.let { match ->
+            val cleaned = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(cleaned)) {
+                return cleaned
+            }
+        }
+
+        return super.extractMerchant(message, sender)
+    }
+
+    override fun extractReference(message: String): String? {
+        // Pattern: "(ID:5448114171)"
+        val idPattern = Regex(
+            """\(ID:\s*([A-Za-z0-9]+)\)""",
+            RegexOption.IGNORE_CASE
+        )
+        idPattern.find(message)?.let { match ->
+            return match.groupValues[1]
+        }
+
+        return super.extractReference(message)
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        // Cashfree confirmations carry no account/card identifier.
+        return null
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        // Cashfree confirmations carry no balance information.
+        return null
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CashfreeParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CashfreeParser.kt
@@ -31,6 +31,17 @@ class CashfreeParser : BankParser() {
     override fun isTransactionMessage(message: String): Boolean {
         val lowerMessage = message.lowercase()
 
+        // Reject OTP / verification messages first so a Cashfree-sender
+        // promo or deep-link that happens to contain "payment" + "confirmed
+        // for order" alongside OTP content can never short-circuit past the
+        // guard below.
+        if (lowerMessage.contains("otp") ||
+            lowerMessage.contains("one time password") ||
+            lowerMessage.contains("verification code")
+        ) {
+            return false
+        }
+
         // Cashfree-specific confirmation phrasing: "Payment ... confirmed for order ..."
         if (lowerMessage.contains("payment") &&
             lowerMessage.contains("confirmed for order")

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/CashfreeParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/CashfreeParserTest.kt
@@ -32,6 +32,30 @@ class CashfreeParserTest {
                 message = "OTP 123456 is your one time password. Do not share.",
                 sender = "JX-CSHfre-S",
                 shouldParse = false
+            ),
+            ParserTestCase(
+                // Cashfree-sender message that lacks the "confirmed for order"
+                // phrasing — must fall through isTransactionMessage to the
+                // base class and ultimately return null (no amount extractable).
+                name = "Cashfree sender without confirmation phrasing returns null",
+                message = "Payment options are available on our portal. Powered by Cashfree",
+                sender = "JX-CSHfre-S",
+                shouldParse = false
+            ),
+            ParserTestCase(
+                // Multi-word merchant containing a space — the merchant regex
+                // (`[^.\n\r]+?` stopping at `.`) must capture the full name
+                // and not bleed into the trailing "Powered by Cashfree" line.
+                name = "Multi-word merchant is captured up to the period",
+                message = "Payment INR 299.00 (ID:9988776655) confirmed for order #order_001 on Sun Direct.\nPowered by Cashfree",
+                sender = "VK-CSHfre-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("299.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Sun Direct",
+                    reference = "9988776655"
+                )
             )
         )
 

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/CashfreeParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/CashfreeParserTest.kt
@@ -1,0 +1,55 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class CashfreeParserTest {
+
+    @TestFactory
+    fun `cashfree parser handles representative messages`(): List<DynamicTest> {
+        val parser = CashfreeParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "Outgoing payment confirmation",
+                message = "Payment INR 50.00 (ID:5448114171) confirmed for order #735571_428_1777162938185 on AuraGold.\nPowered by Cashfree",
+                sender = "JX-CSHfre-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("50.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "AuraGold",
+                    reference = "5448114171"
+                )
+            ),
+            ParserTestCase(
+                name = "OTP message should be rejected",
+                message = "OTP 123456 is your one time password. Do not share.",
+                sender = "JX-CSHfre-S",
+                shouldParse = false
+            )
+        )
+
+        val handleCases = listOf(
+            "JX-CSHfre-S" to true,
+            "VK-CSHfre-T" to true,
+            "JD-CSHfre-S" to true,
+            "CSHFRE" to true,
+            "HDFCBK" to false,
+            "JD-HDFCBK-S" to false,
+            "UNKNOWN" to false
+        )
+
+        return ParserTestUtils.runTestSuite(
+            parser = parser,
+            testCases = testCases,
+            handleCases = handleCases,
+            suiteName = "Cashfree Parser Suite"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Add a parser for **Cashfree**, an Indian payment gateway in the same family as Juspay. Sender follows the DLT format `XX-CSHfre-S`/`T` — we match the `CSHfre` substring case-insensitively so any DLT prefix works.

## Sample handled
```
Payment INR 50.00 (ID:5448114171) confirmed for order #735571_428_1777162938185 on AuraGold.
Powered by Cashfree
```
→ EXPENSE / ₹50.00 / merchant `AuraGold` / reference `5448114171`

## Scope notes
- Only one SMS sample available, so the parser is intentionally narrow to the "Payment INR \<amt\> ... confirmed for order ... on \<Merchant\>" phrasing. Refund / failure / non-INR variants are not modelled yet — easy to extend when those samples land.
- Cashfree is a gateway (no balance, no account, no mandate) so we extend `BankParser` directly, not `BaseIndianBankParser`. Same shape as `JuspayParser`.

## Test plan
- [x] `./gradlew :parser-core:jvmTest --tests "*CashfreeParserTest"` — 9 dynamic tests pass
- [x] Positive parse for the sample above
- [x] `canHandle` matches `JX-CSHfre-S`, `VK-CSHfre-T`, etc.; rejects `HDFCBK`
- [x] OTP/non-Cashfree messages return null