### PR TITLE
Add parsers from Cashiro

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BPCEParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BPCEParser.kt
@@ -48,6 +48,7 @@ class BPCEParser : BankParser() {
         val lowerMessage = message.lowercase()
 
         return when {
+            lowerMessage.contains("virement instantané") && lowerMessage.contains("reçu") -> TransactionType.INCOME
             lowerMessage.contains("virement instantané") -> TransactionType.EXPENSE
             else -> super.extractTransactionType(message)
         }

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BPCEParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BPCEParser.kt
@@ -1,0 +1,76 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+class BPCEParser : BankParser() {
+
+    override fun getBankName() = "BPCE"
+
+    override fun getCurrency() = "EUR"
+
+    override fun canHandle(sender: String): Boolean {
+        return sender == "38015"
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lowerMessage = message.lowercase()
+
+        if (lowerMessage.contains("ajout d'un bénéficiaire")) {
+            return false
+        }
+
+        return lowerMessage.contains("virement instantané") ||
+                super.isTransactionMessage(message)
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        val patterns = listOf(
+            Regex("""de\s+([0-9,]+(?:\.\d{2})?)\s+EUR""", RegexOption.IGNORE_CASE),
+            Regex("""([0-9,]+(?:\.\d{2})?)\s*EUR""", RegexOption.IGNORE_CASE)
+        )
+
+        for (pattern in patterns) {
+            pattern.find(message)?.let { match ->
+                val amountStr = match.groupValues[1].replace(",", ".")
+                return try {
+                    BigDecimal(amountStr)
+                } catch (e: NumberFormatException) {
+                    null
+                }
+            }
+        }
+
+        return super.extractAmount(message)
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lowerMessage = message.lowercase()
+
+        return when {
+            lowerMessage.contains("virement instantané") -> TransactionType.EXPENSE
+            else -> super.extractTransactionType(message)
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        val patterns = listOf(
+            Regex("""vers\s+([^.\n]+?)(?:\s+du\s+|\s+le\s+|$)""", RegexOption.IGNORE_CASE)
+        )
+
+        for (pattern in patterns) {
+            pattern.find(message)?.let { match ->
+                val merchant = cleanMerchantName(match.groupValues[1].trim())
+                if (isValidMerchantName(merchant)) {
+                    return merchant
+                }
+            }
+        }
+
+        return super.extractMerchant(message, sender)
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        return super.extractAccountLast4(message)
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -69,7 +69,9 @@ object BankParserFactory {
         AlecuBankParser(),  // ALECU Credit Union (USA)
         PriorbankParser(),  // Priorbank (Belarus)
         AlinmaBankParser(),  // Alinma Bank (Saudi Arabia)
+        NabilBankParser(),  // Nabil Bank (Nepal) — must be before NMBBankParser (NMB handles NABIL senders broadly)
         NMBBankParser(),  // NMB Bank / Nabil Bank (Nepal)
+        ManjushreeFinanceParser(), // Manjushree Finance (Nepal)
         SiddharthaBankParser(),  // Siddhartha Bank Limited (Nepal)
         PrimeCommercialBankParser(),  // Prime Commercial Bank (Nepal)
         MPesaTanzaniaParser(),  // M-Pesa Tanzania (must be before Kenya M-PESA)
@@ -109,7 +111,8 @@ object BankParserFactory {
         SparkasseRheinMaasParser(),  // Sparkasse Rhein-Maas (Germany)
         EnparaBankParser(),  // Enpara (Turkey) — push notifications
         BankMuscatParser(),  // Bank Muscat (Oman)
-        GreaterBankParser()  // Greater Bank (India)
+        GreaterBankParser(),  // Greater Bank (India)
+        BPCEParser()  // BPCE (France)
         // Add more bank parsers here as we implement them
     )
 

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ManjushreeFinanceParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ManjushreeFinanceParser.kt
@@ -1,0 +1,48 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+class ManjushreeFinanceParser : BankParser() {
+
+    override fun getBankName() = "Manjushree Finance"
+
+    override fun getCurrency() = "NPR"
+
+    override fun canHandle(sender: String): Boolean {
+        val s = sender.uppercase()
+        return s.contains("MFL") || s == "MFL_ALERT" || s.contains("MANJUSHREE")
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        val nprPattern = Regex("""NPR\s+([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE)
+        nprPattern.find(message)?.let { m ->
+            return m.groupValues[1].replace(",", "").toBigDecimalOrNull()
+        }
+        return super.extractAmount(message)
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lower = message.lowercase()
+        if (lower.contains("debited") || lower.contains("debited by")) return TransactionType.EXPENSE
+        if (lower.contains("credited") || lower.contains("deposited")) return TransactionType.INCOME
+        return null
+    }
+
+    override fun extractReference(message: String): String? {
+        val remarks = Regex("""Remarks[:\s]*([^,]+)""", RegexOption.IGNORE_CASE)
+        remarks.find(message)?.let { return it.groupValues[1].trim() }
+        return null
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        val transfer = Regex("""transfer\s+([^,~\n]+)""", RegexOption.IGNORE_CASE)
+        transfer.find(message)?.let {
+            val name = it.groupValues[1].trim()
+            val cleaned = cleanMerchantName(name)
+            if (isValidMerchantName(cleaned)) return cleaned
+        }
+
+        return super.extractMerchant(message, sender)
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ManjushreeFinanceParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ManjushreeFinanceParser.kt
@@ -11,7 +11,7 @@ class ManjushreeFinanceParser : BankParser() {
 
     override fun canHandle(sender: String): Boolean {
         val s = sender.uppercase()
-        return s.contains("MFL") || s == "MFL_ALERT" || s.contains("MANJUSHREE")
+        return s == "MFL" || s == "MFL_ALERT" || s.contains("MANJUSHREE")
     }
 
     override fun extractAmount(message: String): BigDecimal? {

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NabilBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NabilBankParser.kt
@@ -1,0 +1,51 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+class NabilBankParser : BankParser() {
+
+    override fun getBankName() = "Nabil Bank"
+
+    override fun getCurrency() = "NPR"
+
+    override fun canHandle(sender: String): Boolean {
+        val s = sender.uppercase()
+        return s.contains("NABIL") || s == "NABIL_ALERT" || s == "NABILBANK"
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        val nprPattern = Regex("""NPR\s+([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE)
+        nprPattern.find(message)?.let { m ->
+            val amountStr = m.groupValues[1].replace(",", "")
+            return amountStr.toBigDecimalOrNull()
+        }
+
+        return super.extractAmount(message)
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lower = message.lowercase()
+        if (lower.contains("withdrawn")) return TransactionType.EXPENSE
+        if (lower.contains("deposited") || lower.contains("credited")) return TransactionType.INCOME
+        return null
+    }
+
+    override fun extractReference(message: String): String? {
+        val remarks = Regex("""Remarks[:\s]*([A-Z0-9\-~]+)""", RegexOption.IGNORE_CASE)
+        remarks.find(message)?.let { return it.groupValues[1] }
+
+        val refPattern = Regex("""(MTXN[0-9A-Z\-]+)""", RegexOption.IGNORE_CASE)
+        refPattern.find(message)?.let { return it.groupValues[1] }
+
+        return null
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        val maskedPattern = Regex("""#+(\d{4,})""")
+        maskedPattern.find(message)?.let { match ->
+            return extractLast4Digits(match.groupValues[1])
+        }
+        return super.extractAccountLast4(message)
+    }
+}

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/BPCEParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/BPCEParserTest.kt
@@ -1,0 +1,60 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class BPCEParserTest {
+
+    @TestFactory
+    fun `bpce parser handles key paths`(): List<DynamicTest> {
+        val parser = BPCEParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "Instant transfer",
+                message = "Caisse d'Epargne: nous vous confirmons la réalisation de votre virement instantané de 1000,00 EUR du 01/12/2025 à 00h00m00s vers NAME FIRST NAME",
+                sender = "38015",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1000.00"),
+                    currency = "EUR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "NAME FIRST NAME"
+                )
+            ),
+            ParserTestCase(
+                name = "Instant transfer to PayPal",
+                message = "Caisse d'Epargne: nous vous confirmons la réalisation de votre virement instantané de 1000,00 EUR du 03/12/2025 à 18h46m18s vers PAYPAL",
+                sender = "38015",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1000.00"),
+                    currency = "EUR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "PAYPAL"
+                )
+            ),
+            ParserTestCase(
+                name = "Ignore addition of beneficiary",
+                message = "Caisse d'Epargne : Virements - Ajout d'un bénéficiaire le 02/12/2025 sur internet. Si vous n'avez pas initié cette opération, contactez votre agence.",
+                sender = "38015",
+                shouldParse = false
+            )
+        )
+
+        val handleCases = listOf(
+            "38015" to true,
+            "UNKNOWN" to false
+        )
+
+        return ParserTestUtils.runTestSuite(
+            parser = parser,
+            testCases = testCases,
+            handleCases = handleCases,
+            suiteName = "BPCE Parser"
+        )
+    }
+}

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/ManjushreeFinanceParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/ManjushreeFinanceParserTest.kt
@@ -23,15 +23,15 @@ class ManjushreeFinanceParserTest {
         val cases = listOf(
             ParserTestCase(
                 name = "Debited example with merchant",
-                message = """Your A/C ##0168658000001, has been debited by NPR 15,000.00 on 01/04/2026 10:27,Remarks:9769780059~2309320,IBFT,transfer laxmi paudyal~RBB
+                message = """Your A/C ##0168658000001, has been debited by NPR 15,000.00 on 01/04/2026 10:27,Remarks:9800000000~2309320,IBFT,transfer FIRST LAST~RBB
 Manjushree Finance""",
                 sender = "MFL_ALERT",
                 expected = ExpectedTransaction(
                     amount = BigDecimal("15000.00"),
                     currency = "NPR",
                     type = TransactionType.EXPENSE,
-                    reference = "9769780059~2309320",
-                    merchant = "laxmi paudyal"
+                    reference = "9800000000~2309320",
+                    merchant = "FIRST LAST"
                 )
             )
         )

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/ManjushreeFinanceParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/ManjushreeFinanceParserTest.kt
@@ -1,0 +1,53 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class ManjushreeFinanceParserTest {
+
+    @TestFactory
+    fun `manjushree finance parser handles key paths`(): List<DynamicTest> {
+        val parser = ManjushreeFinanceParser()
+
+        ParserTestUtils.printTestHeader(
+            parserName = "Manjushree Finance",
+            bankName = parser.getBankName(),
+            currency = parser.getCurrency()
+        )
+
+        val cases = listOf(
+            ParserTestCase(
+                name = "Debited example with merchant",
+                message = """Your A/C ##0168658000001, has been debited by NPR 15,000.00 on 01/04/2026 10:27,Remarks:9769780059~2309320,IBFT,transfer laxmi paudyal~RBB
+Manjushree Finance""",
+                sender = "MFL_ALERT",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("15000.00"),
+                    currency = "NPR",
+                    type = TransactionType.EXPENSE,
+                    reference = "9769780059~2309320",
+                    merchant = "laxmi paudyal"
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            "MFL_ALERT" to true,
+            "MFL" to true,
+            "MANJUSHREE" to true,
+            "UNKNOWN" to false
+        )
+
+        return ParserTestUtils.runTestSuite(
+            parser = parser,
+            testCases = cases,
+            handleCases = handleCases,
+            suiteName = "Manjushree Finance Parser Tests"
+        )
+    }
+}

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/NabilBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/NabilBankParserTest.kt
@@ -1,0 +1,73 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import com.pennywiseai.parser.core.test.SimpleTestCase
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class NabilBankParserTest {
+
+    private val parser = NabilBankParser()
+
+    @TestFactory
+    fun `nabil bank parser handles key paths`(): List<DynamicTest> {
+        ParserTestUtils.printTestHeader(
+            parserName = "Nabil Bank",
+            bankName = parser.getBankName(),
+            currency = parser.getCurrency()
+        )
+
+        val cases = listOf(
+            ParserTestCase(
+                name = "Withdrawn example with reference",
+                message = """Dear Customer, Your 091##04118 has been withdrawn by NPR 20,008.00 on 17/04/2026 07:58:06, Remarks: MTXN0000517374-130
+Download App: https://rebrand.ly/nBank""",
+                sender = "NABIL_ALERT",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("20008.00"),
+                    currency = "NPR",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "4118",
+                    reference = "MTXN0000517374-130"
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            "NABIL_ALERT" to true,
+            "NABIL" to true,
+            "NMB_ALERT" to false
+        )
+
+        return ParserTestUtils.runTestSuite(
+            parser = parser,
+            testCases = cases,
+            handleCases = handleCases,
+            suiteName = "Nabil Bank Parser Tests"
+        )
+    }
+
+    @TestFactory
+    fun `factory resolves nabil bank`(): List<DynamicTest> {
+        val cases = listOf(
+            SimpleTestCase(
+                bankName = "Nabil Bank",
+                sender = "NABIL_ALERT",
+                currency = "NPR",
+                message = "Dear Customer, Your 091##04118 has been withdrawn by NPR 20,008.00 on 17/04/2026 07:58:06, Remarks: MTXN0000517374-130",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("20008.00"),
+                    currency = "NPR",
+                    type = TransactionType.EXPENSE
+                ),
+                shouldHandle = true
+            )
+        )
+
+        return ParserTestUtils.runFactoryTestSuite(cases, "Factory smoke tests")
+    }
+}


### PR DESCRIPTION
Porting 3 bank parsers from Cashiro to PennywiseAI-tracker:

- **BPCEParser** — Banque Populaire Caisse d'Épargne (France)
- **ManjushreeFinanceParser** — Manjushree Finance (Nepal)
- **NabilBankParser** — Nabil Bank (Nepal)

All parsers registered in BankParserFactory. NabilBankParser placed before NMBBankParser since the latter broadly catches "NABIL" senders. Tests follow the project's @TestFactory + ParserTestUtils conventions.