### PR TITLE
feat: add Sampath Bank (Sri Lanka) parser

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -112,7 +112,8 @@ object BankParserFactory {
         EnparaBankParser(),  // Enpara (Turkey) — push notifications
         BankMuscatParser(),  // Bank Muscat (Oman)
         GreaterBankParser(),  // Greater Bank (India)
-        BPCEParser()  // BPCE (France)
+        BPCEParser(),  // BPCE (France)
+        SampathBankParser()  // Sampath Bank (Sri Lanka)
         // Add more bank parsers here as we implement them
     )
 

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SampathBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SampathBankParser.kt
@@ -1,0 +1,163 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Sampath Bank (Sri Lanka) SMS messages.
+ *
+ * Handles both account transactions and credit-card transactions.
+ *
+ * Account formats (sender: SAMPATHTXN):
+ * - "LKR 5,000.00 credited to AC **8758 for PICKME - 37419306"
+ * - "LKR 4,025.00 debited from AC **8758 for WPY_TAOA_041772_WLT@0347310"
+ * - "GBP 1,000.00 credited to AC **5012 for Remittance ID : [IR26GBP36623] : REALIZE"
+ *
+ * Credit-card format (sender: SAMPCCTXN):
+ * - "Cr Crd no..**0282 Auth Pmt LKR 2,100.00 at SPICE ASIA - DELIVERY Avl Bal LKR 250,000.00 ..."
+ *
+ * Currency is a leading 3-letter code (LKR/GBP/USD), captured dynamically per message.
+ */
+class SampathBankParser : BankParser() {
+
+    override fun getBankName() = "Sampath Bank"
+
+    override fun getCurrency() = "LKR"  // Sri Lankan Rupee (default; foreign-currency variants override per-message)
+
+    override fun canHandle(sender: String): Boolean {
+        val normalized = sender.uppercase()
+        // Tolerate operator/DLT prefixes such as "AD-SAMPATHTXN" by checking containment.
+        return normalized.contains("SAMPATHTXN") ||
+                normalized.contains("SAMPCCTXN") ||
+                normalized.matches(Regex("""^[A-Z]{2}-SAMP(?:ATHTXN|CCTXN)-[A-Z]$"""))
+    }
+
+    /**
+     * Extracts the currency code that precedes the transaction amount.
+     * Falls back to the bank default if no code is present.
+     */
+    private fun extractMessageCurrency(message: String): String {
+        // Match the FIRST "<CODE> <amount>" occurrence to capture the transaction currency
+        // (balance amounts share the same code, so first match is fine).
+        val pattern = Regex("""\b([A-Z]{3})\s+[0-9,]+\.\d{2}""")
+        pattern.find(message)?.let { return it.groupValues[1].uppercase() }
+        return getCurrency()
+    }
+
+    override fun parse(smsBody: String, sender: String, timestamp: Long): ParsedTransaction? {
+        // Delegate to base parsing, then override the currency with the per-message code
+        // (base parse hard-codes getCurrency()).
+        val base = super.parse(smsBody, sender, timestamp) ?: return null
+        val currency = extractMessageCurrency(smsBody)
+        return if (currency == base.currency) base else base.copy(currency = currency)
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // Account: "LKR 5,000.00 credited", "GBP 1,000.00 credited"
+        // Card: "Auth Pmt LKR 2,100.00 at ..."
+        val patterns = listOf(
+            Regex("""Auth\s+Pmt\s+[A-Z]{3}\s+([0-9,]+\.\d{2})""", RegexOption.IGNORE_CASE),
+            Regex("""[A-Z]{3}\s+([0-9,]+\.\d{2})\s+(?:credited|debited)""", RegexOption.IGNORE_CASE)
+        )
+        for (pattern in patterns) {
+            pattern.find(message)?.let { match ->
+                val amountStr = match.groupValues[1].replace(",", "")
+                return try {
+                    BigDecimal(amountStr)
+                } catch (e: NumberFormatException) {
+                    null
+                }
+            }
+        }
+        return super.extractAmount(message)
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lower = message.lowercase()
+        return when {
+            lower.contains("credited to") -> TransactionType.INCOME
+            lower.contains("debited from") -> TransactionType.EXPENSE
+            lower.contains("auth pmt") -> TransactionType.EXPENSE
+            else -> super.extractTransactionType(message)
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // Card: "at SPICE ASIA - DELIVERY Avl Bal LKR ..."
+        val cardPattern = Regex("""\bat\s+(.+?)\s+Avl\s+Bal""", RegexOption.IGNORE_CASE)
+        cardPattern.find(message)?.let { match ->
+            val merchant = match.groupValues[1].trim()
+            if (merchant.isNotEmpty()) return merchant
+        }
+
+        // International remittance: "for Remittance ID : [IR26GBP36623] : REALIZE"
+        val remittancePattern = Regex(
+            """for\s+Remittance\s+ID\s*:\s*\[[^\]]+\]\s*:\s*([^\n]+)""",
+            RegexOption.IGNORE_CASE
+        )
+        remittancePattern.find(message)?.let { match ->
+            val merchant = match.groupValues[1].trim()
+            if (merchant.isNotEmpty()) return merchant
+        }
+
+        // Account: "for PICKME - 37419306" / "for WPY_TAOA_041772_WLT@0347310"
+        // Capture everything after "for " up to newline, then strip a trailing " - <ref>".
+        val forPattern = Regex("""\bfor\s+(.+?)(?:\n|$)""", RegexOption.IGNORE_CASE)
+        forPattern.find(message)?.let { match ->
+            var merchant = match.groupValues[1].trim()
+            // Strip a trailing reference appended after " - "
+            val dashRef = Regex("""\s+-\s+\S+$""")
+            merchant = merchant.replace(dashRef, "").trim()
+            if (merchant.isNotEmpty()) return merchant
+        }
+
+        return super.extractMerchant(message, sender)
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        // Account: "AC **8758"  Card: "Cr Crd no..**0282"
+        val pattern = Regex("""(?:AC|Crd\s+no\.*)\s*\*+\s*(\d{3,})""", RegexOption.IGNORE_CASE)
+        pattern.find(message)?.let { match ->
+            return extractLast4Digits(match.groupValues[1])
+        }
+        return super.extractAccountLast4(message)
+    }
+
+    override fun extractReference(message: String): String? {
+        // International remittance: "Remittance ID : [IR26GBP36623]"
+        val remittancePattern = Regex("""Remittance\s+ID\s*:\s*\[([^\]]+)\]""", RegexOption.IGNORE_CASE)
+        remittancePattern.find(message)?.let { return it.groupValues[1].trim() }
+
+        // Account: "for PICKME - 37419306" -> trailing numeric reference
+        val dashRefPattern = Regex("""\bfor\s+.+?\s+-\s+(\d+)""", RegexOption.IGNORE_CASE)
+        dashRefPattern.find(message)?.let { return it.groupValues[1].trim() }
+
+        return super.extractReference(message)
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        // Card: "Avl Bal LKR 250,000.00"
+        val pattern = Regex("""Avl\s+Bal\s+[A-Z]{3}\s+([0-9,]+\.\d{2})""", RegexOption.IGNORE_CASE)
+        pattern.find(message)?.let { match ->
+            val balStr = match.groupValues[1].replace(",", "")
+            return try {
+                BigDecimal(balStr)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+        return super.extractBalance(message)
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+        if (lower.contains("credited to") ||
+            lower.contains("debited from") ||
+            lower.contains("auth pmt")
+        ) {
+            return true
+        }
+        return super.isTransactionMessage(message)
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SampathBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SampathBankParser.kt
@@ -32,6 +32,16 @@ class SampathBankParser : BankParser() {
         return normalized.contains("SAMPATHTXN") || normalized.contains("SAMPCCTXN")
     }
 
+    override fun detectIsCard(message: String): Boolean {
+        // Sampath credit-card SMS use "Cr Crd no..**0282"; the base class only
+        // recognises "card no."/"credit card", so detect the abbreviated form here.
+        val lower = message.lowercase()
+        if (lower.contains("crd no") || lower.contains("cr crd")) {
+            return true
+        }
+        return super.detectIsCard(message)
+    }
+
     /**
      * Extracts the currency code that precedes the transaction amount.
      * Falls back to the bank default if no code is present.

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SampathBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SampathBankParser.kt
@@ -27,10 +27,9 @@ class SampathBankParser : BankParser() {
 
     override fun canHandle(sender: String): Boolean {
         val normalized = sender.uppercase()
-        // Tolerate operator/DLT prefixes such as "AD-SAMPATHTXN" by checking containment.
-        return normalized.contains("SAMPATHTXN") ||
-                normalized.contains("SAMPCCTXN") ||
-                normalized.matches(Regex("""^[A-Z]{2}-SAMP(?:ATHTXN|CCTXN)-[A-Z]$"""))
+        // Containment covers bare senders and any operator/DLT prefix or suffix
+        // (e.g. "AD-SAMPATHTXN", "SAMPATHTXN-S").
+        return normalized.contains("SAMPATHTXN") || normalized.contains("SAMPCCTXN")
     }
 
     /**

--- a/parser-core/src/test/kotlin/TestSampathBankParser.kt
+++ b/parser-core/src/test/kotlin/TestSampathBankParser.kt
@@ -1,0 +1,84 @@
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.bank.SampathBankParser
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.*
+import java.math.BigDecimal
+
+class SampathBankParserTest {
+
+    @TestFactory
+    fun `sampath bank parser handles account and card transactions`(): List<DynamicTest> {
+        val parser = SampathBankParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "Account credit (LKR)",
+                message = "LKR 5,000.00 credited to AC **8758 for PICKME - 37419306\n22/05/2026 23:36:52\nTo Inq Call 0112303050\nGet protected -Do not Share OTP",
+                sender = "SAMPATHTXN",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("5000.00"),
+                    currency = "LKR",
+                    type = TransactionType.INCOME,
+                    merchant = "PICKME",
+                    reference = "37419306",
+                    accountLast4 = "8758"
+                )
+            ),
+            ParserTestCase(
+                name = "Account debit (LKR)",
+                message = "LKR 4,025.00 debited from AC **8758 for WPY_TAOA_041772_WLT@0347310\n18/05/2026 06:56:52\nTo Inq Call 0112303050\nGet protected -Do not Share OTP",
+                sender = "SAMPATHTXN",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("4025.00"),
+                    currency = "LKR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "WPY_TAOA_041772_WLT@0347310",
+                    accountLast4 = "8758"
+                )
+            ),
+            ParserTestCase(
+                name = "International credit (GBP)",
+                message = "GBP 1,000.00 credited to AC **5012 for Remittance ID : [IR26GBP36623] : REALIZE\n14/05/2026 13:55:02\nTo Inq Call 0112303050\nGet protected -Do not Share OTP",
+                sender = "SAMPATHTXN",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1000.00"),
+                    currency = "GBP",
+                    type = TransactionType.INCOME,
+                    merchant = "REALIZE",
+                    reference = "IR26GBP36623",
+                    accountLast4 = "5012"
+                )
+            ),
+            ParserTestCase(
+                name = "Credit card payment (LKR)",
+                message = "Cr Crd no..**0282 Auth Pmt LKR 2,100.00 at SPICE ASIA - DELIVERY Avl Bal LKR 250,000.00 Enq Call 0112300604\n- Sampath Bank 23-MAY",
+                sender = "SAMPCCTXN",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2100.00"),
+                    currency = "LKR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "SPICE ASIA - DELIVERY",
+                    accountLast4 = "0282",
+                    balance = BigDecimal("250000.00")
+                )
+            )
+        )
+
+        val handleChecks = listOf(
+            "SAMPATHTXN" to true,
+            "SAMPCCTXN" to true,
+            "AD-SAMPATHTXN" to true,
+            "HDFCBK" to false,
+            "UNKNOWN" to false
+        )
+
+        return ParserTestUtils.runTestSuite(
+            parser = parser,
+            testCases = testCases,
+            handleCases = handleChecks,
+            suiteName = "Sampath Bank Parser"
+        )
+    }
+}

--- a/parser-core/src/test/kotlin/TestSampathBankParser.kt
+++ b/parser-core/src/test/kotlin/TestSampathBankParser.kt
@@ -61,7 +61,8 @@ class SampathBankParserTest {
                     type = TransactionType.EXPENSE,
                     merchant = "SPICE ASIA - DELIVERY",
                     accountLast4 = "0282",
-                    balance = BigDecimal("250000.00")
+                    balance = BigDecimal("250000.00"),
+                    isFromCard = true
                 )
             )
         )


### PR DESCRIPTION
## Summary

Adds a parser for **Sampath Bank (Sri Lanka)** — issue #356, our first Sri Lankan bank. Extends the generic `BankParser` (not the Indian/UAE bases).

Handles all four reported formats:

| Format | Sender | Type | Notes |
|---|---|---|---|
| Account credit | `SAMPATHTXN` | INCOME | `LKR 5,000.00 credited to AC **8758 for PICKME - 37419306` |
| Account debit | `SAMPATHTXN` | EXPENSE | raw payee token preserved |
| International credit | `SAMPATHTXN` | INCOME | **currency captured dynamically** (GBP), merchant + remittance ref |
| Credit-card payment | `SAMPCCTXN` | EXPENSE | merchant + available balance |

### Notable detail
Currency is a leading 3-letter code (`LKR`/`GBP`/`USD`), so the parser captures it per-message and overrides the base default rather than hard-coding LKR — the GBP remittance keeps `currency = GBP`.

`canHandle` matches `SAMPATHTXN`/`SAMPCCTXN` (and operator-prefixed forms like `AD-SAMPATHTXN`).

## Tests
`TestSampathBankParser.kt` covers one case per format via the shared `ParserTestUtils` helpers. `:parser-core:jvmTest --tests "*SampathBankParser*"` is green (4 parse cases + 5 handle-checks).

Closes #356