### PR TITLE
feat: add Standard Bank Mozambique parser (#354)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -113,7 +113,8 @@ object BankParserFactory {
         BankMuscatParser(),  // Bank Muscat (Oman)
         GreaterBankParser(),  // Greater Bank (India)
         BPCEParser(),  // BPCE (France)
-        SampathBankParser()  // Sampath Bank (Sri Lanka)
+        SampathBankParser(),  // Sampath Bank (Sri Lanka)
+        StandardBankMozambiqueParser()  // Standard Bank Mozambique
         // Add more bank parsers here as we implement them
     )
 

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -60,6 +60,7 @@ object BankParserFactory {
         LaxmiBankParser(),  // Laxmi Sunrise Bank (Nepal)
         CBEBankParser(),  // Commercial Bank of Ethiopia
         AltanaFCUParser(),  // Altana Federal Credit Union (USA) — must precede EverestBank, which greedily claims numeric senders
+        StandardBankMozambiqueParser(),  // Standard Bank Mozambique — must precede EverestBank (shortcode 7832265 is a 7-digit numeric sender)
         EverestBankParser(),  // Everest Bank (Nepal)
         BancolombiaParser(),  // Bancolombia (Colombia)
         MashreqBankParser(),  // Mashreq Bank (UAE)
@@ -113,8 +114,7 @@ object BankParserFactory {
         BankMuscatParser(),  // Bank Muscat (Oman)
         GreaterBankParser(),  // Greater Bank (India)
         BPCEParser(),  // BPCE (France)
-        SampathBankParser(),  // Sampath Bank (Sri Lanka)
-        StandardBankMozambiqueParser()  // Standard Bank Mozambique
+        SampathBankParser()  // Sampath Bank (Sri Lanka)
         // Add more bank parsers here as we implement them
     )
 

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/StandardBankMozambiqueParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/StandardBankMozambiqueParser.kt
@@ -95,16 +95,20 @@ class StandardBankMozambiqueParser : BankParser() {
     }
 
     override fun extractCurrency(message: String): String? {
-        // Currency follows the amount: "1.234,56 MZN", "1.234,56, MT", "1.234,56 USD"
+        // Currency follows the amount: "1.234,56 MZN", "1.234,56, MT", "1.234,56 USD".
+        // Anchor to a standalone token and accept only known codes so a Portuguese
+        // word (e.g. "na") is never mistaken for a currency when the code is absent;
+        // callers fall back to getCurrency() (MZN) when this returns null.
         val pattern = Regex(
-            """de\s+[0-9.]+,[0-9]{2},?\s+([A-Z]{2,3})""",
+            """de\s+[0-9.]+,[0-9]{2},?\s+([A-Za-z]{2,3})(?=\s|,|${'$'})""",
             RegexOption.IGNORE_CASE
         )
-        pattern.find(message)?.let { match ->
-            val currency = match.groupValues[1].uppercase()
-            return if (currency == "MT") "MZN" else currency
+        val token = pattern.find(message)?.groupValues?.get(1)?.uppercase() ?: return null
+        return when (token) {
+            "MT", "MZN" -> "MZN"
+            "USD" -> "USD"
+            else -> null
         }
-        return null
     }
 
     override fun extractTransactionType(message: String): TransactionType? {

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/StandardBankMozambiqueParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/StandardBankMozambiqueParser.kt
@@ -1,0 +1,154 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Standard Bank Mozambique SMS messages (Portuguese).
+ *
+ * Amounts use European decimal formatting (thousands separator '.', decimal ',')
+ * e.g. "1.234,56". Currency can be MZN (also written "MT") or USD.
+ *
+ * Supported formats:
+ * - Credit (income):
+ *   "Caro Cliente, ocorreu um credito de 1.234,56 MZN na sua conta 9999999999999 a 22/05/2026, 14:54, disponivel em 22/05/2026. Mais info: ..."
+ * - Purchase (expense):
+ *   "Caro Cliente, ocorreu uma operacao de compra de 1.234,56, MT na sua conta 9999999999999 a 09/05/2026, 13:41, MM INVESTMENTS S. Comissao: 0.00MT e Imposto de selo: 0.00MT. Mais info: ..."
+ * - Debit (expense):
+ *   "Caro Cliente, ocorreu um debito de 1.234,56 USD na sua conta 9999999999999 a 15/05/2026, 13:30, C01 AGENCIA DA BEIRA. Comissao: 0.00USD e Imposto de selo: 0.00USD. Mais info: ..."
+ *
+ * Portuguese keys:
+ * - "credito"            = credit  (INCOME)
+ * - "debito"             = debit   (EXPENSE)
+ * - "operacao de compra" = purchase (EXPENSE)
+ * - "na sua conta <digits>" = account number
+ *
+ * Sender patterns: "STDBank" (case-insensitive) and short code "7832265".
+ */
+class StandardBankMozambiqueParser : BankParser() {
+
+    override fun getBankName() = "Standard Bank Mozambique"
+
+    override fun getCurrency() = "MZN"
+
+    override fun canHandle(sender: String): Boolean {
+        val normalizedSender = sender.uppercase()
+        return normalizedSender.contains("STDBANK") ||
+                normalizedSender == "7832265"
+    }
+
+    override fun parse(smsBody: String, sender: String, timestamp: Long): ParsedTransaction? {
+        if (!isTransactionMessage(smsBody)) {
+            return null
+        }
+
+        val amount = extractAmount(smsBody) ?: return null
+        val type = extractTransactionType(smsBody) ?: return null
+        val currency = extractCurrency(smsBody) ?: getCurrency()
+
+        return ParsedTransaction(
+            amount = amount,
+            type = type,
+            merchant = extractMerchant(smsBody, sender),
+            reference = extractReference(smsBody),
+            accountLast4 = extractAccountLast4(smsBody),
+            balance = extractBalance(smsBody),
+            smsBody = smsBody,
+            sender = sender,
+            timestamp = timestamp,
+            bankName = getBankName(),
+            isFromCard = detectIsCard(smsBody),
+            currency = currency
+        )
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+        return lower.contains("credito") ||
+                lower.contains("debito") ||
+                lower.contains("operacao de compra")
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // "credito de 1.234,56 MZN", "compra de 1.234,56, MT", "debito de 1.234,56 USD"
+        val pattern = Regex(
+            """de\s+([0-9.]+,[0-9]{2})""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            return parseEuropeanAmount(match.groupValues[1])
+        }
+        return null
+    }
+
+    /**
+     * Converts a European-formatted amount string (e.g. "1.234,56") to BigDecimal.
+     */
+    private fun parseEuropeanAmount(raw: String): BigDecimal? {
+        val normalized = raw.replace(".", "").replace(",", ".")
+        return try {
+            BigDecimal(normalized)
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    override fun extractCurrency(message: String): String? {
+        // Currency follows the amount: "1.234,56 MZN", "1.234,56, MT", "1.234,56 USD"
+        val pattern = Regex(
+            """de\s+[0-9.]+,[0-9]{2},?\s+([A-Z]{2,3})""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            val currency = match.groupValues[1].uppercase()
+            return if (currency == "MT") "MZN" else currency
+        }
+        return null
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lower = message.lowercase()
+        return when {
+            lower.contains("credito") -> TransactionType.INCOME
+            lower.contains("debito") -> TransactionType.EXPENSE
+            lower.contains("operacao de compra") -> TransactionType.EXPENSE
+            else -> null
+        }
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        // "na sua conta 9999999999999"
+        val pattern = Regex(
+            """na\s+sua\s+conta\s+(\d+)""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            return extractLast4Digits(match.groupValues[1])
+        }
+        return null
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // Merchant/location appears after the time stamp "HH:MM, " and before the
+        // next ". Comissao" (purchase/debit) or ". " segment.
+        // Examples:
+        //   "..., 13:41, MM INVESTMENTS S. Comissao: ..."
+        //   "..., 13:30, C01 AGENCIA DA BEIRA. Comissao: ..."
+        val pattern = Regex(
+            """\d{2}:\d{2},\s+([^.]+?)\.\s*Comissao""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            val merchant = match.groupValues[1].trim()
+            if (isValidMerchantName(merchant)) {
+                return merchant
+            }
+        }
+        return null
+    }
+
+    override fun extractBalance(message: String): BigDecimal? = null
+
+    override fun extractReference(message: String): String? = null
+}

--- a/parser-core/src/test/kotlin/TestStandardBankMozambiqueParser.kt
+++ b/parser-core/src/test/kotlin/TestStandardBankMozambiqueParser.kt
@@ -59,4 +59,18 @@ class StandardBankMozambiqueParserTest {
 
         return ParserTestUtils.runTestSuite(parser, cases, handleChecks, "Standard Bank Mozambique Parser")
     }
+
+    @Test
+    fun `factory routes STDBank and numeric shortcode to this parser`() {
+        // The 7832265 shortcode is a 7-digit numeric sender; EverestBankParser greedily
+        // claims ^\d{7,10}$, so registration order must keep this parser ahead of it.
+        Assertions.assertTrue(
+            BankParserFactory.getParser("STDBank") is StandardBankMozambiqueParser,
+            "STDBank should route to StandardBankMozambiqueParser"
+        )
+        Assertions.assertTrue(
+            BankParserFactory.getParser("7832265") is StandardBankMozambiqueParser,
+            "shortcode 7832265 should route to StandardBankMozambiqueParser, not EverestBankParser"
+        )
+    }
 }

--- a/parser-core/src/test/kotlin/TestStandardBankMozambiqueParser.kt
+++ b/parser-core/src/test/kotlin/TestStandardBankMozambiqueParser.kt
@@ -1,0 +1,62 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.*
+import java.math.BigDecimal
+
+class StandardBankMozambiqueParserTest {
+    @TestFactory
+    fun `standard bank mozambique parser handles common cases`(): List<DynamicTest> {
+        val parser = StandardBankMozambiqueParser()
+
+        val cases = listOf(
+            ParserTestCase(
+                name = "Credit (MZN) - income",
+                message = "Caro Cliente, ocorreu um credito de 1.234,56 MZN na sua conta 1234567890123 a 22/05/2026, 14:54, disponivel em 22/05/2026. Mais info: 800412412/21355700",
+                sender = "STDBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1234.56"),
+                    currency = "MZN",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "0123"
+                )
+            ),
+            ParserTestCase(
+                name = "Purchase (MT -> MZN) - expense with merchant",
+                message = "Caro Cliente, ocorreu uma operacao de compra de 1.234,56, MT na sua conta 1234567890123 a 09/05/2026, 13:41, MM INVESTMENTS S. Comissao: 0.00MT e Imposto de selo: 0.00MT. Mais info: 800412412/21355700",
+                sender = "STDBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1234.56"),
+                    currency = "MZN",
+                    type = TransactionType.EXPENSE,
+                    merchant = "MM INVESTMENTS S",
+                    accountLast4 = "0123"
+                )
+            ),
+            ParserTestCase(
+                name = "Debit (USD) - expense with location",
+                message = "Caro Cliente, ocorreu um debito de 1.234,56 USD na sua conta 1234567890123 a 15/05/2026, 13:30, C01 AGENCIA DA BEIRA. Comissao: 0.00USD e Imposto de selo: 0.00USD. Mais info: 800412412/21355700",
+                sender = "7832265",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1234.56"),
+                    currency = "USD",
+                    type = TransactionType.EXPENSE,
+                    merchant = "C01 AGENCIA DA BEIRA",
+                    accountLast4 = "0123"
+                )
+            )
+        )
+
+        val handleChecks = listOf(
+            "STDBank" to true,
+            "7832265" to true,
+            "HDFCBK" to false,
+            "UNKNOWN" to false
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases, handleChecks, "Standard Bank Mozambique Parser")
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new parser for **Standard Bank Mozambique** (Portuguese SMS) in the `parser-core` module. No Android/app-side files were touched.

## Supported formats

- **Credit (MZN)** — `credito` → INCOME
- **Debit (USD)** — `debito` → EXPENSE
- **Purchase / compra (MT → MZN)** — `operacao de compra` → EXPENSE

Handles:
- European decimal formatting (`1.234,56` → `1234.56`)
- Currency MZN / USD, normalising the `MT` token to `MZN`
- Account last-4 from `na sua conta <digits>`
- Merchant / location for purchase and debit (text after the timestamp, before `. Comissao`)

## Sender patterns

- `STDBank` (case-insensitive, matched via `contains("STDBANK")`)
- Short code `7832265`

## Files

- `parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/StandardBankMozambiqueParser.kt` (new)
- `parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt` (registered)
- `parser-core/src/test/kotlin/TestStandardBankMozambiqueParser.kt` (new)

## Verification

```bash
JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" \
  ./gradlew :parser-core:jvmTest --tests "*StandardBankMozambique*"
JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" \
  ./gradlew :parser-core:jvmTest
```

All 3 sample cases plus 4 handle-checks pass; full `:parser-core:jvmTest` is green (no regressions).

Closes #354