### PR TITLE
feat(txn): bulk-edit selection mode on the transactions list (#369)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
@@ -8,6 +8,9 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -20,6 +23,7 @@ import androidx.compose.foundation.text.BasicTextField
 import com.pennywiseai.tracker.ui.effects.overScrollVertical
 import com.pennywiseai.tracker.ui.effects.rememberOverscrollFlingBehavior
 import androidx.compose.material.icons.Icons
+import androidx.activity.compose.BackHandler
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ShowChart
 import androidx.compose.material.icons.automirrored.filled.Sort
@@ -105,6 +109,12 @@ fun TransactionsScreen(
     val selectedProfileId by viewModel.selectedProfileId.collectAsState()
     val profiles by viewModel.profiles.collectAsState()
     val profileAccountKeys by viewModel.profileAccountKeys.collectAsState()
+
+    // Bulk-edit selection (#369)
+    val selectedIds by viewModel.selectedIds.collectAsState()
+    val bulkSnack by viewModel.bulkSnack.collectAsState()
+    val selectionMode = selectedIds.isNotEmpty()
+    var showBulkCategorySheet by remember { mutableStateOf(false) }
 
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
@@ -244,21 +254,51 @@ fun TransactionsScreen(
             .nestedScroll(scrollBehaviorLarge.nestedScrollConnection),
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         topBar = {
-            CustomTitleTopAppBar(
-                scrollBehaviorSmall = scrollBehaviorSmall,
-                scrollBehaviorLarge = scrollBehaviorLarge,
-                title = "Transactions",
-                hasBackButton = true,
-                navigationContent = {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back"
-                        )
-                    }
-                },
-                hazeState = hazeState
-            )
+            if (selectionMode) {
+                // Contextual top bar for bulk-edit (#369): close left, count as title,
+                // Change Category + Delete on the right.
+                CustomTitleTopAppBar(
+                    scrollBehaviorSmall = scrollBehaviorSmall,
+                    scrollBehaviorLarge = scrollBehaviorLarge,
+                    title = "${selectedIds.size} selected",
+                    hasBackButton = true,
+                    hasActionButton = true,
+                    navigationContent = {
+                        IconButton(onClick = { viewModel.clearSelection() }) {
+                            Icon(Icons.Default.Close, contentDescription = "Exit selection")
+                        }
+                    },
+                    actionContent = {
+                        IconButton(onClick = { showBulkCategorySheet = true }) {
+                            Icon(Icons.Default.Category, contentDescription = "Change category")
+                        }
+                        IconButton(onClick = { viewModel.bulkDelete() }) {
+                            Icon(
+                                Icons.Default.Delete,
+                                contentDescription = "Delete selected",
+                                tint = MaterialTheme.colorScheme.error
+                            )
+                        }
+                    },
+                    hazeState = hazeState
+                )
+            } else {
+                CustomTitleTopAppBar(
+                    scrollBehaviorSmall = scrollBehaviorSmall,
+                    scrollBehaviorLarge = scrollBehaviorLarge,
+                    title = "Transactions",
+                    hasBackButton = true,
+                    navigationContent = {
+                        IconButton(onClick = onNavigateBack) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "Back"
+                            )
+                        }
+                    },
+                    hazeState = hazeState
+                )
+            }
         },
         floatingActionButton = {
             Column(
@@ -486,19 +526,62 @@ fun TransactionsScreen(
                                 items = transactions,
                                 key = { _, transaction -> transaction.id }
                             ) { index, transaction ->
-                                SwipeToEditCategory(
-                                    transaction = transaction,
-                                    onRequestEdit = { pendingCategoryEditId = it.id }
-                                ) {
-                                    com.pennywiseai.tracker.ui.components.cards.TransactionItem(
-                                        transaction = transaction,
-                                        showDate = dateGroup == DateGroup.EARLIER,
-                                        listItemPosition = ListItemPosition.from(index, transactions.size),
-                                        convertedAmount = convertedAmounts[transaction.id],
-                                        displayCurrency = if (isUnifiedMode) selectedCurrency else null,
-                                        profileAccountKeys = profileAccountKeys,
-                                        onClick = { onTransactionClick(transaction.id) }
-                                    )
+                                val isSelected = transaction.id in selectedIds
+                                val rowBackground = if (isSelected)
+                                    MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.35f)
+                                else Color.Transparent
+
+                                if (selectionMode) {
+                                    // In selection mode: outer combinedClickable owns the row.
+                                    // Tap toggles; long-press also toggles (additive). Swipe-to-
+                                    // edit is intentionally suppressed so we don't mix the
+                                    // single-row category quick-edit with the bulk flow.
+                                    Box(
+                                        modifier = Modifier
+                                            .background(rowBackground)
+                                            .combinedClickable(
+                                                onClick = { viewModel.toggleSelection(transaction.id) },
+                                                onLongClick = { viewModel.toggleSelection(transaction.id) }
+                                            )
+                                    ) {
+                                        com.pennywiseai.tracker.ui.components.cards.TransactionItem(
+                                            transaction = transaction,
+                                            showDate = dateGroup == DateGroup.EARLIER,
+                                            listItemPosition = ListItemPosition.from(index, transactions.size),
+                                            convertedAmount = convertedAmounts[transaction.id],
+                                            displayCurrency = if (isUnifiedMode) selectedCurrency else null,
+                                            profileAccountKeys = profileAccountKeys,
+                                            onClick = {} // tap owned by the wrapper
+                                        )
+                                    }
+                                } else {
+                                    // Out of selection mode: keep the existing tap (navigate)
+                                    // and swipe (quick-edit category) behaviours, and add a
+                                    // long-press-only detector to enter selection mode without
+                                    // blocking either of them.
+                                    Box(
+                                        modifier = Modifier
+                                            .pointerInput(transaction.id) {
+                                                detectTapGestures(
+                                                    onLongPress = { viewModel.toggleSelection(transaction.id) }
+                                                )
+                                            }
+                                    ) {
+                                        SwipeToEditCategory(
+                                            transaction = transaction,
+                                            onRequestEdit = { pendingCategoryEditId = it.id }
+                                        ) {
+                                            com.pennywiseai.tracker.ui.components.cards.TransactionItem(
+                                                transaction = transaction,
+                                                showDate = dateGroup == DateGroup.EARLIER,
+                                                listItemPosition = ListItemPosition.from(index, transactions.size),
+                                                convertedAmount = convertedAmounts[transaction.id],
+                                                displayCurrency = if (isUnifiedMode) selectedCurrency else null,
+                                                profileAccountKeys = profileAccountKeys,
+                                                onClick = { onTransactionClick(transaction.id) }
+                                            )
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -546,6 +629,41 @@ fun TransactionsScreen(
                 onDismiss = { pendingCategoryEditId = null }
             )
         }
+    }
+
+    // Bulk category picker (#369). If every selected row already shares a
+    // category, mark it; otherwise pass a "(multiple)" sentinel so nothing is
+    // pre-checked.
+    if (showBulkCategorySheet && selectedIds.isNotEmpty()) {
+        val selectedTxns = uiState.transactions.filter { it.id in selectedIds }
+        val commonCategory = selectedTxns.map { it.category }.distinct().singleOrNull()
+        QuickCategoryPickerSheet(
+            currentCategory = commonCategory ?: "(multiple)",
+            categories = categoriesMap.values.toList(),
+            onCategorySelected = { name ->
+                viewModel.bulkUpdateCategory(name)
+                showBulkCategorySheet = false
+            },
+            onDismiss = { showBulkCategorySheet = false }
+        )
+    }
+
+    // Bulk action snackbar with Undo (#369).
+    LaunchedEffect(bulkSnack) {
+        bulkSnack?.let { snack ->
+            val result = snackbarHostState.showSnackbar(
+                message = snack.message,
+                actionLabel = snack.undo?.let { "Undo" },
+                duration = SnackbarDuration.Short
+            )
+            if (result == SnackbarResult.ActionPerformed) snack.undo?.invoke()
+            viewModel.consumeBulkSnack()
+        }
+    }
+
+    // Hardware back exits selection mode instead of leaving the screen.
+    BackHandler(enabled = selectionMode) {
+        viewModel.clearSelection()
     }
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
@@ -563,7 +563,18 @@ fun TransactionsScreen(
                                         modifier = Modifier
                                             .pointerInput(transaction.id) {
                                                 detectTapGestures(
-                                                    onLongPress = { viewModel.toggleSelection(transaction.id) }
+                                                    // Haptic so an accidental long-press during
+                                                    // an unusually slow swipe is immediately
+                                                    // obvious to the user; selection mode is
+                                                    // then trivially recoverable via Back or the
+                                                    // close button in the contextual top bar.
+                                                    // detectTapGestures already cancels on
+                                                    // touch-slop movement, so a normal-paced
+                                                    // swipe doesn't reach this lambda.
+                                                    onLongPress = {
+                                                        view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                                                        viewModel.toggleSelection(transaction.id)
+                                                    }
                                                 )
                                             }
                                     ) {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -200,6 +200,79 @@ class TransactionsViewModel @Inject constructor(
     
     private val _deletedTransaction = MutableStateFlow<TransactionEntity?>(null)
     val deletedTransaction: StateFlow<TransactionEntity?> = _deletedTransaction.asStateFlow()
+
+    // ─── Bulk-edit selection (#369) ──────────────────────────────────────────
+    //
+    // Selection mode is implicit in [selectedIds.isNotEmpty()] — no separate flag.
+    // Long-press in the list enters this mode and tap-toggles add/remove rows.
+    private val _selectedIds = MutableStateFlow<Set<Long>>(emptySet())
+    val selectedIds: StateFlow<Set<Long>> = _selectedIds.asStateFlow()
+
+    /** One-shot snackbar payload for a bulk action; cleared by the UI after showing. */
+    data class BulkSnack(val message: String, val undo: (() -> Unit)? = null)
+    private val _bulkSnack = MutableStateFlow<BulkSnack?>(null)
+    val bulkSnack: StateFlow<BulkSnack?> = _bulkSnack.asStateFlow()
+    fun consumeBulkSnack() { _bulkSnack.value = null }
+
+    fun toggleSelection(id: Long) {
+        _selectedIds.update { current ->
+            if (current.contains(id)) current - id else current + id
+        }
+    }
+
+    fun clearSelection() { _selectedIds.value = emptySet() }
+
+    /**
+     * Apply [newCategory] to every currently-selected transaction. Captures the
+     * (id → previous-category) pairs first so the snackbar's Undo can restore
+     * them; if a row had its category changed elsewhere in between, the undo
+     * will overwrite that change too — acceptable for an explicit user action.
+     */
+    fun bulkUpdateCategory(newCategory: String) {
+        val ids = _selectedIds.value
+        if (ids.isEmpty()) return
+        viewModelScope.launch {
+            val previous = _uiState.value.transactions
+                .filter { it.id in ids }
+                .associate { it.id to it.category }
+            previous.keys.forEach { id ->
+                transactionRepository.updateCategory(id, newCategory)
+            }
+            clearSelection()
+            _bulkSnack.value = BulkSnack(
+                message = "${previous.size} updated to \"$newCategory\"",
+                undo = {
+                    viewModelScope.launch {
+                        previous.forEach { (id, oldCategory) ->
+                            transactionRepository.updateCategory(id, oldCategory)
+                        }
+                    }
+                }
+            )
+        }
+    }
+
+    /**
+     * Soft-delete every currently-selected transaction. Undo restores them all
+     * via the same per-row undoDelete path the single-row flow uses.
+     */
+    fun bulkDelete() {
+        val ids = _selectedIds.value
+        if (ids.isEmpty()) return
+        viewModelScope.launch {
+            val snapshot = _uiState.value.transactions.filter { it.id in ids }
+            snapshot.forEach { transactionRepository.deleteTransaction(it) }
+            clearSelection()
+            _bulkSnack.value = BulkSnack(
+                message = "${snapshot.size} deleted",
+                undo = {
+                    viewModelScope.launch {
+                        snapshot.forEach { transactionRepository.undoDeleteTransaction(it) }
+                    }
+                }
+            )
+        }
+    }
     
     // Track if initial filters have been applied to prevent resetting on back navigation
     private var hasAppliedInitialFilters = false

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -222,6 +222,20 @@ class TransactionsViewModel @Inject constructor(
 
     fun clearSelection() { _selectedIds.value = emptySet() }
 
+    init {
+        // Prune selected ids that fall out of the visible list (filter change,
+        // search, delete from elsewhere). Otherwise a bulk op would silently
+        // skip rows the user thinks they had selected.
+        viewModelScope.launch {
+            _uiState
+                .map { it.transactions.mapTo(HashSet()) { tx -> tx.id } }
+                .distinctUntilChanged()
+                .collect { visible ->
+                    _selectedIds.update { it intersect visible }
+                }
+        }
+    }
+
     /**
      * Apply [newCategory] to every currently-selected transaction. Captures the
      * (id → previous-category) pairs first so the snackbar's Undo can restore


### PR DESCRIPTION
## Why
Issue #369 asks for a way to edit multiple transactions at once — common case: SMS got categorised wrong for a whole batch, today you re-categorise them one by one.

## UX
- **Long-press** any row in the transactions list → enter selection mode and pre-select that row.
- Contextual top bar shows **"N selected"** with **Change Category** (category icon) and **Delete** (red trash) actions on the right and a **Close (×)** on the left.
- **Tap rows** to toggle selection. **Hardware back** exits selection mode (doesn't leave the screen).
- After a batch op, a **Snackbar** lands with **"Undo"** that reverses every row.

## Scope
- Bulk **category change** and bulk **delete** — the two highest-leverage ops.
- Date/merchant/etc. (also mentioned in the issue) are out of scope for v1 since they're free-text and need their own flows. The selection-mode plumbing makes adding them later mechanical.

## Implementation
### ViewModel
- `selectedIds: StateFlow<Set<Long>>` — selection mode is implicit in `isNotEmpty()` (no separate flag).
- `toggleSelection(id)`, `clearSelection()`.
- `bulkUpdateCategory(newCategory)`: snapshots the `(id → previous category)` map first so Undo restores the per-row originals.
- `bulkDelete()`: soft-deletes every selected row; Undo loops the existing `TransactionRepository.undoDeleteTransaction`.
- One-shot `BulkSnack(message, undo?)` payload the UI consumes after showing.

### Screen
- **Contextual top bar** swaps in when selection is non-empty (close on the left, Category + Delete on the right). Otherwise the existing "Transactions" bar stays put.
- **Row wrapper**:
  - In selection mode: outer `combinedClickable` owns tap/long-press (both toggle), swipe-to-edit suppressed so it doesn't mix metaphors with the single-row category flow.
  - Out of selection mode: outer `pointerInput` attaches a **long-press-only** detector so tap (navigate) and swipe (quick-edit) still flow to the existing inner handlers untouched.
  - Selected rows tint with `primaryContainer @ 35%`.
- `BackHandler(enabled = selectionMode)` clears selection.
- The bulk category sheet **reuses the shared `QuickCategoryPickerSheet`** that #303 extracted — passes the common category when all selected share one, `"(multiple)"` otherwise.

## What I deliberately didn't do
- No new repository batch methods — loops over existing per-row `updateCategory` / `deleteTransaction`. Per-row order is fine for the sizes a user actually selects; can be batched in the DAO later if it matters.
- No `RuleEngine` re-evaluation on bulk category change (manual override).

## Verification
- `./gradlew :app:compileStandardDebugKotlin` — clean.
- Emulator-side manual verification pending (emulator dropped between build and install on my machine).

Closes #369