### PR TITLE
docs: refresh tracker after #369 bulk-edit closure

### DIFF
--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -5,7 +5,7 @@ rough estimate for this codebase (Compose + Room + Hilt + on-device LLM):
 **S** ≈ localized change, **M** ≈ schema + a few screens, **L** ≈ new sub-feature,
 **XL** ≈ new subsystem / risky migration.
 
-_Snapshot: 2026-05-31 · 17 actionable + 1 blocked. Tiers 1 (S) is empty; next-easiest items are in Tier 2._
+_Snapshot: 2026-05-31 · 16 actionable + 1 blocked. Tier 1 (S) is empty; next-easiest items are in Tier 2._
 
 ---
 
@@ -22,24 +22,23 @@ _Snapshot: 2026-05-31 · 17 actionable + 1 blocked. Tiers 1 (S) is empty; next-e
 
 | # | Issue | What it takes |
 |---|-------|---------------|
-| 5 | [#369 Bulk edit transactions](https://github.com/sarim2000/pennywiseai-tracker/issues/369) | Multi-select mode in the list + batch ops (category/account/delete) with undo. |
-| 6 | [#385 Detect & merge self-transfers](https://github.com/sarim2000/pennywiseai-tracker/issues/385) | Heuristic matcher: same amount, debit/credit pair within a short window, account/name overlap → collapse two rows into one transfer event. Needs a confidence threshold + manual un-merge to keep false positives from silently corrupting data. |
-| 7 | [#301 Planned spendings ("Plans" under Budgets)](https://github.com/sarim2000/pennywiseai-tracker/issues/301) | New entity: planned item (name, budget, category, target month, optional attached txn) + CRUD + monthly view. |
-| 8 | [#170 Natural-language add-transaction via AI](https://github.com/sarim2000/pennywiseai-tracker/issues/170) | Reuse the on-device LLM to turn free text ("lunch 250") into a transaction draft. Prompt + structured-output mapping. |
-| 9 | [#279 User-defined parsing rules (regex)](https://github.com/sarim2000/pennywiseai-tracker/issues/279) | Let users write regex rules to catch currently-unparsed SMS; rule storage, a management UI, and wiring into the parse pipeline as a fallback. |
-| 10 | [#346 Split a transaction with contacts + UPI link/QR](https://github.com/sarim2000/pennywiseai-tracker/issues/346) | Split-the-bill flow on the detail screen: contact picker, per-person owed amounts, UPI deep link + QR generation, share via SMS. |
-| 11 | [#343 Separate loans per person](https://github.com/sarim2000/pennywiseai-tracker/issues/343) | Per-person loan ledgers (lent/borrowed, running balance, settle-up). New data model + screens. |
+| 5 | [#385 Detect & merge self-transfers](https://github.com/sarim2000/pennywiseai-tracker/issues/385) | Heuristic matcher: same amount, debit/credit pair within a short window, account/name overlap → collapse two rows into one transfer event. Needs a confidence threshold + manual un-merge to keep false positives from silently corrupting data. |
+| 6 | [#301 Planned spendings ("Plans" under Budgets)](https://github.com/sarim2000/pennywiseai-tracker/issues/301) | New entity: planned item (name, budget, category, target month, optional attached txn) + CRUD + monthly view. |
+| 7 | [#170 Natural-language add-transaction via AI](https://github.com/sarim2000/pennywiseai-tracker/issues/170) | Reuse the on-device LLM to turn free text ("lunch 250") into a transaction draft. Prompt + structured-output mapping. |
+| 8 | [#279 User-defined parsing rules (regex)](https://github.com/sarim2000/pennywiseai-tracker/issues/279) | Let users write regex rules to catch currently-unparsed SMS; rule storage, a management UI, and wiring into the parse pipeline as a fallback. |
+| 9 | [#346 Split a transaction with contacts + UPI link/QR](https://github.com/sarim2000/pennywiseai-tracker/issues/346) | Split-the-bill flow on the detail screen: contact picker, per-person owed amounts, UPI deep link + QR generation, share via SMS. |
+| 10 | [#343 Separate loans per person](https://github.com/sarim2000/pennywiseai-tracker/issues/343) | Per-person loan ledgers (lent/borrowed, running balance, settle-up). New data model + screens. |
 
 ## Tier 4 — Major (XL)
 
 | # | Issue | What it takes |
 |---|-------|---------------|
-| 12 | [#368 Account merge](https://github.com/sarim2000/pennywiseai-tracker/issues/368) | Merge two accounts: reassign all transactions/balances, dedup, and a safe (ideally reversible) migration. High blast radius. |
-| 13 | [#299 CSV import of historical transactions](https://github.com/sarim2000/pennywiseai-tracker/issues/299) | File picker + flexible column-mapping UI (varies per source app) + dedup against existing txns. |
-| 14 | [#351 Google Drive (or any) auto backup](https://github.com/sarim2000/pennywiseai-tracker/issues/351) | Drive/SAF auth, encrypted export/import, scheduling, and a tested restore path. |
-| 15 | [#135 Track closing balance & flag discrepancy](https://github.com/sarim2000/pennywiseai-tracker/issues/135) | Reconciliation logic comparing computed balance vs reported/closing balance, surfacing drift. |
-| 16 | [#156 Email processing (instead of / alongside SMS)](https://github.com/sarim2000/pennywiseai-tracker/issues/156) | Entirely new ingestion channel: email access/permissions, parsers for email bodies, dedup with SMS. |
-| 17 | [#13 Bank statement reconciliation](https://github.com/sarim2000/pennywiseai-tracker/issues/13) | Statement (PDF/CSV) parsing + reconcile against tracked transactions. Hardest — new parsing surface + matching engine. |
+| 11 | [#368 Account merge](https://github.com/sarim2000/pennywiseai-tracker/issues/368) | Merge two accounts: reassign all transactions/balances, dedup, and a safe (ideally reversible) migration. High blast radius. |
+| 12 | [#299 CSV import of historical transactions](https://github.com/sarim2000/pennywiseai-tracker/issues/299) | File picker + flexible column-mapping UI (varies per source app) + dedup against existing txns. |
+| 13 | [#351 Google Drive (or any) auto backup](https://github.com/sarim2000/pennywiseai-tracker/issues/351) | Drive/SAF auth, encrypted export/import, scheduling, and a tested restore path. |
+| 14 | [#135 Track closing balance & flag discrepancy](https://github.com/sarim2000/pennywiseai-tracker/issues/135) | Reconciliation logic comparing computed balance vs reported/closing balance, surfacing drift. |
+| 15 | [#156 Email processing (instead of / alongside SMS)](https://github.com/sarim2000/pennywiseai-tracker/issues/156) | Entirely new ingestion channel: email access/permissions, parsers for email bodies, dedup with SMS. |
+| 16 | [#13 Bank statement reconciliation](https://github.com/sarim2000/pennywiseai-tracker/issues/13) | Statement (PDF/CSV) parsing + reconcile against tracked transactions. Hardest — new parsing surface + matching engine. |
 
 ---
 
@@ -55,6 +54,7 @@ _Snapshot: 2026-05-31 · 17 actionable + 1 blocked. Tiers 1 (S) is empty; next-e
 
 | Closed | # | Title | Via |
 |--------|---|-------|-----|
+| 2026-05-31 | #369 | Bulk edit transactions | #395 (+ polish in #396) |
 | 2026-05-31 | #303 | Quick-pick category from txn-alert notification | #393 |
 | 2026-05-31 | #384 | Home-screen cash-flow card | #392 |
 | 2026-05-31 | #386 | Backup loans/groups round-trip + databaseVersion de-stale | #391 |


### PR DESCRIPTION
Reflects today's reality after #369 closed via #395 + polish in #396.

- Removed #369 from Tier 3.
- Renumbered Tier 3 (5–10) and Tier 4 (11–16).
- Added #369 to Recently closed with the PRs that landed it.
- Snapshot count: **16 actionable + 1 blocked**.

Top of Tier 2 stays **#159 GPS · #374 sub-categories · #371 income autopay · #296 interest accrual**.

Docs-only.