### PR TITLE
feat: add ENDED state and 'Cancelled' section for subscriptions

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/SubscriptionEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/SubscriptionEntity.kt
@@ -49,5 +49,6 @@ data class SubscriptionEntity(
 
 enum class SubscriptionState {
     ACTIVE,
-    HIDDEN  // Soft delete - hidden from view but kept for reactivation detection
+    HIDDEN, // Soft delete - hidden from view but kept for reactivation detection
+    ENDED   // User explicitly cancelled; never auto-reactivates on new mandate SMS
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/SubscriptionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/SubscriptionRepository.kt
@@ -195,6 +195,13 @@ class SubscriptionRepository @Inject constructor(
             // ENDED is terminal — the user explicitly cancelled and we never
             // auto-reactivate or overwrite. Return the ID untouched so any
             // downstream linking still resolves but the row stays cancelled.
+            //
+            // Tradeoff: if the user genuinely re-subscribes to the same
+            // service at the same price, the new mandate gets silently
+            // absorbed into the ENDED row instead of resurrecting it. That's
+            // intentional — auto-reactivation would defeat the whole point
+            // of the ENDED state — and recovery is one tap: open the
+            // Cancelled section on the subscriptions screen → Reactivate.
             if (existing.state == SubscriptionState.ENDED) {
                 Log.d(TAG, "Subscription ${existing.id} is ENDED — leaving untouched.")
                 return existing.id

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/SubscriptionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/SubscriptionRepository.kt
@@ -29,8 +29,11 @@ class SubscriptionRepository @Inject constructor(
     fun getAllSubscriptions(): Flow<List<SubscriptionEntity>> = 
         subscriptionDao.getAllSubscriptions()
     
-    fun getActiveSubscriptions(): Flow<List<SubscriptionEntity>> = 
+    fun getActiveSubscriptions(): Flow<List<SubscriptionEntity>> =
         subscriptionDao.getActiveSubscriptions()
+
+    fun getEndedSubscriptions(): Flow<List<SubscriptionEntity>> =
+        subscriptionDao.getSubscriptionsByState(SubscriptionState.ENDED)
     
     fun getUpcomingSubscriptions(daysAhead: Int = 7): Flow<List<SubscriptionEntity>> {
         val futureDate = LocalDate.now().plusDays(daysAhead.toLong())
@@ -54,7 +57,26 @@ class SubscriptionRepository @Inject constructor(
         updateSubscriptionState(id, SubscriptionState.HIDDEN)
     }
     
-    suspend fun unhideSubscription(id: Long) = 
+    suspend fun unhideSubscription(id: Long) =
+        updateSubscriptionState(id, SubscriptionState.ACTIVE)
+
+    /**
+     * Marks a subscription as ENDED. Unlike HIDDEN, an ENDED subscription
+     * is treated as terminal: new mandate SMS for the same merchant/amount
+     * will not auto-reactivate it. The user can still manually reactivate
+     * via [reactivateSubscription].
+     */
+    suspend fun markAsEnded(id: Long) {
+        Log.d(TAG, "Marking subscription with ID: $id as ENDED")
+        updateSubscriptionState(id, SubscriptionState.ENDED)
+    }
+
+    /**
+     * Manual escape hatch: revert ENDED → ACTIVE. Same code path as
+     * unhideSubscription but separated for symmetry with markAsEnded so
+     * callers can express intent clearly.
+     */
+    suspend fun reactivateSubscription(id: Long) =
         updateSubscriptionState(id, SubscriptionState.ACTIVE)
     
     suspend fun deleteSubscription(id: Long) = 
@@ -170,6 +192,14 @@ class SubscriptionRepository @Inject constructor(
                   "StoredDate=${it.nextPaymentDate}" } ?: "NOT FOUND"}")
 
         val subscription = if (existing != null) {
+            // ENDED is terminal — the user explicitly cancelled and we never
+            // auto-reactivate or overwrite. Return the ID untouched so any
+            // downstream linking still resolves but the row stays cancelled.
+            if (existing.state == SubscriptionState.ENDED) {
+                Log.d(TAG, "Subscription ${existing.id} is ENDED — leaving untouched.")
+                return existing.id
+            }
+
             // Check if this is a hidden subscription that should be reactivated
             // Only reactivate if the new payment date is LATER than the stored date
             val shouldReactivate = existing.state == SubscriptionState.HIDDEN &&

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
@@ -214,8 +214,12 @@ fun SubscriptionsScreen(
 
             // Cancelled subscriptions (collapsible; only rendered when any
             // exist so the section disappears entirely on empty state).
+            // Stable key so `rememberSaveable` below isn't bound to the
+            // positional slot index — without it, expanding the section and
+            // then reactivating / hiding an active subscription would shift
+            // the index and silently collapse the section.
             if (uiState.endedSubscriptions.isNotEmpty()) {
-                item {
+                item(key = "cancelled-section") {
                     var expanded by rememberSaveable { mutableStateOf(false) }
                     EndedSubscriptionsSection(
                         endedSubscriptions = uiState.endedSubscriptions,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
@@ -309,6 +309,8 @@ private fun EndedSubscriptionItem(
     onReactivate: () -> Unit,
     onDelete: () -> Unit
 ) {
+    var showDeleteConfirm by remember { mutableStateOf(false) }
+
     PennyWiseCardV2(modifier = Modifier.fillMaxWidth()) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -330,7 +332,7 @@ private fun EndedSubscriptionItem(
                 )
             }
             TextButton(onClick = onReactivate) { Text("Reactivate") }
-            IconButton(onClick = onDelete) {
+            IconButton(onClick = { showDeleteConfirm = true }) {
                 Icon(
                     imageVector = Icons.Default.Delete,
                     contentDescription = "Delete",
@@ -338,6 +340,29 @@ private fun EndedSubscriptionItem(
                 )
             }
         }
+    }
+
+    if (showDeleteConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirm = false },
+            title = { Text("Delete subscription?") },
+            text = {
+                Text("Permanently delete '${subscription.merchantName}'? This cannot be undone.")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDeleteConfirm = false
+                        onDelete()
+                    }
+                ) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirm = false }) { Text("Cancel") }
+            }
+        )
     }
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
@@ -98,6 +98,23 @@ fun SubscriptionsScreen(
         }
     }
 
+    // Show snackbar with undo action when a subscription is ended.
+    // ENDED is intentionally a "soft action" — there's the Cancelled section
+    // for later recovery — but mirroring the hide-undo flow keeps parity
+    // with the rest of the screen and gives an instant escape hatch.
+    LaunchedEffect(uiState.lastEndedSubscription) {
+        uiState.lastEndedSubscription?.let { subscription ->
+            val result = snackbarHostState.showSnackbar(
+                message = "${subscription.merchantName} ended",
+                actionLabel = "Undo",
+                duration = SnackbarDuration.Short
+            )
+            if (result == SnackbarResult.ActionPerformed) {
+                viewModel.undoEnd()
+            }
+        }
+    }
+
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehaviorLarge.nestedScrollConnection),
         containerColor = Color.Transparent,
@@ -210,8 +227,14 @@ fun SubscriptionsScreen(
                 }
             }
 
-            // Empty State
-            if (uiState.activeSubscriptions.isEmpty() && !uiState.isLoading) {
+            // Empty State — only when there's truly nothing to show. A user
+            // who has ended every subscription would otherwise see the
+            // "No subscriptions detected yet" message right above their
+            // Cancelled section, which is contradictory.
+            if (uiState.activeSubscriptions.isEmpty() &&
+                uiState.endedSubscriptions.isEmpty() &&
+                !uiState.isLoading
+            ) {
                 item {
                     PennyWiseEmptyState(
                         icon = Icons.Default.Subscriptions,
@@ -546,7 +569,7 @@ private fun SwipeableSubscriptionItem(
                                 )
                                 DropdownMenuItem(
                                     text = { Text("End subscription") },
-                                    leadingIcon = { Icon(Icons.Default.CheckCircle, contentDescription = null) },
+                                    leadingIcon = { Icon(Icons.Default.Cancel, contentDescription = null) },
                                     onClick = {
                                         showMenu = false
                                         onMarkAsEnded()

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
@@ -185,12 +185,28 @@ fun SubscriptionsScreen(
                             convertedAmount = uiState.convertedAmounts[subscription.id],
                             displayCurrency = uiState.displayCurrency,
                             onHide = { viewModel.hideSubscription(subscription.id) },
+                            onMarkAsEnded = { viewModel.markAsEnded(subscription.id) },
                             onEdit = { merchantName, amount, nextDate, category ->
                                 viewModel.updateSubscription(subscription.id, merchantName, amount, nextDate, category)
                             },
                             onDelete = { viewModel.deleteSubscription(subscription.id) }
                         )
                     }
+                }
+            }
+
+            // Cancelled subscriptions (collapsible; only rendered when any
+            // exist so the section disappears entirely on empty state).
+            if (uiState.endedSubscriptions.isNotEmpty()) {
+                item {
+                    var expanded by rememberSaveable { mutableStateOf(false) }
+                    EndedSubscriptionsSection(
+                        endedSubscriptions = uiState.endedSubscriptions,
+                        expanded = expanded,
+                        onToggle = { expanded = !expanded },
+                        onReactivate = { viewModel.reactivateSubscription(it) },
+                        onDelete = { viewModel.deleteSubscription(it) }
+                    )
                 }
             }
 
@@ -210,6 +226,89 @@ fun SubscriptionsScreen(
                 items(5) {
                     SubscriptionItemSkeleton()
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EndedSubscriptionsSection(
+    endedSubscriptions: List<SubscriptionEntity>,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+    onReactivate: (Long) -> Unit,
+    onDelete: (Long) -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(Spacing.sm)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onToggle)
+                .padding(vertical = Spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = "Cancelled (${endedSubscriptions.size})",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Icon(
+                imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                contentDescription = if (expanded) "Collapse" else "Expand",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        AnimatedVisibility(visible = expanded) {
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                endedSubscriptions.forEach { sub ->
+                    EndedSubscriptionItem(
+                        subscription = sub,
+                        onReactivate = { onReactivate(sub.id) },
+                        onDelete = { onDelete(sub.id) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EndedSubscriptionItem(
+    subscription: SubscriptionEntity,
+    onReactivate: () -> Unit,
+    onDelete: () -> Unit
+) {
+    PennyWiseCardV2(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = subscription.merchantName,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = CurrencyFormatter.formatCurrency(
+                        subscription.amount, subscription.currency
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            TextButton(onClick = onReactivate) { Text("Reactivate") }
+            IconButton(onClick = onDelete) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = "Delete",
+                    tint = MaterialTheme.colorScheme.error
+                )
             }
         }
     }
@@ -245,6 +344,7 @@ private fun SwipeableSubscriptionItem(
     convertedAmount: BigDecimal? = null,
     displayCurrency: String? = null,
     onHide: () -> Unit,
+    onMarkAsEnded: () -> Unit = {},
     onEdit: (merchantName: String, amount: BigDecimal, nextDate: LocalDate?, category: String?) -> Unit = { _, _, _, _ -> },
     onDelete: () -> Unit = {}
 ) {
@@ -442,6 +542,14 @@ private fun SwipeableSubscriptionItem(
                                     onClick = {
                                         showMenu = false
                                         showEditDialog = true
+                                    }
+                                )
+                                DropdownMenuItem(
+                                    text = { Text("End subscription") },
+                                    leadingIcon = { Icon(Icons.Default.CheckCircle, contentDescription = null) },
+                                    onClick = {
+                                        showMenu = false
+                                        onMarkAsEnded()
                                     }
                                 )
                                 DropdownMenuItem(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
@@ -107,7 +107,18 @@ class SubscriptionsViewModel @Inject constructor(
 
     fun markAsEnded(subscriptionId: Long) {
         viewModelScope.launch {
+            val snapshot = _uiState.value.activeSubscriptions.find { it.id == subscriptionId }
             subscriptionRepository.markAsEnded(subscriptionId)
+            _uiState.value = _uiState.value.copy(lastEndedSubscription = snapshot)
+        }
+    }
+
+    fun undoEnd() {
+        _uiState.value.lastEndedSubscription?.let { subscription ->
+            viewModelScope.launch {
+                subscriptionRepository.reactivateSubscription(subscription.id)
+                _uiState.value = _uiState.value.copy(lastEndedSubscription = null)
+            }
         }
     }
 
@@ -153,5 +164,6 @@ data class SubscriptionsUiState(
     val displayCurrency: String? = null,
     val isUnifiedMode: Boolean = false,
     val isLoading: Boolean = true,
-    val lastHiddenSubscription: SubscriptionEntity? = null
+    val lastHiddenSubscription: SubscriptionEntity? = null,
+    val lastEndedSubscription: SubscriptionEntity? = null
 )

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
@@ -34,17 +34,20 @@ class SubscriptionsViewModel @Inject constructor(
         viewModelScope.launch {
             combine(
                 subscriptionRepository.getActiveSubscriptions(),
+                subscriptionRepository.getEndedSubscriptions(),
                 userPreferencesRepository.unifiedCurrencyMode,
                 userPreferencesRepository.displayCurrency,
                 userPreferencesRepository.baseCurrency
-            ) { subscriptions, isUnified, displayCurrency, baseCurrency ->
-                arrayOf(subscriptions, isUnified, displayCurrency, baseCurrency)
+            ) { subscriptions, ended, isUnified, displayCurrency, baseCurrency ->
+                arrayOf(subscriptions, ended, isUnified, displayCurrency, baseCurrency)
             }.collect { values ->
                 @Suppress("UNCHECKED_CAST")
                 val subscriptions = values[0] as List<SubscriptionEntity>
-                val isUnified = values[1] as Boolean
-                val displayCurrency = values[2] as String
-                val baseCurrency = values[3] as String
+                @Suppress("UNCHECKED_CAST")
+                val endedSubscriptions = values[1] as List<SubscriptionEntity>
+                val isUnified = values[2] as Boolean
+                val displayCurrency = values[3] as String
+                val baseCurrency = values[4] as String
                 val totalMonthlyAmount = if (isUnified) {
                     var total = BigDecimal.ZERO
                     for (sub in subscriptions) {
@@ -73,6 +76,7 @@ class SubscriptionsViewModel @Inject constructor(
 
                 _uiState.value = _uiState.value.copy(
                     activeSubscriptions = subscriptions,
+                    endedSubscriptions = endedSubscriptions,
                     totalMonthlyAmount = totalMonthlyAmount,
                     convertedAmounts = convertedAmounts,
                     displayCurrency = if (isUnified) displayCurrency else baseCurrency,
@@ -98,6 +102,18 @@ class SubscriptionsViewModel @Inject constructor(
                 subscriptionRepository.unhideSubscription(subscription.id)
                 _uiState.value = _uiState.value.copy(lastHiddenSubscription = null)
             }
+        }
+    }
+
+    fun markAsEnded(subscriptionId: Long) {
+        viewModelScope.launch {
+            subscriptionRepository.markAsEnded(subscriptionId)
+        }
+    }
+
+    fun reactivateSubscription(subscriptionId: Long) {
+        viewModelScope.launch {
+            subscriptionRepository.reactivateSubscription(subscriptionId)
         }
     }
 
@@ -131,6 +147,7 @@ class SubscriptionsViewModel @Inject constructor(
 
 data class SubscriptionsUiState(
     val activeSubscriptions: List<SubscriptionEntity> = emptyList(),
+    val endedSubscriptions: List<SubscriptionEntity> = emptyList(),
     val totalMonthlyAmount: BigDecimal = BigDecimal.ZERO,
     val convertedAmounts: Map<Long, BigDecimal> = emptyMap(),
     val displayCurrency: String? = null,


### PR DESCRIPTION
## Summary
From TODO.md: *"mark a subscription as 'ended'"*. The existing `ACTIVE | HIDDEN` model treated HIDDEN as a soft delete that auto-reactivated when a newer-dated mandate SMS arrived — fine for "hide this temporarily", wrong for "I cancelled it".

Add a third state, `ENDED`, with terminal semantics:
- A new mandate SMS for the same merchant **never** reactivates an ENDED row.
- The user can manually reactivate via the "Cancelled" section.

## Changes
- **`SubscriptionEntity`**: add `ENDED` to the `SubscriptionState` enum. Backwards-compat — stored as TEXT via the existing converter, no DB migration.
- **`SubscriptionRepository`**:
  - `markAsEnded(id)` / `reactivateSubscription(id)` mirror the `hide / unhide` pair.
  - `getEndedSubscriptions(): Flow<List<SubscriptionEntity>>` for the UI.
  - `processMandateNotification`: early-return when an existing row is ENDED (never updates / reactivates).
- **`SubscriptionsViewModel`**: collects active + ended subscriptions in one combine block; exposes the two new actions.
- **`SubscriptionsScreen`**:
  - Per-row 3-dot menu now has **End subscription** between Edit and Delete.
  - Collapsible **Cancelled (N)** section below active subscriptions, with Reactivate / Delete actions on each row.

HIDDEN is untouched — swipe-to-hide and the undo snackbar work exactly as before.

## Test plan
- [x] `./gradlew :app:compileStandardDebugKotlin` — clean (only pre-existing warnings)
- [ ] Manual: existing active subscription → 3-dot → End subscription → disappears from Active, shows up in Cancelled (N)
- [ ] Manual: collapse/expand the Cancelled section
- [ ] Manual: Reactivate from Cancelled → moves back to Active
- [ ] Manual: Delete from Cancelled → row gone for good
- [ ] Manual: feed a new mandate SMS for an ENDED merchant — it must not reactivate