### PR TITLE
feat: edit & duplicate smart rules, set account in rules (#367, #373)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/domain/service/RuleEngine.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/service/RuleEngine.kt
@@ -285,6 +285,15 @@ class RuleEngine @Inject constructor() {
                 }
                 transaction.copy(transactionType = newType) to newType.name
             }
+            TransactionField.BANK_NAME -> {
+                // The account a transaction belongs to is identified by its bank name.
+                val newValue = when (action.actionType) {
+                    ActionType.SET -> action.value
+                    ActionType.CLEAR -> ""
+                    else -> transaction.bankName ?: ""
+                }
+                transaction.copy(bankName = newValue.takeIf { it.isNotBlank() }) to newValue
+            }
             else -> transaction to getFieldValue(transaction, null, action.field)
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseDestinations.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseDestinations.kt
@@ -49,7 +49,7 @@ object Faq
 object Rules
 
 @Serializable
-data class CreateRule(val ruleId: String? = null)
+data class CreateRule(val ruleId: String? = null, val duplicateFromId: String? = null)
 
 @Serializable
 object ExchangeRates

--- a/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseNavHost.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseNavHost.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -231,6 +232,11 @@ fun PennyWiseNavHost(
                     navController.navigate(CreateRule(ruleId = ruleId)) {
                         launchSingleTop = true
                     }
+                },
+                onNavigateToDuplicateRule = { ruleId ->
+                    navController.navigate(CreateRule(duplicateFromId = ruleId)) {
+                        launchSingleTop = true
+                    }
                 }
             )
         }
@@ -244,10 +250,27 @@ fun PennyWiseNavHost(
             val createRule = backStackEntry.toRoute<CreateRule>()
             val rulesViewModel: com.pennywiseai.tracker.ui.viewmodel.RulesViewModel = hiltViewModel()
 
-            // Collect rules from the flow to find the existing rule
+            // Collect rules from the flow to find the rule being edited or duplicated.
             val rules by rulesViewModel.rules.collectAsStateWithLifecycle()
-            val existingRule = createRule.ruleId?.let { ruleId ->
-                rules.firstOrNull { it.id == ruleId }
+            val isEditing = createRule.ruleId != null
+
+            // Stable id for a duplicate, kept across recompositions/config changes.
+            val duplicateId = rememberSaveable { java.util.UUID.randomUUID().toString() }
+
+            // Edit prefills from the saved rule; duplicate prefills from the source but
+            // becomes a fresh rule (new id, "(copy)" name) so saving inserts a new one.
+            val prefillRule = when {
+                createRule.ruleId != null ->
+                    rules.firstOrNull { it.id == createRule.ruleId }
+                createRule.duplicateFromId != null ->
+                    rules.firstOrNull { it.id == createRule.duplicateFromId }?.let { source ->
+                        source.copy(
+                            id = duplicateId,
+                            name = "${source.name} (copy)",
+                            isSystemTemplate = false
+                        )
+                    }
+                else -> null
             }
 
             com.pennywiseai.tracker.ui.screens.rules.CreateRuleScreen(
@@ -255,10 +278,16 @@ fun PennyWiseNavHost(
                     navController.safePopBackStack()
                 },
                 onSaveRule = { rule ->
-                    rulesViewModel.createRule(rule)
+                    // Edit updates in place; create/duplicate inserts a new rule.
+                    if (isEditing) {
+                        rulesViewModel.updateRule(rule)
+                    } else {
+                        rulesViewModel.createRule(rule)
+                    }
                     navController.safePopBackStack()
                 },
-                existingRule = existingRule
+                existingRule = prefillRule,
+                isEditing = isEditing
             )
         }
         

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
@@ -30,7 +30,10 @@ import java.util.UUID
 fun CreateRuleScreen(
     onNavigateBack: () -> Unit,
     onSaveRule: (TransactionRule) -> Unit,
-    existingRule: TransactionRule? = null
+    existingRule: TransactionRule? = null,
+    // True only when editing a saved rule. A duplicate passes a prefilled [existingRule]
+    // (carrying a fresh id) but isEditing = false, so it saves as a brand-new rule.
+    isEditing: Boolean = existingRule != null
 ) {
     var ruleName by remember(existingRule) { mutableStateOf(existingRule?.name ?: "") }
     var description by remember(existingRule) { mutableStateOf(existingRule?.description ?: "") }
@@ -157,7 +160,7 @@ fun CreateRuleScreen(
             CustomTitleTopAppBar(
                 scrollBehaviorSmall = scrollBehaviorSmall,
                 scrollBehaviorLarge = scrollBehaviorLarge,
-                title = if (existingRule != null) "Edit Rule" else "Create Rule",
+                title = if (isEditing) "Edit Rule" else "Create Rule",
                 hasBackButton = true,
                 hasActionButton = true,
                 navigationContent = {
@@ -484,6 +487,7 @@ fun CreateRuleScreen(
                                 TransactionField.MERCHANT -> "Set Merchant Name"
                                 TransactionField.TYPE -> "Set Transaction Type"
                                 TransactionField.NARRATION -> "Set Description"
+                                TransactionField.BANK_NAME -> "Set Account"
                                 else -> "Set Field"
                             },
                             onValueChange = { },
@@ -500,7 +504,8 @@ fun CreateRuleScreen(
                                 TransactionField.CATEGORY to "Set Category",
                                 TransactionField.MERCHANT to "Set Merchant Name",
                                 TransactionField.TYPE to "Set Transaction Type",
-                                TransactionField.NARRATION to "Set Description"
+                                TransactionField.NARRATION to "Set Description",
+                                TransactionField.BANK_NAME to "Set Account"
                             ).forEach { (field, label) ->
                                 DropdownMenuItem(
                                     text = { Text(label) },
@@ -621,6 +626,18 @@ fun CreateRuleScreen(
                                 modifier = Modifier.fillMaxWidth(),
                                 minLines = 2,
                                 maxLines = 3
+                            )
+                        }
+
+                        TransactionField.BANK_NAME -> {
+                            // Account / bank the transaction belongs to.
+                            TextField(
+                                value = actionValue,
+                                onValueChange = { actionValue = it },
+                                label = { Text("Account / Bank Name") },
+                                placeholder = { Text("e.g., HDFC Bank") },
+                                modifier = Modifier.fillMaxWidth(),
+                                singleLine = true
                             )
                         }
 

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
@@ -33,7 +33,9 @@ fun CreateRuleScreen(
     existingRule: TransactionRule? = null,
     // True only when editing a saved rule. A duplicate passes a prefilled [existingRule]
     // (carrying a fresh id) but isEditing = false, so it saves as a brand-new rule.
-    isEditing: Boolean = existingRule != null
+    // Defaults to false: a non-null prefill must NOT imply edit, or a duplicate that
+    // omits this flag would overwrite its source. Callers state edit intent explicitly.
+    isEditing: Boolean = false
 ) {
     var ruleName by remember(existingRule) { mutableStateOf(existingRule?.name ?: "") }
     var description by remember(existingRule) { mutableStateOf(existingRule?.description ?: "") }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/RulesScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/RulesScreen.kt
@@ -38,6 +38,7 @@ fun RulesScreen(
     onNavigateBack: () -> Unit,
     onNavigateToCreateRule: () -> Unit,
     onNavigateToEditRule: (String) -> Unit,
+    onNavigateToDuplicateRule: (String) -> Unit,
     viewModel: RulesViewModel = hiltViewModel()
 ) {
     val rules by viewModel.rules.collectAsStateWithLifecycle()
@@ -217,6 +218,9 @@ fun RulesScreen(
                                     onEdit = {
                                         onNavigateToEditRule(rule.id)
                                     },
+                                    onDuplicate = {
+                                        onNavigateToDuplicateRule(rule.id)
+                                    },
                                     onDelete = {
                                         viewModel.deleteRule(rule.id)
                                     },
@@ -275,6 +279,7 @@ private fun RuleCard(
     rule: com.pennywiseai.tracker.domain.model.rule.TransactionRule,
     onToggle: (Boolean) -> Unit,
     onEdit: () -> Unit,
+    onDuplicate: () -> Unit,
     onDelete: () -> Unit,
     onApplyToPast: () -> Unit
 ) {
@@ -383,6 +388,18 @@ private fun RuleCard(
                                 onClick = {
                                     showActionsMenu = false
                                     onEdit()
+                                }
+                            )
+
+                            // Duplicate rule (opens the editor prefilled as a new rule)
+                            DropdownMenuItem(
+                                text = { Text("Duplicate Rule") },
+                                leadingIcon = {
+                                    Icon(Icons.Default.ContentCopy, contentDescription = null)
+                                },
+                                onClick = {
+                                    showActionsMenu = false
+                                    onDuplicate()
                                 }
                             )
 

--- a/app/src/test/java/com/pennywiseai/tracker/domain/service/RuleEngineTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/domain/service/RuleEngineTest.kt
@@ -1,0 +1,66 @@
+package com.pennywiseai.tracker.domain.service
+
+import com.pennywiseai.tracker.data.database.entity.TransactionEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionType
+import com.pennywiseai.tracker.domain.model.rule.ActionType
+import com.pennywiseai.tracker.domain.model.rule.ConditionOperator
+import com.pennywiseai.tracker.domain.model.rule.RuleAction
+import com.pennywiseai.tracker.domain.model.rule.RuleCondition
+import com.pennywiseai.tracker.domain.model.rule.TransactionField
+import com.pennywiseai.tracker.domain.model.rule.TransactionRule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+/**
+ * Covers the account (BANK_NAME) rule action added for issue #373 — previously a
+ * rule could select "account" but the engine silently ignored it.
+ */
+class RuleEngineTest {
+
+    private val engine = RuleEngine()
+
+    private fun txn(bankName: String? = null) = TransactionEntity(
+        amount = BigDecimal("100.00"),
+        merchantName = "Coffee Shop",
+        category = "Food",
+        transactionType = TransactionType.EXPENSE,
+        dateTime = LocalDateTime.of(2026, 1, 1, 10, 0),
+        transactionHash = "hash-1",
+        bankName = bankName
+    )
+
+    private fun rule(action: RuleAction) = TransactionRule(
+        name = "rule",
+        conditions = listOf(
+            RuleCondition(TransactionField.MERCHANT, ConditionOperator.CONTAINS, "Coffee")
+        ),
+        actions = listOf(action)
+    )
+
+    @Test
+    fun `SET account action sets the bank name`() {
+        val (result, applications) = engine.evaluateRules(
+            txn(),
+            smsText = null,
+            rules = listOf(rule(RuleAction(TransactionField.BANK_NAME, ActionType.SET, "HDFC Bank")))
+        )
+
+        assertEquals("HDFC Bank", result.bankName)
+        assertTrue(applications.isNotEmpty())
+    }
+
+    @Test
+    fun `CLEAR account action clears the bank name`() {
+        val (result, _) = engine.evaluateRules(
+            txn(bankName = "HDFC Bank"),
+            smsText = null,
+            rules = listOf(rule(RuleAction(TransactionField.BANK_NAME, ActionType.CLEAR, "")))
+        )
+
+        assertNull(result.bankName)
+    }
+}


### PR DESCRIPTION
Implements two Tier-1 smart-rules issues.

## #367 — Edit & duplicate a smart rule
- **Edit bug fix:** opening a rule and saving always created a *new* rule — the `CreateRule` route resolved the rule for prefill but the NavHost unconditionally called `createRule`. It now calls `updateRule` when editing, `createRule` otherwise.
- **Duplicate:** a new "Duplicate Rule" item in the rule card menu opens the editor pre-filled from the source rule but as a brand-new rule (fresh id, `"(copy)"` name, `isSystemTemplate=false`). A new `isEditing` flag on `CreateRuleScreen` drives the title and ensures a duplicate **inserts** rather than overwriting the source. The duplicate's id is stable across recompositions (`rememberSaveable`).

(Mirrors the Cashiro fork's request — copy a rule and tweak it instead of rebuilding.)

## #373 — Couldn't set "account" in a rule
The action dropdown only offered Category/Merchant/Type/Description, and `RuleEngine.applyAction` silently ignored anything else — so selecting account did nothing.
- Added **"Set Account"** to the action dropdown (mapped to `TransactionField.BANK_NAME`, which already exists on the condition side) with its own labeled input.
- `RuleEngine.applyAction` now handles `BANK_NAME` for `SET`/`CLEAR`.
- **Interpretation note:** "account" maps to the transaction's **bank name** (`TransactionEntity.bankName`), the existing account-identity field. If you intended full bank + last-4 binding, that's a follow-up — happy to extend.

## Tests / verification
- New `RuleEngineTest` covers the SET and CLEAR account actions — green.
- `./gradlew :app:compileStandardDebugKotlin` — clean.

## Files
`PennyWiseDestinations.kt`, `PennyWiseNavHost.kt`, `CreateRuleScreen.kt`, `RulesScreen.kt`, `RuleEngine.kt`, `RuleEngineTest.kt` (new).

Closes #367
Closes #373