### PR TITLE
feat: prefer transaction description over merchant name on rows (#383)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/groups/TransactionGroupDetailScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/groups/TransactionGroupDetailScreen.kt
@@ -456,15 +456,26 @@ private fun AddTransactionToGroupSheet(
                                 horizontalArrangement = Arrangement.SpaceBetween,
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
+                                // Match the description-first heading used on the group's
+                                // own rows so the picker label is consistent with what
+                                // the user will see once the txn is added. (#383)
+                                val txnDescription = txn.description?.takeIf { it.isNotBlank() }
                                 Column(modifier = Modifier.weight(1f)) {
                                     Text(
-                                        txn.merchantName,
+                                        txnDescription ?: txn.merchantName,
                                         style = MaterialTheme.typography.bodyMedium,
                                         fontWeight = FontWeight.Medium,
                                         color = MaterialTheme.colorScheme.onSurface
                                     )
+                                    val pickerSecondary = buildString {
+                                        if (txnDescription != null) {
+                                            append(txn.merchantName)
+                                            append(" · ")
+                                        }
+                                        append(txn.dateTime.format(DateTimeFormatter.ofPattern("d MMM")))
+                                    }
                                     Text(
-                                        txn.dateTime.format(DateTimeFormatter.ofPattern("d MMM")),
+                                        pickerSecondary,
                                         style = MaterialTheme.typography.labelSmall,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant
                                     )

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/groups/TransactionGroupDetailScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/groups/TransactionGroupDetailScreen.kt
@@ -328,15 +328,25 @@ private fun GroupTransactionItem(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
+            // Prefer the user-written description as the heading; fall back to the
+            // (often cryptic) merchant name. (#383)
+            val description = transaction.description?.takeIf { it.isNotBlank() }
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    transaction.merchantName,
+                    description ?: transaction.merchantName,
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium,
                     color = MaterialTheme.colorScheme.onSurface
                 )
+                val secondary = buildString {
+                    if (description != null) {
+                        append(transaction.merchantName)
+                        append(" · ")
+                    }
+                    append(transaction.dateTime.format(DateTimeFormatter.ofPattern("d MMM yyyy")))
+                }
                 Text(
-                    transaction.dateTime.format(DateTimeFormatter.ofPattern("d MMM yyyy")),
+                    secondary,
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/TransactionItem.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/TransactionItem.kt
@@ -66,8 +66,16 @@ fun TransactionItem(
         effectiveProfileId == ProfileEntity.BUSINESS_ID
     }
 
+    // Prefer a user-written description over the parsed merchant name as the
+    // row heading — UPI merchant strings are often cryptic VPAs and a description,
+    // when present, is what the user actually wrote about the transaction. (#383)
+    val description = transaction.description?.takeIf { it.isNotBlank() }
+
     val subtitle = remember(transaction, dateTimeText, isEffectivelyBusiness) {
         buildList {
+            // When the title shows the description, keep the merchant visible here so
+            // the user still sees who the transaction was with.
+            if (description != null) add(transaction.merchantName)
             add(dateTimeText)
             if (transaction.category.isNotBlank() &&
                 !transaction.category.equals("Uncategorized", ignoreCase = true)
@@ -107,7 +115,7 @@ fun TransactionItem(
     val merchantDisplay = LocalMerchantDisplay.current
 
     ListItemCardV2(
-        title = merchantDisplay(transaction.merchantName) ?: transaction.merchantName,
+        title = description ?: merchantDisplay(transaction.merchantName) ?: transaction.merchantName,
         subtitle = subtitle,
         amount = "$amountPrefix$formattedAmount",
         amountColor = amountColor,


### PR DESCRIPTION
## Why
SMS-parsed merchant strings are often cryptic UPI VPAs (`xyz@okhdfcbank`) that don't help the user remember what a transaction was for. When the user has added a description, that's the most useful label for the row.

## Change
When `transaction.description` is non-blank, use it as the row title; otherwise fall back to the existing merchant-name resolution. To preserve context, the merchant name is surfaced as the first segment of the row's subtitle so the user still sees who the transaction was with.

Applied in both rendering paths:
- **`TransactionItem`** — home recent items, transactions list, search results.
- **`GroupTransactionItem`** — rows in the transaction-group detail screen (previously didn't even show a description; now it leads, with merchant in the secondary line).

## Verification
- `./gradlew :app:compileStandardDebugKotlin` — clean.

## Note on the visual-category suggestion in the issue
`TransactionItem` already renders a category-aware `BrandIcon` on the leading edge (which falls back to a category icon when no brand match exists), so the category is already visually present on the most-used row. The issue's secondary ask was the description-as-heading; that's what this PR delivers. Happy to extend with an explicit category chip on `GroupTransactionItem` as a follow-up if you want it there too.

Closes #383