### PR TITLE
fix: only show "Hold for full resync" hint for new users

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
@@ -833,7 +833,7 @@ fun HomeScreen(
                     }
                 }
                 // Hint for long-press functionality - only show for new users (no transactions yet)
-                if (uiState.recentTransactions.isEmpty() && !uiState.isLoading) {
+                if (uiState.recentItems.isEmpty() && !uiState.isLoading) {
                     Text(
                         text = "Hold for full resync",
                         style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -1482,7 +1482,6 @@ data class HomeUiState(
     val lastMonthExpenses: BigDecimal = BigDecimal.ZERO,
     val monthlyChange: BigDecimal = BigDecimal.ZERO,
     val monthlyChangePercent: Int = 0,
-    val recentTransactions: List<TransactionEntity> = emptyList(), // kept for widget compat
     val recentItems: List<HomeRecentItem> = emptyList(),
     val upcomingSubscriptions: List<SubscriptionEntity> = emptyList(),
     val upcomingSubscriptionsTotal: BigDecimal = BigDecimal.ZERO,


### PR DESCRIPTION
## Summary
- The hint label under the sync FAB was guarded by `uiState.recentTransactions.isEmpty()`.
- That field was later stubbed to `emptyList()` (commented "kept for widget compat") so the check has been always-true. Every user has been seeing the hint, not just new ones.
- Repoint the guard at `uiState.recentItems` — the field that actually backs the rendered recent list — and delete the vestigial `recentTransactions` (the only other reference, in `LlmRepository`, hits an unrelated `ChatContext.recentTransactions`).

## History
- Long-press behaviour introduced in `bb64bb0` (2025-11-28)
- Visible hint introduced in `aafca5` (2026-01-24), guard was correct at the time
- `recentTransactions` later reduced to a stub `= emptyList()` — silently regressed the guard

## Test plan
- [x] `./gradlew :app:compileStandardDebugKotlin` — clean
- [ ] Manual: fresh install with no transactions → hint visible
- [ ] Manual: any user with at least one recent transaction → hint hidden