### PR TITLE
fix: show credit-card outstanding (not limit) in account carousel (#382)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/AccountCarousel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/AccountCarousel.kt
@@ -41,8 +41,6 @@ import com.pennywiseai.tracker.ui.theme.Dimensions
 import com.pennywiseai.tracker.ui.theme.Spacing
 import com.pennywiseai.tracker.utils.CurrencyFormatter
 import com.pennywiseai.tracker.utils.formatBalance
-import com.pennywiseai.tracker.utils.formatCreditLimit
-import java.math.BigDecimal
 import dev.chrisbanes.haze.HazeDefaults
 import dev.chrisbanes.haze.HazeEffectScope
 import dev.chrisbanes.haze.HazeState

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/AccountCarousel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/AccountCarousel.kt
@@ -204,12 +204,11 @@ private fun AccountCarouselCard(
                 horizontalArrangement = Arrangement.spacedBy(Spacing.xs)
             ) {
                 Text(
+                    // The label above is "Outstanding" for credit cards; that is the
+                    // amount owed (account.balance), NOT the total creditLimit. Mirrors
+                    // CreditCardsCard / AccountDetailScreen, which already do this.
                     text = if (isAmountHidden) "••••••"
-                           else if (isUnifiedMode) {
-                               if (isCreditCard) CurrencyFormatter.formatCurrency(account.creditLimit ?: BigDecimal.ZERO, selectedCurrency)
-                               else CurrencyFormatter.formatCurrency(account.balance, selectedCurrency)
-                           }
-                           else if (isCreditCard) account.formatCreditLimit()
+                           else if (isUnifiedMode) CurrencyFormatter.formatCurrency(account.balance, selectedCurrency)
                            else account.formatBalance(),
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,


### PR DESCRIPTION
## Bug
The home-screen `AccountCarousel` labels the credit-card amount **"Outstanding"** (see line 197) but read `account.creditLimit` for the value — so users saw their total credit limit in place of the amount owed.

## Fix
Both render branches (unified-mode and per-account) now use `account.balance`, which is the outstanding amount for credit cards per the existing convention in `CreditCardsCard` and `AccountDetailScreen`. The two-branch `if (isCreditCard)` ternary collapses to a single expression because both cases now read the same field; the label-side `isCreditCard` switch on line 197 already produces the correct "Outstanding" vs "Balance" text.

## Verification
- `./gradlew :app:compileStandardDebugKotlin` — clean.

Fixes #382