### PR TITLE
feat(parser): add Navi Mutual Fund SIP/unit-allotment parser (#403)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -7,6 +7,7 @@ object BankParserFactory {
 
     private val parsers = listOf(
         HDFCMutualFundParser(),  // HDFC Mutual Fund (must be before HDFCBankParser to avoid interception by HDFC's broad DLT pattern)
+        NaviMutualFundParser(),  // Navi Mutual Fund (AMC SIP / unit-allotment SMS — NAVAMC sender)
         HDFCBankParser(),
         SBIBankParser(),
         SaraswatBankParser(),

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NaviMutualFundParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NaviMutualFundParser.kt
@@ -1,0 +1,86 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Navi Mutual Fund parser for SIP / unit-allotment SMS.
+ *
+ * Handles senders containing "NAVAMC" (Navi Asset Management Company),
+ * e.g. "AD-NAVAMC-S", "VK-NAVAMC-T".
+ *
+ * Sample SMS:
+ *   "Unit Allotment Update:
+ *    Your SIP purchase of Rs.499.98 in Navi Nifty Next 50 Index Fund DG has been
+ *    processed at applicable NAV. The units will be alloted in 1-2 working days.
+ *    For further queries, please visit the Navi app.
+ *    Team Navi Mutual Fund"
+ *
+ * Notes:
+ * - Account number is not present in AMC unit-allotment SMS; left null.
+ * - Underlying bank-side SIP debit (NACH/mandate) is parsed by the user's bank
+ *   parser and will book a separate transaction. Manual dedupe is expected for v1.
+ * - Mandate / autopay creation messages are NOT covered here; those originate
+ *   from the user's bank, not the AMC.
+ */
+class NaviMutualFundParser : BankParser() {
+
+    override fun getBankName() = "Navi Mutual Fund"
+
+    override fun canHandle(sender: String): Boolean {
+        // Match DLT-style senders like "AD-NAVAMC-S", "VK-NAVAMC-T".
+        // Keyed on "NAVAMC" specifically so we don't false-positive on
+        // generic "NAVI" senders that may belong to Navi's banking arm.
+        return sender.uppercase().contains("NAVAMC")
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+        // Gate strictly on unit-allotment + SIP purchase phrasing so we ignore
+        // NAV updates, account statements, marketing, etc.
+        return lower.contains("unit allotment") && lower.contains("sip purchase")
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // "purchase of Rs.499.98 in ..." — also tolerate optional space after Rs
+        // and Indian-style comma grouping (e.g. "Rs. 1,49,999.98").
+        val pattern = Regex(
+            """purchase\s+of\s+Rs\.?\s*([0-9,]+(?:\.\d+)?)""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            val amountStr = match.groupValues[1].replace(",", "")
+            return try {
+                BigDecimal(amountStr)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+        return null
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // Capture the fund name between "in " and " has been processed".
+        // Kept generic so Navi Largecap / Liquid / ELSS / etc. all flow through.
+        val pattern = Regex(
+            """\bin\s+(.+?)\s+has\s+been\s+processed""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            val fund = match.groupValues[1].trim()
+            if (fund.isNotEmpty()) return fund
+        }
+        return null
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        // Unit allotment from an AMC is always an investment outflow.
+        return TransactionType.INVESTMENT
+    }
+
+    // AMC SMS doesn't carry a bank account number.
+    override fun extractAccountLast4(message: String): String? = null
+
+    // No running balance in AMC SMS.
+    override fun extractBalance(message: String): BigDecimal? = null
+}

--- a/parser-core/src/test/kotlin/TestNaviMutualFundParser.kt
+++ b/parser-core/src/test/kotlin/TestNaviMutualFundParser.kt
@@ -1,0 +1,63 @@
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.bank.NaviMutualFundParser
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.*
+import java.math.BigDecimal
+
+class NaviMutualFundParserTest {
+
+    @TestFactory
+    fun `navi mutual fund parser covers SIP unit-allotment scenarios`(): List<DynamicTest> {
+        val parser = NaviMutualFundParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "SIP unit allotment — Nifty Next 50 Index Fund DG",
+                message = "Unit Allotment Update:\nYour SIP purchase of Rs.499.98 in Navi Nifty Next 50 Index Fund DG has been processed at applicable NAV. The units will be alloted in 1-2 working days. For further queries, please visit the Navi app.\nTeam Navi Mutual Fund",
+                sender = "AD-NAVAMC-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("499.98"),
+                    currency = "INR",
+                    type = TransactionType.INVESTMENT,
+                    merchant = "Navi Nifty Next 50 Index Fund DG"
+                )
+            ),
+            ParserTestCase(
+                name = "SIP unit allotment — Largecap with Indian-style commas",
+                message = "Unit Allotment Update:\nYour SIP purchase of Rs. 1,49,999.98 in Navi Largecap Fund DG has been processed at applicable NAV. The units will be alloted in 1-2 working days.\nTeam Navi Mutual Fund",
+                sender = "VK-NAVAMC-T",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("149999.98"),
+                    currency = "INR",
+                    type = TransactionType.INVESTMENT,
+                    merchant = "Navi Largecap Fund DG"
+                )
+            ),
+            ParserTestCase(
+                name = "Non-allotment NAV update is rejected",
+                message = "NAV updated for Navi Largecap Fund. Latest NAV: 12.3456. Visit the Navi app for details.",
+                sender = "AD-NAVAMC-S",
+                shouldParse = false
+            )
+        )
+
+        val handleChecks = listOf(
+            "AD-NAVAMC-S" to true,
+            "VK-NAVAMC-T" to true,
+            "ad-navamc-s" to true,    // case-insensitive
+            "HDFCBK" to false,
+            "AD-HDFCMF-AC" to false,
+            "NAVI" to false,           // banking-arm sender must NOT match
+            "UNKNOWN" to false
+        )
+
+        return ParserTestUtils.runTestSuite(
+            parser = parser,
+            testCases = testCases,
+            handleCases = handleChecks,
+            suiteName = "Navi Mutual Fund Parser Suite"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new parser-core extension for **Navi Mutual Fund** SIP / unit-allotment SMS (sender pattern `*NAVAMC*`, e.g. `AD-NAVAMC-S`, `VK-NAVAMC-T`).

- Extends `BankParser` directly (not `BaseIndianBankParser`) — this is an AMC notification, not a bank account, so the centralised mandate / balance-update logic doesn't apply.
- Classifies as `TransactionType.INVESTMENT`.
- Extracts the fund name (e.g. `Navi Nifty Next 50 Index Fund DG`) as the merchant.
- Handles decimal precision (`Rs.499.98`) and Indian-style comma grouping (`Rs. 1,49,999.98`).
- `accountLast4` and `balance` deliberately left `null` — AMC SMS doesn't carry that data.
- Gated on `"unit allotment"` + `"sip purchase"` so NAV updates, statements, and marketing don't get parsed as transactions.

## Known limitations (heads-up, not blockers)

- **Double-counting:** the user's bank will separately SMS the underlying NACH/SIP debit (`Rs.499.98 debited via mandate to BSE...`). That gets parsed by the bank's own parser and booked as a second transaction. v1 ships both; user can dedupe manually. Worth tracking as a follow-up.
- **Mandate/autopay parsing is deliberately out of scope** for this PR. The issue checklist mentions it, but the provided sample is a plain unit-allotment notification — mandate-creation SMS originates from the user's bank (HDFC/SBI/etc), not from the AMC. If real mandate-creation samples from Navi AMC surface later, that's a follow-up issue.

## Sender claims

- Matches: any sender whose uppercased form contains `NAVAMC` (e.g. `AD-NAVAMC-S`, `VK-NAVAMC-T`, `ad-navamc-s`)
- Does NOT match: plain `NAVI`, `HDFCBK`, `AD-HDFCMF-AC`, `UNKNOWN`

## Test plan

- [x] `./gradlew :parser-core:jvmTest --tests "*NaviMutualFund*"` — 10/10 passing (3 parse cases incl. negative + 7 handle checks)
- [x] Full `./gradlew :parser-core:jvmTest` regression suite — green
- [x] No Android/app-side files touched

Closes #403