### PR TITLE
fix(backup): lock loans + groups round-trip and de-stale databaseVersion (#386)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import com.google.gson.GsonBuilder
 import com.pennywiseai.tracker.BuildConfig
 import com.pennywiseai.tracker.data.database.PennyWiseDatabase
+import com.pennywiseai.tracker.data.database.SCHEMA_VERSION
 import com.pennywiseai.tracker.data.database.entity.*
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -136,7 +137,7 @@ class BackupExporter @Inject constructor(
             metadata = BackupMetadata(
                 exportId = UUID.randomUUID().toString(),
                 appVersion = BuildConfig.VERSION_NAME,
-                databaseVersion = 20, // Current database version
+                databaseVersion = SCHEMA_VERSION,
                 device = "${Build.MANUFACTURER} ${Build.MODEL}",
                 androidVersion = Build.VERSION.SDK_INT,
                 statistics = BackupStatistics(

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
@@ -50,6 +50,15 @@ import com.pennywiseai.tracker.data.database.entity.TransactionSplitEntity
 import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
 
 /**
+ * Current Room schema version for [PennyWiseDatabase]. Lives at top-level so it
+ * is usable both in the `@Database(version = ...)` annotation below and in
+ * non-Room code (e.g. [com.pennywiseai.tracker.data.backup.BackupExporter])
+ * that needs to record the version it was exported against. Bump this in lock-
+ * step with any schema change.
+ */
+const val SCHEMA_VERSION = 47
+
+/**
  * The PennyWise Room database.
  * 
  * This database stores all financial transaction data locally on the device.
@@ -61,7 +70,7 @@ import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
  */
 @Database(
     entities = [TransactionEntity::class, SubscriptionEntity::class, ChatMessage::class, MerchantMappingEntity::class, CategoryEntity::class, AccountBalanceEntity::class, UnrecognizedSmsEntity::class, CardEntity::class, RuleEntity::class, RuleApplicationEntity::class, ExchangeRateEntity::class, BudgetEntity::class, BudgetCategoryEntity::class, BudgetMonthSnapshotEntity::class, BudgetCategoryMonthSnapshotEntity::class, TransactionSplitEntity::class, BankNotificationEntity::class, LoanEntity::class, TransactionGroupEntity::class, ProfileEntity::class],
-    version = 47,
+    version = SCHEMA_VERSION,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),

--- a/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupModelsTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupModelsTest.kt
@@ -1,6 +1,7 @@
 package com.pennywiseai.tracker.data.backup
 
 import com.google.gson.GsonBuilder
+import com.pennywiseai.tracker.data.database.SCHEMA_VERSION
 import com.pennywiseai.tracker.data.database.entity.*
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -294,7 +295,7 @@ class BackupModelsTest {
             metadata = BackupMetadata(
                 exportId = "loans-groups-test",
                 appVersion = "test",
-                databaseVersion = 47,
+                databaseVersion = SCHEMA_VERSION,
                 device = "Test",
                 androidVersion = 30,
                 statistics = BackupStatistics(
@@ -350,7 +351,11 @@ class BackupModelsTest {
         assertEquals(LoanStatus.SETTLED, deserializedSettled.status)
         assertEquals(LoanDirection.BORROWED, deserializedSettled.direction)
         assertEquals(BigDecimal.ZERO, deserializedSettled.remainingAmount)
-        assertNotNull(deserializedSettled.settledAt)
+        // Equality (not just non-null) — guards against silent timestamp drift
+        // through LocalDateTimeTypeAdapter.
+        assertEquals(settledLoan.settledAt, deserializedSettled.settledAt)
+        assertEquals(settledLoan.createdAt, deserializedSettled.createdAt)
+        assertEquals(settledLoan.updatedAt, deserializedSettled.updatedAt)
 
         // Transaction group round-trips with every field intact.
         assertEquals(1, deserialized.database.transactionGroups.size)

--- a/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupModelsTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupModelsTest.kt
@@ -4,6 +4,7 @@ import com.google.gson.GsonBuilder
 import com.pennywiseai.tracker.data.database.entity.*
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -230,6 +231,139 @@ class BackupModelsTest {
         val budget = deserialized.database.budgets[0]
         assertEquals("Monthly Food", budget.name)
         assertEquals(BudgetPeriodType.MONTHLY, budget.periodType)
+    }
+
+    /**
+     * Regression for issue #386 — backup must round-trip transaction groups and
+     * loans (both ACTIVE and SETTLED), and a transaction's loan_id/group_id
+     * pointers must still match the deserialised entities so the importer can
+     * re-link them. The model used to omit these tables entirely.
+     */
+    @Test
+    fun backupSerializationIncludesLoansAndTransactionGroups() {
+        val now = LocalDateTime.of(2026, 5, 31, 12, 0)
+
+        val activeLoan = LoanEntity(
+            id = 11L,
+            personName = "Alex",
+            direction = LoanDirection.LENT,
+            originalAmount = BigDecimal("500.00"),
+            remainingAmount = BigDecimal("300.00"),
+            currency = "INR",
+            status = LoanStatus.ACTIVE,
+            note = "Trip split",
+            createdAt = now,
+            updatedAt = now
+        )
+        val settledLoan = LoanEntity(
+            id = 12L,
+            personName = "Riya",
+            direction = LoanDirection.BORROWED,
+            originalAmount = BigDecimal("1000.00"),
+            remainingAmount = BigDecimal.ZERO,
+            currency = "INR",
+            status = LoanStatus.SETTLED,
+            note = null,
+            createdAt = now.minusDays(30),
+            updatedAt = now.minusDays(1),
+            settledAt = now.minusDays(1)
+        )
+        val group = TransactionGroupEntity(
+            id = 21L,
+            name = "Goa Trip",
+            note = "March holiday",
+            createdAt = now,
+            updatedAt = now
+        )
+        val transactionLinkedToLoanAndGroup = TransactionEntity(
+            id = 100L,
+            amount = BigDecimal("200.00"),
+            merchantName = "Cafe",
+            category = "Food",
+            transactionType = TransactionType.EXPENSE,
+            dateTime = now,
+            transactionHash = "hash-loans-groups",
+            createdAt = now,
+            updatedAt = now,
+            currency = "INR",
+            loanId = activeLoan.id,
+            groupId = group.id
+        )
+
+        val backup = PennyWiseBackup(
+            metadata = BackupMetadata(
+                exportId = "loans-groups-test",
+                appVersion = "test",
+                databaseVersion = 47,
+                device = "Test",
+                androidVersion = 30,
+                statistics = BackupStatistics(
+                    totalTransactions = 1,
+                    totalCategories = 0,
+                    totalCards = 0,
+                    totalSubscriptions = 0,
+                    totalLoans = 2,
+                    totalTransactionGroups = 1,
+                    dateRange = null
+                )
+            ),
+            database = DatabaseSnapshot(
+                transactions = listOf(transactionLinkedToLoanAndGroup),
+                categories = emptyList(),
+                cards = emptyList(),
+                accountBalances = emptyList(),
+                subscriptions = emptyList(),
+                merchantMappings = emptyList(),
+                unrecognizedSms = emptyList(),
+                chatMessages = emptyList(),
+                loans = listOf(activeLoan, settledLoan),
+                transactionGroups = listOf(group)
+            ),
+            preferences = PreferencesSnapshot(
+                theme = ThemePreferences(isDarkThemeEnabled = null, isDynamicColorEnabled = false),
+                sms = SmsPreferences(hasSkippedSmsPermission = false, smsScanMonths = 6, lastScanTimestamp = null, lastScanPeriod = null),
+                developer = DeveloperPreferences(isDeveloperModeEnabled = false, systemPrompt = null),
+                app = AppPreferences(hasShownScanTutorial = false, firstLaunchTime = null, hasShownReviewPrompt = false, lastReviewPromptTime = null)
+            )
+        )
+
+        val json = gson.toJson(backup)
+        val deserialized = gson.fromJson(json, PennyWiseBackup::class.java)
+
+        // Statistics survive.
+        assertEquals(2, deserialized.metadata.statistics.totalLoans)
+        assertEquals(1, deserialized.metadata.statistics.totalTransactionGroups)
+
+        // Both loans round-trip with every field intact, including the SETTLED
+        // status and the optional settledAt timestamp.
+        assertEquals(2, deserialized.database.loans.size)
+        val deserializedActive = deserialized.database.loans.first { it.id == 11L }
+        assertEquals("Alex", deserializedActive.personName)
+        assertEquals(LoanDirection.LENT, deserializedActive.direction)
+        assertEquals(LoanStatus.ACTIVE, deserializedActive.status)
+        assertEquals(BigDecimal("500.00"), deserializedActive.originalAmount)
+        assertEquals(BigDecimal("300.00"), deserializedActive.remainingAmount)
+        assertEquals("Trip split", deserializedActive.note)
+        assertNull(deserializedActive.settledAt)
+
+        val deserializedSettled = deserialized.database.loans.first { it.id == 12L }
+        assertEquals(LoanStatus.SETTLED, deserializedSettled.status)
+        assertEquals(LoanDirection.BORROWED, deserializedSettled.direction)
+        assertEquals(BigDecimal.ZERO, deserializedSettled.remainingAmount)
+        assertNotNull(deserializedSettled.settledAt)
+
+        // Transaction group round-trips with every field intact.
+        assertEquals(1, deserialized.database.transactionGroups.size)
+        val deserializedGroup = deserialized.database.transactionGroups[0]
+        assertEquals(21L, deserializedGroup.id)
+        assertEquals("Goa Trip", deserializedGroup.name)
+        assertEquals("March holiday", deserializedGroup.note)
+
+        // The transaction's loan_id / group_id still match the deserialised
+        // entities, so the importer can resolve the foreign-key references.
+        val deserializedTxn = deserialized.database.transactions[0]
+        assertEquals(activeLoan.id, deserializedTxn.loanId)
+        assertEquals(group.id, deserializedTxn.groupId)
     }
 
     @Test


### PR DESCRIPTION
Issue #386 reports that an exported backup, re-imported after uninstall, doesn't restore transaction groups and active loans, and produces an error.

## Audit
I traced the entire backup flow before touching anything:

- **Model** (`BackupModels.DatabaseSnapshot`) already has `loans: List<LoanEntity>` and `transactionGroups: List<TransactionGroupEntity>` fields, with counters in `BackupStatistics`.
- **Exporter** already reads `loanDao().getAllLoans().first()` and `transactionGroupDao().getAllGroups().first()` and includes them in `FULL`-privacy backups.
- **Importer** (both `replaceAllData` and `mergeData`) inserts loans + groups **before** transactions so the FK refs on `loan_id` / `group_id` resolve. `replaceAllData` preserves backup ids; `mergeData` dedups by composite key and remaps ids on transactions.
- **Tests** had **no coverage** for loans or groups — they would silently regress with no signal.

So the plumbing exists. This PR adds the regression coverage that locks it in, and fixes a smaller adjacent bug.

## Changes
1. **Round-trip test** for loans + groups (`BackupModelsTest.backupSerializationIncludesLoansAndTransactionGroups`):
   - Two loans, one `ACTIVE` and one `SETTLED` (with `settledAt`), exercising both `LoanDirection` and `LoanStatus` enum values plus the optional `note`/`settledAt` fields.
   - One `TransactionGroupEntity`.
   - One `TransactionEntity` carrying `loanId` + `groupId` pointing at them, asserting the FK refs still match after deserialisation.
2. **Top-level `SCHEMA_VERSION` constant** in `PennyWiseDatabase.kt`, used in both the `@Database(version = …)` annotation and `BackupExporter`. Previously the exporter hardcoded `databaseVersion = 20` while the real schema is 47, so every export was written with a misleading metadata value.

## Verification
- `./gradlew :app:testStandardDebugUnitTest --tests "*BackupModelsTest*"` — green (all 3 tests pass).
- `./gradlew :app:compileStandardDebugKotlin` — clean.

## What's outstanding
This PR doesn't *yet* explain the "See error" the reporter hit at step 5, because the loans/groups path looks correct. I've kept the issue open and will post a comment asking for the exact error message and a sample backup so we can pin down the actual failing branch. The test added here will catch any model-level regression that strips loans/groups from the payload going forward.

Refs #386