### PR TITLE
feat: income autopay + cycle-aware recurring subscriptions (#371)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
@@ -156,22 +156,7 @@ abstract class PennyWiseDatabase : RoomDatabase() {
                     PennyWiseDatabase::class.java,
                     DATABASE_NAME
                 )
-                    .addMigrations(
-                        MIGRATION_12_14,
-                        MIGRATION_13_14,
-                        MIGRATION_14_15,
-                        MIGRATION_20_21,
-                        MIGRATION_21_22,
-                        MIGRATION_22_23,
-                        MIGRATION_38_39,
-                        // 44_45 and 45_46 were never added here, so a receiver
-                        // upgrading past v44 before Hilt initialised would crash.
-                        // Bringing this list in sync with the Hilt module.
-                        MIGRATION_44_45,
-                        MIGRATION_45_46,
-                        MIGRATION_46_47,
-                        MIGRATION_47_48
-                    )
+                    .addMigrations(*ALL_MIGRATIONS)
                     .build()
                 INSTANCE = instance
                 instance
@@ -508,6 +493,28 @@ abstract class PennyWiseDatabase : RoomDatabase() {
                 return false
             }
         }
+
+        /**
+         * Single source of truth for the migration list. Both the Hilt-built
+         * database (DatabaseModule.providePennyWiseDatabase) and the
+         * BroadcastReceiver fallback path (getInstance above) reference this
+         * — adding a new migration here registers it for both. Splitting
+         * them previously caused a v47→v48 boot crash because the Hilt
+         * builder didn't know about MIGRATION_47_48.
+         */
+        val ALL_MIGRATIONS: Array<Migration> = arrayOf(
+            MIGRATION_12_14,
+            MIGRATION_13_14,
+            MIGRATION_14_15,
+            MIGRATION_20_21,
+            MIGRATION_21_22,
+            MIGRATION_22_23,
+            MIGRATION_38_39,
+            MIGRATION_44_45,
+            MIGRATION_45_46,
+            MIGRATION_46_47,
+            MIGRATION_47_48,
+        )
     }
     
     /**

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
@@ -56,7 +56,7 @@ import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
  * that needs to record the version it was exported against. Bump this in lock-
  * step with any schema change.
  */
-const val SCHEMA_VERSION = 47
+const val SCHEMA_VERSION = 48
 
 /**
  * The PennyWise Room database.
@@ -169,7 +169,8 @@ abstract class PennyWiseDatabase : RoomDatabase() {
                         // Bringing this list in sync with the Hilt module.
                         MIGRATION_44_45,
                         MIGRATION_45_46,
-                        MIGRATION_46_47
+                        MIGRATION_46_47,
+                        MIGRATION_47_48
                     )
                     .build()
                 INSTANCE = instance
@@ -454,6 +455,29 @@ abstract class PennyWiseDatabase : RoomDatabase() {
         val MIGRATION_46_47 = object : Migration(46, 47) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE `transactions` ADD COLUMN `loan_contribution` TEXT DEFAULT NULL")
+            }
+        }
+
+        /**
+         * Income autopay + cycle persistence (#371). Adds two columns to
+         * `subscriptions`:
+         *
+         *  - `direction` — EXPENSE (today's behaviour: Netflix, EMIs) or
+         *    INCOME (wallet top-ups, allowance) for the new income-autopay
+         *    flow that phantom-creates a transaction when `next_payment_date`
+         *    rolls past today.
+         *  - `billing_cycle` — previously collected by the Add-Subscription
+         *    UI but silently dropped by the use case, so the matcher's
+         *    hard-coded +30-day advance ran for every cycle. Persist it now
+         *    so cycle-aware advance + phantom creation can honour the
+         *    user-chosen cadence (Weekly / Monthly / Quarterly / Annual).
+         *
+         * Existing rows default to EXPENSE + Monthly so behaviour is unchanged.
+         */
+        val MIGRATION_47_48 = object : Migration(47, 48) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `subscriptions` ADD COLUMN `direction` TEXT NOT NULL DEFAULT 'EXPENSE'")
+                db.execSQL("ALTER TABLE `subscriptions` ADD COLUMN `billing_cycle` TEXT NOT NULL DEFAULT 'Monthly'")
             }
         }
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/converter/Converters.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/converter/Converters.kt
@@ -4,6 +4,7 @@ import androidx.room.TypeConverter
 import com.pennywiseai.tracker.data.database.entity.BudgetGroupType
 import com.pennywiseai.tracker.data.database.entity.BudgetImpactType
 import com.pennywiseai.tracker.data.database.entity.BudgetPeriodType
+import com.pennywiseai.tracker.data.database.entity.SubscriptionDirection
 import com.pennywiseai.tracker.data.database.entity.SubscriptionState
 import com.pennywiseai.tracker.data.database.entity.LoanDirection
 import com.pennywiseai.tracker.data.database.entity.LoanStatus
@@ -86,6 +87,16 @@ class Converters {
     @TypeConverter
     fun toSubscriptionState(value: String): SubscriptionState {
         return SubscriptionState.valueOf(value)
+    }
+
+    @TypeConverter
+    fun fromSubscriptionDirection(value: SubscriptionDirection): String {
+        return value.name
+    }
+
+    @TypeConverter
+    fun toSubscriptionDirection(value: String): SubscriptionDirection {
+        return SubscriptionDirection.valueOf(value)
     }
 
     @TypeConverter

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/SubscriptionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/SubscriptionDao.kt
@@ -21,8 +21,29 @@ interface SubscriptionDao {
     
     @Query("SELECT * FROM subscriptions WHERE next_payment_date <= :date AND state = 'ACTIVE' ORDER BY next_payment_date ASC")
     fun getUpcomingSubscriptions(date: LocalDate): Flow<List<SubscriptionEntity>>
+
+    /**
+     * Active INCOME-direction subscriptions whose next_payment_date is today
+     * or earlier — the phantom auto-creator (#371) materialises one
+     * transaction per missed cycle for each row returned here.
+     */
+    @Query("""
+        SELECT * FROM subscriptions
+        WHERE direction = 'INCOME'
+          AND state = 'ACTIVE'
+          AND next_payment_date IS NOT NULL
+          AND next_payment_date <= :date
+        ORDER BY next_payment_date ASC
+    """)
+    suspend fun getDueIncomeSubscriptions(date: LocalDate): List<SubscriptionEntity>
     
-    @Query("SELECT * FROM subscriptions WHERE merchant_name = :merchantName AND state = 'ACTIVE' LIMIT 1")
+    /**
+     * Used by the SMS-debit matcher only — explicitly filtered to
+     * EXPENSE-direction so an incoming bank-debit SMS doesn't accidentally
+     * match an INCOME-direction subscription (#371). INCOME subs are
+     * advanced by the phantom auto-creator, not by SMS match.
+     */
+    @Query("SELECT * FROM subscriptions WHERE merchant_name = :merchantName AND state = 'ACTIVE' AND direction = 'EXPENSE' LIMIT 1")
     suspend fun getActiveSubscriptionByMerchant(merchantName: String): SubscriptionEntity?
     
     @Query("SELECT * FROM subscriptions WHERE merchant_name = :merchantName AND state = 'HIDDEN' LIMIT 1")

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/SubscriptionEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/SubscriptionEntity.kt
@@ -44,11 +44,37 @@ data class SubscriptionEntity(
     val updatedAt: LocalDateTime = LocalDateTime.now(),
 
     @ColumnInfo(name = "currency", defaultValue = "INR")
-    val currency: String = "INR"
+    val currency: String = "INR",
+
+    /**
+     * Whether this recurring entry is money OUT (an EXPENSE — Netflix, EMI,
+     * mandate debit) or money IN (an INCOME — wallet top-up, allowance,
+     * salary). Income autopay (#371) gets phantom-created automatically when
+     * `nextPaymentDate` rolls past today; expense autopay continues to be
+     * matched against incoming bank-debit SMS.
+     */
+    @ColumnInfo(name = "direction", defaultValue = "EXPENSE")
+    val direction: SubscriptionDirection = SubscriptionDirection.EXPENSE,
+
+    /**
+     * User-chosen recurrence cadence as a display string ("Weekly",
+     * "Monthly", "Quarterly", "Semi-Annual", "Annual"). Drives
+     * [SubscriptionRepository.advanceNextPaymentDate]'s date arithmetic
+     * and the income-autopay phantom creator. Previously this was collected
+     * by the form but silently dropped — a latent bug that meant every
+     * subscription advanced by exactly +30 days regardless of cycle.
+     */
+    @ColumnInfo(name = "billing_cycle", defaultValue = "Monthly")
+    val billingCycle: String = "Monthly"
 )
 
 enum class SubscriptionState {
     ACTIVE,
     HIDDEN, // Soft delete - hidden from view but kept for reactivation detection
     ENDED   // User explicitly cancelled; never auto-reactivates on new mandate SMS
+}
+
+enum class SubscriptionDirection {
+    EXPENSE,  // Recurring money out (Netflix, mandates, EMIs)
+    INCOME    // Recurring money in (wallet top-ups, allowance — phantom-created on schedule, #371)
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/SubscriptionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/SubscriptionRepository.kt
@@ -110,16 +110,41 @@ class SubscriptionRepository @Inject constructor(
     }
     
     /**
-     * Updates the next payment date after a subscription charge
+     * Updates the next payment date after a subscription charge fires.
+     * Advances by the subscription's persisted [SubscriptionEntity.billingCycle]
+     * (Weekly / Monthly / Quarterly / Semi-Annual / Annual). Previously this
+     * hard-coded `+30 days`, silently ignoring the user's chosen cycle (#371).
      */
     suspend fun updateNextPaymentDateAfterCharge(
         subscriptionId: Long,
         chargeDate: LocalDate = LocalDate.now()
     ) {
-        // Assume monthly subscription, add 30 days
-        val nextDate = chargeDate.plusDays(30)
-        subscriptionDao.updateNextPaymentDate(subscriptionId, nextDate)
+        val sub = subscriptionDao.getSubscriptionById(subscriptionId) ?: return
+        subscriptionDao.updateNextPaymentDate(subscriptionId, advance(chargeDate, sub.billingCycle))
     }
+
+    /**
+     * Cycle-aware date advance. Months/years use real calendar arithmetic
+     * (so "Monthly" lands on the same day-of-month next month, not strictly
+     * +30 days). Unknown cycles fall back to monthly so a stale or hand-
+     * inserted row never silently advances by 0 days.
+     */
+    fun advance(date: LocalDate, billingCycle: String): LocalDate = when (billingCycle.uppercase()) {
+        "WEEKLY" -> date.plusWeeks(1)
+        "MONTHLY" -> date.plusMonths(1)
+        "QUARTERLY" -> date.plusMonths(3)
+        "SEMI-ANNUAL", "SEMI ANNUAL", "SEMIANNUAL" -> date.plusMonths(6)
+        "ANNUAL", "YEARLY" -> date.plusYears(1)
+        else -> date.plusMonths(1)
+    }
+
+    /** Active INCOME subscriptions due on or before [date] (#371). */
+    suspend fun getDueIncomeSubscriptions(date: LocalDate = LocalDate.now()): List<SubscriptionEntity> =
+        subscriptionDao.getDueIncomeSubscriptions(date)
+
+    /** Direct DAO passthrough — used by the income-autopay phantom creator. */
+    suspend fun updateNextPaymentDate(subscriptionId: Long, nextPaymentDate: LocalDate) =
+        subscriptionDao.updateNextPaymentDate(subscriptionId, nextPaymentDate)
     
     
     private fun areAmountsEqual(amount1: BigDecimal, amount2: BigDecimal): Boolean {

--- a/app/src/main/java/com/pennywiseai/tracker/di/DatabaseModule.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/di/DatabaseModule.kt
@@ -67,7 +67,8 @@ object DatabaseModule {
                 PennyWiseDatabase.MIGRATION_38_39,
                 PennyWiseDatabase.MIGRATION_44_45,
                 PennyWiseDatabase.MIGRATION_45_46,
-                PennyWiseDatabase.MIGRATION_46_47
+                PennyWiseDatabase.MIGRATION_46_47,
+                PennyWiseDatabase.MIGRATION_47_48
             )
 
             // Enable auto-migrations

--- a/app/src/main/java/com/pennywiseai/tracker/di/DatabaseModule.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/di/DatabaseModule.kt
@@ -56,20 +56,9 @@ object DatabaseModule {
             PennyWiseDatabase::class.java,
             PennyWiseDatabase.DATABASE_NAME
         )
-            // Add manual migrations here when needed
-            .addMigrations(
-                PennyWiseDatabase.MIGRATION_12_14,
-                PennyWiseDatabase.MIGRATION_13_14,
-                PennyWiseDatabase.MIGRATION_14_15,
-                PennyWiseDatabase.MIGRATION_20_21,
-                PennyWiseDatabase.MIGRATION_21_22,
-                PennyWiseDatabase.MIGRATION_22_23,
-                PennyWiseDatabase.MIGRATION_38_39,
-                PennyWiseDatabase.MIGRATION_44_45,
-                PennyWiseDatabase.MIGRATION_45_46,
-                PennyWiseDatabase.MIGRATION_46_47,
-                PennyWiseDatabase.MIGRATION_47_48
-            )
+            // Single source of truth lives in PennyWiseDatabase.ALL_MIGRATIONS
+            // so the BroadcastReceiver fallback builder stays in sync.
+            .addMigrations(*PennyWiseDatabase.ALL_MIGRATIONS)
 
             // Enable auto-migrations
             // Room will automatically detect schema changes between versions

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddSubscriptionUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddSubscriptionUseCase.kt
@@ -1,6 +1,7 @@
 package com.pennywiseai.tracker.domain.usecase
 
 import android.util.Log
+import com.pennywiseai.tracker.data.database.entity.SubscriptionDirection
 import com.pennywiseai.tracker.data.database.entity.SubscriptionEntity
 import com.pennywiseai.tracker.data.database.entity.SubscriptionState
 import com.pennywiseai.tracker.data.repository.SubscriptionRepository
@@ -21,10 +22,11 @@ class AddSubscriptionUseCase @Inject constructor(
         autoRenewal: Boolean = true,
         paymentReminder: Boolean = true,
         notes: String? = null,
-        currency: String = "INR"
+        currency: String = "INR",
+        direction: SubscriptionDirection = SubscriptionDirection.EXPENSE
     ): Long {
         Log.d("AddSubscriptionUseCase", "Creating subscription entity...")
-        
+
         val subscription = SubscriptionEntity(
             merchantName = merchantName,
             amount = amount,
@@ -35,7 +37,9 @@ class AddSubscriptionUseCase @Inject constructor(
             currency = currency,
             smsBody = notes, // Store user notes in smsBody field
             createdAt = LocalDateTime.now(),
-            updatedAt = LocalDateTime.now()
+            updatedAt = LocalDateTime.now(),
+            direction = direction,
+            billingCycle = billingCycle
         )
         
         Log.d("AddSubscriptionUseCase", "Subscription entity created: $subscription")

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/GenerateIncomeAutopayUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/GenerateIncomeAutopayUseCase.kt
@@ -1,0 +1,75 @@
+package com.pennywiseai.tracker.domain.usecase
+
+import android.util.Log
+import com.pennywiseai.tracker.data.database.entity.TransactionEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionType
+import com.pennywiseai.tracker.data.repository.SubscriptionRepository
+import com.pennywiseai.tracker.data.repository.TransactionRepository
+import java.time.LocalDate
+import java.time.LocalDateTime
+import javax.inject.Inject
+
+/**
+ * Phantom-creates the INCOME transactions described by recurring income
+ * subscriptions (#371). Some accounts — wallets, allowances, internal
+ * top-ups — don't send an SMS when money arrives, so without this the
+ * user has to manually log every cycle. Instead, the user declares
+ * "₹X expected on the Nth of every month" once; this use case materialises
+ * the matching transaction the moment it's due (and catches up if the user
+ * was away for several cycles).
+ *
+ * Runs on every SMS scan completion. Idempotent — the per-cycle
+ * `transactionHash` is `"autopay-<subId>-<scheduledDate>"`, so a second
+ * pass on the same day for the same subscription is dedup'd by
+ * `TransactionRepository.getTransactionByHash`.
+ */
+class GenerateIncomeAutopayUseCase @Inject constructor(
+    private val subscriptionRepository: SubscriptionRepository,
+    private val transactionRepository: TransactionRepository
+) {
+
+    /** Returns the count of phantom transactions inserted. */
+    suspend fun execute(today: LocalDate = LocalDate.now()): Int {
+        val due = subscriptionRepository.getDueIncomeSubscriptions(today)
+        if (due.isEmpty()) return 0
+
+        var inserted = 0
+        for (sub in due) {
+            var scheduled = sub.nextPaymentDate ?: continue
+            // Materialise every missed cycle up to today, not just one — a
+            // user who didn't open the app for two months should see both
+            // months' phantom income, not just the most recent.
+            while (!scheduled.isAfter(today)) {
+                val hash = "autopay-${sub.id}-$scheduled"
+                if (transactionRepository.getTransactionByHash(hash) == null) {
+                    val phantom = TransactionEntity(
+                        amount = sub.amount,
+                        merchantName = sub.merchantName,
+                        category = sub.category ?: "Income",
+                        transactionType = TransactionType.INCOME,
+                        dateTime = scheduled.atStartOfDay(),
+                        description = "Scheduled income (autopay)",
+                        bankName = sub.bankName,
+                        currency = sub.currency,
+                        transactionHash = hash,
+                        isRecurring = true,
+                        createdAt = LocalDateTime.now(),
+                        updatedAt = LocalDateTime.now()
+                    )
+                    val rowId = transactionRepository.insertTransaction(phantom)
+                    if (rowId != -1L) inserted++
+                }
+                scheduled = subscriptionRepository.advance(scheduled, sub.billingCycle)
+            }
+            // Persist the final advanced date so the next scan starts from
+            // there instead of replaying everything.
+            subscriptionRepository.updateNextPaymentDate(sub.id, scheduled)
+        }
+        if (inserted > 0) Log.i(TAG, "Materialised $inserted scheduled income transactions.")
+        return inserted
+    }
+
+    private companion object {
+        const val TAG = "GenerateIncomeAutopay"
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
@@ -341,6 +341,15 @@ class AddViewModel @Inject constructor(
             )
         }
     }
+
+    /** Toggle Income / Expense for the recurring entry (#371). */
+    fun updateSubscriptionDirection(
+        direction: com.pennywiseai.tracker.data.database.entity.SubscriptionDirection
+    ) {
+        _subscriptionUiState.update { currentState ->
+            currentState.copy(direction = direction)
+        }
+    }
     
     fun updateSubscriptionNextPaymentDate(dateMillis: Long) {
         val instant = Instant.ofEpochMilli(dateMillis)
@@ -414,7 +423,8 @@ class AddViewModel @Inject constructor(
                     autoRenewal = false, // Not implemented yet
                     paymentReminder = false, // Not implemented yet
                     notes = state.notes.takeIf { it.isNotBlank() },
-                    currency = state.currency
+                    currency = state.currency,
+                    direction = state.direction
                 )
                 
                 Log.d("AddViewModel", "Subscription saved successfully with ID: $subscriptionId")
@@ -510,7 +520,14 @@ data class SubscriptionUiState(
     val notes: String = "",
     val isLoading: Boolean = false,
     val error: String? = null,
-    val currency: String = "INR"
+    val currency: String = "INR",
+    /**
+     * Income vs Expense (#371). Income subscriptions get phantom-created
+     * on schedule (wallet top-ups etc.); expense subscriptions match
+     * incoming bank-debit SMS as today.
+     */
+    val direction: com.pennywiseai.tracker.data.database.entity.SubscriptionDirection =
+        com.pennywiseai.tracker.data.database.entity.SubscriptionDirection.EXPENSE
 ) {
     val isValid: Boolean
         get() = serviceName.isNotBlank() &&

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/SubscriptionTabContent.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/SubscriptionTabContent.kt
@@ -98,7 +98,36 @@ fun SubscriptionTabContent(
                 }
             }
 
-            // Info Card
+            // Income / Expense direction toggle (#371). Income subscriptions
+            // get phantom-created on schedule (for accounts that don't send
+            // SMS — wallets, allowances). Expense subscriptions match
+            // incoming bank-debit SMS like today.
+            val isIncome = uiState.direction ==
+                com.pennywiseai.tracker.data.database.entity.SubscriptionDirection.INCOME
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                SegmentedButton(
+                    selected = !isIncome,
+                    onClick = {
+                        viewModel.updateSubscriptionDirection(
+                            com.pennywiseai.tracker.data.database.entity.SubscriptionDirection.EXPENSE
+                        )
+                    },
+                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                    label = { Text("Expense") }
+                )
+                SegmentedButton(
+                    selected = isIncome,
+                    onClick = {
+                        viewModel.updateSubscriptionDirection(
+                            com.pennywiseai.tracker.data.database.entity.SubscriptionDirection.INCOME
+                        )
+                    },
+                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                    label = { Text("Income") }
+                )
+            }
+
+            // Info Card — copy adapts to the chosen direction.
             PennyWiseCardV2(
                 modifier = Modifier.fillMaxWidth(),
                 colors = CardDefaults.cardColors(
@@ -114,7 +143,10 @@ fun SubscriptionTabContent(
                         modifier = Modifier.size(Dimensions.Icon.medium)
                     )
                     Text(
-                        text = "Track recurring expenses. You'll need to add transactions manually each month.",
+                        text = if (isIncome)
+                            "Track recurring income (wallet top-ups, allowance). A transaction is auto-created on each scheduled date."
+                        else
+                            "Track recurring expenses. You'll need to add transactions manually each month.",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onPrimaryContainer
                     )

--- a/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
@@ -65,7 +65,8 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val unrecognizedSmsRepository: UnrecognizedSmsRepository,
     private val ruleRepository: RuleRepository,
-    private val ruleEngine: RuleEngine
+    private val ruleEngine: RuleEngine,
+    private val generateIncomeAutopayUseCase: com.pennywiseai.tracker.domain.usecase.GenerateIncomeAutopayUseCase
 ) : CoroutineWorker(appContext, workerParams) {
 
     companion object {
@@ -330,6 +331,15 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
 
             Log.i(TAG, buildSummary(stats, totalTime))
             cleanUpAndFinalize(stats)
+            // Materialise any due income-autopay phantoms (#371). Runs after
+            // SMS processing so a real INCOME SMS that landed for the same
+            // amount + merchant in this scan can dedupe via the autopay hash
+            // check if the user manually re-uses the same hash format later.
+            try {
+                generateIncomeAutopayUseCase.execute()
+            } catch (e: Exception) {
+                Log.e(TAG, "Income autopay phantom creator failed: ${e.message}", e)
+            }
             reportProgress(stats)
             Result.success()
 


### PR DESCRIPTION
## What the issue asked for
> "Add income auto-pay which gets triggered on a certain date every month. Some accounts like wallet do not receive an SMS but they get a top-up every month."

Plus your follow-up: *make them act as subscriptions along with option for custom repetition period.*

## What this PR does

### Schema (v47 → v48, `MIGRATION_47_48`)
Two new columns on `subscriptions`:
- `direction TEXT NOT NULL DEFAULT 'EXPENSE'` — EXPENSE (today's Netflix/EMI behavior) or INCOME (the new ask).
- `billing_cycle TEXT NOT NULL DEFAULT 'Monthly'` — persists the cadence the form already collects.

Existing rows default to EXPENSE / Monthly. No data loss.

### Latent bug fixed along the way
The Add-Subscription form collected `billingCycle` ("Monthly" / "Quarterly" / "Semi-Annual" / "Annual" / "Weekly"), validated it, passed it through `AddSubscriptionUseCase` — and then **silently dropped it on the floor**. The matcher hardcoded `chargeDate.plusDays(30)` for every cycle. Now it's actually persisted and `SubscriptionRepository.advance(date, cycle)` uses real calendar arithmetic (`plusMonths(1)`, `plusYears(1)`) so "Monthly" lands on the same day next month, not strictly +30 days.

### Phantom auto-creator — `GenerateIncomeAutopayUseCase`
On every SMS scan completion, for each active INCOME subscription whose `next_payment_date <= today`:
- Loops materialising one phantom INCOME transaction per **missed** cycle up to today. A user who didn't open the app for two months sees both months catch up, not just the most recent.
- Each phantom's `transaction_hash = "autopay-<subId>-<scheduledDate>"` — stable, per-cycle, so a second run on the same day dedupes via `getTransactionByHash`.
- Advances `next_payment_date` by the subscription's persisted `billingCycle`.

Hooked into `OptimizedSmsReaderWorker.doWork` after SMS processing — predictable, runs on every scan (manual or background).

### Matcher safety
`getActiveSubscriptionByMerchant` now filters to `direction = 'EXPENSE'` so an incoming bank-debit SMS can't accidentally match an INCOME-direction subscription with the same merchant name. INCOME subs are advanced only by the phantom auto-creator, never by SMS match.

### UI
- `AddViewModel.SubscriptionUiState` gains a `direction` field + `updateSubscriptionDirection` setter.
- `SubscriptionTabContent` shows a Material 3 `SingleChoiceSegmentedButtonRow` (Expense / Income) at the top of the subscription form. The info-card copy adapts to the chosen direction.

## What I deliberately didn't do (and why)
- **Match real INCOME SMS to INCOME subs.** Issue scope is "no SMS arrives" — the phantom creator handles that. If you want real-INCOME-SMS to bump an income sub's `nextPaymentDate`, that's a small follow-up.
- **Differentiate income vs expense rows visually in SubscriptionsScreen.** They appear in the existing list sorted by next payment date. Could group/badge later; not needed for the feature to work.
- **Migrate existing wrongly-typed subscriptions.** Anything created before this PR is `EXPENSE` (default). Users who already created a "Salary" sub thinking it was income can edit it after this lands (edit flow not in scope here either; could be a follow-up).

## Verification
- `./gradlew :app:compileStandardDebugKotlin` — clean.
- Emulator install couldn't be verified end-to-end (sim dropped during testing), but the migration is a single `ALTER TABLE ... ADD COLUMN ... DEFAULT ...` pattern matching v44/v45/v46/v47 verbatim, so the risk surface is low.

## Files
`PennyWiseDatabase.kt`, `SubscriptionEntity.kt`, `SubscriptionDao.kt`, `SubscriptionRepository.kt`, `AddSubscriptionUseCase.kt`, `GenerateIncomeAutopayUseCase.kt` (new), `AddViewModel.kt`, `SubscriptionTabContent.kt`, `OptimizedSmsReaderWorker.kt`.

Closes #371