### PR TITLE
feat: GitHub Sponsors link (Settings + repo Sponsor button)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# GitHub Sponsors — funds AI/infra spend for PennyWise (Greptile reviews,
+# any future hosted services). The app itself remains AGPL-3.0 and free
+# on F-Droid + GitHub releases.
+github: [sarim2000]

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -501,6 +501,19 @@ fun SettingsScreen(
                         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/sarim2000/pennywiseai-tracker/issues/new/choose"))
                         context.startActivity(intent)
                     },
+                    position = ItemPosition.MIDDLE,
+                    trailingIcon = Icons.AutoMirrored.Filled.OpenInNew
+                )
+                SettingsNavItem(
+                    icon = Icons.Default.FavoriteBorder,
+                    iconBgColor = red_light,
+                    iconTint = red_dark,
+                    title = "Support development",
+                    subtitle = "Help offset AI & infra costs via GitHub Sponsors",
+                    onClick = {
+                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/sponsors/sarim2000"))
+                        context.startActivity(intent)
+                    },
                     position = ItemPosition.BOTTOM,
                     trailingIcon = Icons.AutoMirrored.Filled.OpenInNew
                 )


### PR DESCRIPTION
Lowest-friction monetization for the current scale (1k+ installs / 80 reviews / 4.6★). No Play Billing yet, no review-bomb risk, no AGPL server-side complications, doesn't contradict the README "no hidden costs" promise. Pure goodwill support.

## Changes
- **`.github/FUNDING.yml`** — adds the "Sponsor ❤" button to the GitHub repo header. Pointed at `sarim2000`. Activates as soon as GitHub Sponsors enrollment is approved (file is harmless until then).
- **Settings → Support & Community → "Support development"** — opens [`github.com/sponsors/sarim2000`](https://github.com/sponsors/sarim2000) in the browser. Lives below "Report an Issue", uses the existing `SettingsNavItem` pattern, red heart icon to stand out from the blue/pink neighbours.

## Why this and not Play Billing
At 1k installs the math doesn't work for subscription (~₹50/month realistic), and adding a Play Billing tip jar would burn a week on Merchant account + tax forms + sandbox testing. GitHub Sponsors costs zero infrastructure, taps the same goodwill pool, and skips Google's 15-30% cut.

When the install base or AI/infra spend warrants it, the next monetization step is a one-time Pro unlock (₹199 one-time, client-side features only — AGPL-safe). Subscription stays parked until 10k+ installs + a cloud-cost-bearing feature like sync.

## Out of scope
- No Play Billing.
- No UPI/QR (could add later if Sponsors signup is delayed; either path works).
- F-Droid build is unaffected — same Settings entry shows there, linking to GitHub Sponsors is policy-compliant for F-Droid (non-promotional support link).