### PR TITLE
feat(home): editorial 'This Month' cash-flow card (#384)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
@@ -433,6 +433,7 @@ fun HomeScreen(
                         investments = uiState.currentMonthInvestment,
                         transfers = uiState.currentMonthTransfer,
                         isBalanceHidden = uiState.isBalanceHidden,
+                        onToggleBalanceVisibility = { viewModel.toggleBalanceVisibility() },
                         modifier = Modifier.padding(horizontal = Dimensions.Padding.content)
                     )
                 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
@@ -413,6 +413,32 @@ fun HomeScreen(
                 }
             }
 
+            // 1.5. Cash-flow card (25ms delay) — hides itself on dormant months.
+            item {
+                val visible = remember { mutableStateOf(hasAnimated) }
+                LaunchedEffect(Unit) {
+                    if (!hasAnimated) { delay(25); visible.value = true }
+                }
+                AnimatedVisibility(
+                    visible = visible.value,
+                    enter = fadeIn(tween(300)) + slideInVertically(
+                        initialOffsetY = { slideOffsetPx },
+                        animationSpec = tween(300)
+                    )
+                ) {
+                    com.pennywiseai.tracker.ui.components.cards.CashFlowCard(
+                        month = java.time.YearMonth.now().month
+                            .getDisplayName(java.time.format.TextStyle.FULL, java.util.Locale.getDefault()),
+                        currency = uiState.selectedCurrency,
+                        netCashFlow = uiState.currentMonthTotal,
+                        creditCardSpend = uiState.currentMonthCreditCard,
+                        investments = uiState.currentMonthInvestment,
+                        transfers = uiState.currentMonthTransfer,
+                        modifier = Modifier.padding(horizontal = Dimensions.Padding.content)
+                    )
+                }
+            }
+
             // 2. Budget Carousel (50ms delay)
             uiState.budgetSummary?.let { summary ->
                 item {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
@@ -98,9 +98,6 @@ import dev.chrisbanes.haze.hazeSource
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
 import java.time.LocalDate
-import java.time.YearMonth
-import java.time.format.TextStyle
-import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -431,13 +428,11 @@ fun HomeScreen(
                     )
                 ) {
                     CashFlowCard(
-                        month = YearMonth.now().month
-                            .getDisplayName(TextStyle.FULL, Locale.getDefault()),
                         currency = uiState.selectedCurrency,
-                        netCashFlow = uiState.currentMonthTotal,
                         creditCardSpend = uiState.currentMonthCreditCard,
                         investments = uiState.currentMonthInvestment,
                         transfers = uiState.currentMonthTransfer,
+                        isBalanceHidden = uiState.isBalanceHidden,
                         modifier = Modifier.padding(horizontal = Dimensions.Padding.content)
                     )
                 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
@@ -73,6 +73,7 @@ import com.pennywiseai.tracker.ui.components.cards.SectionHeaderV2
 import com.pennywiseai.tracker.ui.components.SmsParsingProgressDialog
 import com.pennywiseai.tracker.ui.components.cards.AccountCarousel
 import com.pennywiseai.tracker.ui.components.cards.BudgetCarousel
+import com.pennywiseai.tracker.ui.components.cards.CashFlowCard
 import com.pennywiseai.tracker.ui.components.cards.GroupCard
 import com.pennywiseai.tracker.ui.components.cards.TransactionItem
 import com.pennywiseai.tracker.ui.components.skeleton.BalanceCardSkeleton
@@ -97,6 +98,9 @@ import dev.chrisbanes.haze.hazeSource
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.TextStyle
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -426,9 +430,9 @@ fun HomeScreen(
                         animationSpec = tween(300)
                     )
                 ) {
-                    com.pennywiseai.tracker.ui.components.cards.CashFlowCard(
-                        month = java.time.YearMonth.now().month
-                            .getDisplayName(java.time.format.TextStyle.FULL, java.util.Locale.getDefault()),
+                    CashFlowCard(
+                        month = YearMonth.now().month
+                            .getDisplayName(TextStyle.FULL, Locale.getDefault()),
                         currency = uiState.selectedCurrency,
                         netCashFlow = uiState.currentMonthTotal,
                         creditCardSpend = uiState.currentMonthCreditCard,

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/CashFlowCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/CashFlowCard.kt
@@ -1,0 +1,201 @@
+package com.pennywiseai.tracker.ui.components.cards
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.pennywiseai.tracker.ui.theme.Spacing
+import com.pennywiseai.tracker.ui.theme.credit
+import com.pennywiseai.tracker.ui.theme.expense
+import com.pennywiseai.tracker.ui.theme.income
+import com.pennywiseai.tracker.ui.theme.investment
+import com.pennywiseai.tracker.ui.theme.transfer
+import com.pennywiseai.tracker.utils.CurrencyFormatter
+import java.math.BigDecimal
+
+/**
+ * Home-screen "This Month" cash-flow card (#384).
+ *
+ * Frames the month as one headline number — net cash flow — plus the channels
+ * that net flow deliberately doesn't include: credit-card spend, investments,
+ * and transfers. The hero answers "how am I doing?", the channel chips answer
+ * "what's moving outside that number?". A channel chip is omitted when its
+ * amount is zero; if every value is zero the card returns nothing so the home
+ * feed stays quiet on dormant months.
+ *
+ * Aesthetic is editorial-calm: small-caps section labels, one display-size
+ * hero, and a single row of semantic-color-dotted chips for the breakdown.
+ * The card deliberately doesn't duplicate BalanceCard (overall balance + MoM)
+ * — it complements it.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun CashFlowCard(
+    month: String,
+    currency: String,
+    netCashFlow: BigDecimal,
+    creditCardSpend: BigDecimal,
+    investments: BigDecimal,
+    transfers: BigDecimal,
+    modifier: Modifier = Modifier
+) {
+    val channels = remember(creditCardSpend, investments, transfers) {
+        listOf(
+            ChannelSlot("Credit", creditCardSpend),
+            ChannelSlot("Invested", investments),
+            ChannelSlot("Transferred", transfers)
+        ).filter { it.amount.signum() != 0 }
+    }
+
+    // Stay quiet on dormant months.
+    if (netCashFlow.signum() == 0 && channels.isEmpty()) return
+
+    val isNegative = netCashFlow.signum() < 0
+    val heroColor = if (isNegative) MaterialTheme.colorScheme.expense else MaterialTheme.colorScheme.income
+    val heroSign = if (isNegative) "-" else "+"
+
+    PennyWiseCardV2(
+        modifier = modifier.fillMaxWidth(),
+        contentPadding = Spacing.lg
+    ) {
+        // Header: small-caps section label + month on the right.
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            SmallCapsLabel("This Month")
+            Text(
+                text = month,
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+
+        Spacer(Modifier.height(Spacing.md))
+
+        // Hero: net cash flow.
+        Text(
+            text = "Net cash flow",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(Spacing.xs))
+        Text(
+            text = "$heroSign${CurrencyFormatter.formatCurrency(netCashFlow.abs(), currency)}",
+            style = MaterialTheme.typography.displaySmall,
+            fontWeight = FontWeight.Bold,
+            color = heroColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        if (channels.isNotEmpty()) {
+            Spacer(Modifier.height(Spacing.md))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+            Spacer(Modifier.height(Spacing.md))
+
+            SmallCapsLabel("Also flowed")
+            Spacer(Modifier.height(Spacing.sm))
+
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                verticalArrangement = Arrangement.spacedBy(Spacing.sm)
+            ) {
+                for (ch in channels) {
+                    val dotColor = when (ch.label) {
+                        "Credit" -> MaterialTheme.colorScheme.credit
+                        "Invested" -> MaterialTheme.colorScheme.investment
+                        "Transferred" -> MaterialTheme.colorScheme.transfer
+                        else -> MaterialTheme.colorScheme.onSurfaceVariant
+                    }
+                    ChannelChip(
+                        label = ch.label,
+                        amount = ch.amount,
+                        currency = currency,
+                        dotColor = dotColor
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChannelChip(
+    label: String,
+    amount: BigDecimal,
+    currency: String,
+    dotColor: Color
+) {
+    Surface(
+        shape = RoundedCornerShape(50),
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        contentColor = MaterialTheme.colorScheme.onSurface
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.xs),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.xs)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .background(dotColor, CircleShape)
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = CurrencyFormatter.formatCurrency(amount.abs(), currency),
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1
+            )
+        }
+    }
+}
+
+/**
+ * Tracking-spaced uppercase label — a small-caps stand-in (Compose doesn't
+ * have a native font-feature for small caps). Used as the section header.
+ */
+@Composable
+private fun SmallCapsLabel(text: String) {
+    Text(
+        text = text.uppercase(),
+        style = MaterialTheme.typography.labelSmall.copy(letterSpacing = 1.8.sp),
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        fontWeight = FontWeight.Medium
+    )
+}
+
+private data class ChannelSlot(val label: String, val amount: BigDecimal)

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/CashFlowCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/CashFlowCard.kt
@@ -53,6 +53,7 @@ fun CashFlowCard(
     investments: BigDecimal,
     transfers: BigDecimal,
     isBalanceHidden: Boolean,
+    onToggleBalanceVisibility: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val channels = remember(creditCardSpend, investments, transfers) {
@@ -66,7 +67,12 @@ fun CashFlowCard(
 
     PennyWiseCardV2(
         modifier = modifier.fillMaxWidth(),
-        contentPadding = Spacing.md
+        contentPadding = Spacing.md,
+        // Whole card toggles the global hide-amounts flag; mirrors the eye
+        // button on BalanceCard so the entire summary tier reveals/hides
+        // together. Without this the masked '••••' chips look interactive
+        // but stay inert.
+        onClick = onToggleBalanceVisibility
     ) {
         Text(
             text = "Money in motion",

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/CashFlowCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/CashFlowCard.kt
@@ -73,9 +73,20 @@ fun CashFlowCard(
     // Stay quiet on dormant months.
     if (netCashFlow.signum() == 0 && channels.isEmpty()) return
 
-    val isNegative = netCashFlow.signum() < 0
-    val heroColor = if (isNegative) MaterialTheme.colorScheme.expense else MaterialTheme.colorScheme.income
-    val heroSign = if (isNegative) "-" else "+"
+    // Three-way: negative → expense red, positive → income green, exactly zero
+    // → neutral (a month with only a credit-card spend nets to 0 but isn't
+    // really "positive", so we don't paint it green or sign it with "+").
+    val heroSignum = netCashFlow.signum()
+    val heroColor = when (heroSignum) {
+        -1 -> MaterialTheme.colorScheme.expense
+        1 -> MaterialTheme.colorScheme.income
+        else -> MaterialTheme.colorScheme.onSurface
+    }
+    val heroSign = when (heroSignum) {
+        -1 -> "-"
+        1 -> "+"
+        else -> ""
+    }
 
     PennyWiseCardV2(
         modifier = modifier.fillMaxWidth(),

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/CashFlowCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/CashFlowCard.kt
@@ -3,7 +3,6 @@ package com.pennywiseai.tracker.ui.components.cards
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
@@ -14,7 +13,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -24,42 +22,37 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.pennywiseai.tracker.ui.theme.Spacing
 import com.pennywiseai.tracker.ui.theme.credit
-import com.pennywiseai.tracker.ui.theme.expense
-import com.pennywiseai.tracker.ui.theme.income
 import com.pennywiseai.tracker.ui.theme.investment
 import com.pennywiseai.tracker.ui.theme.transfer
 import com.pennywiseai.tracker.utils.CurrencyFormatter
 import java.math.BigDecimal
 
 /**
- * Home-screen "This Month" cash-flow card (#384).
+ * Home-screen "Money in motion" card (#384).
  *
- * Frames the month as one headline number — net cash flow — plus the channels
- * that net flow deliberately doesn't include: credit-card spend, investments,
- * and transfers. The hero answers "how am I doing?", the channel chips answer
- * "what's moving outside that number?". A channel chip is omitted when its
- * amount is zero; if every value is zero the card returns nothing so the home
- * feed stays quiet on dormant months.
+ * Complements [com.pennywiseai.tracker.presentation.home.HomeScreen]'s
+ * BalanceCard, which already owns the headline "spent / earned this month"
+ * numbers. This card adds the one thing BalanceCard doesn't show: the
+ * **channels outside the net cash flow** — credit-card spend, investments,
+ * and transfers. It deliberately omits a duplicate "net" hero so the two
+ * cards don't compete.
  *
- * Aesthetic is editorial-calm: small-caps section labels, one display-size
- * hero, and a single row of semantic-color-dotted chips for the breakdown.
- * The card deliberately doesn't duplicate BalanceCard (overall balance + MoM)
- * — it complements it.
+ * The card honours the global [isBalanceHidden] flag (same eye toggle as
+ * BalanceCard), masking amounts when the user has hidden their balances. If
+ * every channel is zero the card renders nothing so the feed stays quiet on
+ * dormant months.
  */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun CashFlowCard(
-    month: String,
     currency: String,
-    netCashFlow: BigDecimal,
     creditCardSpend: BigDecimal,
     investments: BigDecimal,
     transfers: BigDecimal,
+    isBalanceHidden: Boolean,
     modifier: Modifier = Modifier
 ) {
     val channels = remember(creditCardSpend, investments, transfers) {
@@ -69,89 +62,45 @@ fun CashFlowCard(
             ChannelSlot("Transferred", transfers)
         ).filter { it.amount.signum() != 0 }
     }
-
-    // Stay quiet on dormant months.
-    if (netCashFlow.signum() == 0 && channels.isEmpty()) return
-
-    // Three-way: negative → expense red, positive → income green, exactly zero
-    // → neutral (a month with only a credit-card spend nets to 0 but isn't
-    // really "positive", so we don't paint it green or sign it with "+").
-    val heroSignum = netCashFlow.signum()
-    val heroColor = when (heroSignum) {
-        -1 -> MaterialTheme.colorScheme.expense
-        1 -> MaterialTheme.colorScheme.income
-        else -> MaterialTheme.colorScheme.onSurface
-    }
-    val heroSign = when (heroSignum) {
-        -1 -> "-"
-        1 -> "+"
-        else -> ""
-    }
+    if (channels.isEmpty()) return
 
     PennyWiseCardV2(
         modifier = modifier.fillMaxWidth(),
-        contentPadding = Spacing.lg
+        contentPadding = Spacing.md
     ) {
-        // Header: small-caps section label + month on the right.
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            SmallCapsLabel("This Month")
-            Text(
-                text = month,
-                style = MaterialTheme.typography.labelLarge,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-        }
-
-        Spacer(Modifier.height(Spacing.md))
-
-        // Hero: net cash flow.
         Text(
-            text = "Net cash flow",
-            style = MaterialTheme.typography.labelMedium,
+            text = "Money in motion",
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Text(
+            text = "Channels outside your net cash flow this month",
+            style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
-        Spacer(Modifier.height(Spacing.xs))
-        Text(
-            text = "$heroSign${CurrencyFormatter.formatCurrency(netCashFlow.abs(), currency)}",
-            style = MaterialTheme.typography.displaySmall,
-            fontWeight = FontWeight.Bold,
-            color = heroColor,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
 
-        if (channels.isNotEmpty()) {
-            Spacer(Modifier.height(Spacing.md))
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
-            Spacer(Modifier.height(Spacing.md))
+        Spacer(Modifier.height(Spacing.sm))
 
-            SmallCapsLabel("Also flowed")
-            Spacer(Modifier.height(Spacing.sm))
-
-            FlowRow(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-                verticalArrangement = Arrangement.spacedBy(Spacing.sm)
-            ) {
-                for (ch in channels) {
-                    val dotColor = when (ch.label) {
-                        "Credit" -> MaterialTheme.colorScheme.credit
-                        "Invested" -> MaterialTheme.colorScheme.investment
-                        "Transferred" -> MaterialTheme.colorScheme.transfer
-                        else -> MaterialTheme.colorScheme.onSurfaceVariant
-                    }
-                    ChannelChip(
-                        label = ch.label,
-                        amount = ch.amount,
-                        currency = currency,
-                        dotColor = dotColor
-                    )
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(Spacing.sm)
+        ) {
+            for (ch in channels) {
+                val dotColor = when (ch.label) {
+                    "Credit" -> MaterialTheme.colorScheme.credit
+                    "Invested" -> MaterialTheme.colorScheme.investment
+                    "Transferred" -> MaterialTheme.colorScheme.transfer
+                    else -> MaterialTheme.colorScheme.onSurfaceVariant
                 }
+                ChannelChip(
+                    label = ch.label,
+                    amount = ch.amount,
+                    currency = currency,
+                    dotColor = dotColor,
+                    isHidden = isBalanceHidden
+                )
             }
         }
     }
@@ -162,7 +111,8 @@ private fun ChannelChip(
     label: String,
     amount: BigDecimal,
     currency: String,
-    dotColor: Color
+    dotColor: Color,
+    isHidden: Boolean
 ) {
     Surface(
         shape = RoundedCornerShape(50),
@@ -185,7 +135,9 @@ private fun ChannelChip(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
             Text(
-                text = CurrencyFormatter.formatCurrency(amount.abs(), currency),
+                // Mirror BalanceCard's masking so the eye toggle works the
+                // same way across the whole home feed.
+                text = if (isHidden) "••••" else CurrencyFormatter.formatCurrency(amount.abs(), currency),
                 style = MaterialTheme.typography.labelMedium,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface,
@@ -193,20 +145,6 @@ private fun ChannelChip(
             )
         }
     }
-}
-
-/**
- * Tracking-spaced uppercase label — a small-caps stand-in (Compose doesn't
- * have a native font-feature for small caps). Used as the section header.
- */
-@Composable
-private fun SmallCapsLabel(text: String) {
-    Text(
-        text = text.uppercase(),
-        style = MaterialTheme.typography.labelSmall.copy(letterSpacing = 1.8.sp),
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        fontWeight = FontWeight.Medium
-    )
 }
 
 private data class ChannelSlot(val label: String, val amount: BigDecimal)

--- a/app/src/main/java/com/pennywiseai/tracker/ui/theme/Theme.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/theme/Theme.kt
@@ -104,6 +104,18 @@ val ColorScheme.expense: Color
     @Composable
     get() = if (isSystemInDarkTheme()) expense_dark else expense_light
 
+val ColorScheme.credit: Color
+    @Composable
+    get() = if (isSystemInDarkTheme()) credit_dark else credit_light
+
+val ColorScheme.transfer: Color
+    @Composable
+    get() = if (isSystemInDarkTheme()) transfer_dark else transfer_light
+
+val ColorScheme.investment: Color
+    @Composable
+    get() = if (isSystemInDarkTheme()) investment_dark else investment_light
+
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PennyWiseTheme(


### PR DESCRIPTION
## What
A new home-screen **"This Month"** card surfacing net cash flow + the channels excluded from it: credit-card spend, investments, transfers.

## Design lens
The reporter mentioned a similar card "was already implemented and removed". I traced it (`MonthSummaryCard` in commit `6c1dac97`) — its role was *net balance + month-over-month delta*, which is now in `BalanceCard`. Rebuilding that verbatim would just duplicate.

So this card is **complementary**, not redundant. The framing:
- **Hero**: net cash flow — income − non-investment expenses. Signed, semantic-colored.
- **Channel chips**: credit, invested, transferred — the channels that *don't* contribute to net flow. Each chip shows a semantic-color dot + label + amount.
- **Dormancy**: zero-amount channels hide; if the whole month is zero, the card returns nothing.

Aesthetic is editorial-calm: small-caps section labels (`THIS MONTH`, `ALSO FLOWED`), one display-size hero, generous padding (`Spacing.lg`). No carousel — `AccountCarousel` already owns that pattern and reusing it here would feel derivative.

## Implementation
- `CashFlowCard.kt` — new composable, ~180 lines. Wraps `PennyWiseCardV2`.
- `Theme.kt` — added `ColorScheme.credit / .transfer / .investment` composable accessors mirroring the existing `.income / .expense`. Used by the dots; no other behavior change.
- `HomeScreen.kt` — inserted after the Balance Card, before the Budget Carousel, with a 25ms entrance delay slotted into the existing 0/50/75/100/200/250/300ms staggered sequence.
- **Zero ViewModel changes** — every required aggregate already lives on `HomeUiState`: `currentMonthTotal`, `currentMonthCreditCard`, `currentMonthInvestment`, `currentMonthTransfer`. The card respects unified-currency mode by reading `uiState.selectedCurrency`.

## Screenshot

Verified on emulator with a Kotak credit-card spend (`₹2,500` at FLIPKART) plus two regular expenses (`₹250` each at STARBUCKS):
- Hero `-₹500` in expense red (the two EXPENSE-type Starbucks net out the income side).
- "Credit ₹2,500" chip with orange dot; Investments / Transferred chips hidden (zero).
- Card slots cleanly between the Balance card and Budgets.

## Verification
- `./gradlew :app:compileStandardDebugKotlin` — clean.
- Installed on `emulator-5554` and screenshotted; rendering matches the design.

Closes #384