### PR TITLE
fix(parser): classify modern Slice UPI as EXPENSE, not CREDIT (Slice Bank, not card)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SliceParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SliceParser.kt
@@ -100,25 +100,53 @@ class SliceParser : BankParser() {
         }
     }
 
+    /**
+     * Returns true when the message clearly references a Slice credit-card product
+     * (legacy, pre-2022 RBI PPI pivot). Modern Slice is a UPI / savings-account
+     * product, so without explicit card context we treat debits as EXPENSE, not
+     * CREDIT (which downstream is interpreted as "credit card account").
+     */
+    private fun hasCardContext(lowerMessage: String): Boolean {
+        return lowerMessage.contains("credit card") ||
+                lowerMessage.contains("credit limit") ||
+                lowerMessage.contains("available limit") ||
+                lowerMessage.contains("card ending") ||
+                lowerMessage.contains("card xx") ||
+                lowerMessage.contains("card no") ||
+                lowerMessage.contains("on your slice card") ||
+                lowerMessage.contains("slice card")
+    }
+
     override fun extractTransactionType(message: String): TransactionType? {
         val lowerMessage = message.lowercase()
+        val cardContext = hasCardContext(lowerMessage)
 
         return when {
-            // Slice credits/cashbacks
+            // Slice credits/cashbacks (income side unchanged)
             lowerMessage.contains("credited") -> TransactionType.INCOME
             lowerMessage.contains("received") -> TransactionType.INCOME
             lowerMessage.contains("cashback") -> TransactionType.INCOME
             lowerMessage.contains("refund") -> TransactionType.INCOME
 
-            // Slice payments/debits
-            lowerMessage.contains("debited") -> TransactionType.CREDIT
-            lowerMessage.contains("spent") -> TransactionType.CREDIT
-            lowerMessage.contains("paid") -> TransactionType.CREDIT
-            lowerMessage.contains("sent") -> TransactionType.CREDIT  // UPI transfers
-            lowerMessage.contains("payment") && !lowerMessage.contains("received") -> TransactionType.CREDIT
-            // Only map "transaction" to CREDIT if it's a successful transaction
-            lowerMessage.contains("transaction") && !lowerMessage.contains("credited") && 
-                isSuccessMessage(message) && !isFailureMessage(message) -> TransactionType.CREDIT
+            // Slice payments/debits.
+            // After RBI's 2022 PPI guidelines, Slice pivoted from a credit-card
+            // product to a UPI / savings-account product (Slice Bank). Debits
+            // from the bank account must be EXPENSE so that downstream code
+            // does not classify the account as a credit card. Only fall back
+            // to CREDIT when the message explicitly mentions card context.
+            lowerMessage.contains("debited") -> TransactionType.EXPENSE
+            lowerMessage.contains("sent") -> TransactionType.EXPENSE  // UPI transfer
+            lowerMessage.contains("spent") ->
+                if (cardContext) TransactionType.CREDIT else TransactionType.EXPENSE
+            lowerMessage.contains("paid") ->
+                if (cardContext) TransactionType.CREDIT else TransactionType.EXPENSE
+            lowerMessage.contains("payment") && !lowerMessage.contains("received") ->
+                if (cardContext) TransactionType.CREDIT else TransactionType.EXPENSE
+            // Only map bare "transaction" word to a type if it's a successful
+            // transaction; default to EXPENSE unless clearly card-context.
+            lowerMessage.contains("transaction") && !lowerMessage.contains("credited") &&
+                isSuccessMessage(message) && !isFailureMessage(message) ->
+                if (cardContext) TransactionType.CREDIT else TransactionType.EXPENSE
 
             else -> super.extractTransactionType(message)
         }

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SliceParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SliceParserTest.kt
@@ -13,10 +13,50 @@ class SliceParserTest {
     private val parser = SliceParser()
 
     @TestFactory
-    fun `slice parser handles credit card transactions`(): List<DynamicTest> {
+    fun `slice parser classifies bank vs card debits correctly`(): List<DynamicTest> {
         val testCases = listOf(
+            // --- Modern Slice Bank (post-2022 RBI PPI pivot): UPI / savings account ---
             ParserTestCase(
-                name = "Slice credit card transaction on amazon.in",
+                name = "Modern Slice UPI transfer (sent to) should be EXPENSE, not CREDIT",
+                message = "Sent Rs.500 to MERCHANT NAME (UPI transaction success). Sent from slice.",
+                sender = "JK-SLICEIT",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("500"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "MERCHANT NAME",
+                    accountLast4 = null,
+                    reference = null
+                )
+            ),
+            ParserTestCase(
+                name = "Modern Slice debited (bank account)",
+                message = "Rs.250 debited from your slice account via UPI. Txn ID 1234567890.",
+                sender = "AD-SLCEIT-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("250"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = null,
+                    reference = null
+                )
+            ),
+            ParserTestCase(
+                name = "Modern Slice paid via UPI (no card context) is EXPENSE",
+                message = "Rs.100 paid to MERCHANT via slice UPI. Txn ID 9876543210.",
+                sender = "AD-SLCEIT-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("100"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = null,
+                    reference = null
+                )
+            ),
+
+            // --- Legacy Slice credit card (kept for regression: must remain CREDIT) ---
+            ParserTestCase(
+                name = "Legacy slice credit card transaction on amazon.in (CREDIT)",
                 message = "Your slice credit card transaction of RS. 50000 on amazon.in is successful. If not you, call 08048329999 - slice",
                 sender = "AD-SLCEIT-S",
                 expected = ExpectedTransaction(
@@ -29,7 +69,7 @@ class SliceParserTest {
                 )
             ),
             ParserTestCase(
-                name = "Slice credit card transaction with different amount",
+                name = "Legacy slice credit card transaction with decimal amount (CREDIT)",
                 message = "Your slice credit card transaction of RS. 1234.56 on flipkart.com is successful.",
                 sender = "AX-SLICEIT-S",
                 expected = ExpectedTransaction(
@@ -42,20 +82,21 @@ class SliceParserTest {
                 )
             ),
             ParserTestCase(
-                name = "Slice UPI transfer (sent to)",
-                message = "Sent Rs.500 to John Doe (UPI transaction success). Sent from slice.",
-                sender = "JK-SLICEIT",
+                name = "Slice card 'spent' wording with card context stays CREDIT",
+                message = "Rs.350 spent on your slice credit card at MERCHANT. Available limit: Rs.10000.",
+                sender = "AD-SLCEIT-S",
                 expected = ExpectedTransaction(
-                    amount = BigDecimal("500"),
+                    amount = BigDecimal("350"),
                     currency = "INR",
                     type = TransactionType.CREDIT,
-                    merchant = "John Doe",
                     accountLast4 = null,
                     reference = null
                 )
             ),
+
+            // --- Income side (regression: must remain INCOME) ---
             ParserTestCase(
-                name = "Slice credit (credited)",
+                name = "Cashback credited to slice account (INCOME)",
                 message = "Rs.1000 credited to your slice account as cashback.",
                 sender = "AD-SLCEIT-S",
                 expected = ExpectedTransaction(
@@ -67,6 +108,8 @@ class SliceParserTest {
                     reference = null
                 )
             ),
+
+            // --- Non-transaction / failure regressions ---
             ParserTestCase(
                 name = "Non-transaction message (OTP)",
                 message = "Your OTP for slice transaction is 123456. Do not share.",
@@ -92,14 +135,14 @@ class SliceParserTest {
                 shouldParse = false
             ),
             ParserTestCase(
-                name = "Date phrase should not be extracted as merchant",
+                name = "Date phrase should not be extracted as merchant (legacy card path)",
                 message = "Your slice credit card transaction of RS. 50000 on Feb 15 is successful.",
                 sender = "AD-SLCEIT-S",
                 expected = ExpectedTransaction(
                     amount = BigDecimal("50000"),
                     currency = "INR",
                     type = TransactionType.CREDIT,
-                    merchant = null,  // Date phrase should be rejected, fallback to super.extractMerchant which may return "Slice"
+                    merchant = null,
                     accountLast4 = null,
                     reference = null
                 )


### PR DESCRIPTION
## Summary

Users reported that **Slice accounts were being created as credit-card accounts** in PennyWise, even though Slice is now a UPI / savings-account product (Slice Bank).

### Root cause

After RBI's 2022 Prepaid Payment Instrument (PPI) guidelines, Slice was forced to pivot away from its original credit-card product to a UPI / savings-account product (via SBM Bank, later their own SFB). Modern Slice SMS use UPI verbs (`sent`, `paid`, `debited`) for what are really bank-account debits.

`SliceParser.extractTransactionType` was still mapping every debit verb (`debited`, `spent`, `paid`, `sent`, `payment`, `transaction`) to `TransactionType.CREDIT`. Downstream, `SmsTransactionProcessor.kt:251` uses `CREDIT` as the signal that the underlying account is a credit card:

```kotlin
val isCreditCard = (parsedTransaction.type.toEntityType() == TransactionType.CREDIT) || …
```

So every modern Slice UPI debit was creating / labelling the user's Slice account as a credit card.

### Fix

In `SliceParser.extractTransactionType`:

- `debited` and `sent` (UPI transfer) -> `EXPENSE`
- `spent`, `paid`, `payment`, bare `transaction` -> `EXPENSE` by default; only escalate to `CREDIT` when the message has explicit **card context** (`credit card`, `credit limit`, `available limit`, `card ending`, `slice card`, ...) via a new `hasCardContext()` helper.
- Income side (`credited`, `received`, `cashback`, `refund`) is unchanged.
- `SmsTransactionProcessor` is untouched — its heuristic is correct in general; the bug was the parser misclassifying the type.

### Sample SMS covered by tests

- `Sent Rs.500 to MERCHANT (UPI transaction success). Sent from slice.` -> `EXPENSE`
- `Rs.250 debited from your slice account via UPI. Txn ID 1234567890.` -> `EXPENSE`
- `Rs.100 paid to MERCHANT via slice UPI. Txn ID 9876543210.` -> `EXPENSE`
- `Your slice credit card transaction of RS. 50000 on amazon.in is successful.` -> `CREDIT` (legacy regression)
- `Rs.350 spent on your slice credit card at MERCHANT. Available limit: Rs.10000.` -> `CREDIT` (card context regression)
- `Rs.1000 credited to your slice account as cashback.` -> `INCOME` (regression)
- Plus existing OTP / declined / failed / unsuccessful negative regressions.

### Known follow-up (not in scope here)

This PR fixes new transactions going forward. Users who already have a Slice account that was mis-classified as a credit card can use the in-app **account-merge** feature (shipped recently) to merge their mis-classified Slice account into a fresh savings-account Slice entry. No data migration is bundled with this PR.

## Test plan

- [x] `./gradlew :parser-core:jvmTest --tests "*Slice*"` — 19 / 19 pass (Slice cases + handle checks).
- [x] `./gradlew :parser-core:jvmTest` (full suite) — 1142 / 1142 pass, 0 failures.
- [ ] After deploy: confirm new Slice UPI SMS lands as a regular bank/savings account rather than a credit-card account.