### PR TITLE
feat: edit auto-detected card metadata in Unlinked Cards

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
@@ -252,6 +252,9 @@ fun ManageAccountsScreen(
                             },
                             onDeleteCard = { cardId ->
                                 viewModel.deleteCard(cardId)
+                            },
+                            onUpdateCard = { bankName, cardType, nickname ->
+                                viewModel.updateCardDetails(card.id, bankName, cardType, nickname)
                             }
                         )
                     }
@@ -1387,9 +1390,15 @@ private fun OrphanedCardItem(
     card: com.pennywiseai.tracker.data.database.entity.CardEntity,
     accounts: List<com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity>,
     onLinkToAccount: (String) -> Unit,
-    onDeleteCard: (Long) -> Unit
+    onDeleteCard: (Long) -> Unit,
+    onUpdateCard: (
+        bankName: String,
+        cardType: com.pennywiseai.tracker.data.database.entity.CardType,
+        nickname: String?
+    ) -> Unit = { _, _, _ -> }
 ) {
     var showLinkDialog by remember { mutableStateOf(false) }
+    var showEditDialog by remember { mutableStateOf(false) }
     var expandedSource by remember { mutableStateOf(false) }
     
     Card(
@@ -1468,7 +1477,19 @@ private fun OrphanedCardItem(
                         Spacer(modifier = Modifier.width(Spacing.xs))
                         Text("Link")
                     }
-                    
+
+                    OutlinedButton(
+                        onClick = { showEditDialog = true }
+                    ) {
+                        Icon(
+                            Icons.Default.Edit,
+                            contentDescription = null,
+                            modifier = Modifier.size(Dimensions.Icon.small)
+                        )
+                        Spacer(modifier = Modifier.width(Spacing.xs))
+                        Text("Edit")
+                    }
+
                     OutlinedButton(
                         onClick = { onDeleteCard(card.id) },
                         colors = ButtonDefaults.outlinedButtonColors(
@@ -1499,6 +1520,94 @@ private fun OrphanedCardItem(
             }
         )
     }
+
+    if (showEditDialog) {
+        EditCardDialog(
+            card = card,
+            onDismiss = { showEditDialog = false },
+            onConfirm = { bankName, cardType, nickname ->
+                onUpdateCard(bankName, cardType, nickname)
+                showEditDialog = false
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EditCardDialog(
+    card: com.pennywiseai.tracker.data.database.entity.CardEntity,
+    onDismiss: () -> Unit,
+    onConfirm: (
+        bankName: String,
+        cardType: com.pennywiseai.tracker.data.database.entity.CardType,
+        nickname: String?
+    ) -> Unit
+) {
+    var bankName by remember { mutableStateOf(card.bankName) }
+    var cardType by remember { mutableStateOf(card.cardType) }
+    var nickname by remember { mutableStateOf(card.nickname.orEmpty()) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Edit card") },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(Spacing.md)
+            ) {
+                Text(
+                    text = "••${card.cardLast4}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                OutlinedTextField(
+                    value = bankName,
+                    onValueChange = { bankName = it },
+                    label = { Text("Bank") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+                    Text(
+                        text = "Card type",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                        val options = listOf(
+                            com.pennywiseai.tracker.data.database.entity.CardType.DEBIT to "Debit",
+                            com.pennywiseai.tracker.data.database.entity.CardType.CREDIT to "Credit"
+                        )
+                        options.forEachIndexed { index, (type, label) ->
+                            SegmentedButton(
+                                selected = cardType == type,
+                                onClick = { cardType = type },
+                                shape = SegmentedButtonDefaults.itemShape(index, options.size)
+                            ) { Text(label) }
+                        }
+                    }
+                }
+                OutlinedTextField(
+                    value = nickname,
+                    onValueChange = { nickname = it },
+                    label = { Text("Nickname (optional)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onConfirm(bankName, cardType, nickname.ifBlank { null })
+                },
+                enabled = bankName.isNotBlank()
+            ) { Text("Save") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
@@ -419,15 +419,28 @@ class ManageAccountsViewModel @Inject constructor(
     ) {
         viewModelScope.launch {
             try {
-                val existing = cardRepository.getCardById(cardId) ?: return@launch
+                val existing = cardRepository.getCardById(cardId)
+                if (existing == null) {
+                    // The card was removed from another session between the
+                    // dialog opening and Save. Surface it so the user isn't
+                    // left wondering why nothing happened.
+                    _uiState.update {
+                        it.copy(errorMessage = "Card no longer exists — it may have been deleted.")
+                    }
+                    return@launch
+                }
+                // updatedAt is stamped inside CardRepository.updateCard, so
+                // we leave it alone here.
                 cardRepository.updateCard(
                     existing.copy(
                         bankName = bankName.trim(),
                         cardType = cardType,
-                        nickname = nickname?.trim()?.takeIf { it.isNotEmpty() },
-                        updatedAt = LocalDateTime.now()
+                        nickname = nickname?.trim()?.takeIf { it.isNotEmpty() }
                     )
                 )
+                _uiState.update { it.copy(successMessage = "Card updated") }
+                delay(2000)
+                _uiState.update { it.copy(successMessage = null) }
                 loadCards()
             } catch (e: Exception) {
                 android.util.Log.e("ManageAccountsViewModel", "Failed to update card", e)

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
@@ -401,6 +401,43 @@ class ManageAccountsViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Overrides the parser's auto-detected card metadata. Used when a card
+     * has been wrongly classified (e.g. detected as DEBIT when it's really
+     * a credit card, or filed under the wrong bank). Nickname is purely
+     * cosmetic but lives on the same dialog because the user already has
+     * the edit sheet open.
+     *
+     * Trimming + null-on-blank for nickname keeps the entity column tidy
+     * (empty strings would otherwise leak through to the UI).
+     */
+    fun updateCardDetails(
+        cardId: Long,
+        bankName: String,
+        cardType: CardType,
+        nickname: String?
+    ) {
+        viewModelScope.launch {
+            try {
+                val existing = cardRepository.getCardById(cardId) ?: return@launch
+                cardRepository.updateCard(
+                    existing.copy(
+                        bankName = bankName.trim(),
+                        cardType = cardType,
+                        nickname = nickname?.trim()?.takeIf { it.isNotEmpty() },
+                        updatedAt = LocalDateTime.now()
+                    )
+                )
+                loadCards()
+            } catch (e: Exception) {
+                android.util.Log.e("ManageAccountsViewModel", "Failed to update card", e)
+                _uiState.update {
+                    it.copy(errorMessage = "Failed to update card: ${e.message}")
+                }
+            }
+        }
+    }
+
     fun deleteAccount(bankName: String, accountLast4: String) {
         viewModelScope.launch {
             try {


### PR DESCRIPTION
## Summary
From TODO.md: *"change cards that have been identified incorrectly"*.

When a parser sees a card-bearing transaction it auto-creates a `CardEntity` with a guessed bank, card type (DEBIT/CREDIT) and (sometimes) nickname. Wrong guesses landed in the **Unlinked Cards** section with no way to correct them — only Link or Delete.

## Changes
- New **Edit** button between Link and Delete on each `OrphanedCardItem`.
- New `EditCardDialog` (AlertDialog) with three editable fields:
  - Bank name
  - Card type — segmented `Debit / Credit`
  - Nickname (optional)
- The card's last-4 digits stay read-only (changing those would mean a different card, not a fix to mis-detection).
- `ManageAccountsViewModel.updateCardDetails(cardId, bankName, cardType, nickname)` trims input, drops blank nickname to null, and reloads the cards list so the row moves to the right section if the type changed.

`CardRepository.updateCard` already existed, so no DAO/migration work needed.

## Side effect worth noting
Flipping a card DEBIT→CREDIT removes it from the Unlinked Cards section (per the existing `loadCards()` filter: credit cards aren't shown as orphans). The corresponding credit-card row would surface in the Credit Cards section once the next CC SMS lands and an `AccountBalanceEntity` is created for it. This is consistent with how existing credit-card detection works.

## Test plan
- [x] `./gradlew :app:compileStandardDebugKotlin` — clean
- [ ] Manual: open Unlinked Cards → Edit → change bank name → Save → row reflects new bank
- [ ] Manual: change DEBIT → CREDIT → Save → row leaves Unlinked Cards
- [ ] Manual: set nickname → Save → reopen Edit → nickname pre-filled
- [ ] Manual: clear nickname → Save → reopen → field empty
- [ ] Manual: try blank bank name → Save disabled