### PR TITLE
feat: replace UPI VPAs with contact names at display time

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,10 @@
     <!-- Biometric permission for app lock feature -->
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 
+    <!-- Read contacts to replace UPI VPAs with contact names at display time.
+         Opt-in via Settings; the app degrades gracefully if denied. -->
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+
     <!-- Explicitly remove AD_ID permission to ensure privacy -->
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/contacts/ContactsResolver.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/contacts/ContactsResolver.kt
@@ -61,11 +61,17 @@ class ContactsResolver @Inject constructor(
      * cached, else null while scheduling a background query. The first
      * render after this call paints the original merchant; the second
      * (triggered by Compose when the cache map updates) paints the contact.
+     *
+     * Permission is rechecked on every call AHEAD of the cache lookup so
+     * that revoking READ_CONTACTS via OS Settings stops surfacing cached
+     * contact names on the next render. On Android 10 and below the
+     * process survives permission revocation, so a check that only ran on
+     * new queries would leave the cache leaking names.
      */
     fun resolve(phoneLast10: String): String? {
         if (phoneLast10.length != 10 || !phoneLast10.all { it.isDigit() }) return null
-        if (cache.containsKey(phoneLast10)) return cache[phoneLast10]
         if (!hasPermission()) return null
+        if (cache.containsKey(phoneLast10)) return cache[phoneLast10]
         scheduleQuery(phoneLast10)
         return null
     }

--- a/app/src/main/java/com/pennywiseai/tracker/data/contacts/ContactsResolver.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/contacts/ContactsResolver.kt
@@ -4,62 +4,90 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.provider.ContactsContract
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.core.content.ContextCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
  * Resolves a 10-digit phone number to a contact display name by querying
- * `ContactsContract` and caching the result for the app session.
+ * `ContactsContract` off the main thread and caching the result for the
+ * app session.
  *
  * Used by the "Replace UPI VPAs with contact names" feature: when the UI is
  * about to render a merchant that looks like `9876543210@paytm`, it asks
- * this resolver for `9876543210`. Misses are cached as null so we never
- * re-query a number that isn't in the user's contacts.
+ * this resolver for `9876543210`. Misses are cached so we never re-query a
+ * number that isn't in the user's contacts.
  *
- * Permission is checked on every call rather than at construction so a
- * mid-session revocation degrades gracefully (subsequent calls return
- * null instead of throwing). [clearCache] should be invoked whenever the
- * caller knows the contacts set may have changed (toggle on, manual
- * refresh button).
+ * Threading: [resolve] is called from Compose composition (main thread).
+ * The first call for a given phone schedules a background query on
+ * Dispatchers.IO and immediately returns null; once the query completes,
+ * the result is written into a SnapshotStateMap which triggers
+ * recomposition for any composable that read it, and the contact name
+ * appears on the next frame.
+ *
+ * Permission is checked on every scheduled query rather than at
+ * construction so a mid-session revocation degrades gracefully.
+ * [clearCache] should be invoked whenever the caller knows the contacts
+ * set may have changed (toggle flip, manual refresh).
  */
 @Singleton
 class ContactsResolver @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
 
-    // Both hits and misses are cached. Value is null when the lookup ran
-    // and found no contact for that number; absence-of-key means we haven't
-    // queried yet. Using ConcurrentHashMap lets render-time lookups happen
-    // from any thread without an explicit lock.
-    private val cache = ConcurrentHashMap<String, Optional>()
+    // Owned by this singleton; outlives any individual screen but is tied
+    // to the application lifetime. SupervisorJob so one failed query
+    // doesn't cancel the rest.
+    private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    // mutableStateMapOf so Compose readers re-render when an async query
+    // writes back. Value is null for "queried and no contact". Absence of
+    // a key means "haven't queried yet".
+    private val cache = mutableStateMapOf<String, String?>()
+
+    // Tracks queries already in flight so we don't fan out duplicates
+    // when many list rows for the same phone render at once.
+    private val pending = ConcurrentHashMap.newKeySet<String>()
 
     /**
-     * Returns the contact's display name for [phoneLast10], or null if no
-     * matching contact, no permission, or the input doesn't look like a
-     * 10-digit number.
+     * Returns the resolved contact name for [phoneLast10] if it's already
+     * cached, else null while scheduling a background query. The first
+     * render after this call paints the original merchant; the second
+     * (triggered by Compose when the cache map updates) paints the contact.
      */
     fun resolve(phoneLast10: String): String? {
         if (phoneLast10.length != 10 || !phoneLast10.all { it.isDigit() }) return null
-        cache[phoneLast10]?.let { return it.value }
-
-        if (!hasPermission()) {
-            // Don't cache the miss when it's caused by missing permission —
-            // the user may grant it later in the same session and we want
-            // a subsequent call to actually query.
-            return null
-        }
-
-        val resolved = queryContactName(phoneLast10)
-        cache[phoneLast10] = Optional(resolved)
-        return resolved
+        if (cache.containsKey(phoneLast10)) return cache[phoneLast10]
+        if (!hasPermission()) return null
+        scheduleQuery(phoneLast10)
+        return null
     }
 
     /** Drops every cached lookup. Call after a toggle change or manual refresh. */
     fun clearCache() {
         cache.clear()
+        pending.clear()
+    }
+
+    private fun scheduleQuery(phoneLast10: String) {
+        // pending.add returns true only the first time, so concurrent
+        // calls for the same number don't all spin up a query.
+        if (!pending.add(phoneLast10)) return
+        ioScope.launch {
+            val name = queryContactName(phoneLast10)
+            // Cache the result (even if null = "queried, no contact") so a
+            // subsequent resolve() returns immediately instead of polling
+            // ContactsContract again.
+            cache[phoneLast10] = name
+            pending.remove(phoneLast10)
+        }
     }
 
     private fun hasPermission(): Boolean =
@@ -89,7 +117,4 @@ class ContactsResolver @Inject constructor(
             null
         }
     }
-
-    /** Wrapper so we can distinguish "cached miss" from "not yet queried". */
-    private data class Optional(val value: String?)
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/contacts/ContactsResolver.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/contacts/ContactsResolver.kt
@@ -1,0 +1,95 @@
+package com.pennywiseai.tracker.data.contacts
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.provider.ContactsContract
+import androidx.core.content.ContextCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Resolves a 10-digit phone number to a contact display name by querying
+ * `ContactsContract` and caching the result for the app session.
+ *
+ * Used by the "Replace UPI VPAs with contact names" feature: when the UI is
+ * about to render a merchant that looks like `9876543210@paytm`, it asks
+ * this resolver for `9876543210`. Misses are cached as null so we never
+ * re-query a number that isn't in the user's contacts.
+ *
+ * Permission is checked on every call rather than at construction so a
+ * mid-session revocation degrades gracefully (subsequent calls return
+ * null instead of throwing). [clearCache] should be invoked whenever the
+ * caller knows the contacts set may have changed (toggle on, manual
+ * refresh button).
+ */
+@Singleton
+class ContactsResolver @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+
+    // Both hits and misses are cached. Value is null when the lookup ran
+    // and found no contact for that number; absence-of-key means we haven't
+    // queried yet. Using ConcurrentHashMap lets render-time lookups happen
+    // from any thread without an explicit lock.
+    private val cache = ConcurrentHashMap<String, Optional>()
+
+    /**
+     * Returns the contact's display name for [phoneLast10], or null if no
+     * matching contact, no permission, or the input doesn't look like a
+     * 10-digit number.
+     */
+    fun resolve(phoneLast10: String): String? {
+        if (phoneLast10.length != 10 || !phoneLast10.all { it.isDigit() }) return null
+        cache[phoneLast10]?.let { return it.value }
+
+        if (!hasPermission()) {
+            // Don't cache the miss when it's caused by missing permission —
+            // the user may grant it later in the same session and we want
+            // a subsequent call to actually query.
+            return null
+        }
+
+        val resolved = queryContactName(phoneLast10)
+        cache[phoneLast10] = Optional(resolved)
+        return resolved
+    }
+
+    /** Drops every cached lookup. Call after a toggle change or manual refresh. */
+    fun clearCache() {
+        cache.clear()
+    }
+
+    private fun hasPermission(): Boolean =
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.READ_CONTACTS
+        ) == PackageManager.PERMISSION_GRANTED
+
+    private fun queryContactName(phoneLast10: String): String? {
+        // PhoneLookup matches against normalised phone numbers, so we can
+        // pass just the last 10 digits and it will match contacts saved
+        // with or without a country-code prefix.
+        val uri = ContactsContract.PhoneLookup.CONTENT_FILTER_URI
+            .buildUpon()
+            .appendPath(phoneLast10)
+            .build()
+        val projection = arrayOf(ContactsContract.PhoneLookup.DISPLAY_NAME)
+        return try {
+            context.contentResolver.query(uri, projection, null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val idx = cursor.getColumnIndex(ContactsContract.PhoneLookup.DISPLAY_NAME)
+                    if (idx >= 0) cursor.getString(idx) else null
+                } else null
+            }
+        } catch (_: SecurityException) {
+            // Permission was revoked between the check above and the query.
+            null
+        }
+    }
+
+    /** Wrapper so we can distinguish "cached miss" from "not yet queried". */
+    private data class Optional(val value: String?)
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/contacts/LocalMerchantDisplay.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/contacts/LocalMerchantDisplay.kt
@@ -1,0 +1,18 @@
+package com.pennywiseai.tracker.data.contacts
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * Renders a merchant string for display. Default is identity (return the
+ * raw merchant) so any composable rendered outside the app's main tree
+ * (e.g. previews, dialogs without our wrapper) stays correct.
+ *
+ * Set this at the screen / nav root from a value that closes over the
+ * current [useContactsForVpa] preference and the singleton
+ * [ContactsResolver]. Consumers then read it without needing the
+ * preference or resolver wired through each composable's props.
+ *
+ * staticCompositionLocalOf because the value only flips on a settings
+ * toggle, so we don't need per-read recomposition tracking.
+ */
+val LocalMerchantDisplay = staticCompositionLocalOf<(String?) -> String?> { { it } }

--- a/app/src/main/java/com/pennywiseai/tracker/data/contacts/MerchantContactDisplay.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/contacts/MerchantContactDisplay.kt
@@ -34,6 +34,11 @@ fun displayMerchantName(
     return resolver.resolve(phone) ?: merchant
 }
 
+// Compiled once. Captures an optional +91 prefix followed by exactly 10
+// digits. Lookbehind / lookahead reject longer digit runs without
+// false-positive-ing on the underscores common in Indian VPAs (\b would).
+private val INDIAN_MOBILE_REGEX = Regex("""(?<!\d)(?:\+?91)?(\d{10})(?!\d)""")
+
 /**
  * Pulls a 10-digit Indian mobile number out of [text] if one is present.
  * Returns the last 10 digits of the matched run so a `+91` prefix is
@@ -41,11 +46,6 @@ fun displayMerchantName(
  * country-code) run is present.
  */
 internal fun extractIndianMobile(text: String): String? {
-    // Capture an optional +91 prefix followed by exactly 10 digits. The
-    // surrounding boundaries (\b would also accept underscores, which
-    // Indian VPAs sometimes use, so we hand-roll a non-digit / SOI / EOI
-    // guard via a non-capturing lookbehind / lookahead.
-    val regex = Regex("""(?<!\d)(?:\+?91)?(\d{10})(?!\d)""")
-    val match = regex.find(text) ?: return null
+    val match = INDIAN_MOBILE_REGEX.find(text) ?: return null
     return match.groupValues[1]
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/contacts/MerchantContactDisplay.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/contacts/MerchantContactDisplay.kt
@@ -1,0 +1,51 @@
+package com.pennywiseai.tracker.data.contacts
+
+/**
+ * Render-time helper that swaps a UPI-style merchant for a matching
+ * contact name when the user has opted into [useContactsForVpa]. Lives in
+ * the data layer so transaction lists, transaction details, the home
+ * recent-transactions card, and anywhere else that renders a merchant
+ * string can share one consistent rule.
+ *
+ * No-op when:
+ *  - the toggle is off (returns the original merchant)
+ *  - the merchant doesn't contain a 10-digit phone (very common: most
+ *    merchants are plain text like "AMAZON" or "SWIGGY")
+ *  - the contact lookup misses (returns the original merchant)
+ *
+ * VPA phone extraction handles the common Indian-UPI shapes:
+ *   - `9876543210@paytm`                → 9876543210
+ *   - `Q987654321@ybl` (PhonePe prefix) → 987654321 (only 9 digits, skipped)
+ *   - `9876543210`                       → 9876543210 (bare number)
+ *   - `+919876543210@paytm`              → 9876543210 (drop country code)
+ *
+ * We require exactly 10 digits because that's the Indian mobile-number
+ * length; PhoneLookup will normalise away any leading +91 from the
+ * contact side.
+ */
+fun displayMerchantName(
+    merchant: String?,
+    useContactsForVpa: Boolean,
+    resolver: ContactsResolver
+): String? {
+    if (merchant.isNullOrBlank()) return merchant
+    if (!useContactsForVpa) return merchant
+    val phone = extractIndianMobile(merchant) ?: return merchant
+    return resolver.resolve(phone) ?: merchant
+}
+
+/**
+ * Pulls a 10-digit Indian mobile number out of [text] if one is present.
+ * Returns the last 10 digits of the matched run so a `+91` prefix is
+ * silently dropped. Returns null when no 10-digit (or 12-digit
+ * country-code) run is present.
+ */
+internal fun extractIndianMobile(text: String): String? {
+    // Capture an optional +91 prefix followed by exactly 10 digits. The
+    // surrounding boundaries (\b would also accept underscores, which
+    // Indian VPAs sometimes use, so we hand-roll a non-digit / SOI / EOI
+    // guard via a non-capturing lookbehind / lookahead.
+    val regex = Regex("""(?<!\d)(?:\+?91)?(\d{10})(?!\d)""")
+    val match = regex.find(text) ?: return null
+    return match.groupValues[1]
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
@@ -116,6 +116,9 @@ class UserPreferencesRepository @Inject constructor(
         val PROFILE_BACKGROUND_COLOR = intPreferencesKey("profile_background_color")
         val HAS_COMPLETED_ONBOARDING = booleanPreferencesKey("has_completed_onboarding")
         val MAIN_ACCOUNT_KEY = stringPreferencesKey("main_account_key")
+
+        // UPI VPA → contact name lookup (opt-in; gated by READ_CONTACTS).
+        val USE_CONTACTS_FOR_VPA = booleanPreferencesKey("use_contacts_for_vpa")
     }
 
     val userPreferences: Flow<UserPreferences> = context.dataStore.data
@@ -545,6 +548,19 @@ class UserPreferencesRepository @Inject constructor(
     suspend fun setBalanceHidden(hidden: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[PreferencesKeys.BALANCE_HIDDEN] = hidden
+        }
+    }
+
+    // Replace UPI VPAs with matching contact names at display time.
+    // Off by default — turning on prompts for READ_CONTACTS.
+    val useContactsForVpa: Flow<Boolean> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.USE_CONTACTS_FOR_VPA] ?: false
+        }
+
+    suspend fun setUseContactsForVpa(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.USE_CONTACTS_FOR_VPA] = enabled
         }
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailScreen.kt
@@ -2,6 +2,7 @@ package com.pennywiseai.tracker.presentation.transactions
 
 import android.content.Intent
 import android.net.Uri
+import com.pennywiseai.tracker.data.contacts.LocalMerchantDisplay
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -555,8 +556,12 @@ private fun TransactionReceipt(
 
                 Spacer(modifier = Modifier.height(Spacing.sm))
 
+                // Show the contact-resolved name when the user has the
+                // toggle on; the raw merchant is still what the Edit
+                // field below renders so users can correct mis-detections.
+                val merchantDisplay = LocalMerchantDisplay.current
                 Text(
-                    text = transaction.merchantName,
+                    text = merchantDisplay(transaction.merchantName) ?: transaction.merchantName,
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.SemiBold,
                     textAlign = TextAlign.Center

--- a/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
@@ -26,6 +26,10 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.derivedStateOf
+import com.pennywiseai.tracker.data.contacts.LocalMerchantDisplay
+import com.pennywiseai.tracker.data.contacts.displayMerchantName
 import com.pennywiseai.tracker.presentation.home.HomeScreen
 import com.pennywiseai.tracker.presentation.subscriptions.SubscriptionsScreen
 import com.pennywiseai.tracker.presentation.transactions.TransactionsScreen
@@ -60,6 +64,16 @@ fun MainScreen(
 
     // What's New dialog state
     val whatsNewVersion by mainViewModel.whatsNewVersion.collectAsState()
+
+    // UPI VPA → contact name. Read the toggle as state; the lambda closes
+    // over the current value + the singleton resolver, and is provided
+    // through a CompositionLocal so every transaction-rendering composable
+    // (TransactionItem, TransactionDetailScreen header, etc.) can apply the
+    // same rule without prop-drilling the resolver everywhere.
+    val useContactsForVpa by mainViewModel.useContactsForVpa.collectAsState()
+    val merchantDisplay = remember(useContactsForVpa) {
+        { raw: String? -> displayMerchantName(raw, useContactsForVpa, mainViewModel.contactsResolver) }
+    }
 
     // Haze state for blur effects
     val hazeState = remember { HazeState() }
@@ -98,6 +112,7 @@ fun MainScreen(
         }
     }
 
+    CompositionLocalProvider(LocalMerchantDisplay provides merchantDisplay) {
     Box(modifier = Modifier
         .fillMaxSize()
         .background(MaterialTheme.colorScheme.background)
@@ -507,4 +522,5 @@ fun MainScreen(
             )
         }
     }
+    } // CompositionLocalProvider
 }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/TransactionItem.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/TransactionItem.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import android.view.HapticFeedbackConstants
-import androidx.compose.runtime.CompositionLocalProvider
 import com.pennywiseai.tracker.data.contacts.LocalMerchantDisplay
 import com.pennywiseai.tracker.data.database.entity.ProfileEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/TransactionItem.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/TransactionItem.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import android.view.HapticFeedbackConstants
+import androidx.compose.runtime.CompositionLocalProvider
+import com.pennywiseai.tracker.data.contacts.LocalMerchantDisplay
 import com.pennywiseai.tracker.data.database.entity.ProfileEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
@@ -91,9 +93,10 @@ fun TransactionItem(
 
     val sharedTransitionScope = LocalSharedTransitionScope.current
     val animatedVisibilityScope = LocalNavAnimatedVisibilityScope.current
+    val merchantDisplay = LocalMerchantDisplay.current
 
     ListItemCardV2(
-        title = transaction.merchantName,
+        title = merchantDisplay(transaction.merchantName) ?: transaction.merchantName,
         subtitle = subtitle,
         amount = "$amountPrefix$formattedAmount",
         amountColor = amountColor,

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -106,6 +106,15 @@ fun SettingsScreen(
     val unifiedCurrencyMode by settingsViewModel.unifiedCurrencyMode.collectAsStateWithLifecycle(initialValue = false)
     val displayCurrency by settingsViewModel.displayCurrency.collectAsStateWithLifecycle(initialValue = "")
     val availableCurrencies by settingsViewModel.availableCurrencies.collectAsStateWithLifecycle()
+    val useContactsForVpa by settingsViewModel.useContactsForVpa.collectAsStateWithLifecycle(initialValue = false)
+    // Launches the runtime permission request. If granted, we flip the
+    // preference on; if denied, leave the switch off so the user can try
+    // again without us silently turning the feature on later.
+    val readContactsLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) settingsViewModel.setUseContactsForVpa(true)
+    }
     var showSmsScanDialog by remember { mutableStateOf(false) }
     var showExportOptionsDialog by remember { mutableStateOf(false) }
     var showTimeoutDialog by remember { mutableStateOf(false) }
@@ -251,6 +260,36 @@ fun SettingsScreen(
                         )
                     }
                 }
+            }
+
+            // ── Contacts ──
+            SectionHeaderV2(title = "Contacts")
+            SettingsGroup {
+                SettingsSwitchRow(
+                    icon = Icons.Default.Contacts,
+                    iconBgColor = teal_light,
+                    iconTint = teal_dark,
+                    title = "Replace UPI VPAs with contact names",
+                    subtitle = "Show 'John Doe' instead of '9876543210@paytm'. Needs contacts permission.",
+                    checked = useContactsForVpa,
+                    onCheckedChange = { wantsOn ->
+                        if (wantsOn) {
+                            val alreadyGranted = androidx.core.content.ContextCompat
+                                .checkSelfPermission(
+                                    context,
+                                    android.Manifest.permission.READ_CONTACTS
+                                ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+                            if (alreadyGranted) {
+                                settingsViewModel.setUseContactsForVpa(true)
+                            } else {
+                                readContactsLauncher.launch(android.Manifest.permission.READ_CONTACTS)
+                            }
+                        } else {
+                            settingsViewModel.setUseContactsForVpa(false)
+                        }
+                    },
+                    position = ItemPosition.SINGLE
+                )
             }
 
             // ── Security ──

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -47,7 +47,8 @@ class SettingsViewModel @Inject constructor(
     private val unrecognizedSmsRepository: UnrecognizedSmsRepository,
     private val transactionRepository: TransactionRepository,
     private val backupExporter: BackupExporter,
-    private val backupImporter: BackupImporter
+    private val backupImporter: BackupImporter,
+    private val contactsResolver: com.pennywiseai.tracker.data.contacts.ContactsResolver
 ) : ViewModel() {
     
     private val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
@@ -84,6 +85,9 @@ class SettingsViewModel @Inject constructor(
     // Unified Currency Mode
     val unifiedCurrencyMode = userPreferencesRepository.unifiedCurrencyMode
     val displayCurrency = userPreferencesRepository.displayCurrency
+
+    // Replace UPI VPAs with contact names (gated by READ_CONTACTS).
+    val useContactsForVpa = userPreferencesRepository.useContactsForVpa
 
     val availableCurrencies: StateFlow<List<String>> = transactionRepository.getAllCurrencies()
         .map { transactionCurrencies ->
@@ -419,6 +423,20 @@ class SettingsViewModel @Inject constructor(
     fun toggleDeveloperMode(enabled: Boolean) {
         viewModelScope.launch {
             userPreferencesRepository.setDeveloperModeEnabled(enabled)
+        }
+    }
+
+    /**
+     * Flip the UPI-contact-resolution preference. The screen is responsible
+     * for ensuring READ_CONTACTS is granted before passing `true` — this
+     * just persists. Toggling either direction wipes the resolver cache so
+     * stale results don't leak across the flag flip (and so a re-enable
+     * after permission grant picks up the user's contacts immediately).
+     */
+    fun setUseContactsForVpa(enabled: Boolean) {
+        viewModelScope.launch {
+            userPreferencesRepository.setUseContactsForVpa(enabled)
+            contactsResolver.clearCache()
         }
     }
     

--- a/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/MainViewModel.kt
@@ -22,7 +22,7 @@ import javax.inject.Inject
 class MainViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val userPreferencesRepository: UserPreferencesRepository,
-    val contactsResolver: ContactsResolver
+    internal val contactsResolver: ContactsResolver
 ) : ViewModel() {
 
     private val _whatsNewVersion = MutableStateFlow<WhatsNewVersion?>(null)

--- a/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/MainViewModel.kt
@@ -4,25 +4,35 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.BuildConfig
+import com.pennywiseai.tracker.data.contacts.ContactsResolver
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.ui.components.WhatsNewContent
 import com.pennywiseai.tracker.ui.components.WhatsNewVersion
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val userPreferencesRepository: UserPreferencesRepository
+    private val userPreferencesRepository: UserPreferencesRepository,
+    val contactsResolver: ContactsResolver
 ) : ViewModel() {
 
     private val _whatsNewVersion = MutableStateFlow<WhatsNewVersion?>(null)
     val whatsNewVersion: StateFlow<WhatsNewVersion?> = _whatsNewVersion.asStateFlow()
+
+    // Project the toggle as a StateFlow so MainScreen can synchronously
+    // build a CompositionLocal closure over the latest value without
+    // collecting on every render path.
+    val useContactsForVpa: StateFlow<Boolean> = userPreferencesRepository.useContactsForVpa
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     init {
         checkWhatsNew()


### PR DESCRIPTION
## Summary
From TODO.md: *"if the UPI ID of the user paid to/from contains the phone number, maybe lookup and rename the merchant using contacts?"*

Renders `9876543210@paytm` as **John Doe** wherever a transaction is shown, by looking up the user's contacts. Off by default; opt-in via Settings.

## Design choice — live lookup, not rewrite
Doing the lookup at **display time** rather than rewriting `merchant_name`:
- Contacts changes show up instantly (no sync logic, no stale alias table)
- Raw VPA stays on the entity, so the Edit field still shows the parsed value
- Toggle off ⇒ instant revert to VPA; no data migration

Performance: an in-memory cache in `ContactsResolver` (keyed by phone-last-10) memoises both hits and misses for the app session. Cache is cleared on toggle flip.

## Pieces
- **`AndroidManifest`**: `READ_CONTACTS` permission declared.
- **`UserPreferencesRepository.useContactsForVpa`**: new boolean Flow, default false.
- **`ContactsResolver`** (`data/contacts`, `@Singleton`): `ConcurrentHashMap<phoneLast10, Optional<String>>` cache; resolves via `ContactsContract.PhoneLookup`; re-checks permission on every call so mid-session revocation degrades to `null` instead of throwing; `clearCache()` on toggle flip.
- **`displayMerchantName` / `extractIndianMobile`**: pure helper. Pulls a 10-digit Indian mobile (`+91` optional) from the merchant, sends it through the resolver, falls back to the original on miss / toggle off.
- **`LocalMerchantDisplay`**: `staticCompositionLocalOf<(String?) -> String?>` with identity default. `MainScreen` wraps the NavHost in a `CompositionLocalProvider`; consumers (`TransactionItem`, `TransactionDetailScreen` header) read it without prop-drilling. Identity default keeps previews / out-of-tree composables correct.
- **Settings → Contacts section** with a single switch. Enable flow:
  1. user taps switch on
  2. if `READ_CONTACTS` not granted, launch runtime permission request
  3. only flip the pref on if granted
  4. graceful no-op if denied

## Deliberately NOT wrapped
- `TransactionDetailScreen` **Edit** field (line 1069) — users editing a mis-detected merchant should see the actual stored value, not the alias.

## Test plan
- [x] `./gradlew :app:compileStandardDebugKotlin` — clean
- [ ] Manual: toggle off → all VPAs render raw
- [ ] Manual: toggle on without granting permission → switch stays off
- [ ] Manual: toggle on + grant permission → contact-matching merchants rename in list and detail header; non-matching stay as VPA
- [ ] Manual: revoke permission via OS settings → app stops showing contact names on next render, no crash
- [ ] Manual: toggle off after on → instant revert to VPAs
- [ ] Manual: transactions with non-VPA merchant names (e.g. "AMAZON") render unchanged