### PR TITLE
fix: ICICI dual-account IMPS detected as transfer

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ICICIBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ICICIBankParser.kt
@@ -55,10 +55,16 @@ class ICICIBankParser : BaseIndianBankParser() {
             null
         }
 
+        val merchant = if (transferAccounts != null) {
+            labelTransferRail(smsBody)
+        } else {
+            extractMerchant(smsBody, sender)
+        }
+
         return ParsedTransaction(
             amount = amount,
             type = type,
-            merchant = extractMerchant(smsBody, sender),
+            merchant = merchant,
             reference = extractReference(smsBody),
             accountLast4 = transferAccounts?.first ?: extractAccountLast4(smsBody),
             balance = extractBalance(smsBody),
@@ -74,6 +80,12 @@ class ICICIBankParser : BaseIndianBankParser() {
         )
     }
 
+    private fun labelTransferRail(message: String): String = when {
+        message.contains("IMPS", ignoreCase = true) -> "IMPS Transfer"
+        message.contains("NEFT", ignoreCase = true) -> "NEFT Transfer"
+        else -> "Account Transfer"
+    }
+
     /**
      * Detects ICICI's `Acct XX debited ... & Acct YY credited` IMPS/NEFT pattern
      * and returns (fromAccount, toAccount) when both account references appear
@@ -86,7 +98,7 @@ class ICICIBankParser : BaseIndianBankParser() {
             RegexOption.IGNORE_CASE
         )
         val creditedAcctPattern = Regex(
-            """Acct\s+([X*\d]+)\s+credited""",
+            """Acct\s+([X*\d]+)\s+(?:is\s+)?credited""",
             RegexOption.IGNORE_CASE
         )
 
@@ -235,16 +247,6 @@ class ICICIBankParser : BaseIndianBankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
-        // Pattern -1: dual-account transfer (IMPS/NEFT). The SMS has no merchant
-        // name in this case, so label it by the rail.
-        if (extractTransferAccounts(message) != null) {
-            return when {
-                message.contains("IMPS", ignoreCase = true) -> "IMPS Transfer"
-                message.contains("NEFT", ignoreCase = true) -> "NEFT Transfer"
-                else -> "Account Transfer"
-            }
-        }
-
         // Pattern 0: NEFT/RTGS transfer to beneficiary - use "NEFT Transfer" as merchant
         // These are outgoing transfers where we don't know the beneficiary name
         if (message.contains("credited to the beneficiary", ignoreCase = true) ||

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ICICIBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ICICIBankParser.kt
@@ -32,9 +32,16 @@ class ICICIBankParser : BaseIndianBankParser() {
             return null
         }
 
-        val type = extractTransactionType(smsBody)
-        if (type == null) {
-            return null
+        // Detect ICICI's dual-account transfer pattern (e.g. IMPS where the SMS
+        // mentions both `Acct XX debited` and `Acct YY credited` in the same body).
+        // This routes such SMS to TRANSFER so a later pipeline pass can dedupe
+        // against the credit-side SMS using the IMPS/NEFT reference.
+        val transferAccounts = extractTransferAccounts(smsBody)
+
+        val type = if (transferAccounts != null) {
+            TransactionType.TRANSFER
+        } else {
+            extractTransactionType(smsBody) ?: return null
         }
 
         // Extract currency dynamically for multi-currency support
@@ -53,7 +60,7 @@ class ICICIBankParser : BaseIndianBankParser() {
             type = type,
             merchant = extractMerchant(smsBody, sender),
             reference = extractReference(smsBody),
-            accountLast4 = extractAccountLast4(smsBody),
+            accountLast4 = transferAccounts?.first ?: extractAccountLast4(smsBody),
             balance = extractBalance(smsBody),
             creditLimit = availableLimit,
             smsBody = smsBody,
@@ -61,8 +68,38 @@ class ICICIBankParser : BaseIndianBankParser() {
             timestamp = timestamp,
             bankName = getBankName(),
             isFromCard = detectIsCard(smsBody),
-            currency = currency
+            currency = currency,
+            fromAccount = transferAccounts?.first,
+            toAccount = transferAccounts?.second
         )
+    }
+
+    /**
+     * Detects ICICI's `Acct XX debited ... & Acct YY credited` IMPS/NEFT pattern
+     * and returns (fromAccount, toAccount) when both account references appear
+     * in the same SMS and differ. Returns null otherwise so the regular type
+     * extraction stays in charge.
+     */
+    private fun extractTransferAccounts(message: String): Pair<String, String>? {
+        val debitedAcctPattern = Regex(
+            """Acct\s+([X*\d]+)\s+(?:is\s+)?debited""",
+            RegexOption.IGNORE_CASE
+        )
+        val creditedAcctPattern = Regex(
+            """Acct\s+([X*\d]+)\s+credited""",
+            RegexOption.IGNORE_CASE
+        )
+
+        val debitedMatch = debitedAcctPattern.find(message) ?: return null
+        val creditedMatch = creditedAcctPattern.find(message) ?: return null
+
+        val fromAcct = extractLast4Digits(debitedMatch.groupValues[1])
+        val toAcct = extractLast4Digits(creditedMatch.groupValues[1])
+
+        if (fromAcct.isNullOrBlank() || toAcct.isNullOrBlank() || fromAcct == toAcct) {
+            return null
+        }
+        return Pair(fromAcct, toAcct)
     }
 
     /**
@@ -198,6 +235,16 @@ class ICICIBankParser : BaseIndianBankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
+        // Pattern -1: dual-account transfer (IMPS/NEFT). The SMS has no merchant
+        // name in this case, so label it by the rail.
+        if (extractTransferAccounts(message) != null) {
+            return when {
+                message.contains("IMPS", ignoreCase = true) -> "IMPS Transfer"
+                message.contains("NEFT", ignoreCase = true) -> "NEFT Transfer"
+                else -> "Account Transfer"
+            }
+        }
+
         // Pattern 0: NEFT/RTGS transfer to beneficiary - use "NEFT Transfer" as merchant
         // These are outgoing transfers where we don't know the beneficiary name
         if (message.contains("credited to the beneficiary", ignoreCase = true) ||
@@ -438,6 +485,15 @@ class ICICIBankParser : BaseIndianBankParser() {
     }
 
     override fun extractReference(message: String): String? {
+        // Pattern 0: "IMPS:xxxxx" — keep ahead of UPI so dual-rail SMS pick the IMPS ref
+        val impsPattern = Regex(
+            """IMPS:([A-Za-z0-9]+)""",
+            RegexOption.IGNORE_CASE
+        )
+        impsPattern.find(message)?.let { match ->
+            return match.groupValues[1]
+        }
+
         // Pattern 1: "RRN 1xxxxx3xxxxx"
         val rrnPattern = Regex(
             """RRN\s+([A-Za-z0-9]+)""",

--- a/parser-core/src/test/kotlin/TestICICIBankParser.kt
+++ b/parser-core/src/test/kotlin/TestICICIBankParser.kt
@@ -182,6 +182,21 @@ class ICICIBankParserTest {
                     type = TransactionType.EXPENSE,
                     merchant = "NEFT Transfer"
                 )
+            ),
+            ParserTestCase(
+                name = "IMPS dual-account debit is TRANSFER",
+                message = "ICICI Bank Acct XX123 debited with Rs 10 on 20-Dec-25 & Acct XX456 credited.IMPS:ABCDEF123456. Call 18002662 for dispute or SMS BLOCK 700 to 9215676766",
+                sender = "JD-ICICIT-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("10"),
+                    currency = "INR",
+                    type = TransactionType.TRANSFER,
+                    merchant = "IMPS Transfer",
+                    accountLast4 = "123",
+                    fromAccount = "123",
+                    toAccount = "456",
+                    reference = "ABCDEF123456"
+                )
             )
         )
 

--- a/parser-core/src/test/kotlin/TestICICIBankParser.kt
+++ b/parser-core/src/test/kotlin/TestICICIBankParser.kt
@@ -197,6 +197,36 @@ class ICICIBankParserTest {
                     toAccount = "456",
                     reference = "ABCDEF123456"
                 )
+            ),
+            ParserTestCase(
+                name = "NEFT dual-account debit gets NEFT Transfer label",
+                message = "ICICI Bank Acct XX111 debited with Rs 5000 on 15-Jan-26 & Acct XX222 credited. NEFT RRN ZX9876543210. -ICICI Bank",
+                sender = "JD-ICICIT-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("5000"),
+                    currency = "INR",
+                    type = TransactionType.TRANSFER,
+                    merchant = "NEFT Transfer",
+                    accountLast4 = "111",
+                    fromAccount = "111",
+                    toAccount = "222",
+                    reference = "ZX9876543210"
+                )
+            ),
+            ParserTestCase(
+                name = "IMPS dual-account with 'is debited' / 'is credited' variant",
+                message = "ICICI Bank Acct XX333 is debited with Rs 200 and Acct XX444 is credited. IMPS:LMNOPQ987654. -ICICI Bank",
+                sender = "JD-ICICIT-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("200"),
+                    currency = "INR",
+                    type = TransactionType.TRANSFER,
+                    merchant = "IMPS Transfer",
+                    accountLast4 = "333",
+                    fromAccount = "333",
+                    toAccount = "444",
+                    reference = "LMNOPQ987654"
+                )
             )
         )
 


### PR DESCRIPTION
## Summary
- Closes #282 (parser side). ICICI sends a single SMS that names both the debited and credited account when the user does an IMPS transfer (e.g. own ICICI → own Federal Bank). We were classifying these as `EXPENSE`, which caused a duplicate when the receiving bank's credit SMS arrived separately.
- Detect the `Acct XX debited & Acct YY credited` pattern. When matched:
  - type becomes `TRANSFER`
  - `fromAccount` / `toAccount` are populated
  - merchant is labelled by rail (`IMPS Transfer` / `NEFT Transfer` / `Account Transfer`)
  - `IMPS:<ref>` is captured into the `reference` field
- The pipeline dedup that uses this reference to suppress the counterpart credit SMS is intentionally **not** in this PR — it needs access to the user's known accounts and belongs in `SmsTransactionProcessor`. Filing a follow-up.

## Test plan
- [x] `./gradlew :parser-core:jvmTest --tests ICICIBankParserTest` — green
- [x] Full `./gradlew :parser-core:jvmTest` — no regressions
- [x] New case: `Acct XX123 debited & Acct XX456 credited.IMPS:...` → TRANSFER, fromAccount=`123`, toAccount=`456`, merchant=`IMPS Transfer`, reference captured
- [x] Existing ICICI tests still pass — UPI debits with `; <name> credited`, ATM withdrawals, salary credits, "NEFT credited to beneficiary" still classified as EXPENSE