### PR TITLE
fix: "All Time" SMS scan no longer caps at 10 years

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
@@ -785,12 +785,18 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
             val needsFullScan = forceResync || lastScanTimestamp == 0L || (lastScanPeriod >= 0 && scanMonths > lastScanPeriod) || scanAllTimeToggled || scanAllTimeToggledOff
 
             val scanStartTime = if (needsFullScan) {
-                java.util.Calendar.getInstance().apply {
-                    if (scanAllTime) add(java.util.Calendar.YEAR, -10)
-                    else             add(java.util.Calendar.MONTH, -scanMonths)
-                    set(java.util.Calendar.HOUR_OF_DAY, 0); set(java.util.Calendar.MINUTE, 0)
-                    set(java.util.Calendar.SECOND, 0);      set(java.util.Calendar.MILLISECOND, 0)
-                }.timeInMillis
+                if (scanAllTime) {
+                    // "All Time" must mean truly all SMS the Telephony provider still
+                    // has, not the last 10 years. Anything older simply isn't on the
+                    // device any more, so a 0L lower bound is safe.
+                    0L
+                } else {
+                    java.util.Calendar.getInstance().apply {
+                        add(java.util.Calendar.MONTH, -scanMonths)
+                        set(java.util.Calendar.HOUR_OF_DAY, 0); set(java.util.Calendar.MINUTE, 0)
+                        set(java.util.Calendar.SECOND, 0);      set(java.util.Calendar.MILLISECOND, 0)
+                    }.timeInMillis
+                }
             } else {
                 val threeDaysAgo = now - 3 * 24 * 60 * 60 * 1000L
                 val periodLimit  = java.util.Calendar.getInstance().apply {


### PR DESCRIPTION
## Summary
- Closes #298 (the parser-side cap; OEM retention is out of scope).
- Worker was caching `now - 10 years` as the lower bound when `scanAllTime = true`. Replaced with `0L` so the Telephony provider returns every inbox message it still has.
- Fixed-period branch (e.g. "Last 6 months") is unchanged.

## Test plan
- [x] `./gradlew :app:compileStandardDebugKotlin` — clean
- [ ] Manual: enable "All Time" scan and confirm SMS older than 10 years are processed (where the provider still has them)
- Note: a reporter's "2600 of 4000+" mismatch could still be OEM retention pruning or outbox SMS (we correctly filter to `MESSAGE_TYPE_INBOX`); both are outside this change.