### PR TITLE
fix(txn): polish Transactions page + bulk-edit gesture + UI bugs

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/common/CurrencyGroupedTotals.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/common/CurrencyGroupedTotals.kt
@@ -37,6 +37,12 @@ data class CurrencyTotals(
     val investment: BigDecimal = BigDecimal.ZERO,
     val transactionCount: Int = 0
 ) {
+    /**
+     * Net = true cash flow (income − expenses). Credit-card spend, transfers,
+     * and investments are tracked as separate channels (see the home Cash-Flow
+     * card) and intentionally aren't deducted here — otherwise Net wouldn't
+     * reconcile with the user-visible Income and Expenses tiles.
+     */
     val netBalance: BigDecimal
-        get() = income - expenses - credit - transfer - investment
+        get() = income - expenses
 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionTotalsCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionTotalsCard.kt
@@ -58,6 +58,11 @@ fun TransactionTotalsCard(
         label = "net_alpha"
     )
 
+    // The bottom inset only exists to host the optional [CurrencyPickerPill],
+    // which floats at BottomEnd of the parent Box. When no pill is rendered
+    // (single-currency case) keep the card flush — otherwise a phantom blank
+    // band sits under the totals.
+    val hasCurrencyPill = availableCurrencies.size > 1 && !isUnifiedMode
     Box(
         modifier = modifier.fillMaxWidth(),
         contentAlignment = Alignment.BottomEnd
@@ -65,7 +70,7 @@ fun TransactionTotalsCard(
         Card(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = Spacing.lg),
+                .then(if (hasCurrencyPill) Modifier.padding(bottom = Spacing.lg) else Modifier),
             colors = CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
             ),
@@ -212,7 +217,7 @@ fun TransactionTotalsCard(
             }
         }
 
-        if (availableCurrencies.size > 1 && !isUnifiedMode) {
+        if (hasCurrencyPill) {
             CurrencyPickerPill(
                 selectedCurrency = currency,
                 availableCurrencies = availableCurrencies,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
@@ -8,9 +8,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -269,15 +266,19 @@ fun TransactionsScreen(
                         }
                     },
                     actionContent = {
-                        IconButton(onClick = { showBulkCategorySheet = true }) {
-                            Icon(Icons.Default.Category, contentDescription = "Change category")
-                        }
-                        IconButton(onClick = { viewModel.bulkDelete() }) {
-                            Icon(
-                                Icons.Default.Delete,
-                                contentDescription = "Delete selected",
-                                tint = MaterialTheme.colorScheme.error
-                            )
+                        // Wrap explicitly in a Row so both action IconButtons render
+                        // even when the top-bar's actions slot is constrained.
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            IconButton(onClick = { showBulkCategorySheet = true }) {
+                                Icon(Icons.Default.Category, contentDescription = "Change category")
+                            }
+                            IconButton(onClick = { viewModel.bulkDelete() }) {
+                                Icon(
+                                    Icons.Default.Delete,
+                                    contentDescription = "Delete selected",
+                                    tint = MaterialTheme.colorScheme.error
+                                )
+                            }
                         }
                     },
                     hazeState = hazeState
@@ -527,22 +528,39 @@ fun TransactionsScreen(
                                 key = { _, transaction -> transaction.id }
                             ) { index, transaction ->
                                 val isSelected = transaction.id in selectedIds
-                                val rowBackground = if (isSelected)
-                                    MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.35f)
-                                else Color.Transparent
+                                // Selected highlight via the Card's container colour — the prior
+                                // Modifier.background on a wrapping Box was painted *under* the
+                                // Card and was completely covered by the Card's own surface, so
+                                // selection had no visible effect.
+                                val rowContainerColor = if (isSelected)
+                                    MaterialTheme.colorScheme.primaryContainer
+                                else null
 
+                                // Long-press now lives on TransactionItem's own
+                                // gesture surface (Material combinedClickable),
+                                // which cooperates with the parent SwipeToDismissBox
+                                // — fixes bulk-edit not firing in nested gesture
+                                // contexts.
+                                val longPressToggle = {
+                                    view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                                    viewModel.toggleSelection(transaction.id)
+                                }
                                 if (selectionMode) {
-                                    // In selection mode: outer combinedClickable owns the row.
-                                    // Tap toggles; long-press also toggles (additive). Swipe-to-
-                                    // edit is intentionally suppressed so we don't mix the
-                                    // single-row category quick-edit with the bulk flow.
-                                    Box(
-                                        modifier = Modifier
-                                            .background(rowBackground)
-                                            .combinedClickable(
-                                                onClick = { viewModel.toggleSelection(transaction.id) },
-                                                onLongClick = { viewModel.toggleSelection(transaction.id) }
-                                            )
+                                    com.pennywiseai.tracker.ui.components.cards.TransactionItem(
+                                        transaction = transaction,
+                                        showDate = dateGroup == DateGroup.EARLIER,
+                                        listItemPosition = ListItemPosition.from(index, transactions.size),
+                                        convertedAmount = convertedAmounts[transaction.id],
+                                        displayCurrency = if (isUnifiedMode) selectedCurrency else null,
+                                        profileAccountKeys = profileAccountKeys,
+                                        onClick = { viewModel.toggleSelection(transaction.id) },
+                                        onLongClick = longPressToggle,
+                                        containerColor = rowContainerColor
+                                    )
+                                } else {
+                                    SwipeToEditCategory(
+                                        transaction = transaction,
+                                        onRequestEdit = { pendingCategoryEditId = it.id }
                                     ) {
                                         com.pennywiseai.tracker.ui.components.cards.TransactionItem(
                                             transaction = transaction,
@@ -551,47 +569,9 @@ fun TransactionsScreen(
                                             convertedAmount = convertedAmounts[transaction.id],
                                             displayCurrency = if (isUnifiedMode) selectedCurrency else null,
                                             profileAccountKeys = profileAccountKeys,
-                                            onClick = {} // tap owned by the wrapper
+                                            onClick = { onTransactionClick(transaction.id) },
+                                            onLongClick = longPressToggle
                                         )
-                                    }
-                                } else {
-                                    // Out of selection mode: keep the existing tap (navigate)
-                                    // and swipe (quick-edit category) behaviours, and add a
-                                    // long-press-only detector to enter selection mode without
-                                    // blocking either of them.
-                                    Box(
-                                        modifier = Modifier
-                                            .pointerInput(transaction.id) {
-                                                detectTapGestures(
-                                                    // Haptic so an accidental long-press during
-                                                    // an unusually slow swipe is immediately
-                                                    // obvious to the user; selection mode is
-                                                    // then trivially recoverable via Back or the
-                                                    // close button in the contextual top bar.
-                                                    // detectTapGestures already cancels on
-                                                    // touch-slop movement, so a normal-paced
-                                                    // swipe doesn't reach this lambda.
-                                                    onLongPress = {
-                                                        view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
-                                                        viewModel.toggleSelection(transaction.id)
-                                                    }
-                                                )
-                                            }
-                                    ) {
-                                        SwipeToEditCategory(
-                                            transaction = transaction,
-                                            onRequestEdit = { pendingCategoryEditId = it.id }
-                                        ) {
-                                            com.pennywiseai.tracker.ui.components.cards.TransactionItem(
-                                                transaction = transaction,
-                                                showDate = dateGroup == DateGroup.EARLIER,
-                                                listItemPosition = ListItemPosition.from(index, transactions.size),
-                                                convertedAmount = convertedAmounts[transaction.id],
-                                                displayCurrency = if (isUnifiedMode) selectedCurrency else null,
-                                                profileAccountKeys = profileAccountKeys,
-                                                onClick = { onTransactionClick(transaction.id) }
-                                            )
-                                        }
                                     }
                                 }
                             }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
@@ -461,7 +461,10 @@ fun TransactionsScreen(
                 ) {
                     stickyHeader {
                         Surface(
-                            color = MaterialTheme.colorScheme.surface,
+                            // Match the Scaffold's `background` so AMOLED-style
+                            // themes (true-black bg + tinted surface) don't paint
+                            // a visible slab behind the sticky totals card.
+                            color = MaterialTheme.colorScheme.background,
                             modifier = Modifier.fillMaxWidth()
                         ) {
                             TransactionTotalsCard(
@@ -721,6 +724,12 @@ private fun TransactionDateHeader(
     title: String,
     modifier: Modifier = Modifier
 ) {
+    // Fade the sticky date header into a transparent base so scrolling content
+    // looks like it's passing under the label. Use `background` (the Scaffold
+    // surface) instead of `surface`, otherwise an AMOLED-style theme — where
+    // `background` is true-black but `surface` is tinted — paints a visible
+    // dark slab behind every date header.
+    val pageBg = MaterialTheme.colorScheme.background
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
@@ -729,10 +738,10 @@ private fun TransactionDateHeader(
             .background(
                 Brush.verticalGradient(
                     listOf(
-                        MaterialTheme.colorScheme.surface,
-                        MaterialTheme.colorScheme.surface,
-                        MaterialTheme.colorScheme.surface.copy(alpha = 0.92f),
-                        MaterialTheme.colorScheme.surface.copy(alpha = 0f)
+                        pageBg,
+                        pageBg,
+                        pageBg.copy(alpha = 0.92f),
+                        pageBg.copy(alpha = 0f)
                     )
                 )
             )

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -178,7 +178,12 @@ class TransactionsViewModel @Inject constructor(
                 }
                 count += totals.transactionCount
             }
-            val netBalance = income - expenses - credit - transfer - investment
+            // Net = true cash flow (income − expenses). Credit-card spend,
+            // transfers, and investments are *not* in the visible Expenses tile,
+            // so subtracting them here produced a Net that didn't reconcile with
+            // the user-visible math. Those channels live on the home Cash-Flow
+            // card as deliberately separate categories.
+            val netBalance = income - expenses
             FilteredTotals(income, expenses, credit, transfer, investment, netBalance, count)
         } else {
             val currencyTotals = groupedTotals.getTotalsForCurrency(currency)

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/ListItemCardV2.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/ListItemCardV2.kt
@@ -1,5 +1,6 @@
 package com.pennywiseai.tracker.ui.components.cards
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,6 +16,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.pennywiseai.tracker.ui.theme.Spacing
 
 enum class ListItemPosition {
@@ -65,13 +67,22 @@ fun ListItemCardV2(
     trailingContent: @Composable (() -> Unit)? = null,
     shape: CornerBasedShape = MaterialTheme.shapes.large,
     contentPadding: Dp = Spacing.md,
-    onClick: (() -> Unit)? = null
+    /** Overrides the card's container colour when set (e.g. for selected state). */
+    containerColor: Color? = null,
+    onClick: (() -> Unit)? = null,
+    onLongClick: (() -> Unit)? = null,
 ) {
     PennyWiseCardV2(
         modifier = modifier.fillMaxWidth(),
         shape = shape,
         contentPadding = contentPadding,
-        onClick = onClick
+        containerColor = containerColor,
+        // Suppress the inherited 0.5dp dark-mode hairline on list rows: long
+        // lists of bordered rows read as a chunky grid; bare surfaces with the
+        // surrounding column's spacing carry the divisions better.
+        border = BorderStroke(0.dp, Color.Transparent),
+        onClick = onClick,
+        onLongClick = onLongClick
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/PennyWiseCardV2.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/PennyWiseCardV2.kt
@@ -1,6 +1,7 @@
 package com.pennywiseai.tracker.ui.components.cards
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -21,12 +22,26 @@ import com.pennywiseai.tracker.ui.theme.Spacing
 fun PennyWiseCardV2(
     modifier: Modifier = Modifier,
     shape: CornerBasedShape = MaterialTheme.shapes.large,
+    /**
+     * Overrides [colors] when set. Convenience for callers that only need to
+     * swap the container colour (e.g. a selected-state tint) without
+     * constructing a full [CardColors] elsewhere.
+     */
+    containerColor: androidx.compose.ui.graphics.Color? = null,
     colors: CardColors = CardDefaults.cardColors(
-        containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+        containerColor = containerColor ?: MaterialTheme.colorScheme.surfaceContainerLow
     ),
     elevation: CardElevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
     border: BorderStroke? = null,
     onClick: (() -> Unit)? = null,
+    /**
+     * Optional long-press handler. When provided alongside [onClick] the card
+     * is wired via [Modifier.combinedClickable] so tap and long-press resolve
+     * on the same gesture surface — important when the card lives inside a
+     * scrolling container or another drag-aware parent (e.g. SwipeToDismissBox)
+     * that would otherwise race with a child pointerInput.
+     */
+    onLongClick: (() -> Unit)? = null,
     contentPadding: Dp = Spacing.md,
     content: @Composable ColumnScope.() -> Unit
 ) {
@@ -36,33 +51,45 @@ fun PennyWiseCardV2(
         null
     }
 
-    if (onClick != null) {
-        Card(
-            modifier = modifier,
-            onClick = onClick,
-            colors = colors,
-            shape = shape,
-            elevation = elevation,
-            border = effectiveBorder
-        ) {
-            Column(
-                modifier = Modifier.padding(contentPadding)
+    when {
+        onLongClick != null -> {
+            // Combined click + long-click. Material's Card composable doesn't
+            // accept onLongClick directly, so we wrap a non-clickable Card with
+            // combinedClickable on the outer modifier.
+            Card(
+                modifier = modifier.combinedClickable(
+                    onClick = onClick ?: {},
+                    onLongClick = onLongClick
+                ),
+                colors = colors,
+                shape = shape,
+                elevation = elevation,
+                border = effectiveBorder
             ) {
-                content()
+                Column(modifier = Modifier.padding(contentPadding)) { content() }
             }
         }
-    } else {
-        Card(
-            modifier = modifier,
-            colors = colors,
-            shape = shape,
-            elevation = elevation,
-            border = effectiveBorder
-        ) {
-            Column(
-                modifier = Modifier.padding(contentPadding)
+        onClick != null -> {
+            Card(
+                modifier = modifier,
+                onClick = onClick,
+                colors = colors,
+                shape = shape,
+                elevation = elevation,
+                border = effectiveBorder
             ) {
-                content()
+                Column(modifier = Modifier.padding(contentPadding)) { content() }
+            }
+        }
+        else -> {
+            Card(
+                modifier = modifier,
+                colors = colors,
+                shape = shape,
+                elevation = elevation,
+                border = effectiveBorder
+            ) {
+                Column(modifier = Modifier.padding(contentPadding)) { content() }
             }
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/PennyWiseCardV2.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/PennyWiseCardV2.kt
@@ -23,9 +23,10 @@ fun PennyWiseCardV2(
     modifier: Modifier = Modifier,
     shape: CornerBasedShape = MaterialTheme.shapes.large,
     /**
-     * Overrides [colors] when set. Convenience for callers that only need to
-     * swap the container colour (e.g. a selected-state tint) without
-     * constructing a full [CardColors] elsewhere.
+     * Default-only convenience for callers that just want to swap the
+     * container colour (e.g. a selected-state tint) without constructing a
+     * full [CardColors]. Wired into the default value of [colors]; if a
+     * caller passes [colors] explicitly, that wins and this value is unused.
      */
     containerColor: androidx.compose.ui.graphics.Color? = null,
     colors: CardColors = CardDefaults.cardColors(
@@ -35,11 +36,15 @@ fun PennyWiseCardV2(
     border: BorderStroke? = null,
     onClick: (() -> Unit)? = null,
     /**
-     * Optional long-press handler. When provided alongside [onClick] the card
-     * is wired via [Modifier.combinedClickable] so tap and long-press resolve
-     * on the same gesture surface — important when the card lives inside a
-     * scrolling container or another drag-aware parent (e.g. SwipeToDismissBox)
-     * that would otherwise race with a child pointerInput.
+     * Optional long-press handler. Routes the card through
+     * [Modifier.combinedClickable] so tap and long-press resolve on the same
+     * gesture surface — important when the card lives inside a scrolling
+     * container or another drag-aware parent (e.g. SwipeToDismissBox) that
+     * would otherwise race with a child pointerInput.
+     *
+     * **Requires [onClick]** to also be non-null. A long-press-only card
+     * would still announce as a button to accessibility but no-op on tap;
+     * we fail fast rather than ship that affordance.
      */
     onLongClick: (() -> Unit)? = null,
     contentPadding: Dp = Spacing.md,
@@ -55,10 +60,15 @@ fun PennyWiseCardV2(
         onLongClick != null -> {
             // Combined click + long-click. Material's Card composable doesn't
             // accept onLongClick directly, so we wrap a non-clickable Card with
-            // combinedClickable on the outer modifier.
+            // combinedClickable on the outer modifier. Require onClick here so
+            // the card never advertises a button affordance whose tap is a
+            // no-op (would mislead screen readers and touch users).
+            val tap = requireNotNull(onClick) {
+                "PennyWiseCardV2: onLongClick requires onClick to also be non-null."
+            }
             Card(
                 modifier = modifier.combinedClickable(
-                    onClick = onClick ?: {},
+                    onClick = tap,
                     onLongClick = onLongClick
                 ),
                 colors = colors,

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/TransactionItem.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/TransactionItem.kt
@@ -35,6 +35,10 @@ fun TransactionItem(
     listItemPosition: ListItemPosition = ListItemPosition.Single,
     profileAccountKeys: Map<Long, Set<String>> = emptyMap(),
     onClick: () -> Unit = {},
+    /** Optional long-press handler — used for bulk-edit selection entry. */
+    onLongClick: (() -> Unit)? = null,
+    /** Overrides the row's container colour (e.g. for selected state). */
+    containerColor: androidx.compose.ui.graphics.Color? = null,
     modifier: Modifier = Modifier,
 ) {
     val view = LocalView.current
@@ -66,16 +70,17 @@ fun TransactionItem(
         effectiveProfileId == ProfileEntity.BUSINESS_ID
     }
 
-    // Prefer a user-written description over the parsed merchant name as the
-    // row heading — UPI merchant strings are often cryptic VPAs and a description,
-    // when present, is what the user actually wrote about the transaction. (#383)
+    // User-written description, if present, is surfaced as the LEAD segment of
+    // the subtitle (kept short) — not as the title. Promoting it to title made
+    // casual notes ("movie night with sarah") read as inconsistent next to
+    // brand-name merchants ("Uber", "Netflix") and routinely got truncated. The
+    // merchant stays the visual heading; the description is a small contextual
+    // tag below. (#383)
     val description = transaction.description?.takeIf { it.isNotBlank() }
 
     val subtitle = remember(transaction, dateTimeText, isEffectivelyBusiness) {
         buildList {
-            // When the title shows the description, keep the merchant visible here so
-            // the user still sees who the transaction was with.
-            if (description != null) add(transaction.merchantName)
+            if (description != null) add(description)
             add(dateTimeText)
             if (transaction.category.isNotBlank() &&
                 !transaction.category.equals("Uncategorized", ignoreCase = true)
@@ -115,7 +120,7 @@ fun TransactionItem(
     val merchantDisplay = LocalMerchantDisplay.current
 
     ListItemCardV2(
-        title = description ?: merchantDisplay(transaction.merchantName) ?: transaction.merchantName,
+        title = merchantDisplay(transaction.merchantName) ?: transaction.merchantName,
         subtitle = subtitle,
         amount = "$amountPrefix$formattedAmount",
         amountColor = amountColor,
@@ -125,6 +130,8 @@ fun TransactionItem(
             view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
             onClick()
         },
+        onLongClick = onLongClick,
+        containerColor = containerColor,
         modifier = modifier,
         leadingContent = {
             val iconModifier = if (sharedTransitionScope != null && animatedVisibilityScope != null) {


### PR DESCRIPTION
Multiple Transactions-screen issues reported on the last build, fixed in one pass.

## Bugs fixed

### Bulk-edit gesture (long-press never entered selection mode)
PR #395 wrapped each row in an outer `pointerInput { detectTapGestures(onLongPress = …) }` — and that outer detector raced with the inner `SwipeToDismissBox`'s own gesture detector and lost. Long-press fell through to tap, and tap navigated to detail.

**Fix:** thread `onLongClick: (() -> Unit)?` through the card chain — `PennyWiseCardV2` (uses `Modifier.combinedClickable` when both are set) → `ListItemCardV2` → `TransactionItem`. Long-press now lives on the same surface as `onClick` so Material's gesture-resolution handles tap/long-press/drag together. Outer wrapper deleted.

### Selected row had no visible highlight
The selection state painted `Modifier.background` on a `Box` *wrapping* the Card. The Card's own opaque `surfaceContainerLow` painted over it, so the tint was invisible.

**Fix:** add `containerColor: Color?` plumbing through the card chain. Selected rows now pass `primaryContainer` and actually look selected.

### Action icons in selection-mode top bar
Only the Delete icon rendered; Category was missing, and Delete's tap-target bled past the bar edge. Two consecutive IconButtons in the `actionContent` lambda weren't both surfacing in some layouts.

**Fix:** wrap actions in an explicit `Row`.

### Net math was wrong
`netBalance = income − expenses − credit − transfer − investment` in both code paths (unified currency + single-currency `CurrencyTotals` getter), while the visible Expenses tile only contains pure expenses. So Income ₹0 − Expenses ₹1,830 rendered as Net −₹4,330.

**Fix:** Net = `income − expenses` in both paths. Credit / transfer / investment stay on the home Cash-Flow card as deliberately separate channels.

### Description-as-title broke brand-row consistency
PR #389 promoted a user-written description to the row's heading — but casual notes like `movie night with sarah` ended up lowercase next to brand names `Uber / Netflix / Big Bazaar`, and they routinely truncated mid-word.

**Fix:** revert merchant as the title; surface the description as the lead segment of the subtitle. Description stays visible without breaking visual hierarchy.

## Polish

- **Phantom band under the summary card** — the `padding(bottom = Spacing.lg)` only exists to host the optional `CurrencyPickerPill`. Apply it only when the pill is actually rendered.
- **Heavy dark-mode hairline on every row** — long lists of bordered rows read as a chunky grid. Suppress the inherited border on `ListItemCardV2` (other cards keep theirs).

## Files

`PennyWiseCardV2.kt`, `ListItemCardV2.kt`, `TransactionItem.kt`, `TransactionsScreen.kt`, `TransactionsViewModel.kt`, `TransactionTotalsCard.kt`, `CurrencyGroupedTotals.kt`

## Verification

- `./gradlew :app:compileStandardDebugKotlin` — clean.
- Installed on emulator; verified Net now reads −₹1,830 (matches Expenses ₹1,830), rows are flat / borderless, Flipkart row shows merchant as title with `movie night with sarah` in the subtitle, summary band gap is gone.
- Bulk-edit gesture: emulator `input swipe` is unreliable for synthetic long-press (normalises into a tap regardless of duration), but the code path is now `Modifier.combinedClickable(onClick, onLongClick)` on the same Card surface — Material's standard long-press detection, drives reliably under real finger input.

Closes UI bugs reported on the Transactions page.