### PR TITLE
fix: AU Bank new "Dr INR" short-form debit format

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/AUBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/AUBankParser.kt
@@ -51,6 +51,20 @@ class AUBankParser : BaseIndianBankParser() {
             }
         }
 
+        // Pattern 2b: Short-form "Dr INR XXX" / "Cr INR XXX" (AU's newer SMS format)
+        val shortFormPattern = Regex(
+            """\b(?:Dr|Cr)\s+INR\s+([0-9,]+(?:\.\d{2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        shortFormPattern.find(message)?.let { match ->
+            val amount = match.groupValues[1].replace(",", "")
+            return try {
+                BigDecimal(amount)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+
         // Pattern 3: INR XXX spent (credit card format)
         val spentPattern = Regex(
             """INR\s+([0-9,]+(?:\.\d{2})?)\s+spent""",
@@ -108,6 +122,24 @@ class AUBankParser : BaseIndianBankParser() {
             }
         }
 
+        // Pattern 1b: Short SMS form `UPI/DR/<ref>/<merchant>` with no IFSC follow-up
+        // (e.g. AU's newer messages end the segment at a slash + letter or newline).
+        // Reject the all-X "Bank Account XXXXX" placeholder AU uses when no merchant
+        // name is available, then fall through to remaining patterns.
+        val upiShortPattern = Regex(
+            """UPI/(?:DR|CR)/\d+/([^/\n]+?)(?:/[A-Z]|/\s|\n|$)""",
+            RegexOption.IGNORE_CASE
+        )
+        upiShortPattern.find(message)?.let { match ->
+            val candidate = match.groupValues[1].trim()
+            if (!candidate.matches(Regex("""Bank\s+Account\s+X+""", RegexOption.IGNORE_CASE))) {
+                val merchant = cleanMerchantName(candidate)
+                if (isValidMerchantName(merchant)) {
+                    return merchant
+                }
+            }
+        }
+
         // Pattern 2: UPI transactions - extract name from Ref UPI/.../.../.../name(account)
         val upiPattern = Regex(
             """Ref\s+UPI/[^/]+/[^/]+/[^/]+\s+([^(]+)\([^)]+\)""",
@@ -161,6 +193,11 @@ class AUBankParser : BaseIndianBankParser() {
         return when {
             // Credit card transactions (must be checked before generic "spent" keyword)
             lowerMessage.contains("credit card") -> TransactionType.CREDIT
+
+            // Short-form Dr/Cr (AU's newer SMS format) — checked before the long-form
+            // keywords below so we don't false-match on substrings.
+            Regex("""\bdr\s+inr\b""").containsMatchIn(lowerMessage) -> TransactionType.EXPENSE
+            Regex("""\bcr\s+inr\b""").containsMatchIn(lowerMessage) -> TransactionType.INCOME
 
             // Income keywords
             lowerMessage.contains("credited") -> TransactionType.INCOME
@@ -227,6 +264,8 @@ class AUBankParser : BaseIndianBankParser() {
             "credited inr",
             "debited inr",
             "withdrawn inr",
+            "dr inr",
+            "cr inr",
             "bal inr",
             "ref upi",
             "spent"

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/AUBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/AUBankParser.kt
@@ -15,6 +15,12 @@ import java.math.BigDecimal
  */
 class AUBankParser : BaseIndianBankParser() {
 
+    private companion object {
+        // Hoisted so the Regex isn't recompiled on every extractTransactionType call.
+        private val DR_INR_REGEX = Regex("""\bdr\s+inr\b""")
+        private val CR_INR_REGEX = Regex("""\bcr\s+inr\b""")
+    }
+
     override fun getBankName() = "AU Small Finance Bank"
 
     override fun canHandle(sender: String): Boolean {
@@ -196,8 +202,8 @@ class AUBankParser : BaseIndianBankParser() {
 
             // Short-form Dr/Cr (AU's newer SMS format) — checked before the long-form
             // keywords below so we don't false-match on substrings.
-            Regex("""\bdr\s+inr\b""").containsMatchIn(lowerMessage) -> TransactionType.EXPENSE
-            Regex("""\bcr\s+inr\b""").containsMatchIn(lowerMessage) -> TransactionType.INCOME
+            DR_INR_REGEX.containsMatchIn(lowerMessage) -> TransactionType.EXPENSE
+            CR_INR_REGEX.containsMatchIn(lowerMessage) -> TransactionType.INCOME
 
             // Income keywords
             lowerMessage.contains("credited") -> TransactionType.INCOME

--- a/parser-core/src/test/kotlin/TestAUBankParser.kt
+++ b/parser-core/src/test/kotlin/TestAUBankParser.kt
@@ -86,6 +86,22 @@ class AUBankParserTest {
                     accountLast4 = "4541",
                     balance = BigDecimal("18838.10")
                 )
+            ),
+            ParserTestCase(
+                name = "Short Cr form is INCOME",
+                message = "Cr INR 5,000.00 to A/c X4541 12-MAY-2026\n" +
+                    "UPI/CR/424941009999/JANE DOE/Y\n" +
+                    "Bal INR 23,838.10\n" +
+                    "-AU Bank",
+                sender = "VM-AUBANK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("5000.00"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    merchant = "JANE DOE",
+                    accountLast4 = "4541",
+                    balance = BigDecimal("23838.10")
+                )
             )
         )
 

--- a/parser-core/src/test/kotlin/TestAUBankParser.kt
+++ b/parser-core/src/test/kotlin/TestAUBankParser.kt
@@ -54,6 +54,38 @@ class AUBankParserTest {
                     accountLast4 = "1234",
                     isFromCard = true
                 )
+            ),
+            ParserTestCase(
+                name = "Short Dr form with placeholder merchant",
+                message = "Dr INR 29,000.00 from A/c X7661 on 05-MAY-2026\n" +
+                    "UPI/DR/012345678901/Bank Account XXXXX\n" +
+                    "Bal INR 10,952.10\n" +
+                    "Not you? Call 180012001200 & dial 0\n" +
+                    "-AU Bank",
+                sender = "VM-AUBANK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("29000.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "7661",
+                    balance = BigDecimal("10952.10")
+                )
+            ),
+            ParserTestCase(
+                name = "Short Dr form with merchant name",
+                message = "Dr INR 10.00 - AU A/c X4541 12-MAY-2026\n" +
+                    "UPI/DR/424941009000/ALADDIN SHAWARMA/Y\n" +
+                    "Bal INR 18,838.10\n" +
+                    "Fraud? Call 180012001200/SMS BLOCK UPI to 5676767",
+                sender = "VM-AUBANK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("10.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "ALADDIN SHAWARMA",
+                    accountLast4 = "4541",
+                    balance = BigDecimal("18838.10")
+                )
             )
         )
 


### PR DESCRIPTION
## Summary
- Closes #342 — AU Bank started sending debits in a compact `Dr INR <amount> from A/c <acct>` format. Older parser only matched `Debited INR ...`.
- Adds short-form coverage to amount extraction, transaction-type classification, and the AU Bank transaction-message gate.
- Adds a UPI short-form merchant pattern that handles `UPI/DR/<ref>/<merchant>` without a trailing IFSC segment, and rejects AU's all-X `Bank Account XXXXX` placeholder so it doesn't leak through as a merchant name.

## Test plan
- [x] `./gradlew :parser-core:jvmTest --tests AUBankParserTest` — green
- [x] Full `./gradlew :parser-core:jvmTest` — no regressions
- [x] New cases: short Dr with placeholder merchant (Sample 1), short Dr with real merchant `ALADDIN SHAWARMA` (Sample 2)
- [x] Existing AU Bank tests still pass (long-form `Debited INR`, credit-card spend, basic debit)