### PR TITLE
Enrich transactions from GPay statements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
 
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3
+
     - name: Cache Gradle packages
       uses: actions/cache@v4
       with:
@@ -36,6 +39,12 @@ jobs:
 
     - name: Run parser-core tests
       run: ./gradlew :parser-core:test --continue
+
+    - name: Compile standard debug app Kotlin
+      run: ./gradlew :app:compileStandardDebugKotlin
+
+    - name: Run standard debug unit tests
+      run: ./gradlew :app:testStandardDebugUnitTest
 
     - name: Upload parser test results
       uses: actions/upload-artifact@v4

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
@@ -189,6 +189,14 @@ interface TransactionDao {
 
     @Query("""
         SELECT * FROM transactions
+        WHERE reference = :reference
+        AND is_deleted = 0
+        ORDER BY date_time ASC
+    """)
+    suspend fun getTransactionsByReference(reference: String): List<TransactionEntity>
+
+    @Query("""
+        SELECT * FROM transactions
         WHERE is_deleted = 0
         AND reference = :reference
         AND amount = :amount

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
@@ -6,6 +6,7 @@ import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionSplitEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.database.entity.TransactionWithSplits
+import com.pennywiseai.tracker.data.statement.StatementTransactionEnricher
 import com.pennywiseai.tracker.data.manager.TransactionDeduplication
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -137,6 +138,14 @@ class TransactionRepository @Inject constructor(
 
     suspend fun getTransactionByReference(reference: String): TransactionEntity? =
         transactionDao.getTransactionByReference(reference)
+
+    suspend fun findStatementMergeCandidate(transaction: TransactionEntity): TransactionEntity? {
+        val reference = transaction.reference?.takeIf { it.isNotBlank() } ?: return null
+        return transactionDao.getTransactionsByReference(reference)
+            .firstOrNull { candidate ->
+                StatementTransactionEnricher.isStatementMatch(candidate, transaction)
+            }
+    }
 
     suspend fun findPotentialDuplicates(transaction: TransactionEntity): List<TransactionEntity> {
         if (!TransactionDeduplication.hasUpiReference(transaction)) return emptyList()

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/GPayPdfParser.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/GPayPdfParser.kt
@@ -51,8 +51,10 @@ class GPayPdfParser : PdfStatementParser {
 
     // Date parts — each on its own line
     private val dateLineRegex = Regex("""^(\d{1,2})\s+(\w{3}),?$""")       // "01 Sep,"
+    private val fullDateLineRegex = Regex("""^(\d{1,2}\s+\w{3},\s+20\d{2})$""") // "15 Oct, 2025"
+    private val datePrefixedRowRegex = Regex("""^(\d{1,2}\s+\w{3},\s+20\d{2})\s+(.+)$""")
     private val yearLineRegex = Regex("""^(20\d{2})$""")                    // "2025"
-    private val timeLineRegex = Regex("""^(\d{1,2}:\d{2})\s*([AaPp][Mm])$""") // "03:02 PM"
+    private val timeLineRegex = Regex("""^(\d{1,2}:\d{2})\s*([AaPp][Mm])(?:\s+(.+))?$""") // "03:02 PM ..."
 
     // ─── Public API ───────────────────────────────────────────────────────────
 
@@ -107,8 +109,30 @@ class GPayPdfParser : PdfStatementParser {
             if (line.isEmpty()) continue
 
             val isDate = dateLineRegex.matches(line)
+            val isFullDate = fullDateLineRegex.matches(line)
             val isYear = yearLineRegex.matches(line)
             val isTime = timeLineRegex.matches(line)
+
+            val datePrefixedRow = datePrefixedRowRegex.find(line)
+            if (datePrefixedRow != null) {
+                val fullDate = datePrefixedRow.groupValues[1]
+                val rest = datePrefixedRow.groupValues[2].trim()
+                val rowParts = splitAnchorAndAmount(rest)
+                if (isTransactionAnchor(rowParts.anchorLine)) {
+                    if (inBlock && current.isNotEmpty()) {
+                        blocks.add(current.toString().trim())
+                        current.clear()
+                    }
+                    current.appendLine(fullDate)
+                    current.appendLine(rowParts.anchorLine)
+                    rowParts.amountLine?.let { current.appendLine(it) }
+                    pendingDate = null
+                    pendingYear = null
+                    pendingTime = null
+                    inBlock = true
+                    continue
+                }
+            }
 
             if (isTransactionAnchor(line)) {
                 if (inBlock && current.isNotEmpty()) {
@@ -133,7 +157,12 @@ class GPayPdfParser : PdfStatementParser {
             // always belong to the next anchor's transaction. Track the most
             // recent triplet so the next anchor can consume it.
             if (isDate) { pendingDate = line; continue }
+            if (isFullDate) { pendingDate = line; pendingYear = null; continue }
             if (isYear) { pendingYear = line; continue }
+            if (isTime && inBlock && !timeLineRegex.find(line)?.groupValues?.getOrNull(3).isNullOrBlank()) {
+                current.appendLine(line)
+                continue
+            }
             if (isTime) { pendingTime = line; continue }
 
             if (inBlock) current.appendLine(line)
@@ -241,14 +270,22 @@ class GPayPdfParser : PdfStatementParser {
 
         for (line in lines) {
             when {
-                dateLine == null && dateLineRegex.matches(line) -> dateLine = line
+                dateLine == null && (dateLineRegex.matches(line) || fullDateLineRegex.matches(line)) -> {
+                    dateLine = line
+                }
                 yearLine == null && yearLineRegex.matches(line) -> yearLine = line
-                timeLine == null && timeLineRegex.matches(line) -> timeLine = line
+                timeLine == null && timeLineRegex.matches(line) -> {
+                    val match = timeLineRegex.find(line)
+                    timeLine = listOfNotNull(
+                        match?.groupValues?.getOrNull(1),
+                        match?.groupValues?.getOrNull(2)
+                    ).joinToString(" ")
+                }
             }
-            if (dateLine != null && yearLine != null && timeLine != null) break
+            if (dateLine != null && (yearLine != null || fullDateLineRegex.matches(dateLine)) && timeLine != null) break
         }
 
-        if (dateLine == null || yearLine == null || timeLine == null) {
+        if (dateLine == null || timeLine == null || (yearLine == null && !fullDateLineRegex.matches(dateLine))) {
             Log.e(TAG, "Incomplete timestamp for '$merchant' — " +
                     "date='$dateLine' year='$yearLine' time='$timeLine' | lines=$lines")
             return null
@@ -257,7 +294,11 @@ class GPayPdfParser : PdfStatementParser {
         // Normalise: "01 Sep," → "01 Sep" then build "01 Sep, 2025 03:02 PM"
         val dateClean = dateLine.trimEnd(',', ' ')
         val timeClean = timeLine.replace(Regex("""\s+"""), " ").uppercase()
-        val combined  = "$dateClean, $yearLine $timeClean"
+        val combined = if (fullDateLineRegex.matches(dateLine)) {
+            "$dateClean $timeClean"
+        } else {
+            "$dateClean, $yearLine $timeClean"
+        }
 
         return try {
             val sdf = SimpleDateFormat(DATE_FORMAT_PATTERN, Locale.ENGLISH).apply {
@@ -276,6 +317,15 @@ class GPayPdfParser : PdfStatementParser {
             Log.e(TAG, "Date parse exception for '$merchant' — input='$combined': ${e.message}")
             null
         }
+    }
+
+    private fun splitAnchorAndAmount(value: String): RowParts {
+        val amountMatch = Regex("""\s+((?:₹|Rs\.?)\s*[0-9][0-9,]*(?:\.[0-9]{1,2})?)$""")
+            .find(value)
+            ?: return RowParts(value.trim(), null)
+
+        val anchorLine = value.substring(0, amountMatch.range.first).trim()
+        return RowParts(anchorLine, amountMatch.groupValues[1].trim())
     }
 
     /**
@@ -306,4 +356,5 @@ class GPayPdfParser : PdfStatementParser {
     // ─── Data classes ─────────────────────────────────────────────────────────
 
     private data class AccountInfo(val bankName: String?, val last4: String?)
+    private data class RowParts(val anchorLine: String, val amountLine: String?)
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/ImportStatementUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/ImportStatementUseCase.kt
@@ -2,15 +2,13 @@ package com.pennywiseai.tracker.data.statement
 
 import android.content.Context
 import android.net.Uri
-import com.pennywiseai.tracker.data.mapper.toEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.time.Instant
+import java.math.BigDecimal
 import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.ZoneId
 import javax.inject.Inject
 
 class ImportStatementUseCase @Inject constructor(
@@ -33,64 +31,36 @@ class ImportStatementUseCase @Inject constructor(
                 )
             }
 
-            var skippedByHash = 0
-            var skippedByReference = 0
-            var skippedByAmountDate = 0
-
-            val toInsert = parsedTransactions.mapNotNull { parsed ->
-                val hash = parsed.transactionHash?.takeIf { it.isNotBlank() }
-                    ?: parsed.generateTransactionId()
-
-                // Tier 0: Exact re-import detection via hash
-                if (transactionRepository.getTransactionByHash(hash) != null) {
-                    skippedByHash++
-                    return@mapNotNull null
-                }
-
-                // Tier 1: Cross-source dedup via UPI reference
-                val ref = parsed.reference
-                if (ref != null && transactionRepository.getTransactionByReference(ref) != null) {
-                    skippedByReference++
-                    return@mapNotNull null
-                }
-
-                // Tier 2: Cross-source dedup via amount + same calendar day
-                val dateTime = LocalDateTime.ofInstant(
-                    Instant.ofEpochMilli(parsed.timestamp),
-                    ZoneId.systemDefault()
-                )
-                val startOfDay = dateTime.toLocalDate().atStartOfDay()
-                val endOfDay = dateTime.toLocalDate().atTime(LocalTime.MAX)
-
-                val amountMatches = transactionRepository.getTransactionByAmountAndDate(
-                    parsed.amount, startOfDay, endOfDay
-                )
-                if (amountMatches.isNotEmpty()) {
-                    skippedByAmountDate++
-                    return@mapNotNull null
-                }
-
-                parsed.toEntity()
-            }
-
-            if (toInsert.isNotEmpty()) {
-                transactionRepository.insertTransactions(toInsert)
-            }
-
-            val skippedDuplicates = skippedByHash + skippedByReference + skippedByAmountDate
-
-            StatementImportResult.Success(
-                imported = toInsert.size,
-                skippedDuplicates = skippedDuplicates,
-                skippedByReference = skippedByReference,
-                skippedByAmountDate = skippedByAmountDate,
-                skippedByHash = skippedByHash,
-                totalParsed = parsedTransactions.size
-            )
+            StatementImportProcessor(repositoryStore()).process(parsedTransactions)
         } catch (e: Exception) {
             StatementImportResult.Error(
                 e.message ?: "Failed to import statement."
             )
+        }
+    }
+
+    private fun repositoryStore() = object : StatementImportProcessor.TransactionStore {
+        override suspend fun getTransactionByHash(transactionHash: String): TransactionEntity? =
+            transactionRepository.getTransactionByHash(transactionHash)
+
+        override suspend fun findStatementMergeCandidate(
+            transaction: TransactionEntity
+        ): TransactionEntity? =
+            transactionRepository.findStatementMergeCandidate(transaction)
+
+        override suspend fun updateTransaction(transaction: TransactionEntity) {
+            transactionRepository.updateTransaction(transaction)
+        }
+
+        override suspend fun getTransactionByAmountAndDate(
+            amount: BigDecimal,
+            dateStart: LocalDateTime,
+            dateEnd: LocalDateTime
+        ): List<TransactionEntity> =
+            transactionRepository.getTransactionByAmountAndDate(amount, dateStart, dateEnd)
+
+        override suspend fun insertTransactions(transactions: List<TransactionEntity>) {
+            transactionRepository.insertTransactions(transactions)
         }
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/StatementImportProcessor.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/StatementImportProcessor.kt
@@ -36,8 +36,15 @@ internal class StatementImportProcessor(
                 ?: parsed.generateTransactionId()
             val statementEntity = parsed.toEntity()
 
-            if (transactionStore.getTransactionByHash(hash) != null) {
-                skippedByHash++
+            val hashMatch = transactionStore.getTransactionByHash(hash)
+            if (hashMatch != null) {
+                val merged = StatementTransactionEnricher.enrich(hashMatch, statementEntity)
+                if (!hashMatch.isDeleted && StatementTransactionEnricher.hasEnrichment(hashMatch, merged)) {
+                    transactionStore.updateTransaction(merged)
+                    enriched++
+                } else {
+                    skippedByHash++
+                }
                 return@mapNotNull null
             }
 
@@ -69,7 +76,7 @@ internal class StatementImportProcessor(
                 parsed.amount, startOfDay, endOfDay
             )
             val fallbackMergeCandidates = amountMatches.filter { candidate ->
-                StatementTransactionEnricher.isFallbackStatementMatch(candidate, statementEntity)
+                StatementTransactionEnricher.isAmountDateFallbackEnrichmentCandidate(candidate, statementEntity)
             }
             if (fallbackMergeCandidates.size == 1) {
                 val existing = fallbackMergeCandidates.single()

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/StatementImportProcessor.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/StatementImportProcessor.kt
@@ -1,0 +1,107 @@
+package com.pennywiseai.tracker.data.statement
+
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.tracker.data.database.entity.TransactionEntity
+import com.pennywiseai.tracker.data.mapper.toEntity
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+
+internal class StatementImportProcessor(
+    private val transactionStore: TransactionStore
+) {
+    interface TransactionStore {
+        suspend fun getTransactionByHash(transactionHash: String): TransactionEntity?
+        suspend fun findStatementMergeCandidate(transaction: TransactionEntity): TransactionEntity?
+        suspend fun updateTransaction(transaction: TransactionEntity)
+        suspend fun getTransactionByAmountAndDate(
+            amount: BigDecimal,
+            dateStart: LocalDateTime,
+            dateEnd: LocalDateTime
+        ): List<TransactionEntity>
+
+        suspend fun insertTransactions(transactions: List<TransactionEntity>)
+    }
+
+    suspend fun process(parsedTransactions: List<ParsedTransaction>): StatementImportResult.Success {
+        var skippedByHash = 0
+        var skippedByReference = 0
+        var skippedByAmountDate = 0
+        var enriched = 0
+
+        val toInsert = parsedTransactions.mapNotNull { parsed ->
+            val hash = parsed.transactionHash?.takeIf { it.isNotBlank() }
+                ?: parsed.generateTransactionId()
+            val statementEntity = parsed.toEntity()
+
+            if (transactionStore.getTransactionByHash(hash) != null) {
+                skippedByHash++
+                return@mapNotNull null
+            }
+
+            val ref = parsed.reference
+            if (!ref.isNullOrBlank()) {
+                val existing = transactionStore.findStatementMergeCandidate(statementEntity)
+                if (existing != null) {
+                    val merged = StatementTransactionEnricher.enrich(existing, statementEntity)
+                    if (StatementTransactionEnricher.hasEnrichment(existing, merged)) {
+                        transactionStore.updateTransaction(merged)
+                        enriched++
+                    } else {
+                        skippedByReference++
+                    }
+                    return@mapNotNull null
+                }
+            }
+
+            // Reference-bearing statement rows can still match older SMS imports
+            // that were saved before parsers extracted UPI references.
+            val dateTime = LocalDateTime.ofInstant(
+                Instant.ofEpochMilli(parsed.timestamp),
+                ZoneId.systemDefault()
+            )
+            val startOfDay = dateTime.toLocalDate().atStartOfDay()
+            val endOfDay = dateTime.toLocalDate().atTime(LocalTime.MAX)
+
+            val amountMatches = transactionStore.getTransactionByAmountAndDate(
+                parsed.amount, startOfDay, endOfDay
+            )
+            val fallbackMergeCandidates = amountMatches.filter { candidate ->
+                StatementTransactionEnricher.isFallbackStatementMatch(candidate, statementEntity)
+            }
+            if (fallbackMergeCandidates.size == 1) {
+                val existing = fallbackMergeCandidates.single()
+                transactionStore.updateTransaction(
+                    StatementTransactionEnricher.enrich(existing, statementEntity)
+                )
+                enriched++
+                return@mapNotNull null
+            }
+
+            if (amountMatches.isNotEmpty()) {
+                skippedByAmountDate++
+                return@mapNotNull null
+            }
+
+            statementEntity
+        }
+
+        if (toInsert.isNotEmpty()) {
+            transactionStore.insertTransactions(toInsert)
+        }
+
+        val skippedDuplicates = skippedByHash + skippedByReference + skippedByAmountDate
+
+        return StatementImportResult.Success(
+            imported = toInsert.size,
+            skippedDuplicates = skippedDuplicates,
+            skippedByReference = skippedByReference,
+            skippedByAmountDate = skippedByAmountDate,
+            skippedByHash = skippedByHash,
+            enriched = enriched,
+            totalParsed = parsedTransactions.size
+        )
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/StatementImportResult.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/StatementImportResult.kt
@@ -7,7 +7,8 @@ sealed class StatementImportResult {
         val skippedByReference: Int,
         val skippedByAmountDate: Int,
         val skippedByHash: Int,
-        val totalParsed: Int
+        val totalParsed: Int,
+        val enriched: Int = 0
     ) : StatementImportResult()
 
     data class Error(val message: String) : StatementImportResult()

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/StatementTransactionEnricher.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/StatementTransactionEnricher.kt
@@ -1,0 +1,115 @@
+package com.pennywiseai.tracker.data.statement
+
+import com.pennywiseai.tracker.data.database.entity.TransactionEntity
+import java.time.Duration
+import java.time.LocalDateTime
+
+object StatementTransactionEnricher {
+    val MATCH_WINDOW: Duration = Duration.ofMinutes(5)
+
+    private val genericValues = setOf(
+        "",
+        "unknown",
+        "unknown merchant",
+        "upi",
+        "upi transaction",
+        "upi payment",
+        "upi credit",
+        "payment",
+        "google pay"
+    )
+
+    fun isStatementMatch(existing: TransactionEntity, statement: TransactionEntity): Boolean {
+        val existingReference = existing.reference?.trim().orEmpty()
+        val statementReference = statement.reference?.trim().orEmpty()
+        if (existingReference.isBlank() || existingReference != statementReference) return false
+        return hasSameTransactionDetails(existing, statement)
+    }
+
+    fun isFallbackStatementMatch(existing: TransactionEntity, statement: TransactionEntity): Boolean {
+        if (!hasSameTransactionDetails(existing, statement)) return false
+        return canUseStatementValue(existing.merchantName, statement.merchantName) ||
+                canUseStatementValue(existing.description, statement.description) ||
+                existing.fromAccount.isNullOrBlank() && !statement.fromAccount.isNullOrBlank() ||
+                existing.toAccount.isNullOrBlank() && !statement.toAccount.isNullOrBlank()
+    }
+
+    fun enrich(existing: TransactionEntity, statement: TransactionEntity): TransactionEntity {
+        var changed = false
+
+        val merchantName = if (canUseStatementValue(existing.merchantName, statement.merchantName)) {
+            changed = true
+            statement.merchantName
+        } else {
+            existing.merchantName
+        }
+
+        val description = if (canUseStatementValue(existing.description, statement.description)) {
+            changed = true
+            statement.description
+        } else {
+            existing.description
+        }
+
+        val fromAccount = if (existing.fromAccount.isNullOrBlank() && !statement.fromAccount.isNullOrBlank()) {
+            changed = true
+            statement.fromAccount
+        } else {
+            existing.fromAccount
+        }
+
+        val toAccount = if (existing.toAccount.isNullOrBlank() && !statement.toAccount.isNullOrBlank()) {
+            changed = true
+            statement.toAccount
+        } else {
+            existing.toAccount
+        }
+
+        return if (changed) {
+            existing.copy(
+                merchantName = merchantName,
+                description = description,
+                fromAccount = fromAccount,
+                toAccount = toAccount,
+                updatedAt = LocalDateTime.now()
+            )
+        } else {
+            existing
+        }
+    }
+
+    fun hasEnrichment(existing: TransactionEntity, enriched: TransactionEntity): Boolean =
+        existing.merchantName != enriched.merchantName ||
+                existing.description != enriched.description ||
+                existing.fromAccount != enriched.fromAccount ||
+                existing.toAccount != enriched.toAccount
+
+    private fun canUseStatementValue(existing: String?, statement: String?): Boolean {
+        val incoming = statement?.trim().orEmpty()
+        if (incoming.isBlank() || isGeneric(incoming)) return false
+
+        val current = existing?.trim().orEmpty()
+        return current.isBlank() || isGeneric(current)
+    }
+
+    private fun hasSameTransactionDetails(
+        existing: TransactionEntity,
+        statement: TransactionEntity
+    ): Boolean {
+        if (existing.amount.compareTo(statement.amount) != 0) return false
+        if (existing.currency != statement.currency) return false
+        if (existing.transactionType != statement.transactionType) return false
+        if (!accountsMatch(existing.accountNumber, statement.accountNumber)) return false
+
+        val gap = Duration.between(existing.dateTime, statement.dateTime).abs()
+        return gap <= MATCH_WINDOW
+    }
+
+    private fun isGeneric(value: String): Boolean =
+        value.trim().lowercase() in genericValues
+
+    private fun accountsMatch(existingAccount: String?, statementAccount: String?): Boolean =
+        existingAccount.isNullOrBlank() ||
+                statementAccount.isNullOrBlank() ||
+                existingAccount == statementAccount
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/StatementTransactionEnricher.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/StatementTransactionEnricher.kt
@@ -28,6 +28,24 @@ object StatementTransactionEnricher {
 
     fun isFallbackStatementMatch(existing: TransactionEntity, statement: TransactionEntity): Boolean {
         if (!hasSameTransactionDetails(existing, statement)) return false
+        return hasUsableStatementDetails(existing, statement)
+    }
+
+    fun isAmountDateFallbackEnrichmentCandidate(
+        existing: TransactionEntity,
+        statement: TransactionEntity
+    ): Boolean {
+        if (existing.amount.compareTo(statement.amount) != 0) return false
+        if (existing.currency != statement.currency) return false
+        if (existing.transactionType != statement.transactionType) return false
+        if (!accountsMatch(existing.accountNumber, statement.accountNumber)) return false
+        return hasUsableStatementDetails(existing, statement)
+    }
+
+    private fun hasUsableStatementDetails(
+        existing: TransactionEntity,
+        statement: TransactionEntity
+    ): Boolean {
         return canUseStatementValue(existing.merchantName, statement.merchantName) ||
                 canUseStatementValue(existing.description, statement.description) ||
                 existing.fromAccount.isNullOrBlank() && !statement.fromAccount.isNullOrBlank() ||

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/statement/ImportStatementScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/statement/ImportStatementScreen.kt
@@ -240,6 +240,14 @@ private fun SuccessContent(
                 isHighlighted = true
             )
 
+            if (result.enriched > 0) {
+                ResultRow(
+                    label = "Transactions enriched",
+                    value = "${result.enriched}",
+                    isHighlighted = true
+                )
+            }
+
             ResultRow(
                 label = "Total parsed from PDF",
                 value = "${result.totalParsed}"

--- a/app/src/test/java/com/pennywiseai/tracker/data/statement/GPayPdfParserTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/statement/GPayPdfParserTest.kt
@@ -59,6 +59,23 @@ class GPayPdfParserTest {
         Paid by HDFC Bank 1234
     """.trimIndent()
 
+    private val tableLayoutStatementText = """
+        Transaction statement
+        Date & time               Transaction details                                      Amount
+
+        15 Oct, 2025              Paid to SAMPLE MERCHANT A                               ₹12.34
+        11:08 AM                  UPI Transaction ID: 123456789012
+                                       Paid by Example Bank 1234
+
+        16 Oct, 2025              Received from SAMPLE SENDER                            ₹567.89
+        09:41 AM                  UPI Transaction ID: 223456789012
+                                       Paid to Example Bank 1234
+
+        16 Oct, 2025              Paid to SAMPLE MERCHANT B                                ₹42.00
+        11:13 AM                  UPI Transaction ID: 323456789012
+                                       Paid by Example Bank 1234
+    """.trimIndent()
+
     @Test
     fun `parser handles the fixture`() {
         assertTrue("canHandle should recognise the GPay statement", parser.canHandle(statementText))
@@ -116,6 +133,32 @@ class GPayPdfParserTest {
         assertEquals("Amazon", txs[2].merchant)
         assertEquals(TransactionType.EXPENSE, txs[2].type)
         assertEquals(BigDecimal("1250.50"), txs[2].amount)
+    }
+
+    @Test
+    fun `parses table layout extracted from Google Pay PDF`() {
+        val txs = parser.parse(tableLayoutStatementText)
+
+        assertEquals(3, txs.size)
+
+        assertEquals("SAMPLE MERCHANT A", txs[0].merchant)
+        assertEquals(TransactionType.EXPENSE, txs[0].type)
+        assertEquals(BigDecimal("12.34"), txs[0].amount)
+        assertEquals("123456789012", txs[0].reference)
+        assertEquals("1234", txs[0].accountLast4)
+        assertEquals(epochForIstDate("15 Oct, 2025 11:08 AM"), txs[0].timestamp)
+
+        assertEquals("SAMPLE SENDER", txs[1].merchant)
+        assertEquals(TransactionType.INCOME, txs[1].type)
+        assertEquals(BigDecimal("567.89"), txs[1].amount)
+        assertEquals("223456789012", txs[1].reference)
+        assertEquals(epochForIstDate("16 Oct, 2025 09:41 AM"), txs[1].timestamp)
+
+        assertEquals("SAMPLE MERCHANT B", txs[2].merchant)
+        assertEquals(TransactionType.EXPENSE, txs[2].type)
+        assertEquals(BigDecimal("42.00"), txs[2].amount)
+        assertEquals("323456789012", txs[2].reference)
+        assertEquals(epochForIstDate("16 Oct, 2025 11:13 AM"), txs[2].timestamp)
     }
 
     @Test

--- a/app/src/test/java/com/pennywiseai/tracker/data/statement/StatementImportProcessorTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/statement/StatementImportProcessorTest.kt
@@ -1,0 +1,224 @@
+package com.pennywiseai.tracker.data.statement
+
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType as ParsedTransactionType
+import com.pennywiseai.tracker.data.database.entity.TransactionEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionType
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class StatementImportProcessorTest {
+
+    private val baseTime = LocalDateTime.of(2025, 9, 1, 15, 2)
+
+    @Test
+    fun `referenced statement falls through to amount date dedup when reference has no match`() = runBlocking {
+        val existingSmsWithoutReference = transaction(
+            merchantName = "Specific Merchant",
+            reference = null
+        )
+        val store = FakeTransactionStore(
+            amountDateMatches = listOf(existingSmsWithoutReference)
+        )
+        val processor = StatementImportProcessor(store)
+
+        val result = processor.process(
+            listOf(parsedTransaction(reference = "190200588907"))
+        )
+
+        assertEquals(0, result.imported)
+        assertEquals(1, result.skippedDuplicates)
+        assertEquals(0, result.skippedByReference)
+        assertEquals(1, result.skippedByAmountDate)
+        assertTrue(store.inserted.isEmpty())
+        assertEquals(1, store.amountDateQueries.size)
+    }
+
+    @Test
+    fun `amount date fallback enriches one generic transaction instead of inserting duplicate`() = runBlocking {
+        val existingSmsWithoutReference = transaction(
+            id = 8,
+            merchantName = "UPI Transaction",
+            description = null,
+            reference = null
+        )
+        val store = FakeTransactionStore(
+            amountDateMatches = listOf(existingSmsWithoutReference)
+        )
+        val processor = StatementImportProcessor(store)
+
+        val result = processor.process(
+            listOf(
+                parsedTransaction(
+                    merchant = "Swiggy",
+                    reference = "190200588907"
+                )
+            )
+        )
+
+        assertEquals(0, result.imported)
+        assertEquals(1, result.enriched)
+        assertEquals(0, result.skippedByAmountDate)
+        assertEquals("Swiggy", store.updated.single().merchantName)
+        assertTrue(store.inserted.isEmpty())
+        assertEquals(1, store.amountDateQueries.size)
+    }
+
+    @Test
+    fun `amount date fallback does not enrich ambiguous generic transactions`() = runBlocking {
+        val store = FakeTransactionStore(
+            amountDateMatches = listOf(
+                transaction(id = 8, merchantName = "UPI Transaction", reference = null),
+                transaction(id = 9, merchantName = "UPI Transaction", reference = null)
+            )
+        )
+        val processor = StatementImportProcessor(store)
+
+        val result = processor.process(
+            listOf(
+                parsedTransaction(
+                    merchant = "Swiggy",
+                    reference = "190200588907"
+                )
+            )
+        )
+
+        assertEquals(0, result.imported)
+        assertEquals(0, result.enriched)
+        assertEquals(1, result.skippedByAmountDate)
+        assertTrue(store.updated.isEmpty())
+        assertTrue(store.inserted.isEmpty())
+    }
+
+    @Test
+    fun `referenced statement is inserted when neither reference nor amount date dedup matches`() = runBlocking {
+        val store = FakeTransactionStore()
+        val processor = StatementImportProcessor(store)
+
+        val result = processor.process(
+            listOf(parsedTransaction(reference = "190200588907"))
+        )
+
+        assertEquals(1, result.imported)
+        assertEquals(0, result.skippedDuplicates)
+        assertEquals("190200588907", store.inserted.single().reference)
+        assertEquals(1, store.amountDateQueries.size)
+    }
+
+    @Test
+    fun `reference match enriches existing transaction instead of inserting duplicate`() = runBlocking {
+        val existingSms = transaction(
+            id = 7,
+            merchantName = "UPI Transaction",
+            description = null,
+            reference = "190200588907"
+        )
+        val store = FakeTransactionStore(mergeCandidate = existingSms)
+        val processor = StatementImportProcessor(store)
+
+        val result = processor.process(
+            listOf(
+                parsedTransaction(
+                    merchant = "Swiggy",
+                    reference = "190200588907"
+                )
+            )
+        )
+
+        assertEquals(0, result.imported)
+        assertEquals(1, result.enriched)
+        assertEquals("Swiggy", store.updated.single().merchantName)
+        assertTrue(store.inserted.isEmpty())
+        assertTrue(store.amountDateQueries.isEmpty())
+    }
+
+    private class FakeTransactionStore(
+        private val hashMatch: TransactionEntity? = null,
+        private val mergeCandidate: TransactionEntity? = null,
+        private val amountDateMatches: List<TransactionEntity> = emptyList()
+    ) : StatementImportProcessor.TransactionStore {
+        val inserted = mutableListOf<TransactionEntity>()
+        val updated = mutableListOf<TransactionEntity>()
+        val amountDateQueries = mutableListOf<Pair<LocalDateTime, LocalDateTime>>()
+
+        override suspend fun getTransactionByHash(transactionHash: String): TransactionEntity? =
+            hashMatch
+
+        override suspend fun findStatementMergeCandidate(
+            transaction: TransactionEntity
+        ): TransactionEntity? =
+            mergeCandidate
+
+        override suspend fun updateTransaction(transaction: TransactionEntity) {
+            updated += transaction
+        }
+
+        override suspend fun getTransactionByAmountAndDate(
+            amount: BigDecimal,
+            dateStart: LocalDateTime,
+            dateEnd: LocalDateTime
+        ): List<TransactionEntity> {
+            amountDateQueries += dateStart to dateEnd
+            return amountDateMatches
+        }
+
+        override suspend fun insertTransactions(transactions: List<TransactionEntity>) {
+            inserted += transactions
+        }
+    }
+
+    private fun parsedTransaction(
+        amount: BigDecimal = BigDecimal("450.00"),
+        type: ParsedTransactionType = ParsedTransactionType.EXPENSE,
+        merchant: String = "Sample Store",
+        reference: String? = "190200588907",
+        accountLast4: String = "2468",
+        timestamp: Long = baseTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+        transactionHash: String = "statement-hash"
+    ): ParsedTransaction = ParsedTransaction(
+        amount = amount,
+        type = type,
+        merchant = merchant,
+        reference = reference,
+        accountLast4 = accountLast4,
+        balance = null,
+        smsBody = "Google Pay statement row",
+        sender = "GPAY_PDF",
+        timestamp = timestamp,
+        bankName = "Google Pay",
+        transactionHash = transactionHash,
+        currency = "INR"
+    )
+
+    private fun transaction(
+        id: Long = 1,
+        amount: BigDecimal = BigDecimal("450.00"),
+        transactionType: TransactionType = TransactionType.EXPENSE,
+        reference: String? = "190200588907",
+        accountNumber: String? = "2468",
+        merchantName: String = "UPI Transaction",
+        description: String? = null,
+        dateTime: LocalDateTime = baseTime
+    ): TransactionEntity = TransactionEntity(
+        id = id,
+        amount = amount,
+        merchantName = merchantName,
+        category = "Others",
+        transactionType = transactionType,
+        dateTime = dateTime,
+        description = description,
+        smsBody = "Bank SMS",
+        bankName = "South Indian Bank",
+        smsSender = "SIBSMS",
+        accountNumber = accountNumber,
+        balanceAfter = null,
+        transactionHash = "sms-hash-$id",
+        currency = "INR",
+        reference = reference
+    )
+}

--- a/app/src/test/java/com/pennywiseai/tracker/data/statement/StatementImportProcessorTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/statement/StatementImportProcessorTest.kt
@@ -70,6 +70,102 @@ class StatementImportProcessorTest {
     }
 
     @Test
+    fun `amount date fallback enriches generic transaction when statement time does not match`() = runBlocking {
+        val existingSmsWithoutReference = transaction(
+            id = 8,
+            merchantName = "UPI Transaction",
+            description = null,
+            reference = null,
+            dateTime = baseTime
+        )
+        val store = FakeTransactionStore(
+            amountDateMatches = listOf(existingSmsWithoutReference)
+        )
+        val processor = StatementImportProcessor(store)
+
+        val result = processor.process(
+            listOf(
+                parsedTransaction(
+                    merchant = "Swiggy",
+                    reference = "190200588907",
+                    timestamp = baseTime.toLocalDate()
+                        .atStartOfDay()
+                        .atZone(ZoneId.systemDefault())
+                        .toInstant()
+                        .toEpochMilli()
+                )
+            )
+        )
+
+        assertEquals(0, result.imported)
+        assertEquals(1, result.enriched)
+        assertEquals(0, result.skippedByAmountDate)
+        assertEquals("Swiggy", store.updated.single().merchantName)
+        assertTrue(store.inserted.isEmpty())
+        assertEquals(1, store.amountDateQueries.size)
+    }
+
+    @Test
+    fun `amount date fallback does not enrich opposite direction transaction`() = runBlocking {
+        val store = FakeTransactionStore(
+            amountDateMatches = listOf(
+                transaction(
+                    id = 8,
+                    merchantName = "UPI Transaction",
+                    transactionType = TransactionType.INCOME,
+                    reference = null
+                )
+            )
+        )
+        val processor = StatementImportProcessor(store)
+
+        val result = processor.process(
+            listOf(
+                parsedTransaction(
+                    merchant = "Swiggy",
+                    reference = "190200588907",
+                    type = ParsedTransactionType.EXPENSE
+                )
+            )
+        )
+
+        assertEquals(0, result.imported)
+        assertEquals(0, result.enriched)
+        assertEquals(1, result.skippedByAmountDate)
+        assertTrue(store.updated.isEmpty())
+        assertTrue(store.inserted.isEmpty())
+    }
+
+    @Test
+    fun `hash duplicate enriches generic transaction instead of skipping`() = runBlocking {
+        val existingGeneric = transaction(
+            id = 8,
+            merchantName = "UPI Transaction",
+            description = null,
+            reference = "190200588907"
+        )
+        val store = FakeTransactionStore(hashMatch = existingGeneric)
+        val processor = StatementImportProcessor(store)
+
+        val result = processor.process(
+            listOf(
+                parsedTransaction(
+                    merchant = "Swiggy",
+                    reference = "190200588907",
+                    transactionHash = existingGeneric.transactionHash
+                )
+            )
+        )
+
+        assertEquals(0, result.imported)
+        assertEquals(1, result.enriched)
+        assertEquals(0, result.skippedByHash)
+        assertEquals("Swiggy", store.updated.single().merchantName)
+        assertTrue(store.inserted.isEmpty())
+        assertTrue(store.amountDateQueries.isEmpty())
+    }
+
+    @Test
     fun `amount date fallback does not enrich ambiguous generic transactions`() = runBlocking {
         val store = FakeTransactionStore(
             amountDateMatches = listOf(

--- a/app/src/test/java/com/pennywiseai/tracker/data/statement/StatementTransactionEnricherTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/statement/StatementTransactionEnricherTest.kt
@@ -53,6 +53,38 @@ class StatementTransactionEnricherTest {
     }
 
     @Test
+    fun `amount date fallback candidate allows same-day statement without matching time`() {
+        val sms = transaction(id = 1, merchantName = "UPI Transaction", reference = "")
+        val statement = transaction(
+            id = 2,
+            merchantName = "Sample Store",
+            sender = "PhonePe PDF",
+            dateTime = baseTime.toLocalDate().atStartOfDay()
+        )
+
+        assertTrue(StatementTransactionEnricher.isAmountDateFallbackEnrichmentCandidate(sms, statement))
+    }
+
+    @Test
+    fun `amount date fallback candidate still rejects opposite direction`() {
+        val sms = transaction(
+            id = 1,
+            merchantName = "UPI Transaction",
+            transactionType = TransactionType.INCOME,
+            reference = ""
+        )
+        val statement = transaction(
+            id = 2,
+            merchantName = "Sample Store",
+            transactionType = TransactionType.EXPENSE,
+            sender = "PhonePe PDF",
+            dateTime = baseTime.toLocalDate().atStartOfDay()
+        )
+
+        assertFalse(StatementTransactionEnricher.isAmountDateFallbackEnrichmentCandidate(sms, statement))
+    }
+
+    @Test
     fun `does not match amount mismatch`() {
         val sms = transaction(id = 1, amount = BigDecimal("450.00"))
         val statement = transaction(id = 2, amount = BigDecimal("451.00"))

--- a/app/src/test/java/com/pennywiseai/tracker/data/statement/StatementTransactionEnricherTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/statement/StatementTransactionEnricherTest.kt
@@ -1,0 +1,167 @@
+package com.pennywiseai.tracker.data.statement
+
+import com.pennywiseai.tracker.data.database.entity.TransactionEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+class StatementTransactionEnricherTest {
+
+    private val baseTime = LocalDateTime.of(2025, 9, 1, 15, 2)
+
+    @Test
+    fun `matches same reference amount direction account and close timestamp`() {
+        val sms = transaction(id = 1, merchantName = "UPI Transaction")
+        val statement = transaction(
+            id = 2,
+            merchantName = "Sample Store",
+            sender = "GPay PDF",
+            dateTime = baseTime.plusMinutes(4)
+        )
+
+        assertTrue(StatementTransactionEnricher.isStatementMatch(sms, statement))
+    }
+
+    @Test
+    fun `fallback matches generic transaction with same details and close timestamp`() {
+        val sms = transaction(id = 1, merchantName = "UPI Transaction", reference = "")
+        val statement = transaction(
+            id = 2,
+            merchantName = "Sample Store",
+            sender = "GPay PDF",
+            dateTime = baseTime.plusMinutes(4)
+        )
+
+        assertTrue(StatementTransactionEnricher.isFallbackStatementMatch(sms, statement))
+    }
+
+    @Test
+    fun `fallback does not match specific merchant`() {
+        val sms = transaction(id = 1, merchantName = "Specific Merchant", reference = "")
+        val statement = transaction(
+            id = 2,
+            merchantName = "Sample Store",
+            sender = "GPay PDF",
+            dateTime = baseTime.plusMinutes(4)
+        )
+
+        assertFalse(StatementTransactionEnricher.isFallbackStatementMatch(sms, statement))
+    }
+
+    @Test
+    fun `does not match amount mismatch`() {
+        val sms = transaction(id = 1, amount = BigDecimal("450.00"))
+        val statement = transaction(id = 2, amount = BigDecimal("451.00"))
+
+        assertFalse(StatementTransactionEnricher.isStatementMatch(sms, statement))
+    }
+
+    @Test
+    fun `does not match timestamp outside tolerance`() {
+        val sms = transaction(id = 1, dateTime = baseTime)
+        val statement = transaction(id = 2, dateTime = baseTime.plusMinutes(6))
+
+        assertFalse(StatementTransactionEnricher.isStatementMatch(sms, statement))
+    }
+
+    @Test
+    fun `does not match opposite direction`() {
+        val sms = transaction(id = 1, transactionType = TransactionType.INCOME)
+        val statement = transaction(id = 2, transactionType = TransactionType.EXPENSE)
+
+        assertFalse(StatementTransactionEnricher.isStatementMatch(sms, statement))
+    }
+
+    @Test
+    fun `enriches generic merchant and blank details`() {
+        val sms = transaction(
+            id = 1,
+            merchantName = "UPI Transaction",
+            description = null,
+            fromAccount = null,
+            toAccount = null
+        )
+        val statement = transaction(
+            id = 2,
+            merchantName = "Sample Store",
+            description = "Google Pay statement",
+            fromAccount = "wallet",
+            toAccount = "2468"
+        )
+
+        val enriched = StatementTransactionEnricher.enrich(sms, statement)
+
+        assertTrue(StatementTransactionEnricher.hasEnrichment(sms, enriched))
+        assertEquals("Sample Store", enriched.merchantName)
+        assertEquals("Google Pay statement", enriched.description)
+        assertEquals("wallet", enriched.fromAccount)
+        assertEquals("2468", enriched.toAccount)
+    }
+
+    @Test
+    fun `does not overwrite specific existing merchant or notes`() {
+        val sms = transaction(
+            id = 1,
+            merchantName = "Specific Merchant",
+            description = "User note"
+        )
+        val statement = transaction(
+            id = 2,
+            merchantName = "Sample Store",
+            description = "Google Pay statement"
+        )
+
+        val enriched = StatementTransactionEnricher.enrich(sms, statement)
+
+        assertFalse(StatementTransactionEnricher.hasEnrichment(sms, enriched))
+        assertEquals("Specific Merchant", enriched.merchantName)
+        assertEquals("User note", enriched.description)
+    }
+
+    @Test
+    fun `does not use generic statement values`() {
+        val sms = transaction(id = 1, merchantName = "Unknown Merchant")
+        val statement = transaction(id = 2, merchantName = "UPI Transaction")
+
+        val enriched = StatementTransactionEnricher.enrich(sms, statement)
+
+        assertFalse(StatementTransactionEnricher.hasEnrichment(sms, enriched))
+        assertEquals("Unknown Merchant", enriched.merchantName)
+    }
+
+    private fun transaction(
+        id: Long,
+        amount: BigDecimal = BigDecimal("450.00"),
+        transactionType: TransactionType = TransactionType.EXPENSE,
+        reference: String = "111222333444",
+        accountNumber: String = "2468",
+        merchantName: String = "UPI Transaction",
+        description: String? = null,
+        fromAccount: String? = null,
+        toAccount: String? = null,
+        sender: String = "SIBSMS",
+        dateTime: LocalDateTime = baseTime
+    ): TransactionEntity = TransactionEntity(
+        id = id,
+        amount = amount,
+        merchantName = merchantName,
+        category = "Others",
+        transactionType = transactionType,
+        dateTime = dateTime,
+        description = description,
+        smsBody = "sample source",
+        bankName = "South Indian Bank",
+        smsSender = sender,
+        accountNumber = accountNumber,
+        balanceAfter = null,
+        transactionHash = "hash-$id",
+        currency = "INR",
+        fromAccount = fromAccount,
+        toAccount = toAccount,
+        reference = reference
+    )
+}


### PR DESCRIPTION
## Summary
- Change Google Pay statement imports from skipping reference matches to enriching matching existing transactions
- Match existing transactions by reference/UTR with amount, direction, account, currency, and ±5 minute timestamp safety checks
- Update only low-quality or missing fields such as generic merchant names, blank descriptions, and missing account direction fields
- Preserve specific existing merchant names and user-entered notes
- Show enriched transaction count in the import success summary

## Tests
- ./gradlew :app:testStandardDebugUnitTest --tests com.pennywiseai.tracker.data.statement.StatementTransactionEnricherTest --tests com.pennywiseai.tracker.data.statement.GPayPdfParserTest