### PR TITLE
fix: backup import NPE when older backups omit new list fields

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
@@ -69,10 +69,48 @@ class BackupImporter @Inject constructor(
             context.contentResolver.openInputStream(uri)?.use { inputStream ->
                 val reader = BufferedReader(InputStreamReader(inputStream))
                 val content = reader.readText()
-                gson.fromJson(content, PennyWiseBackup::class.java)
+                val parsed = gson.fromJson(content, PennyWiseBackup::class.java)
+                parsed.copy(database = parsed.database.normalized())
             } ?: throw Exception("Failed to read backup file")
         }
     }
+
+    /**
+     * Gson sets every collection field via reflection, bypassing the Kotlin
+     * `= emptyList()` default initialisers on [DatabaseSnapshot]. Older
+     * backups that don't carry a given list key end up with `null` stored
+     * under a property whose declared type is non-null `List<T>` — any
+     * .forEach / .map / .isNotEmpty() call on it then NPEs at runtime even
+     * though the code looks safe.
+     *
+     * Run every collection field through an elvis to empty-list once, right
+     * after parsing, so the rest of the importer can keep its non-null
+     * assumptions. USELESS_ELVIS warnings are suppressed because they are
+     * deliberately load-bearing here.
+     */
+    @Suppress("USELESS_ELVIS")
+    private fun DatabaseSnapshot.normalized(): DatabaseSnapshot = copy(
+        transactions = transactions ?: emptyList(),
+        categories = categories ?: emptyList(),
+        cards = cards ?: emptyList(),
+        accountBalances = accountBalances ?: emptyList(),
+        subscriptions = subscriptions ?: emptyList(),
+        merchantMappings = merchantMappings ?: emptyList(),
+        unrecognizedSms = unrecognizedSms ?: emptyList(),
+        chatMessages = chatMessages ?: emptyList(),
+        rules = rules ?: emptyList(),
+        ruleApplications = ruleApplications ?: emptyList(),
+        exchangeRates = exchangeRates ?: emptyList(),
+        budgets = budgets ?: emptyList(),
+        budgetCategories = budgetCategories ?: emptyList(),
+        transactionSplits = transactionSplits ?: emptyList(),
+        bankNotifications = bankNotifications ?: emptyList(),
+        loans = loans ?: emptyList(),
+        transactionGroups = transactionGroups ?: emptyList(),
+        profiles = profiles ?: emptyList(),
+        budgetMonthSnapshots = budgetMonthSnapshots ?: emptyList(),
+        budgetCategoryMonthSnapshots = budgetCategoryMonthSnapshots ?: emptyList()
+    )
     
     /**
      * Check if backup version is compatible

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
@@ -118,7 +118,16 @@ data class DateRange(
 )
 
 /**
- * Complete database snapshot
+ * Complete database snapshot.
+ *
+ * WARNING for future maintainers: when adding a new `List<T>` field here,
+ * also add the matching `field = field ?: emptyList()` line to
+ * BackupImporter.normalized(). Gson uses `Unsafe.allocateInstance` for
+ * deserialisation and never calls the Kotlin constructor, so the
+ * `= emptyList()` default below has no effect for backups whose JSON
+ * omits the new key — the field arrives as null at runtime under a
+ * non-null declared type, and the first .forEach / .map / .isNotEmpty()
+ * NPEs. normalized() is the runtime safety net that fixes that up.
  */
 data class DatabaseSnapshot(
     @SerializedName("transactions")


### PR DESCRIPTION
## Summary
Tester hit a hard crash on import (see screenshot):

> Import failed: Attempt to invoke interface method `java.util.Iterator java.lang.Iterable.iterator()` on a null object reference

## Root cause
Gson sets every Kotlin property via reflection during deserialisation, **bypassing the `= emptyList()` default initialisers** on `DatabaseSnapshot`. When an older backup file lacks a list key the current code expects (`loans`, `transactionGroups`, `profiles`, the budget snapshots — and any older list that pre-dates the source backup), Gson stores `null` in a property whose declared type is non-null `List<T>`. The first `.forEach` / `.isNotEmpty()` / `.map` call against that property NPEs at runtime even though every call site looks safe.

## Fix
Normalise the snapshot once, right after `gson.fromJson`, by running every list field through `field ?: emptyList()`. The `USELESS_ELVIS` warnings are suppressed because they're deliberately load-bearing — the property type lies to the compiler about non-null-ness, the elvis is the actual runtime safety net.

Applied to **all** list fields, not just the ones #333 added, so any future addition stays robust.

## Test plan
- [x] `./gradlew :app:compileStandardDebugKotlin` clean
- [x] `BackupModelsTest` still passes
- [ ] Manual: import a v1.0 backup that lacks the new fields — should succeed end-to-end, no crash dialog
- [ ] Manual: import a v1.1 backup with loans / groups / profiles present — should still restore everything correctly