### PR TITLE
fix: mark dividend as income

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParser.kt
@@ -202,6 +202,14 @@ abstract class BankParser {
      * Can be overridden by specific bank parsers for custom logic.
      */
     protected open fun isInvestmentTransaction(lowerMessage: String): Boolean {
+        // Credits to a bank account are income, not investment (ACH dividends, vendor payments, etc.)
+        // Only use "credited" and "deposited" — "received" is ambiguous
+        // (e.g. "X has received Rs Y from your A/c" means outgoing money)
+        if (lowerMessage.contains("credited") ||
+            lowerMessage.contains("deposited")) {
+            return false
+        }
+
         val investmentKeywords = listOf(
             // Clearing corporations
             "iccl",                         // Indian Clearing Corporation Limited

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParser.kt
@@ -202,14 +202,6 @@ abstract class BankParser {
      * Can be overridden by specific bank parsers for custom logic.
      */
     protected open fun isInvestmentTransaction(lowerMessage: String): Boolean {
-        // Credits to a bank account are income, not investment (ACH dividends, vendor payments, etc.)
-        // Only use "credited" and "deposited" — "received" is ambiguous
-        // (e.g. "X has received Rs Y from your A/c" means outgoing money)
-        if (lowerMessage.contains("credited") ||
-            lowerMessage.contains("deposited")) {
-            return false
-        }
-
         val investmentKeywords = listOf(
             // Clearing corporations
             "iccl",                         // Indian Clearing Corporation Limited

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BaseIndianBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BaseIndianBankParser.kt
@@ -27,61 +27,7 @@ abstract class BaseIndianBankParser : BankParser() {
             return false
         }
 
-        val investmentKeywords = listOf(
-            // Clearing corporations
-            "iccl",                         // Indian Clearing Corporation Limited
-            "indian clearing corporation",
-            "nsccl",                        // NSE Clearing Corporation
-            "nse clearing",
-            "clearing corporation",
-
-            // Auto-pay indicators (excluding mandate/UMRN to avoid subscription false positives)
-            "nach",                         // National Automated Clearing House
-            "ach",                          // Automated Clearing House
-            "ecs",                          // Electronic Clearing Service
-
-            // Investment platforms
-            "groww",
-            "zerodha",
-            "upstox",
-            "kite",
-            "kuvera",
-            "paytm money",
-            "etmoney",
-            "coin by zerodha",
-            "smallcase",
-            "angel one",
-            "angel broking",
-            "5paisa",
-            "icici securities",
-            "icici direct",
-            "hdfc securities",
-            "kotak securities",
-            "motilal oswal",
-            "sharekhan",
-            "edelweiss",
-            "axis direct",
-            "sbi securities",
-
-            // Investment types
-            "mutual fund",
-            "sip",                          // Systematic Investment Plan
-            "elss",                         // Tax saving funds
-            "ipo",                          // Initial Public Offering
-            "folio",                        // Mutual fund folio
-            "demat",
-            "stockbroker",
-            "digital gold",                 // Digital Gold investments
-            "sovereign gold",               // Sovereign Gold Bonds
-
-            // Stock exchanges
-            "nse",                          // National Stock Exchange
-            "bse",                          // Bombay Stock Exchange
-            "cdsl",                         // Central Depository Services
-            "nsdl"                          // National Securities Depository
-        )
-
-        return investmentKeywords.any { lowerMessage.contains(it) }
+        return super.isInvestmentTransaction(lowerMessage)
     }
 
     // ==========================================

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BaseIndianBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BaseIndianBankParser.kt
@@ -19,6 +19,14 @@ abstract class BaseIndianBankParser : BankParser() {
      * Contains keywords specific to Indian investment platforms and terms.
      */
     override fun isInvestmentTransaction(lowerMessage: String): Boolean {
+        // Credits to a bank account are income, not investment (ACH dividends, vendor payments, etc.)
+        // Only use "credited" and "deposited" — "received" is ambiguous
+        // (e.g. "X has received Rs Y from your A/c" means outgoing money)
+        if (lowerMessage.contains("credited") ||
+            lowerMessage.contains("deposited")) {
+            return false
+        }
+
         val investmentKeywords = listOf(
             // Clearing corporations
             "iccl",                         // Indian Clearing Corporation Limited

--- a/parser-core/src/test/kotlin/TestICICIBankParser.kt
+++ b/parser-core/src/test/kotlin/TestICICIBankParser.kt
@@ -227,6 +227,32 @@ class ICICIBankParserTest {
                     toAccount = "444",
                     reference = "LMNOPQ987654"
                 )
+            ),
+            ParserTestCase(
+                name = "ACH credit via ICICI",
+                message = "ICICI Bank Account XX227 credited:Rs. 104.00 on 19-May-26. Info ACH*VARUNBEVERAGES LIMI*778. Available Balance is Rs 1,11,231.93",
+                sender = "AD-ICICIT-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("104.00"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    merchant = "VARUNBEVERAGES LIMI Dividend",
+                    accountLast4 = "227",
+                    balance = BigDecimal("111231.93")
+                )
+            ),
+            ParserTestCase(
+                name = "ACH debit via ICICI is INVESTMENT",
+                message = "ICICI Bank Account XX123 debited Rs. 5,000.00 on 19-May-26 InfoACH*BD-ACHKFL.Avl Bal Rs. 3,25,000.04.To dispute call 1800 blah blah",
+                sender = "AX-ICICIT",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("5000.00"),
+                    currency = "INR",
+                    type = TransactionType.INVESTMENT,
+                    //merchant = "", - can't detect merchant
+                    accountLast4 = "123",
+                    balance = BigDecimal("325000.04")
+                )
             )
         )
 


### PR DESCRIPTION
## Summary

Dividends are currently being marked as investment due to matching with the ach regex. Add a new check to isInvestmentTransaction function to avoid marking sms containing "credited" and "deposited" as investment.

## Type of change

- [ ] feat: New feature
- [ X] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Code improvement (no behavior change)
- [ ] perf: Performance improvement
- [ ] style: Formatting (no behavior change)
- [ ] test: Add/update tests
- [ ] chore/ci: Build or CI changes

## Screenshots/Recordings (optional)

<!-- Add images or videos for UI changes. -->

## How to test

<!-- Steps for reviewers to verify the change locally. -->
1. run the test cases

## Breaking changes

- [ X] No breaking changes
- [ ] Yes (describe): 

## Related issues

<!-- e.g., Closes #123, Fixes #456 -->

## Checklist

- [ X] Focused PR (single purpose)
- [ X] Tests added/updated (if applicable)
- [ X] Docs updated (if applicable)
- [ X] `./gradlew test` passes locally
- [ X] `./gradlew lint` passes locally
- [ X] Follows existing code style and patterns


