### PR TITLE
feat: duplicate a transaction as a pre-filled template (#370)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/PennyWiseApp.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/PennyWiseApp.kt
@@ -107,7 +107,7 @@ fun PennyWiseApp(
     // Navigate directly to Add Transaction when requested (e.g., from widget shortcut)
     LaunchedEffect(openAddTransaction) {
         if (openAddTransaction) {
-            navController.navigate(com.pennywiseai.tracker.navigation.AddTransaction) {
+            navController.navigate(com.pennywiseai.tracker.navigation.AddTransaction()) {
                 launchSingleTop = true
             }
             onAddTransactionShortcutHandled()

--- a/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseDestinations.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseDestinations.kt
@@ -34,7 +34,7 @@ object Chat
 data class TransactionDetail(val transactionId: Long)
 
 @Serializable
-object AddTransaction
+data class AddTransaction(val sourceTransactionId: Long? = null)
 
 @Serializable
 data class AccountDetail(val bankName: String, val accountLast4: String)

--- a/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseNavHost.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseNavHost.kt
@@ -168,11 +168,16 @@ fun PennyWiseNavHost(
                         navController.navigate(LoanDetail(loanId)) {
                             launchSingleTop = true
                         }
+                    },
+                    onDuplicateTransaction = { sourceId ->
+                        navController.navigate(AddTransaction(sourceTransactionId = sourceId)) {
+                            launchSingleTop = true
+                        }
                     }
                 )
             }
         }
-        
+
         composable<AddTransaction>(
             enterTransition = { fadeIn(tween(300)) + slideInVertically { it / 4 } },
             exitTransition = { fadeOut(tween(200)) },
@@ -428,7 +433,7 @@ fun PennyWiseNavHost(
                     navController.navigate(TransactionDetail(transactionId)) { launchSingleTop = true }
                 },
                 onAddTransactionClick = {
-                    navController.navigate(AddTransaction) { launchSingleTop = true }
+                    navController.navigate(AddTransaction()) { launchSingleTop = true }
                 },
                 onNavigateToSettings = {
                     navController.navigate(Settings) { launchSingleTop = true }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
@@ -2,6 +2,7 @@ package com.pennywiseai.tracker.presentation.add
 
 import android.content.Context
 import android.net.Uri
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
@@ -12,6 +13,7 @@ import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.receipt.ReceiptManager
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository
+import com.pennywiseai.tracker.data.repository.TransactionRepository
 import com.pennywiseai.tracker.domain.usecase.AddTransactionUseCase
 import com.pennywiseai.tracker.domain.usecase.AddSubscriptionUseCase
 import com.pennywiseai.tracker.domain.usecase.GetCategoriesUseCase
@@ -36,8 +38,14 @@ class AddViewModel @Inject constructor(
     private val accountBalanceRepository: AccountBalanceRepository,
     private val budgetGroupRepository: BudgetGroupRepository,
     private val userPreferencesRepository: UserPreferencesRepository,
-    private val receiptManager: ReceiptManager
+    private val transactionRepository: TransactionRepository,
+    private val receiptManager: ReceiptManager,
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+
+    // When launched via "Duplicate", this holds the id of the source transaction
+    // whose values should pre-fill the form. Null for a fresh add.
+    private val sourceTransactionId: Long? = savedStateHandle.get<Long>("sourceTransactionId")
     
     // General UI State
     private val _uiState = MutableStateFlow(AddUiState())
@@ -58,6 +66,49 @@ class AddViewModel @Inject constructor(
             val baseCurrency = userPreferencesRepository.baseCurrency.first()
             _transactionUiState.update { it.copy(currency = baseCurrency) }
             _subscriptionUiState.update { it.copy(currency = baseCurrency) }
+
+            // If launched via "Duplicate", prefill the transaction form from the
+            // source. Done after the default currency so the source's currency wins.
+            sourceTransactionId?.let { prefillFromTransaction(it) }
+        }
+    }
+
+    /**
+     * Loads the given transaction and copies its editable values into the
+     * transaction form as a brand-new draft. The original is never modified;
+     * id/hash/receipt are intentionally not copied so saving creates a new
+     * transaction. The date defaults to now (template behaviour) while all
+     * other fields are copied verbatim.
+     */
+    private suspend fun prefillFromTransaction(transactionId: Long) {
+        val source = transactionRepository.getTransactionById(transactionId) ?: return
+
+        // Best-effort match of the source account to an existing account so the
+        // account selector is pre-populated when possible.
+        val matchedAccount = source.accountNumber?.let { accountNumber ->
+            val last4 = accountNumber.takeLast(4)
+            accounts.value.firstOrNull { account ->
+                account.bankName == source.bankName && account.accountLast4 == last4
+            }
+        }
+
+        _transactionUiState.update { currentState ->
+            currentState.copy(
+                amount = source.amount.stripTrailingZeros().toPlainString(),
+                amountError = null,
+                transactionType = source.transactionType,
+                merchant = source.merchantName,
+                merchantError = null,
+                category = source.category,
+                categoryError = null,
+                date = LocalDateTime.now(),
+                notes = source.description ?: "",
+                isRecurring = source.isRecurring,
+                currency = source.currency,
+                selectedAccount = matchedAccount,
+                budgetImpactType = source.budgetImpactType,
+                budgetCategory = source.budgetCategory
+            )
         }
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
@@ -83,15 +83,6 @@ class AddViewModel @Inject constructor(
     private suspend fun prefillFromTransaction(transactionId: Long) {
         val source = transactionRepository.getTransactionById(transactionId) ?: return
 
-        // Best-effort match of the source account to an existing account so the
-        // account selector is pre-populated when possible.
-        val matchedAccount = source.accountNumber?.let { accountNumber ->
-            val last4 = accountNumber.takeLast(4)
-            accounts.value.firstOrNull { account ->
-                account.bankName == source.bankName && account.accountLast4 == last4
-            }
-        }
-
         _transactionUiState.update { currentState ->
             currentState.copy(
                 amount = source.amount.stripTrailingZeros().toPlainString(),
@@ -105,10 +96,26 @@ class AddViewModel @Inject constructor(
                 notes = source.description ?: "",
                 isRecurring = source.isRecurring,
                 currency = source.currency,
-                selectedAccount = matchedAccount,
                 budgetImpactType = source.budgetImpactType,
                 budgetCategory = source.budgetCategory
             )
+        }
+
+        // Best-effort match of the source account to an existing account. `accounts`
+        // is a WhileSubscribed StateFlow whose value is still empty at init time, so
+        // we wait for the first non-empty emission instead of reading .value once
+        // (which always returned emptyList() and left the selector blank).
+        val last4 = source.accountNumber?.takeLast(4)
+        if (source.bankName != null || last4 != null) {
+            viewModelScope.launch {
+                val matched = accounts.first { it.isNotEmpty() }
+                    .firstOrNull { it.bankName == source.bankName && it.accountLast4 == last4 }
+                    ?: return@launch
+                // Don't override a selection the user may have already made.
+                _transactionUiState.update { state ->
+                    if (state.selectedAccount == null) state.copy(selectedAccount = matched) else state
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailScreen.kt
@@ -109,6 +109,7 @@ fun TransactionDetailScreen(
     transactionId: Long,
     onNavigateBack: () -> Unit,
     onNavigateToLoanDetail: (Long) -> Unit = {},
+    onDuplicateTransaction: (Long) -> Unit = {},
     viewModel: TransactionDetailViewModel = hiltViewModel()
 ) {
     val transaction by viewModel.transaction.collectAsStateWithLifecycle()
@@ -220,7 +221,22 @@ fun TransactionDetailScreen(
                             contentDescription = "Manage Group"
                         )
                     }
-                    
+
+                    // Duplicate FAB - opens the add form pre-filled as a new draft
+                    transaction?.let { txn ->
+                        SmallFloatingActionButton(
+                            onClick = { onDuplicateTransaction(txn.id) },
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.ContentCopy,
+                                contentDescription = "Duplicate Transaction"
+                            )
+                        }
+                    }
+
+
                     // Report Issue FAB
                     FloatingActionButton(
                         onClick = {

--- a/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
@@ -186,7 +186,7 @@ fun MainScreen(
                     },
                     onNavigateToAddScreen = {
                         rootNavController?.navigate(
-                            com.pennywiseai.tracker.navigation.AddTransaction
+                            com.pennywiseai.tracker.navigation.AddTransaction()
                         ) { launchSingleTop = true }
                     },
                     onTransactionClick = { transactionId ->
@@ -274,7 +274,7 @@ fun MainScreen(
                     },
                     onAddTransactionClick = {
                         rootNavController?.navigate(
-                            com.pennywiseai.tracker.navigation.AddTransaction
+                            com.pennywiseai.tracker.navigation.AddTransaction()
                         ) { launchSingleTop = true }
                     },
                     onNavigateToSettings = {
@@ -302,7 +302,7 @@ fun MainScreen(
                     },
                     onAddSubscriptionClick = {
                         rootNavController?.navigate(
-                            com.pennywiseai.tracker.navigation.AddTransaction
+                            com.pennywiseai.tracker.navigation.AddTransaction()
                         ) { launchSingleTop = true }
                     }
                 )


### PR DESCRIPTION
## What

Adds a **Duplicate** action to the transaction detail screen. Tapping it opens the manual add-transaction form pre-filled with the source transaction's values as a brand-new draft. The original transaction is never edited; saving creates a new transaction.

## Flow

1. On the transaction detail screen, a new Duplicate FAB (ContentCopy icon) appears alongside the existing Delete / Group / Report FABs.
2. Tapping it navigates to the Add screen with the source transaction id.
3. The Add form is pre-filled: amount, transaction type, merchant, category, notes, currency, recurring flag, budget impact type/category, and a best-effort match of the source account (by bank name + last 4).
4. The date defaults to **now** (template behaviour) rather than copying the original date.
5. `id`, `transactionHash`, and the receipt are intentionally **not** copied, so saving inserts a fresh transaction.

## Product decisions

- Date defaults to now rather than the original date, since a duplicate is generally a new occurrence.
- Account match is best-effort: if the source account can't be resolved to an existing `AccountBalanceEntity`, the selector is simply left empty.

## Files changed

- `navigation/PennyWiseDestinations.kt` — `AddTransaction` is now `data class AddTransaction(val sourceTransactionId: Long? = null)`.
- `navigation/PennyWiseNavHost.kt` — wires `onDuplicateTransaction` from the detail screen to navigate to `AddTransaction(sourceTransactionId = ...)`; updated existing call site to `AddTransaction()`.
- `presentation/add/AddViewModel.kt` — injects `TransactionRepository` + `SavedStateHandle`, reads the arg, and prefills the form on init.
- `presentation/transactions/TransactionDetailScreen.kt` — adds the Duplicate FAB and `onDuplicateTransaction` callback.
- `PennyWiseApp.kt`, `ui/MainScreen.kt` — updated existing `AddTransaction` call sites to `AddTransaction()`.

## Verification

`./gradlew :app:compileStandardDebugKotlin` → BUILD SUCCESSFUL (only pre-existing warnings).

Closes #370