### PR TITLE
fix: parse Kotak RCS transaction alerts (#360)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KotakBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KotakBankParser.kt
@@ -18,7 +18,14 @@ class KotakBankParser : BankParser() {
         val normalizedSender = sender.uppercase()
 
         // DLT patterns for Kotak Bank — covers KOTAKB, KOTAKD, and similar variants
-        return normalizedSender.matches(Regex("^[A-Z]{2}-KOTAK[A-Z]-[ST]$"))
+        if (normalizedSender.matches(Regex("^[A-Z]{2}-KOTAK[A-Z]-[ST]$"))) {
+            return true
+        }
+
+        // RCS senders arrive with a decoded display name (e.g. "Kotak",
+        // "Kotak Mahindra Bank", "Kotak811") instead of the DLT header, so match
+        // any sender that contains the brand token.
+        return normalizedSender.contains("KOTAK")
     }
 
     override fun extractMerchant(message: String, sender: String): String? {

--- a/parser-core/src/test/kotlin/TestKotakBankParser.kt
+++ b/parser-core/src/test/kotlin/TestKotakBankParser.kt
@@ -152,6 +152,22 @@ class KotakBankParserTest {
                     accountLast4 = "1234"
                 )
             ),
+            // Issue #360: Kotak migrated "Sent" UPI alerts to RCS, which deliver a
+            // decoded display-name sender ("Kotak Mahindra Bank") rather than a DLT
+            // header. The parser must still handle and parse these correctly.
+            ParserTestCase(
+                name = "RCS Sent UPI with display-name sender",
+                message = "Sent Rs.205.00 from XXXXXX1234 to ANNAPOORNESWARI K M on 26/05/2026. UPI ref no. 651229267141. Not you? Tap https://kotk.in/KOTAKD/E7LzzX to report -Kotak",
+                sender = "Kotak Mahindra Bank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("205.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "ANNAPOORNESWARI K M",
+                    reference = "651229267141",
+                    accountLast4 = "1234"
+                )
+            ),
             ParserTestCase(
                 name = "Issue #360 - Sent UPI with single-word payee (KOTAKD-S)",
                 message = "Sent Rs.90.00 from XXXXXX9886 to RAMESH on 25/05/2026. UPI ref no. 653114209367. Not you? Tap https://kotk.in/KOTAKD/S6ztop to report -Kotak",
@@ -183,11 +199,19 @@ class KotakBankParserTest {
         )
 
         val handleChecks = listOf(
+            // DLT senders still match
             "JD-KOTAKB-S" to true,
             "JD-KOTAKB-T" to true,
             "VM-KOTAKD-S" to true,
             "JD-KOTAKD-S" to true,
-            "VM-KOTAKB" to false,
+            // RCS display-name senders (issue #360) match via the contains("KOTAK") branch
+            "Kotak" to true,
+            "Kotak Mahindra Bank" to true,
+            "Kotak811" to true,
+            // Intentional superset: a bare DLT header without the -S/-T suffix also
+            // matches via contains("KOTAK"). Asserted so the behavior stays documented.
+            "VM-KOTAKB" to true,
+            // Non-Kotak senders are rejected
             "UNKNOWN" to false
         )
 


### PR DESCRIPTION
## Context

Issue #360: Kotak "Sent" UPI alerts stopped being parsed. Kotak migrated these alerts from SMS to **RCS**.

This PR is rebased on `main`, which already removed the PNB-only RCS sender filter in `OptimizedSmsReaderWorker` (so RCS from any bank is now ingested). But that alone isn't enough for Kotak — see below.

## Problem

RCS messages arrive with a decoded **display-name sender** (e.g. `Kotak Mahindra Bank`), not the DLT header (`JD-KOTAKD-S`). `KotakBankParser.canHandle` only matched the strict DLT regex `^[A-Z]{2}-KOTAK[A-Z]-[ST]$`, so even after main ingests the RCS message, no parser claims it and it stays unparsed.

## Changes

- **KotakBankParser.canHandle**: keep the strict DLT regex as a fast path, and add a `contains("KOTAK")` branch so RCS display-name senders (`Kotak`, `Kotak Mahindra Bank`, `Kotak811`, …) are recognised — mirroring how `PNBBankParser` matches `PUNJAB NATIONAL BANK`.
- **Tests**: added an RCS display-name parse case + handle-checks, alongside the existing DLT-sender #360 cases.

## Verification

- `./gradlew :parser-core:jvmTest --tests "*KotakBankParser*"` — green

## Note

`contains("KOTAK")` also matches a bare DLT header like `VM-KOTAKB` (no `-S`/`-T` suffix) — an intentional superset, consistent with PNB's approach.

Fixes #360