### PR TITLE
test(kotak): regression cases for issue #360 'Sent' UPI format

### DIFF
--- a/parser-core/src/test/kotlin/TestKotakBankParser.kt
+++ b/parser-core/src/test/kotlin/TestKotakBankParser.kt
@@ -136,6 +136,35 @@ class KotakBankParserTest {
                     accountLast4 = "9722"
                 )
             ),
+            // Issue #360: "Sent" UPI format from a JD-KOTAKD-S sender. Merchant must
+            // be the payee between "to" and "on <date>", never the "Not you? Tap
+            // https://kotk.in/..." report link or the "-Kotak" signature.
+            ParserTestCase(
+                name = "Issue #360 - Sent UPI with multi-word payee (KOTAKD-S)",
+                message = "Sent Rs.205.00 from XXXXXX1234 to ANNAPOORNESWARI K M on 26/05/2026. UPI ref no. 651229267141. Not you? Tap https://kotk.in/KOTAKD/E7LzzX to report -Kotak",
+                sender = "JD-KOTAKD-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("205.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "ANNAPOORNESWARI K M",
+                    reference = "651229267141",
+                    accountLast4 = "1234"
+                )
+            ),
+            ParserTestCase(
+                name = "Issue #360 - Sent UPI with single-word payee (KOTAKD-S)",
+                message = "Sent Rs.90.00 from XXXXXX9886 to RAMESH on 25/05/2026. UPI ref no. 653114209367. Not you? Tap https://kotk.in/KOTAKD/S6ztop to report -Kotak",
+                sender = "JD-KOTAKD-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("90.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "RAMESH",
+                    reference = "653114209367",
+                    accountLast4 = "9886"
+                )
+            ),
             // Negative case: a credit/refund-style message that contains the word
             // "sent" (e.g. "...has been sent to your A/c...") must still be parsed
             // as INCOME — the parser should anchor on "sent rs", not bare "sent".
@@ -157,6 +186,7 @@ class KotakBankParserTest {
             "JD-KOTAKB-S" to true,
             "JD-KOTAKB-T" to true,
             "VM-KOTAKD-S" to true,
+            "JD-KOTAKD-S" to true,
             "VM-KOTAKB" to false,
             "UNKNOWN" to false
         )


### PR DESCRIPTION
## Context

Issue #360 reports Kotak "Sent" UPI SMS (sender `JD-KOTAKD-S`) not being parsed. On investigation the parser **already handles this format correctly** — `canHandle` matches the `KOTAKD` sender, and amount/type/merchant/reference/account all extract as expected. The suite already had structurally identical `VM-KOTAKD-S` cases.

## Change

Test-only. Adds the two exact samples from #360 as explicit regression cases (multi-word payee "ANNAPOORNESWARI K M" and single-word "RAMESH"), plus `JD-KOTAKD-S` to the handle-checks. This guards the payee extraction against ever capturing the `Not you? Tap https://kotk.in/...` report link or the `-Kotak` signature.

`:parser-core:jvmTest --tests "*KotakBankParser*"` is green.

Relates to #360 (kept open pending the reporter's literal sender string — see issue comment).