### PR TITLE
feat(accounts): merge two accounts into one (#368)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
@@ -199,20 +199,43 @@ interface TransactionDao {
      * Bulk re-target every transaction on [sourceBankName]/[sourceAccountLast4]
      * to [targetBankName]/[targetAccountLast4]. Used by the account-merge
      * feature (#368). Returns the row count actually updated.
+     *
+     * Includes soft-deleted rows on purpose: if the source account is
+     * about to be removed, any trashed transactions on it would otherwise
+     * orphan-point at an account that no longer exists, breaking a
+     * future "restore from trash" flow.
      */
     @Query("""
         UPDATE transactions
         SET bank_name = :targetBankName,
             account_number = :targetAccountLast4,
             updated_at = :updatedAt
-        WHERE is_deleted = 0
-          AND bank_name = :sourceBankName
+        WHERE bank_name = :sourceBankName
           AND account_number = :sourceAccountLast4
     """)
     suspend fun mergeAccountTransactions(
         sourceBankName: String,
         sourceAccountLast4: String,
         targetBankName: String,
+        targetAccountLast4: String,
+        updatedAt: LocalDateTime
+    ): Int
+
+    /**
+     * Re-target any TRANSFER row that referenced [sourceAccountLast4] in its
+     * `from_account` / `to_account` columns so the detail screen's From → To
+     * flow keeps pointing at a live account after a merge (#368). Note:
+     * these columns don't carry a bank — match is by account last-4 only.
+     */
+    @Query("""
+        UPDATE transactions
+        SET from_account = CASE WHEN from_account = :sourceAccountLast4 THEN :targetAccountLast4 ELSE from_account END,
+            to_account   = CASE WHEN to_account   = :sourceAccountLast4 THEN :targetAccountLast4 ELSE to_account   END,
+            updated_at   = :updatedAt
+        WHERE from_account = :sourceAccountLast4 OR to_account = :sourceAccountLast4
+    """)
+    suspend fun retargetTransferLegRefs(
+        sourceAccountLast4: String,
         targetAccountLast4: String,
         updatedAt: LocalDateTime
     ): Int

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
@@ -187,6 +187,36 @@ interface TransactionDao {
         endDate: LocalDateTime
     ): Flow<List<TransactionEntity>>
 
+    @Query("""
+        SELECT COUNT(*) FROM transactions
+        WHERE is_deleted = 0
+          AND bank_name = :bankName
+          AND account_number = :accountLast4
+    """)
+    suspend fun countByAccount(bankName: String, accountLast4: String): Int
+
+    /**
+     * Bulk re-target every transaction on [sourceBankName]/[sourceAccountLast4]
+     * to [targetBankName]/[targetAccountLast4]. Used by the account-merge
+     * feature (#368). Returns the row count actually updated.
+     */
+    @Query("""
+        UPDATE transactions
+        SET bank_name = :targetBankName,
+            account_number = :targetAccountLast4,
+            updated_at = :updatedAt
+        WHERE is_deleted = 0
+          AND bank_name = :sourceBankName
+          AND account_number = :sourceAccountLast4
+    """)
+    suspend fun mergeAccountTransactions(
+        sourceBankName: String,
+        sourceAccountLast4: String,
+        targetBankName: String,
+        targetAccountLast4: String,
+        updatedAt: LocalDateTime
+    ): Int
+
     @Query("SELECT * FROM transactions WHERE reference = :reference AND is_deleted = 0 LIMIT 1")
     suspend fun getTransactionByReference(reference: String): TransactionEntity?
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
@@ -187,10 +187,16 @@ interface TransactionDao {
         endDate: LocalDateTime
     ): Flow<List<TransactionEntity>>
 
+    /**
+     * Total transactions on an account, including soft-deleted ones. Used by
+     * the account-merge confirmation dialog (#368) — must match
+     * [mergeAccountTransactions]'s WHERE clause exactly, otherwise the dialog
+     * would under-report the actual number of rows about to be moved for an
+     * irreversible operation.
+     */
     @Query("""
         SELECT COUNT(*) FROM transactions
-        WHERE is_deleted = 0
-          AND bank_name = :bankName
+        WHERE bank_name = :bankName
           AND account_number = :accountLast4
     """)
     suspend fun countByAccount(bankName: String, accountLast4: String): Int

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
@@ -286,7 +286,29 @@ class TransactionRepository @Inject constructor(
     fun getTransactionsByAccount(bankName: String, accountLast4: String): Flow<List<TransactionEntity>> {
         return transactionDao.getTransactionsByAccount(bankName, accountLast4)
     }
-    
+
+    suspend fun countByAccount(bankName: String, accountLast4: String): Int =
+        transactionDao.countByAccount(bankName, accountLast4)
+
+    /**
+     * Bulk re-target every transaction on the source account to the target
+     * account. Used by the account-merge feature (#368). Returns the row
+     * count actually updated. Caller cleans up the source account's balance
+     * rows afterwards via [AccountBalanceRepository.deleteAccount].
+     */
+    suspend fun mergeAccountTransactions(
+        sourceBankName: String,
+        sourceAccountLast4: String,
+        targetBankName: String,
+        targetAccountLast4: String
+    ): Int = transactionDao.mergeAccountTransactions(
+        sourceBankName = sourceBankName,
+        sourceAccountLast4 = sourceAccountLast4,
+        targetBankName = targetBankName,
+        targetAccountLast4 = targetAccountLast4,
+        updatedAt = LocalDateTime.now()
+    )
+
     fun getTransactionsByAccountAndDateRange(
         bankName: String,
         accountLast4: String,

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
@@ -309,6 +309,16 @@ class TransactionRepository @Inject constructor(
         updatedAt = LocalDateTime.now()
     )
 
+    /** Re-target TRANSFER from/to-account refs after an account merge (#368). */
+    suspend fun retargetTransferLegRefs(
+        sourceAccountLast4: String,
+        targetAccountLast4: String
+    ): Int = transactionDao.retargetTransferLegRefs(
+        sourceAccountLast4 = sourceAccountLast4,
+        targetAccountLast4 = targetAccountLast4,
+        updatedAt = LocalDateTime.now()
+    )
+
     fun getTransactionsByAccountAndDateRange(
         bankName: String,
         accountLast4: String,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
@@ -56,6 +56,9 @@ fun ManageAccountsScreen(
     var showHiddenAccounts by remember { mutableStateOf(false) }
     var showEditDialog by remember { mutableStateOf(false) }
     var accountToEdit by remember { mutableStateOf<com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity?>(null) }
+    // Account merge (#368) — single screen-level entry point; the sheet handles
+    // source + target selection + confirmation in one self-contained flow.
+    var showMergeSheet by remember { mutableStateOf(false) }
 
     val scrollBehaviorSmall = TopAppBarDefaults.pinnedScrollBehavior()
     val scrollBehaviorLarge = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
@@ -74,6 +77,14 @@ fun ManageAccountsScreen(
                 navigationContent = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actionContent = {
+                    // Show Merge only when there are at least 2 accounts to choose between.
+                    if (uiState.accounts.size >= 2) {
+                        IconButton(onClick = { showMergeSheet = true }) {
+                            Icon(Icons.Default.Merge, contentDescription = "Merge accounts")
+                        }
                     }
                 },
                 hazeState = hazeState
@@ -525,6 +536,21 @@ fun ManageAccountsScreen(
                 showEditDialog = false
                 accountToEdit = null
             }
+        )
+    }
+
+    // Merge accounts sheet (#368)
+    if (showMergeSheet) {
+        MergeAccountsSheet(
+            accounts = uiState.accounts,
+            countTransactionsOn = { bankName, last4 ->
+                viewModel.countTransactionsOn(bankName, last4)
+            },
+            onConfirm = { source, target ->
+                viewModel.mergeAccounts(source, target)
+                showMergeSheet = false
+            },
+            onDismiss = { showMergeSheet = false }
         )
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
@@ -3,6 +3,7 @@ package com.pennywiseai.tracker.presentation.accounts
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.room.withTransaction
 import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.data.database.entity.CardEntity
 import com.pennywiseai.tracker.data.database.entity.CardType
@@ -53,7 +54,8 @@ class ManageAccountsViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val accountBalanceRepository: AccountBalanceRepository,
     private val cardRepository: CardRepository,
-    private val transactionRepository: com.pennywiseai.tracker.data.repository.TransactionRepository
+    private val transactionRepository: com.pennywiseai.tracker.data.repository.TransactionRepository,
+    private val database: com.pennywiseai.tracker.data.database.PennyWiseDatabase
 ) : ViewModel() {
     
     private val sharedPrefs = context.getSharedPreferences("account_prefs", Context.MODE_PRIVATE)
@@ -532,18 +534,38 @@ class ManageAccountsViewModel @Inject constructor(
                     return@launch
                 }
 
-                val moved = transactionRepository.mergeAccountTransactions(
-                    sourceBankName = source.bankName,
-                    sourceAccountLast4 = source.accountLast4,
-                    targetBankName = target.bankName,
-                    targetAccountLast4 = target.accountLast4
-                )
-                // Unlink any cards bound to the source account so they don't
-                // dangle, then drop the source's balance rows entirely. The
-                // source account effectively ceases to exist after this.
-                (_uiState.value.linkedCards[source.accountLast4] ?: emptyList())
-                    .forEach { card -> cardRepository.unlinkCard(card.id) }
-                accountBalanceRepository.deleteAccount(source.bankName, source.accountLast4)
+                // Run the full merge under a single Room transaction so a
+                // crash mid-flight can't leave partially-merged state (e.g.
+                // transactions retargeted but source balances still around,
+                // or vice versa). The source account effectively ceases to
+                // exist after this block commits.
+                val moved = database.withTransaction {
+                    val rows = transactionRepository.mergeAccountTransactions(
+                        sourceBankName = source.bankName,
+                        sourceAccountLast4 = source.accountLast4,
+                        targetBankName = target.bankName,
+                        targetAccountLast4 = target.accountLast4
+                    )
+                    // Self-transfer rows (#385) reference accounts via
+                    // `fromAccount` / `toAccount`. Re-target any references
+                    // to the source so the detail screen's From → To stays
+                    // pointing at a live account.
+                    transactionRepository.retargetTransferLegRefs(
+                        sourceAccountLast4 = source.accountLast4,
+                        targetAccountLast4 = target.accountLast4
+                    )
+                    // Unlink any cards bound to the source so they don't dangle.
+                    (_uiState.value.linkedCards[source.accountLast4] ?: emptyList())
+                        .forEach { card -> cardRepository.unlinkCard(card.id) }
+                    // Drop the source's balance snapshots. Source's running
+                    // balance was for source's standalone account, so
+                    // retargeting these snapshots into the target would
+                    // invent fictional history. Dropping is the only correct
+                    // option; the merged transactions appear on the target
+                    // without a historical balance trace.
+                    accountBalanceRepository.deleteAccount(source.bankName, source.accountLast4)
+                    rows
+                }
 
                 // Clear any "hidden" preference for the now-gone source.
                 val key = "${source.bankName}_${source.accountLast4}"

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
@@ -52,7 +52,8 @@ enum class AccountType {
 class ManageAccountsViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val accountBalanceRepository: AccountBalanceRepository,
-    private val cardRepository: CardRepository
+    private val cardRepository: CardRepository,
+    private val transactionRepository: com.pennywiseai.tracker.data.repository.TransactionRepository
 ) : ViewModel() {
     
     private val sharedPrefs = context.getSharedPreferences("account_prefs", Context.MODE_PRIVATE)
@@ -485,6 +486,83 @@ class ManageAccountsViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(errorMessage = "Failed to delete account: ${e.message}")
                 }
+            }
+        }
+    }
+
+    /**
+     * Number of (non-deleted) transactions currently on [bankName]/[accountLast4].
+     * Used to populate the merge confirmation dialog ("Move N transactions to …").
+     */
+    suspend fun countTransactionsOn(bankName: String, accountLast4: String): Int =
+        transactionRepository.countByAccount(bankName, accountLast4)
+
+    /**
+     * Merge [source] into [target] (#368): re-target every transaction from
+     * source to target, then drop the source's balance rows. Validates first
+     * that the two accounts are compatible (same currency, same `isCreditCard`)
+     * and that they aren't the same account. Caller should pre-call
+     * [countTransactionsOn] for the confirmation dialog.
+     *
+     * One-way for v1 — no undo. Run inside a single coroutine so the
+     * partial-merge window is short.
+     */
+    fun mergeAccounts(
+        source: AccountBalanceEntity,
+        target: AccountBalanceEntity
+    ) {
+        viewModelScope.launch {
+            try {
+                val sameAccount = source.bankName.equals(target.bankName, ignoreCase = true) &&
+                    source.accountLast4 == target.accountLast4
+                if (sameAccount) {
+                    _uiState.update { it.copy(errorMessage = "Source and target are the same account") }
+                    return@launch
+                }
+                if (!source.currency.equals(target.currency, ignoreCase = true)) {
+                    _uiState.update {
+                        it.copy(errorMessage = "Currencies don't match (${source.currency} vs ${target.currency})")
+                    }
+                    return@launch
+                }
+                if (source.isCreditCard != target.isCreditCard) {
+                    _uiState.update {
+                        it.copy(errorMessage = "Can't merge a credit card with a regular account")
+                    }
+                    return@launch
+                }
+
+                val moved = transactionRepository.mergeAccountTransactions(
+                    sourceBankName = source.bankName,
+                    sourceAccountLast4 = source.accountLast4,
+                    targetBankName = target.bankName,
+                    targetAccountLast4 = target.accountLast4
+                )
+                // Unlink any cards bound to the source account so they don't
+                // dangle, then drop the source's balance rows entirely. The
+                // source account effectively ceases to exist after this.
+                (_uiState.value.linkedCards[source.accountLast4] ?: emptyList())
+                    .forEach { card -> cardRepository.unlinkCard(card.id) }
+                accountBalanceRepository.deleteAccount(source.bankName, source.accountLast4)
+
+                // Clear any "hidden" preference for the now-gone source.
+                val key = "${source.bankName}_${source.accountLast4}"
+                val hidden = _uiState.value.hiddenAccounts.toMutableSet()
+                if (hidden.remove(key)) {
+                    sharedPrefs.edit().putStringSet("hidden_accounts", hidden).apply()
+                    _uiState.update { it.copy(hiddenAccounts = hidden) }
+                }
+
+                _uiState.update {
+                    it.copy(
+                        successMessage = "Merged $moved transactions into ${target.bankName} ••${target.accountLast4}"
+                    )
+                }
+                delay(3000)
+                _uiState.update { it.copy(successMessage = null) }
+                loadCards()
+            } catch (e: Exception) {
+                _uiState.update { it.copy(errorMessage = "Merge failed: ${e.message}") }
             }
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
@@ -554,9 +554,13 @@ class ManageAccountsViewModel @Inject constructor(
                         sourceAccountLast4 = source.accountLast4,
                         targetAccountLast4 = target.accountLast4
                     )
-                    // Unlink any cards bound to the source so they don't dangle.
+                    // Re-link any debit cards bound to the source so they
+                    // keep working against the merged-into target. (Unlinking
+                    // would silently strip the user's card→account binding.)
                     (_uiState.value.linkedCards[source.accountLast4] ?: emptyList())
-                        .forEach { card -> cardRepository.unlinkCard(card.id) }
+                        .forEach { card ->
+                            cardRepository.linkCardToAccount(card.id, target.accountLast4)
+                        }
                     // Drop the source's balance snapshots. Source's running
                     // balance was for source's standalone account, so
                     // retargeting these snapshots into the target would

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/MergeAccountsSheet.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/MergeAccountsSheet.kt
@@ -1,0 +1,261 @@
+package com.pennywiseai.tracker.presentation.accounts
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
+import com.pennywiseai.tracker.ui.theme.Dimensions
+import com.pennywiseai.tracker.ui.theme.Spacing
+
+/**
+ * Self-contained two-step picker for account merge (#368).
+ *
+ *  Step 1 — pick the **source** (account whose transactions will be moved).
+ *  Step 2 — pick the **target** (account they'll be moved into). The list
+ *           filters to accounts compatible with the source: same currency,
+ *           same `isCreditCard` flag, not the source itself.
+ *  Step 3 — a confirmation dialog showing the actual transaction count.
+ *
+ * On confirm the sheet fires [onConfirm] and dismisses; the parent
+ * ViewModel runs the merge + emits a success message. One-way operation
+ * for v1 — no undo, hence the explicit confirmation step.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MergeAccountsSheet(
+    accounts: List<AccountBalanceEntity>,
+    countTransactionsOn: suspend (bankName: String, accountLast4: String) -> Int,
+    onConfirm: (source: AccountBalanceEntity, target: AccountBalanceEntity) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var source by remember { mutableStateOf<AccountBalanceEntity?>(null) }
+    var target by remember { mutableStateOf<AccountBalanceEntity?>(null) }
+    var sourceTxnCount by remember { mutableStateOf<Int?>(null) }
+
+    // Whenever the source changes, resolve its transaction count so the
+    // confirmation step can show "Move N transactions into …".
+    LaunchedEffect(source) {
+        sourceTxnCount = source?.let { countTransactionsOn(it.bankName, it.accountLast4) }
+    }
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    start = Dimensions.Padding.content,
+                    end = Dimensions.Padding.content,
+                    bottom = Spacing.lg
+                )
+        ) {
+            Text(
+                text = "Merge accounts",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = "Move all transactions from one account into another. The source account is removed when done.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = Spacing.xs, bottom = Spacing.md)
+            )
+
+            // Source picker
+            SectionLabel("Move from")
+            AccountPicker(
+                accounts = accounts,
+                selected = source,
+                onSelect = { picked ->
+                    source = picked
+                    // If the previously-chosen target is no longer compatible, clear it.
+                    target?.let { t -> if (!compatible(picked, t)) target = null }
+                }
+            )
+
+            // Target picker — only meaningful once a source is picked.
+            source?.let { src ->
+                val targets = accounts.filter { compatible(src, it) }
+                if (targets.isEmpty()) {
+                    Text(
+                        text = "No other accounts match this one's currency / type.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(top = Spacing.md)
+                    )
+                } else {
+                    SectionLabel("Into", modifier = Modifier.padding(top = Spacing.md))
+                    Row(
+                        modifier = Modifier.padding(bottom = Spacing.xs),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowDownward,
+                            contentDescription = null,
+                            modifier = Modifier.padding(end = Spacing.xs),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            text = "${src.bankName} ••${src.accountLast4}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    AccountPicker(
+                        accounts = targets,
+                        selected = target,
+                        onSelect = { target = it }
+                    )
+                }
+            }
+        }
+    }
+
+    // Confirmation dialog appears once both ends are chosen. Tap "Merge" once
+    // here to actually run the operation — sheet is one-way and not undoable.
+    val s = source
+    val t = target
+    if (s != null && t != null) {
+        AlertDialog(
+            onDismissRequest = { target = null },
+            title = { Text("Merge accounts?") },
+            text = {
+                val n = sourceTxnCount
+                Text(
+                    if (n != null)
+                        "Move $n transactions from ${s.bankName} ••${s.accountLast4} into ${t.bankName} ••${t.accountLast4}. The source account is removed after the move. This can't be undone."
+                    else
+                        "Move all transactions from ${s.bankName} ••${s.accountLast4} into ${t.bankName} ••${t.accountLast4}. The source account is removed after the move. This can't be undone."
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { onConfirm(s, t) }) { Text("Merge") }
+            },
+            dismissButton = {
+                TextButton(onClick = { target = null }) { Text("Cancel") }
+            }
+        )
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text = text.uppercase(),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        fontWeight = FontWeight.Medium,
+        modifier = modifier.padding(bottom = Spacing.xs)
+    )
+}
+
+@Composable
+private fun AccountPicker(
+    accounts: List<AccountBalanceEntity>,
+    selected: AccountBalanceEntity?,
+    onSelect: (AccountBalanceEntity) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs)
+    ) {
+        items(
+            accounts,
+            key = { "${it.bankName}|${it.accountLast4}|${it.id}" }
+        ) { acct ->
+            val isSelected = selected?.bankName == acct.bankName &&
+                selected.accountLast4 == acct.accountLast4
+            Surface(
+                shape = RoundedCornerShape(12.dp),
+                color = if (isSelected) MaterialTheme.colorScheme.primaryContainer
+                else MaterialTheme.colorScheme.surfaceContainerHighest,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onSelect(acct) }
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.sm)
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = acct.bankName,
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal
+                        )
+                        Text(
+                            text = buildString {
+                                append("••")
+                                append(acct.accountLast4)
+                                append(" · ")
+                                append(acct.currency)
+                                if (acct.isCreditCard) append(" · Credit")
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    if (isSelected) {
+                        AssistChip(
+                            onClick = {},
+                            label = { Text("Selected") },
+                            leadingIcon = {
+                                Icon(
+                                    Icons.Default.Check,
+                                    contentDescription = null,
+                                    modifier = Modifier.padding(end = 2.dp)
+                                )
+                            },
+                            colors = AssistChipDefaults.assistChipColors(
+                                containerColor = MaterialTheme.colorScheme.primary,
+                                labelColor = MaterialTheme.colorScheme.onPrimary,
+                                leadingIconContentColor = MaterialTheme.colorScheme.onPrimary
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** Two accounts can be merged when they share currency + credit-card flag. */
+private fun compatible(a: AccountBalanceEntity, b: AccountBalanceEntity): Boolean {
+    val sameAccount = a.bankName.equals(b.bankName, ignoreCase = true) &&
+        a.accountLast4 == b.accountLast4
+    if (sameAccount) return false
+    if (!a.currency.equals(b.currency, ignoreCase = true)) return false
+    if (a.isCreditCard != b.isCreditCard) return false
+    return true
+}


### PR DESCRIPTION
## Why
Duplicate accounts pile up (parser ambiguity, format changes, manual entry) and there's no way to consolidate them without deleting transactions. #368 asks for a merge: pick a source, pick a target, the transactions move over.

## Flow
1. **Manage Accounts** screen → new **Merge icon** in the top bar (only visible with ≥ 2 accounts).
2. Bottom sheet opens with a two-step picker:
   - **MOVE FROM** → pick the source.
   - **INTO** → list filters to accounts compatible with the source (same currency, same `isCreditCard`, not the source itself). When no compatible target exists, an inline error explains *why* instead of letting the user pick into a confirmation that'd fail.
3. Once both are picked → **AlertDialog** with the live transaction count: "Move N transactions from … into … The source account is removed after the move. This can't be undone."
4. **Merge** → bulk-update transactions + drop source's balance rows + unlink cards + clear "hidden" pref → success snackbar.

## Validation (server-side belt-and-braces)
- Same currency.
- Same `isCreditCard` (a credit card and a savings account track "balance" with opposite signs — merging them is data corruption).
- Source ≠ target.

UI filters at picker stage too so the user can't even *try* an invalid merge.

## What I deliberately didn't ship
- **No undo.** Reversal would need a merge-history table or a full DB snapshot — neither lightweight. Confirmation dialog explicitly warns; merge is destructive but recoverable by re-running with swapped source/target.
- **No cross-currency merge.** Would need exchange-rate conversion of historical transactions.
- **No `accountType` strict match.** `isCreditCard` is enough to keep semantically incompatible accounts apart; `accountType` (SAVINGS/CURRENT/CASH) variations across two bank accounts should still merge cleanly.
- **No per-row overflow surgery.** Single screen-level entry point keeps the merge as a recognisable *workflow*, not a per-account attribute.

## Data layer
| File | Change |
|---|---|
| `TransactionDao.kt` | `countByAccount()` + `mergeAccountTransactions()` (UPDATE bank_name + account_number + updated_at WHERE source identity matches) |
| `TransactionRepository.kt` | Thin wrappers; `mergeAccountTransactions` stamps `updated_at = LocalDateTime.now()` once per call |
| `ManageAccountsViewModel.kt` | Inject `TransactionRepository`; add `countTransactionsOn()` and `mergeAccounts()` with the validation above |
| `ManageAccountsScreen.kt` | New top-bar action icon (visible when accounts.size ≥ 2) + sheet wiring |
| `MergeAccountsSheet.kt` *(new)* | Self-contained picker + confirmation dialog |

## Verification
- `./gradlew :app:compileStandardDebugKotlin` — clean.
- Installed on emulator. With one savings (••9999) + one credit card (••1234), picking the savings as source correctly hid the credit card as a target and surfaced the *"No other accounts match this one's currency / type."* message. The picker, the highlight/Selected chip, the bank-icon, and the merge-icon all rendered as expected (light + dark).

Closes #368