### PR TITLE
fix: parse HDFC credit-card refund SMS instead of dropping them

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/HDFCBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/HDFCBankParser.kt
@@ -341,9 +341,12 @@ class HDFCBankParser : BaseIndianBankParser() {
         }
 
         // Pattern for "HDFC Bank Credit Card ####" / "HDFC Bank Debit Card ####"
-        // (refund SMS uses this format without the `x` mask prefix).
+        // (refund SMS uses this format without the `x` mask prefix). The `\b`
+        // after the capture group prevents us from greedily grabbing the
+        // first 4 of a longer digit run, which would return the wrong
+        // last-4 if HDFC ever uses 5+ digits.
         val plainCardPattern = Regex(
-            """HDFC\s+Bank\s+(?:Credit|Debit)\s+Card\s+(\d{4})""",
+            """HDFC\s+Bank\s+(?:Credit|Debit)\s+Card\s+(\d{4})\b""",
             RegexOption.IGNORE_CASE
         )
         plainCardPattern.find(message)?.let { match ->

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/HDFCBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/HDFCBankParser.kt
@@ -340,6 +340,16 @@ class HDFCBankParser : BaseIndianBankParser() {
             return match.groupValues[1]
         }
 
+        // Pattern for "HDFC Bank Credit Card ####" / "HDFC Bank Debit Card ####"
+        // (refund SMS uses this format without the `x` mask prefix).
+        val plainCardPattern = Regex(
+            """HDFC\s+Bank\s+(?:Credit|Debit)\s+Card\s+(\d{4})""",
+            RegexOption.IGNORE_CASE
+        )
+        plainCardPattern.find(message)?.let { match ->
+            return match.groupValues[1]
+        }
+
         // Pattern for "BLOCK DC ####" format — already exactly 4 digits
         val blockDCPattern = Regex("""BLOCK\s+DC\s+(\d{4})""", RegexOption.IGNORE_CASE)
         blockDCPattern.find(message)?.let { match ->
@@ -495,7 +505,8 @@ class HDFCBankParser : BaseIndianBankParser() {
             "spent", "received", "transferred", "paid",
             "sent", // HDFC uses "Sent Rs.X From HDFC Bank"
             "deducted", // Add support for "deducted from" pattern
-            "txn" // HDFC uses "Txn Rs.X" for card transactions
+            "txn", // HDFC uses "Txn Rs.X" for card transactions
+            "refund" // "Refund initiated: Amt: Rs.X on HDFC Bank Credit Card ####"
         )
 
         return hdfcTransactionKeywords.any { lowerMessage.contains(it) }

--- a/parser-core/src/test/kotlin/TestHDFCBankParser.kt
+++ b/parser-core/src/test/kotlin/TestHDFCBankParser.kt
@@ -76,6 +76,21 @@ T&C. Ignore if paid""",
                     merchant = "ACME TECHNOLOGIES",
                     balance = BigDecimal("8.00")
                 )
+            ),
+
+            // Credit-card refund — incoming credit to the card. Reported via
+            // TODO.md: parser was dropping these silently because the message
+            // lacks the standard "debited/credited/spent/..." keywords.
+            ParserTestCase(
+                name = "Credit Card Refund Initiated - Income",
+                message = "Refund initiated: Amt: Rs.34274.66 on HDFC Bank Credit Card 1111. To receive your Refund,please update your Bank details: TnC.",
+                sender = "VM-HDFCBK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("34274.66"),
+                    currency = "INR",
+                    type = com.pennywiseai.parser.core.TransactionType.INCOME,
+                    accountLast4 = "1111"
+                )
             )
         )
 


### PR DESCRIPTION
## Summary
TODO.md flagged: *"Please add refund amount of credit card to the credit balance."*

Sample SMS:
> Refund initiated: Amt: Rs.34274.66 on HDFC Bank Credit Card 1111. To receive your Refund,please update your Bank details: TnC.

This message was being silently dropped at the parser level — two gaps in `HDFCBankParser`:

1. **`isTransactionMessage` rejected it.** None of the existing HDFC keywords (`debited`/`credited`/`spent`/`withdrawn`/`sent`/`deducted`/`txn`) appear in a "Refund initiated" SMS. `extractTransactionType` already maps `refund` → INCOME, but execution never reached that point. Fix: add `refund` to the keyword list.
2. **`extractAccountLast4` only matched `Card x####`** (with the mask prefix). Refund SMS use the plain `HDFC Bank Credit Card ####` form. Fix: add a `HDFC\s+Bank\s+(?:Credit|Debit)\s+Card\s+(\d{4})` pattern.

With both fixes the message parses as INCOME with `accountLast4 = "1111"`, which the app's existing credit-card balance update path then applies — closing the "refund should land on the credit balance" loop. No app-side changes were needed.

## Test plan
- [x] New test `Credit Card Refund Initiated - Income` added in `TestHDFCBankParser.kt` — failed against `main`, passes with the fix.
- [x] Full `:parser-core:jvmTest` suite green — no regressions on existing HDFC cases or other parsers.