### PR TITLE
Fix/allow icon refresh on category update

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/AccountDetailScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/AccountDetailScreen.kt
@@ -537,6 +537,7 @@ private fun TransactionItem(
             ) {
                 BrandIcon(
                     merchantName = transaction.merchantName,
+                    category = transaction.category,
                     size = 48.dp,
                     showBackground = true
                 )

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailScreen.kt
@@ -549,6 +549,7 @@ private fun TransactionReceipt(
                 }
                 BrandIcon(
                     merchantName = transaction.merchantName,
+                    category = transaction.category,
                     modifier = heroIconModifier,
                     size = 56.dp,
                     showBackground = true
@@ -1077,6 +1078,7 @@ private fun EditableTransactionHeader(
                 leadingIcon = {
                     BrandIcon(
                         merchantName = transaction.merchantName,
+                        category = transaction.category,
                         size = 24.dp,
                         showBackground = false
                     )

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/BrandIcon.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/BrandIcon.kt
@@ -23,6 +23,7 @@ import com.pennywiseai.tracker.ui.icons.BrandIcons
 import com.pennywiseai.tracker.ui.icons.CategoryMapping
 import com.pennywiseai.tracker.ui.icons.IconProvider
 import com.pennywiseai.tracker.ui.icons.IconResource
+import com.pennywiseai.tracker.ui.icons.isValidCategoryOverride
 
 /**
  * Displays a brand icon with intelligent fallback
@@ -36,7 +37,17 @@ fun BrandIcon(
     showBackground: Boolean = true
 ) {
     val iconResource = IconProvider.getTransactionIcon(merchantName, category)
-    val brandColor = BrandIcons.getBrandColor(merchantName)
+
+    val backgroundColor = if (category.isValidCategoryOverride()
+        && iconResource !is IconResource.DrawableResource
+    ) {
+        CategoryMapping.categories[category]?.color
+            ?: MaterialTheme.colorScheme.surfaceVariant
+    } else {
+        val brandColor = BrandIcons.getBrandColor(merchantName)
+        brandColor?.let { Color(it.toColorInt()) }
+            ?: MaterialTheme.colorScheme.surfaceVariant
+    }
     
     Box(
         modifier = modifier
@@ -45,10 +56,7 @@ fun BrandIcon(
                 if (showBackground) {
                     Modifier
                         .clip(CircleShape)
-                        .background(
-                            brandColor?.let { Color(it.toColorInt()) }
-                                ?: MaterialTheme.colorScheme.surfaceVariant
-                        )
+                        .background(backgroundColor)
                         .padding(8.dp)
                 } else {
                     Modifier

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/BrandIcon.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/BrandIcon.kt
@@ -30,11 +30,12 @@ import com.pennywiseai.tracker.ui.icons.IconResource
 @Composable
 fun BrandIcon(
     merchantName: String,
+    category: String? = null,
     modifier: Modifier = Modifier,
     size: Dp = 40.dp,
     showBackground: Boolean = true
 ) {
-    val iconResource = IconProvider.getIconForMerchant(merchantName)
+    val iconResource = IconProvider.getTransactionIcon(merchantName, category)
     val brandColor = BrandIcons.getBrandColor(merchantName)
     
     Box(

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/BrandIcon.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/BrandIcon.kt
@@ -41,8 +41,7 @@ fun BrandIcon(
     val backgroundColor = if (category.isValidCategoryOverride()
         && iconResource !is IconResource.DrawableResource
     ) {
-        CategoryMapping.categories[category]?.color
-            ?: MaterialTheme.colorScheme.surfaceVariant
+        (iconResource as IconResource.VectorIcon).tint
     } else {
         val brandColor = BrandIcons.getBrandColor(merchantName)
         brandColor?.let { Color(it.toColorInt()) }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/TransactionItem.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/TransactionItem.kt
@@ -135,7 +135,8 @@ fun TransactionItem(
                 merchantName = transaction.merchantName,
                 modifier = iconModifier,
                 size = Dimensions.Icon.list,
-                showBackground = true
+                showBackground = true,
+                category = transaction.category
             )
         },
         trailingContent = {

--- a/app/src/main/java/com/pennywiseai/tracker/ui/icons/CategoryMapping.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/icons/CategoryMapping.kt
@@ -228,6 +228,31 @@ object IconProvider {
         return CategoryMapping.categories[category]
             ?: CategoryMapping.categories["Others"]!!
     }
+
+    /**
+     * Get icon for a transaction, using an explicitly set category when available.
+     * 1. Try brand-specific icon
+     * 2. If not found, use provided category (if valid)
+     * 3. Otherwise, derive category from merchant name
+     * 4. If still not found, use default icon
+     */
+    fun getTransactionIcon(merchantName: String, category: String?): IconResource {
+        BrandIcons.getIconResource(merchantName)?.let { iconRes ->
+            return IconResource.DrawableResource(iconRes)
+        }
+
+        val effectiveCategory = if (!category.isNullOrBlank()
+            && !category.equals("Uncategorized", ignoreCase = true)
+        ) category else CategoryMapping.getCategory(merchantName)
+
+        val categoryInfo = CategoryMapping.categories[effectiveCategory]
+            ?: CategoryMapping.categories["Others"]!!
+
+        return IconResource.VectorIcon(
+            icon = categoryInfo.icon,
+            tint = categoryInfo.color
+        )
+    }
 }
 
 /**

--- a/app/src/main/java/com/pennywiseai/tracker/ui/icons/CategoryMapping.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/icons/CategoryMapping.kt
@@ -241,9 +241,8 @@ object IconProvider {
             return IconResource.DrawableResource(iconRes)
         }
 
-        val effectiveCategory = if (!category.isNullOrBlank()
-            && !category.equals("Uncategorized", ignoreCase = true)
-        ) category else CategoryMapping.getCategory(merchantName)
+        val effectiveCategory = if (category.isValidCategoryOverride()) category
+            else CategoryMapping.getCategory(merchantName)
 
         val categoryInfo = CategoryMapping.categories[effectiveCategory]
             ?: CategoryMapping.categories["Others"]!!
@@ -262,3 +261,10 @@ sealed class IconResource {
     data class DrawableResource(val resId: Int) : IconResource()
     data class VectorIcon(val icon: ImageVector, val tint: Color) : IconResource()
 }
+
+/**
+ * Returns true if this category string represents a valid override
+ * (non-null, non-blank, not the "Uncategorized" sentinel).
+ */
+internal fun String?.isValidCategoryOverride(): Boolean =
+    !this.isNullOrBlank() && !this.equals("Uncategorized", ignoreCase = true)

--- a/app/src/test/java/com/pennywiseai/tracker/ui/icons/CategoryMappingTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/ui/icons/CategoryMappingTest.kt
@@ -1,5 +1,9 @@
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import com.pennywiseai.tracker.ui.icons.CategoryMapping
+import com.pennywiseai.tracker.ui.icons.IconProvider
+import com.pennywiseai.tracker.ui.icons.IconResource
 
 class CategoryMappingTest {
 
@@ -74,6 +78,80 @@ class CategoryMappingTest {
 
         // Test some should remain as Others (too generic)
         assertEquals("Others", getCategory("Twin Made"))
+    }
+
+    // ---------------------------------------------------------------------------
+    // IconProvider.getTransactionIcon
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun testGetTransactionIcon_noCategory_derivesFromMerchant() {
+        // null category → derive from merchant name (Food & Dining)
+        val result = IconProvider.getTransactionIcon("Piri Piri Flaming Grill", null)
+        val iconResult: IconResource.VectorIcon = result as? IconResource.VectorIcon
+            ?: throw AssertionError("Expected VectorIcon but got $result")
+        val foodInfo = CategoryMapping.categories["Food & Dining"]!!
+        assertEquals(foodInfo.icon, iconResult.icon)
+        assertEquals(foodInfo.color, iconResult.tint)
+    }
+
+    @Test
+    fun testGetTransactionIcon_withCategory_usesGivenCategory() {
+        // "7-11" derives as "Groceries", but override forces "Transportation"
+        val result = IconProvider.getTransactionIcon("7-11", "Transportation")
+        val iconResult: IconResource.VectorIcon = result as? IconResource.VectorIcon
+            ?: throw AssertionError("Expected VectorIcon but got $result")
+        val transportInfo = CategoryMapping.categories["Transportation"]!!
+        assertEquals(transportInfo.icon, iconResult.icon)
+        assertEquals(transportInfo.color, iconResult.tint)
+    }
+
+    @Test
+    fun testGetTransactionIcon_emptyCategory_fallsBackToDerived() {
+        // Empty string → derive from merchant name
+        val result = IconProvider.getTransactionIcon("Piri Piri Flaming Grill", "")
+        val iconResult: IconResource.VectorIcon = result as? IconResource.VectorIcon
+            ?: throw AssertionError("Expected VectorIcon but got $result")
+        val foodInfo = CategoryMapping.categories["Food & Dining"]!!
+        assertEquals(foodInfo.icon, iconResult.icon)
+    }
+
+    @Test
+    fun testGetTransactionIcon_uncategorized_fallsBackToDerived() {
+        // "Uncategorized" → derive from merchant name
+        val result = IconProvider.getTransactionIcon("Piri Piri Flaming Grill", "Uncategorized")
+        val iconResult: IconResource.VectorIcon = result as? IconResource.VectorIcon
+            ?: throw AssertionError("Expected VectorIcon but got $result")
+        val foodInfo = CategoryMapping.categories["Food & Dining"]!!
+        assertEquals(foodInfo.icon, iconResult.icon)
+    }
+
+    @Test
+    fun testGetTransactionIcon_brandIconTakesPriority() {
+        // "Starbucks" has a brand drawable → returns DrawableResource even with override
+        val result = IconProvider.getTransactionIcon("Starbucks", "Transportation")
+        assertTrue(result is IconResource.DrawableResource, "Expected DrawableResource for a known brand")
+    }
+
+    @Test
+    fun testGetTransactionIcon_nonExistentCategory_fallsBackToOthers() {
+        // Non-existent category name → fallback to "Others"
+        val result = IconProvider.getTransactionIcon("7-11", "NonExistentCategory")
+        val iconResult: IconResource.VectorIcon = result as? IconResource.VectorIcon
+            ?: throw AssertionError("Expected VectorIcon but got $result")
+        val othersInfo = CategoryMapping.categories["Others"]!!
+        assertEquals(othersInfo.icon, iconResult.icon)
+        assertEquals(othersInfo.color, iconResult.tint)
+    }
+
+    @Test
+    fun testGetTransactionIcon_overrideToOthers_usesOthers() {
+        val result = IconProvider.getTransactionIcon("Piri Piri Flaming Grill", "Others")
+        val iconResult: IconResource.VectorIcon = result as? IconResource.VectorIcon
+            ?: throw AssertionError("Expected VectorIcon but got $result")
+        val othersInfo = CategoryMapping.categories["Others"]!!
+        assertEquals(othersInfo.icon, iconResult.icon)
+        assertEquals(othersInfo.color, iconResult.tint)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug where changing a transaction's category updated the subtitle text but not the icon. 
The icon resolution now takes into account the category of the transaction as well rather than just using merchant(and fallback to merchant category).

## Type of change

- [x] fix: Bug fix

## How to test

1. Open a transaction with a merchant that has no brand logo
2. Change its category (e.g. from "Food & Dining" → "Transportation")
3. Verify the icon and circle background colour update to match the new category
4. Verify transactions with brand logos (e.g. "Starbucks") still show the brand icon and brand colour regardless of category override
5. Run `./gradlew :app:testFdroidDebugUnitTest`

## Breaking changes

- [x] No breaking changes

All new parameters (`BrandIcon.category`) default to `null`, preserving existing behaviour for all existing callers (AnalyticsScreen, HomeScreen, SubscriptionsScreen, AccountCarousel).

## Checklist

- [x] Focused PR (single purpose)
- [x] Tests added/updated (7 new unit tests)
- [ ] Docs updated
- [x] `./gradlew test` passes locally
- [x] Follows existing code style and patterns
