### PR TITLE
feat(notif): 'More categories…' picker action on transaction alerts (#303)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,7 +51,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        
+
+        <!-- Translucent picker launched from the "More categories…" txn-alert
+             notification action (#303). singleTask + excludeFromRecents so a
+             second tap doesn't stack instances and it never shows in Recents. -->
+        <activity
+            android:name=".receiver.QuickCategoryPickerActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:launchMode="singleTask"
+            android:noHistory="true"
+            android:theme="@style/Theme.PennyWise.Transparent" />
+
         <!-- Disable default WorkManager initialization -->
         <provider
             android:name="androidx.startup.InitializationProvider"

--- a/app/src/main/java/com/pennywiseai/tracker/di/ApplicationModule.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/di/ApplicationModule.kt
@@ -9,7 +9,21 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+/**
+ * Qualifier for an application-lifetime [CoroutineScope] — use this for
+ * fire-and-forget work that must outlive the calling Activity/ViewModel
+ * (e.g. a DB write started from a transient activity that finishes
+ * immediately after).
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ApplicationScope
 
 /**
  * Hilt module that provides application-level dependencies.
@@ -37,6 +51,17 @@ object ApplicationModule {
      * @param userPreferencesRepository User preferences for base currency
      * @return CurrencyConversionService for currency conversion operations
      */
+    /**
+     * Application-lifetime [CoroutineScope] for fire-and-forget work that
+     * must outlive its launching component. SupervisorJob so a single failed
+     * child doesn't take the scope down.
+     */
+    @Provides
+    @Singleton
+    @ApplicationScope
+    fun provideApplicationScope(): CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     @Provides
     @Singleton
     fun provideCurrencyConversionService(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
@@ -607,69 +607,6 @@ private fun SwipeToEditCategory(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun QuickCategoryPickerSheet(
-    transaction: TransactionEntity,
-    categories: List<CategoryEntity>,
-    onCategorySelected: (String) -> Unit,
-    onDismiss: () -> Unit
-) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState
-    ) {
-        Text(
-            text = "Change category",
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(
-                start = Dimensions.Padding.content,
-                end = Dimensions.Padding.content,
-                bottom = Spacing.sm
-            )
-        )
-        // LazyColumn so long category lists stay reachable when the sheet is
-        // fully expanded — a plain Column would render items past the screen
-        // bottom unscrollable.
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = Spacing.md)
-        ) {
-            items(categories, key = { it.id }) { category ->
-                val selected = transaction.category == category.name
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable { onCategorySelected(category.name) }
-                        .padding(
-                            horizontal = Dimensions.Padding.content,
-                            vertical = Spacing.sm
-                        ),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(Spacing.md)
-                ) {
-                    CategoryChip(category = category, showText = false)
-                    Text(
-                        text = category.name,
-                        modifier = Modifier.weight(1f),
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal
-                    )
-                    if (selected) {
-                        Icon(
-                            imageVector = Icons.Default.Check,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
 @Composable
 private fun TransactionDateHeader(
     title: String,

--- a/app/src/main/java/com/pennywiseai/tracker/receiver/QuickCategoryPickerActivity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/receiver/QuickCategoryPickerActivity.kt
@@ -1,20 +1,26 @@
 package com.pennywiseai.tracker.receiver
 
+import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.produceState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.core.app.NotificationManagerCompat
+import com.pennywiseai.tracker.data.database.entity.CategoryEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.repository.CategoryRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
+import com.pennywiseai.tracker.di.ApplicationScope
 import com.pennywiseai.tracker.ui.components.QuickCategoryPickerSheet
 import com.pennywiseai.tracker.ui.theme.PennyWiseTheme
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
@@ -25,6 +31,11 @@ import kotlinx.coroutines.launch
  * the 3 quick-picks rendered as inline notification buttons — without
  * navigating into the full transaction-detail screen.
  *
+ * Declared `singleTask` in the manifest so re-launches don't stack; that
+ * means a second notification tap routes through [onNewIntent] rather than
+ * a fresh [onCreate], which is why the picker args live in a mutableState
+ * the Compose tree observes.
+ *
  * On pick: update the transaction's category, dismiss the originating
  * notification, finish. On dismiss without picking: finish.
  */
@@ -34,63 +45,109 @@ class QuickCategoryPickerActivity : ComponentActivity() {
     @Inject lateinit var transactionRepository: TransactionRepository
     @Inject lateinit var categoryRepository: CategoryRepository
 
-    // App-scoped scope for the category update — we don't want the write to
-    // be cancelled if the activity finishes (it does, immediately after).
-    private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    // App-lifetime scope so the DB write survives finish() — the activity
+    // closes immediately after the user picks.
+    @Inject @ApplicationScope lateinit var appScope: CoroutineScope
+
+    // Holds the args from the latest intent (initial or via onNewIntent), so
+    // a second notification tap re-targets the picker at the new transaction.
+    private val currentArgs = mutableStateOf<PickerArgs?>(null)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val transactionId = intent.getLongExtra(EXTRA_TRANSACTION_ID, -1L)
-        val notificationId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
-        if (transactionId == -1L) {
+        val initial = PickerArgs.from(intent)
+        if (initial == null) {
             finish()
             return
         }
+        currentArgs.value = initial
 
         setContent {
             PennyWiseTheme {
-                // Load the transaction + categories asynchronously. Sheet
-                // doesn't render until both are available, which keeps the
-                // activity instant — the user just sees the system scrim
-                // first, then the sheet slides up.
-                val transaction by produceState<com.pennywiseai.tracker.data.database.entity.TransactionEntity?>(
-                    initialValue = null,
-                    key1 = transactionId
-                ) {
-                    value = transactionRepository.getTransactionById(transactionId)
-                }
-                val categories by produceState(
-                    initialValue = emptyList<com.pennywiseai.tracker.data.database.entity.CategoryEntity>()
-                ) {
-                    value = categoryRepository.getAllCategories().first()
-                }
+                val args by currentArgs
+                args?.let { PickerHost(it) }
+            }
+        }
+    }
 
-                val txn = transaction
-                if (txn != null && categories.isNotEmpty()) {
-                    QuickCategoryPickerSheet(
-                        currentCategory = txn.category,
-                        categories = categories,
-                        onCategorySelected = { newCategory ->
-                            if (newCategory != txn.category) {
-                                ioScope.launch {
-                                    transactionRepository.updateCategory(txn.id, newCategory)
-                                }
-                            }
-                            if (notificationId != -1) {
-                                NotificationManagerCompat.from(applicationContext)
-                                    .cancel(notificationId)
-                            }
-                            finish()
-                        },
-                        onDismiss = { finish() }
-                    )
-                }
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        // singleTask routes second-tap intents here. Update the args so the
+        // Compose tree re-keys produceState onto the new transactionId; the
+        // bottom-sheet keeps its surface and just refreshes its content.
+        setIntent(intent)
+        PickerArgs.from(intent)?.let { currentArgs.value = it }
+    }
+
+    @androidx.compose.runtime.Composable
+    private fun PickerHost(args: PickerArgs) {
+        // Explicit "loaded" flags so we can tell "still resolving" apart from
+        // "resolved as null/empty" — important because the activity otherwise
+        // leaves a blank transparent window on screen when data is missing.
+        var transaction by remember(args.transactionId) { mutableStateOf<TransactionEntity?>(null) }
+        var transactionLoaded by remember(args.transactionId) { mutableStateOf(false) }
+        var categories by remember { mutableStateOf<List<CategoryEntity>>(emptyList()) }
+        var categoriesLoaded by remember { mutableStateOf(false) }
+
+        LaunchedEffect(args.transactionId) {
+            transaction = transactionRepository.getTransactionById(args.transactionId)
+            transactionLoaded = true
+        }
+        LaunchedEffect(Unit) {
+            categories = categoryRepository.getAllCategories().first()
+            categoriesLoaded = true
+        }
+
+        // Finish silently when the load resolves to nothing renderable.
+        LaunchedEffect(transactionLoaded, categoriesLoaded) {
+            if (transactionLoaded && categoriesLoaded &&
+                (transaction == null || categories.isEmpty())
+            ) {
+                Log.w(TAG, "Picker has no transaction or no categories — finishing.")
+                finish()
+            }
+        }
+
+        val txn = transaction
+        if (txn != null && categories.isNotEmpty()) {
+            // Snapshot the args this composition is targeting so the callback
+            // doesn't accidentally see an args update from onNewIntent mid-flight.
+            val activeNotificationId = args.notificationId
+            QuickCategoryPickerSheet(
+                currentCategory = txn.category,
+                categories = categories,
+                onCategorySelected = { newCategory ->
+                    if (newCategory != txn.category) {
+                        appScope.launch {
+                            transactionRepository.updateCategory(txn.id, newCategory)
+                        }
+                    }
+                    if (activeNotificationId != -1) {
+                        NotificationManagerCompat.from(applicationContext)
+                            .cancel(activeNotificationId)
+                    }
+                    finish()
+                },
+                onDismiss = { finish() }
+            )
+        }
+    }
+
+    private data class PickerArgs(val transactionId: Long, val notificationId: Int) {
+        companion object {
+            fun from(intent: Intent?): PickerArgs? {
+                intent ?: return null
+                val txnId = intent.getLongExtra(EXTRA_TRANSACTION_ID, -1L)
+                if (txnId == -1L) return null
+                val notifId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
+                return PickerArgs(txnId, notifId)
             }
         }
     }
 
     companion object {
+        private const val TAG = "QuickCategoryPicker"
         const val EXTRA_TRANSACTION_ID = "transaction_id"
         const val EXTRA_NOTIFICATION_ID = "notification_id"
     }

--- a/app/src/main/java/com/pennywiseai/tracker/receiver/QuickCategoryPickerActivity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/receiver/QuickCategoryPickerActivity.kt
@@ -1,0 +1,97 @@
+package com.pennywiseai.tracker.receiver
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.core.app.NotificationManagerCompat
+import com.pennywiseai.tracker.data.repository.CategoryRepository
+import com.pennywiseai.tracker.data.repository.TransactionRepository
+import com.pennywiseai.tracker.ui.components.QuickCategoryPickerSheet
+import com.pennywiseai.tracker.ui.theme.PennyWiseTheme
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+/**
+ * Translucent activity launched from the txn-alert notification's
+ * "More categories…" action (#303). Hosts the shared
+ * [QuickCategoryPickerSheet] so the user can pick any category — not just
+ * the 3 quick-picks rendered as inline notification buttons — without
+ * navigating into the full transaction-detail screen.
+ *
+ * On pick: update the transaction's category, dismiss the originating
+ * notification, finish. On dismiss without picking: finish.
+ */
+@AndroidEntryPoint
+class QuickCategoryPickerActivity : ComponentActivity() {
+
+    @Inject lateinit var transactionRepository: TransactionRepository
+    @Inject lateinit var categoryRepository: CategoryRepository
+
+    // App-scoped scope for the category update — we don't want the write to
+    // be cancelled if the activity finishes (it does, immediately after).
+    private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val transactionId = intent.getLongExtra(EXTRA_TRANSACTION_ID, -1L)
+        val notificationId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
+        if (transactionId == -1L) {
+            finish()
+            return
+        }
+
+        setContent {
+            PennyWiseTheme {
+                // Load the transaction + categories asynchronously. Sheet
+                // doesn't render until both are available, which keeps the
+                // activity instant — the user just sees the system scrim
+                // first, then the sheet slides up.
+                val transaction by produceState<com.pennywiseai.tracker.data.database.entity.TransactionEntity?>(
+                    initialValue = null,
+                    key1 = transactionId
+                ) {
+                    value = transactionRepository.getTransactionById(transactionId)
+                }
+                val categories by produceState(
+                    initialValue = emptyList<com.pennywiseai.tracker.data.database.entity.CategoryEntity>()
+                ) {
+                    value = categoryRepository.getAllCategories().first()
+                }
+
+                val txn = transaction
+                if (txn != null && categories.isNotEmpty()) {
+                    QuickCategoryPickerSheet(
+                        currentCategory = txn.category,
+                        categories = categories,
+                        onCategorySelected = { newCategory ->
+                            if (newCategory != txn.category) {
+                                ioScope.launch {
+                                    transactionRepository.updateCategory(txn.id, newCategory)
+                                }
+                            }
+                            if (notificationId != -1) {
+                                NotificationManagerCompat.from(applicationContext)
+                                    .cancel(notificationId)
+                            }
+                            finish()
+                        },
+                        onDismiss = { finish() }
+                    )
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val EXTRA_TRANSACTION_ID = "transaction_id"
+        const val EXTRA_NOTIFICATION_ID = "notification_id"
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/receiver/SmsBroadcastReceiver.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/receiver/SmsBroadcastReceiver.kt
@@ -219,9 +219,11 @@ class SmsBroadcastReceiver : BroadcastReceiver() {
                     .setContentIntent(pendingIntent)
                     .setAutoCancel(true)
 
-                // Add quick action buttons for top categories (only if different from current)
+                // Notification action slots are precious (Android collapses past 3),
+                // so we reserve the last for "More…" — the full picker — and let the
+                // top 2 most-used categories fill the first two for one-tap recategorise. (#303)
                 val notificationId = transactionId.toInt()
-                topCategories.filter { it != category }.take(3).forEachIndexed { index, topCategory ->
+                topCategories.filter { it != category }.take(2).forEachIndexed { index, topCategory ->
                     val categoryIntent = Intent(context, NotificationActionReceiver::class.java).apply {
                         action = NotificationActionReceiver.ACTION_CHANGE_CATEGORY
                         putExtra(NotificationActionReceiver.EXTRA_TRANSACTION_ID, transactionId)
@@ -242,6 +244,21 @@ class SmsBroadcastReceiver : BroadcastReceiver() {
                         categoryPendingIntent
                     )
                 }
+
+                // "More…" — launches the translucent picker activity so the user
+                // can choose any category, not just the top 2 quick-picks above.
+                val pickerIntent = Intent(context, QuickCategoryPickerActivity::class.java).apply {
+                    putExtra(QuickCategoryPickerActivity.EXTRA_TRANSACTION_ID, transactionId)
+                    putExtra(QuickCategoryPickerActivity.EXTRA_NOTIFICATION_ID, notificationId)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                }
+                val pickerPendingIntent = PendingIntent.getActivity(
+                    context,
+                    transactionId.toInt() + 100, // distinct request-code lane
+                    pickerIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                notificationBuilder.addAction(0, "More…", pickerPendingIntent)
 
                 val notification = notificationBuilder.build()
                 notificationManager.notify(notificationId, notification)

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/QuickCategoryPickerSheet.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/QuickCategoryPickerSheet.kt
@@ -1,0 +1,120 @@
+package com.pennywiseai.tracker.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import com.pennywiseai.tracker.data.database.entity.CategoryEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionEntity
+import com.pennywiseai.tracker.ui.theme.Dimensions
+import com.pennywiseai.tracker.ui.theme.Spacing
+
+/**
+ * Modal bottom-sheet picker for changing a transaction's category. Used both
+ * from the transactions list (long-press / overflow) and from the txn-alert
+ * notification's "More categories…" action (#303). Shared so the in-app and
+ * notification flows present identical UI.
+ *
+ * @param currentCategory The transaction's current category name — gets a
+ *  check-mark and bold weight so the user sees what they're overriding.
+ * @param categories Flat, already-ordered list of selectable categories.
+ * @param onCategorySelected Fired with the chosen category name; caller is
+ *  responsible for persisting and dismissing.
+ * @param onDismiss Called when the user dismisses the sheet without picking.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun QuickCategoryPickerSheet(
+    currentCategory: String,
+    categories: List<CategoryEntity>,
+    onCategorySelected: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Text(
+            text = "Change category",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(
+                start = Dimensions.Padding.content,
+                end = Dimensions.Padding.content,
+                bottom = Spacing.sm
+            )
+        )
+        // LazyColumn so long category lists stay reachable when the sheet is
+        // fully expanded — a plain Column would render items past the screen
+        // bottom unscrollable.
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = Spacing.md)
+        ) {
+            items(categories, key = { it.id }) { category ->
+                val selected = currentCategory == category.name
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onCategorySelected(category.name) }
+                        .padding(
+                            horizontal = Dimensions.Padding.content,
+                            vertical = Spacing.sm
+                        ),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.md)
+                ) {
+                    CategoryChip(category = category, showText = false)
+                    Text(
+                        text = category.name,
+                        modifier = Modifier.weight(1f),
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal
+                    )
+                    if (selected) {
+                        Icon(
+                            imageVector = Icons.Default.Check,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Convenience overload for call sites that already have a TransactionEntity
+ * in hand (e.g. TransactionsScreen). Delegates to the form above using the
+ * transaction's current category.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun QuickCategoryPickerSheet(
+    transaction: TransactionEntity,
+    categories: List<CategoryEntity>,
+    onCategorySelected: (String) -> Unit,
+    onDismiss: () -> Unit
+) = QuickCategoryPickerSheet(
+    currentCategory = transaction.category,
+    categories = categories,
+    onCategorySelected = onCategorySelected,
+    onDismiss = onDismiss
+)

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,7 +2,19 @@
 <resources>
     <!-- Base theme -->
     <style name="Theme.Pennywisecompose" parent="android:Theme.Material.Light.NoActionBar" />
-    
+
+    <!-- Transparent host theme for QuickCategoryPickerActivity: a Compose
+         bottom-sheet floats over whatever's behind it, no window decor,
+         no background dim (the ModalBottomSheet draws its own scrim). -->
+    <style name="Theme.PennyWise.Transparent" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
+
+
     <!-- Splash Screen theme for light mode -->
     <style name="Theme.PennyWise.SplashScreen" parent="Theme.SplashScreen">
         <!-- Set the background color -->


### PR DESCRIPTION
## Why
Issue #303 asks for a way to re-categorise a transaction directly from its alert notification — ideally a "popup window to select category" so the user doesn't have to open the full app → transaction detail → edit mode.

The notification already had 3 quick-pick category buttons, but those only cover the top-3 most-used categories. Anything else still required the long path.

## What
- **Keep** the top **2** quick-pick category buttons (one-tap stays one-tap for common cases).
- **Add** a 3rd `More…` action that launches a translucent activity hosting the existing category picker as a Material 3 `ModalBottomSheet` over whatever's behind it. Pick any category → write through → notification dismissed → activity finished.

## Implementation
| File | Change |
|---|---|
| `ui/components/QuickCategoryPickerSheet.kt` *(new)* | Extracted from `TransactionsScreen.kt`. Two overloads — one keyed by `TransactionEntity` for the in-app flow, one by `currentCategory: String` for callers that don't have the entity in hand. Same UI for both. |
| `TransactionsScreen.kt` | Dropped the private duplicate; uses the shared composable via the existing `ui.components.*` wildcard import. |
| `receiver/QuickCategoryPickerActivity.kt` *(new)* | Translucent `ComponentActivity` (`@AndroidEntryPoint`). Reads `transaction_id` + `notification_id` extras, loads txn + categories, renders the shared sheet. On pick: `transactionRepository.updateCategory(...)` on an app-scoped `CoroutineScope` (so finishing doesn't cancel the write) → `NotificationManagerCompat.cancel(notificationId)` → `finish()`. On dismiss: just `finish()`. |
| `res/values/themes.xml` | New `Theme.PennyWise.Transparent`: no window decor, no background dim — the `ModalBottomSheet` draws its own scrim. |
| `AndroidManifest.xml` | Register the activity `exported="false"`, `singleTask`, `excludeFromRecents="true"`, `noHistory="true"` so it never shows in Recents and re-taps don't stack. |
| `receiver/SmsBroadcastReceiver.kt` | `take(2)` quick-picks instead of `take(3)`; append a 3rd `More…` action wired to `QuickCategoryPickerActivity` via `PendingIntent.getActivity`. |

## Verified end-to-end on emulator
1. Sent a fresh Kotak SMS (`Sent Rs.420.00 … to BIG BAZAAR`) → notification posted with **Food & Dining · Shopping · More…**.
2. Tapped **More…** → translucent picker slid up over the launcher, "Others" check-marked as the current category.
3. Tapped **Shopping** → activity finished, notification dismissed.
4. Opened the app → transaction's subtitle now reads `31 May • 7:49 PM • Shopping` with the orange Shopping icon.

`./gradlew :app:compileStandardDebugKotlin` — clean.

Closes #303