### PR TITLE
fix: parse SABB salary-credit messages as income (#376)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SabbBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SabbBankParser.kt
@@ -81,7 +81,7 @@ class SabbBankParser : BankParser() {
     override fun extractTransactionType(message: String): TransactionType? {
         return when {
             // Incoming / deposit first so it wins over generic "حوالة"
-            message.contains("راتب") -> TransactionType.INCOME   // salary credit
+            message.contains("حوالة راتب") -> TransactionType.INCOME   // salary credit
             message.contains("إيداع") -> TransactionType.INCOME
             message.contains("واردة") -> TransactionType.INCOME
 
@@ -96,7 +96,7 @@ class SabbBankParser : BankParser() {
 
     override fun extractMerchant(message: String, sender: String): String? {
         // Salary credit (حوالة راتب) has no merchant line; label it as "Salary".
-        if (message.contains("راتب")) {
+        if (message.contains("حوالة راتب")) {
             return "Salary"
         }
 

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SabbBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SabbBankParser.kt
@@ -11,6 +11,7 @@ import java.math.BigDecimal
  *   شراء إنترنت                            (Online / internet purchase)
  *   حوالة صادرة مقبولة                     (Outgoing transfer)
  *   إيداع حوالة واردة                      (Incoming deposit / transfer)
+ *   حوالة راتب                             (Salary transfer / credit)
  *
  * Common fields:
  *   بطاقة: ***1234;mada(Samsung Pay)       Card with last 4
@@ -80,6 +81,7 @@ class SabbBankParser : BankParser() {
     override fun extractTransactionType(message: String): TransactionType? {
         return when {
             // Incoming / deposit first so it wins over generic "حوالة"
+            message.contains("راتب") -> TransactionType.INCOME   // salary credit
             message.contains("إيداع") -> TransactionType.INCOME
             message.contains("واردة") -> TransactionType.INCOME
 
@@ -93,6 +95,11 @@ class SabbBankParser : BankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
+        // Salary credit (حوالة راتب) has no merchant line; label it as "Salary".
+        if (message.contains("راتب")) {
+            return "Salary"
+        }
+
         val isIncoming = message.contains("إيداع") || message.contains("واردة")
         val isOutgoingTransfer = message.contains("صادرة")
 

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SabbBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SabbBankParserTest.kt
@@ -94,6 +94,23 @@ class SabbBankParserTest {
                     merchant = "FAHAD Ahmed",
                     accountLast4 = "9999"
                 )
+            ),
+            ParserTestCase(
+                name = "Salary credit (حوالة راتب) as income",
+                message = """
+                    حوالة راتب
+                    إلى: **001
+                    مبلغ: 12,345.67 SAR
+                    في: 2026-05 21 10:00:00
+                """.trimIndent(),
+                sender = "SAB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("12345.67"),
+                    currency = "SAR",
+                    type = TransactionType.INCOME,
+                    merchant = "Salary",
+                    accountLast4 = "001"
+                )
             )
         )
 


### PR DESCRIPTION
## Problem

SABB (Saudi Awwal Bank) salary-credit alerts were not being captured as income. These alerts use the Arabic format `حوالة راتب` ("salary transfer"), which `SabbBankParser` did not recognise, so `extractTransactionType` returned null and the base parser dropped the message.

Sample salary SMS:
```
حوالة راتب
إلى: **001
مبلغ: 12,345.67 SAR
في: 2026-05 21 10:00:00
```
- `حوالة راتب` = salary transfer
- `إلى: **001` = to account ending 001
- `مبلغ: 12,345.67 SAR` = amount 12345.67 SAR

## Fix (parser-core only)

- `extractTransactionType`: added a `راتب` (salary) case mapping to `TransactionType.INCOME`, placed first so it wins over the generic `حوالة` transfer handling.
- `extractMerchant`: salary credits have no merchant/from line, so they are labelled `"Salary"`.
- Existing amount (`مبلغ: 12,345.67 SAR`) and account (`إلى: **001` -> `001`) extraction already handled these fields; no changes needed there.

No Android/app-side files touched.

## Verification

```
./gradlew :parser-core:jvmTest --tests "*Sabb*"
./gradlew :parser-core:jvmTest
```
Both green. Added a new test case asserting amount `12345.67`, currency `SAR`, type `INCOME`, merchant `Salary`, account last-4 `001`. All existing SABB cases (POS purchase, online purchase, outgoing transfer, incoming deposit) and the full parser-core suite still pass.

Fixes #376