### PR TITLE
feat(subscriptions): tap-to-mark-paid bottom sheet (#412)

### DIFF
--- a/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/49.json
+++ b/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/49.json
@@ -1,0 +1,1735 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 49,
+    "identityHash": "2f1f5a1dd2ed2a5d3fedd0efd6b3fd9f",
+    "entities": [
+      {
+        "tableName": "transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` TEXT NOT NULL, `merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `transaction_type` TEXT NOT NULL, `date_time` TEXT NOT NULL, `description` TEXT, `sms_body` TEXT, `bank_name` TEXT, `sms_sender` TEXT, `account_number` TEXT, `balance_after` TEXT, `transaction_hash` TEXT NOT NULL DEFAULT '', `is_recurring` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `from_account` TEXT, `to_account` TEXT, `reference` TEXT, `loan_id` INTEGER DEFAULT NULL, `loan_contribution` TEXT DEFAULT NULL, `receipt_path` TEXT DEFAULT NULL, `budget_category` TEXT DEFAULT NULL, `budget_impact_type` TEXT DEFAULT NULL, `group_id` INTEGER DEFAULT NULL, `profile_id` INTEGER DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionType",
+            "columnName": "transaction_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateTime",
+            "columnName": "date_time",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsSender",
+            "columnName": "sms_sender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountNumber",
+            "columnName": "account_number",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "balanceAfter",
+            "columnName": "balance_after",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "transactionHash",
+            "columnName": "transaction_hash",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isRecurring",
+            "columnName": "is_recurring",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "fromAccount",
+            "columnName": "from_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toAccount",
+            "columnName": "to_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "loanId",
+            "columnName": "loan_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "loanContribution",
+            "columnName": "loan_contribution",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "receiptPath",
+            "columnName": "receipt_path",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetCategory",
+            "columnName": "budget_category",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetImpactType",
+            "columnName": "budget_impact_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "group_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transactions_transaction_hash",
+            "unique": true,
+            "columnNames": [
+              "transaction_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_transactions_transaction_hash` ON `${TABLE_NAME}` (`transaction_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `merchant_name` TEXT NOT NULL, `amount` TEXT NOT NULL, `next_payment_date` TEXT, `state` TEXT NOT NULL, `bank_name` TEXT, `umn` TEXT, `category` TEXT, `sms_body` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `direction` TEXT NOT NULL DEFAULT 'EXPENSE', `billing_cycle` TEXT NOT NULL DEFAULT 'Monthly', `last_paid_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextPaymentDate",
+            "columnName": "next_payment_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umn",
+            "columnName": "umn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'EXPENSE'"
+          },
+          {
+            "fieldPath": "billingCycle",
+            "columnName": "billing_cycle",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Monthly'"
+          },
+          {
+            "fieldPath": "lastPaidAt",
+            "columnName": "last_paid_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `message` TEXT NOT NULL, `isUser` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `isSystemPrompt` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUser",
+            "columnName": "isUser",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemPrompt",
+            "columnName": "isSystemPrompt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "merchant_mappings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`merchant_name`))",
+        "fields": [
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "merchant_name"
+          ]
+        }
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `color` TEXT NOT NULL, `is_system` INTEGER NOT NULL, `is_income` INTEGER NOT NULL, `display_order` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIncome",
+            "columnName": "is_income",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_categories_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_categories_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "account_balances",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT NOT NULL, `balance` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `transaction_id` INTEGER, `credit_limit` TEXT, `is_credit_card` INTEGER NOT NULL DEFAULT 0, `sms_source` TEXT, `source_type` TEXT, `account_type` TEXT, `created_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `statement_day` INTEGER DEFAULT NULL, `profile_id` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "creditLimit",
+            "columnName": "credit_limit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isCreditCard",
+            "columnName": "is_credit_card",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "smsSource",
+            "columnName": "sms_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "source_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountType",
+            "columnName": "account_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "statementDay",
+            "columnName": "statement_day",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_account_balances_bank_name_account_last4_timestamp",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "account_last4",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4_timestamp` ON `${TABLE_NAME}` (`bank_name`, `account_last4`, `timestamp`)"
+          },
+          {
+            "name": "index_account_balances_bank_name_account_last4",
+            "unique": false,
+            "columnNames": [
+              "bank_name",
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4` ON `${TABLE_NAME}` (`bank_name`, `account_last4`)"
+          },
+          {
+            "name": "index_account_balances_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "unrecognized_sms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sender` TEXT NOT NULL, `sms_body` TEXT NOT NULL, `received_at` TEXT NOT NULL, `reported` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receivedAt",
+            "columnName": "received_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reported",
+            "columnName": "reported",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_unrecognized_sms_sender_sms_body",
+            "unique": true,
+            "columnNames": [
+              "sender",
+              "sms_body"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_unrecognized_sms_sender_sms_body` ON `${TABLE_NAME}` (`sender`, `sms_body`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `card_last4` TEXT NOT NULL, `card_type` TEXT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT, `nickname` TEXT, `is_active` INTEGER NOT NULL DEFAULT 1, `last_balance` TEXT, `last_balance_source` TEXT, `last_balance_date` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardLast4",
+            "columnName": "card_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardType",
+            "columnName": "card_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastBalance",
+            "columnName": "last_balance",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceSource",
+            "columnName": "last_balance_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceDate",
+            "columnName": "last_balance_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cards_bank_name_card_last4",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cards_bank_name_card_last4` ON `${TABLE_NAME}` (`bank_name`, `card_last4`)"
+          },
+          {
+            "name": "index_cards_card_last4",
+            "unique": false,
+            "columnNames": [
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_card_last4` ON `${TABLE_NAME}` (`card_last4`)"
+          },
+          {
+            "name": "index_cards_account_last4",
+            "unique": false,
+            "columnNames": [
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_account_last4` ON `${TABLE_NAME}` (`account_last4`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `conditions` TEXT NOT NULL, `actions` TEXT NOT NULL, `is_active` INTEGER NOT NULL, `is_system_template` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conditions",
+            "columnName": "conditions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actions",
+            "columnName": "actions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemTemplate",
+            "columnName": "is_system_template",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_rules_priority_is_active",
+            "unique": false,
+            "columnNames": [
+              "priority",
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_priority_is_active` ON `${TABLE_NAME}` (`priority`, `is_active`)"
+          },
+          {
+            "name": "index_transaction_rules_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "rule_applications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `rule_id` TEXT NOT NULL, `rule_name` TEXT NOT NULL, `transaction_id` TEXT NOT NULL, `fields_modified` TEXT NOT NULL, `applied_at` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`rule_id`) REFERENCES `transaction_rules`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "rule_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleName",
+            "columnName": "rule_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fieldsModified",
+            "columnName": "fields_modified",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedAt",
+            "columnName": "applied_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rule_applications_rule_id",
+            "unique": false,
+            "columnNames": [
+              "rule_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_rule_id` ON `${TABLE_NAME}` (`rule_id`)"
+          },
+          {
+            "name": "index_rule_applications_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          },
+          {
+            "name": "index_rule_applications_applied_at",
+            "unique": false,
+            "columnNames": [
+              "applied_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_applied_at` ON `${TABLE_NAME}` (`applied_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transaction_rules",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "rule_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "exchange_rates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `from_currency` TEXT NOT NULL, `to_currency` TEXT NOT NULL, `rate` TEXT NOT NULL, `provider` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `updated_at_unix` INTEGER NOT NULL DEFAULT 0, `expires_at` TEXT NOT NULL, `expires_at_unix` INTEGER NOT NULL DEFAULT 0, `is_custom_rate` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCurrency",
+            "columnName": "from_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCurrency",
+            "columnName": "to_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtUnix",
+            "columnName": "updated_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expires_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAtUnix",
+            "columnName": "expires_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isCustomRate",
+            "columnName": "is_custom_rate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_exchange_rates_from_currency_to_currency",
+            "unique": true,
+            "columnNames": [
+              "from_currency",
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_exchange_rates_from_currency_to_currency` ON `${TABLE_NAME}` (`from_currency`, `to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_from_currency",
+            "unique": false,
+            "columnNames": [
+              "from_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_from_currency` ON `${TABLE_NAME}` (`from_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_to_currency",
+            "unique": false,
+            "columnNames": [
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_to_currency` ON `${TABLE_NAME}` (`to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          },
+          {
+            "name": "index_exchange_rates_expires_at_unix",
+            "unique": false,
+            "columnNames": [
+              "expires_at_unix"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_expires_at_unix` ON `${TABLE_NAME}` (`expires_at_unix`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `period_type` TEXT NOT NULL, `start_date` TEXT NOT NULL, `end_date` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `is_active` INTEGER NOT NULL DEFAULT 1, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "periodType",
+            "columnName": "period_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budgets_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_budgets_is_active",
+            "unique": false,
+            "columnNames": [
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_is_active` ON `${TABLE_NAME}` (`is_active`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budget_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL DEFAULT '0', FOREIGN KEY(`budget_id`) REFERENCES `budgets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budget_categories_budget_id",
+            "unique": false,
+            "columnNames": [
+              "budget_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budget_categories_budget_id` ON `${TABLE_NAME}` (`budget_id`)"
+          },
+          {
+            "name": "index_budget_categories_budget_id_category_name",
+            "unique": true,
+            "columnNames": [
+              "budget_id",
+              "category_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_budget_categories_budget_id_category_name` ON `${TABLE_NAME}` (`budget_id`, `category_name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "budgets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "budget_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "budget_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `budget_name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetName",
+            "columnName": "budget_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "budget_category_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "transaction_splits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `transaction_id` INTEGER NOT NULL, `category` TEXT NOT NULL, `amount` TEXT NOT NULL, `created_at` TEXT NOT NULL, FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_splits_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_splits_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bank_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `package_name` TEXT NOT NULL, `sender_alias` TEXT NOT NULL, `message_body` TEXT NOT NULL, `message_hash` TEXT NOT NULL, `posted_at` TEXT NOT NULL, `processed` INTEGER NOT NULL, `transaction_id` INTEGER, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderAlias",
+            "columnName": "sender_alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageBody",
+            "columnName": "message_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageHash",
+            "columnName": "message_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postedAt",
+            "columnName": "posted_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "processed",
+            "columnName": "processed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bank_notifications_package_name_message_hash",
+            "unique": true,
+            "columnNames": [
+              "package_name",
+              "message_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_bank_notifications_package_name_message_hash` ON `${TABLE_NAME}` (`package_name`, `message_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "loans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `person_name` TEXT NOT NULL, `direction` TEXT NOT NULL, `original_amount` TEXT NOT NULL, `remaining_amount` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `status` TEXT NOT NULL DEFAULT 'ACTIVE', `note` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `settled_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personName",
+            "columnName": "person_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalAmount",
+            "columnName": "original_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remainingAmount",
+            "columnName": "remaining_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'ACTIVE'"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settledAt",
+            "columnName": "settled_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_loans_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_loans_person_name",
+            "unique": false,
+            "columnNames": [
+              "person_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_person_name` ON `${TABLE_NAME}` (`person_name`)"
+          },
+          {
+            "name": "index_loans_created_at",
+            "unique": false,
+            "columnNames": [
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_created_at` ON `${TABLE_NAME}` (`created_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `note` TEXT DEFAULT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_groups_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_groups_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `color_hex` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorHex",
+            "columnName": "color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2f1f5a1dd2ed2a5d3fedd0efd6b3fd9f')"
+    ]
+  }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
@@ -56,7 +56,7 @@ import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
  * that needs to record the version it was exported against. Bump this in lock-
  * step with any schema change.
  */
-const val SCHEMA_VERSION = 48
+const val SCHEMA_VERSION = 49
 
 /**
  * The PennyWise Room database.
@@ -466,6 +466,18 @@ abstract class PennyWiseDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Adds `last_paid_at` to subscriptions so the UI can show a "Paid"
+         * badge after the user marks a cycle paid, and the use case can
+         * refuse a same-cycle re-tap (#412 follow-up). Nullable — existing
+         * rows have no payment history yet.
+         */
+        val MIGRATION_48_49 = object : Migration(48, 49) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `subscriptions` ADD COLUMN `last_paid_at` TEXT DEFAULT NULL")
+            }
+        }
+
         val MIGRATION_38_39 = object : Migration(38, 39) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 // Add receipt_path to transactions if missing
@@ -514,6 +526,7 @@ abstract class PennyWiseDatabase : RoomDatabase() {
             MIGRATION_45_46,
             MIGRATION_46_47,
             MIGRATION_47_48,
+            MIGRATION_48_49,
         )
     }
     

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/SubscriptionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/SubscriptionDao.kt
@@ -79,7 +79,22 @@ interface SubscriptionDao {
     
     @Query("UPDATE subscriptions SET next_payment_date = :nextPaymentDate, updated_at = datetime('now') WHERE id = :id")
     suspend fun updateNextPaymentDate(id: Long, nextPaymentDate: LocalDate)
-    
+
+    /**
+     * Atomic write of both fields when the user marks-as-paid (#412): we
+     * record the date they confirmed payment AND advance the schedule in
+     * one DB hit. The "Paid" badge on the row reads `last_paid_at`; the
+     * use case reads it to refuse a same-cycle re-tap.
+     */
+    @Query("""
+        UPDATE subscriptions
+        SET last_paid_at = :paidAt,
+            next_payment_date = :nextPaymentDate,
+            updated_at = datetime('now')
+        WHERE id = :id
+    """)
+    suspend fun markPaid(id: Long, paidAt: LocalDate, nextPaymentDate: LocalDate)
+
     @Delete
     suspend fun deleteSubscription(subscription: SubscriptionEntity)
     

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
@@ -162,16 +162,26 @@ interface TransactionDao {
     suspend fun getTransactionByHash(transactionHash: String): TransactionEntity?
 
     /**
-     * Find recent EXPENSE transactions whose merchant matches (case-
-     * insensitive) — used to surface candidate auto-pay charges when the
-     * user opens the mark-as-paid sheet for a subscription (#412). Skips
-     * phantom rows we created ourselves (`subpay-...`, `autopay-...`
+     * Find recent EXPENSE transactions whose merchant AND amount match —
+     * used to surface candidate auto-pay charges when the user opens the
+     * mark-as-paid sheet for a subscription (#412). Both filters matter:
+     * a one-off ₹789 Netflix purchase shouldn't show up as a candidate
+     * for a ₹499 monthly sub.
+     *
+     * Skips phantom rows we created ourselves (`subpay-...`, `autopay-...`
      * transaction hashes) so the user only sees real bank-derived
      * payments to link against.
+     *
+     * Amount comparison: `CAST(amount AS REAL)` handles the BigDecimal
+     * text representation drift ("499" vs "499.00"). Tiny epsilon
+     * (±₹0.01) absorbs any float-conversion rounding without matching
+     * meaningfully different amounts.
      */
     @Query("""
         SELECT * FROM transactions
         WHERE LOWER(merchant_name) = LOWER(:merchant)
+          AND CAST(amount AS REAL) BETWEEN CAST(:amount AS REAL) - 0.01
+                                       AND CAST(:amount AS REAL) + 0.01
           AND transaction_type = 'EXPENSE'
           AND is_deleted = 0
           AND date_time >= :since
@@ -179,8 +189,9 @@ interface TransactionDao {
         ORDER BY date_time DESC
         LIMIT :limit
     """)
-    suspend fun findRecentExpensesByMerchant(
+    suspend fun findRecentExpensesByMerchantAndAmount(
         merchant: String,
+        amount: java.math.BigDecimal,
         since: LocalDateTime,
         limit: Int = 5,
     ): List<TransactionEntity>

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
@@ -160,6 +160,30 @@ interface TransactionDao {
     // Method to check if transaction exists by hash (including deleted)
     @Query("SELECT * FROM transactions WHERE transaction_hash = :transactionHash LIMIT 1")
     suspend fun getTransactionByHash(transactionHash: String): TransactionEntity?
+
+    /**
+     * Find recent EXPENSE transactions whose merchant matches (case-
+     * insensitive) — used to surface candidate auto-pay charges when the
+     * user opens the mark-as-paid sheet for a subscription (#412). Skips
+     * phantom rows we created ourselves (`subpay-...`, `autopay-...`
+     * transaction hashes) so the user only sees real bank-derived
+     * payments to link against.
+     */
+    @Query("""
+        SELECT * FROM transactions
+        WHERE LOWER(merchant_name) = LOWER(:merchant)
+          AND transaction_type = 'EXPENSE'
+          AND is_deleted = 0
+          AND date_time >= :since
+          AND (transaction_hash NOT LIKE 'subpay-%' AND transaction_hash NOT LIKE 'autopay-%')
+        ORDER BY date_time DESC
+        LIMIT :limit
+    """)
+    suspend fun findRecentExpensesByMerchant(
+        merchant: String,
+        since: LocalDateTime,
+        limit: Int = 5,
+    ): List<TransactionEntity>
     
     @Query("""
         SELECT * FROM transactions 

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/SubscriptionEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/SubscriptionEntity.kt
@@ -65,7 +65,19 @@ data class SubscriptionEntity(
      * subscription advanced by exactly +30 days regardless of cycle.
      */
     @ColumnInfo(name = "billing_cycle", defaultValue = "Monthly")
-    val billingCycle: String = "Monthly"
+    val billingCycle: String = "Monthly",
+
+    /**
+     * When the user (or auto-pay link) last confirmed this subscription's
+     * cycle was paid. Drives the "Paid" badge on the row so users don't
+     * accidentally re-tap mark-as-paid for the same cycle (#412). The
+     * mark-as-paid use case also reads this to refuse a re-tap in the
+     * same cycle window — without it, a re-tap would create a new
+     * phantom for the (now-future) next cycle and advance the schedule
+     * again. Null when the subscription has never been marked paid.
+     */
+    @ColumnInfo(name = "last_paid_at")
+    val lastPaidAt: LocalDate? = null,
 )
 
 enum class SubscriptionState {

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/SubscriptionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/SubscriptionRepository.kt
@@ -129,13 +129,16 @@ class SubscriptionRepository @Inject constructor(
      * +30 days). Unknown cycles fall back to monthly so a stale or hand-
      * inserted row never silently advances by 0 days.
      */
-    fun advance(date: LocalDate, billingCycle: String): LocalDate = when (billingCycle.uppercase()) {
-        "WEEKLY" -> date.plusWeeks(1)
-        "MONTHLY" -> date.plusMonths(1)
-        "QUARTERLY" -> date.plusMonths(3)
-        "SEMI-ANNUAL", "SEMI ANNUAL", "SEMIANNUAL" -> date.plusMonths(6)
-        "ANNUAL", "YEARLY" -> date.plusYears(1)
-        else -> date.plusMonths(1)
+    fun advance(date: LocalDate, billingCycle: String, reverse: Boolean = false): LocalDate {
+        val sign = if (reverse) -1L else 1L
+        return when (billingCycle.uppercase()) {
+            "WEEKLY" -> date.plusWeeks(sign)
+            "MONTHLY" -> date.plusMonths(sign)
+            "QUARTERLY" -> date.plusMonths(3L * sign)
+            "SEMI-ANNUAL", "SEMI ANNUAL", "SEMIANNUAL" -> date.plusMonths(6L * sign)
+            "ANNUAL", "YEARLY" -> date.plusYears(sign)
+            else -> date.plusMonths(sign)
+        }
     }
 
     /** Active INCOME subscriptions due on or before [date] (#371). */
@@ -145,6 +148,10 @@ class SubscriptionRepository @Inject constructor(
     /** Direct DAO passthrough — used by the income-autopay phantom creator. */
     suspend fun updateNextPaymentDate(subscriptionId: Long, nextPaymentDate: LocalDate) =
         subscriptionDao.updateNextPaymentDate(subscriptionId, nextPaymentDate)
+
+    /** See [SubscriptionDao.markPaid]. */
+    suspend fun markPaid(subscriptionId: Long, paidAt: LocalDate, nextPaymentDate: LocalDate) =
+        subscriptionDao.markPaid(subscriptionId, paidAt, nextPaymentDate)
     
     
     private fun areAmountsEqual(amount1: BigDecimal, amount2: BigDecimal): Boolean {

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
@@ -140,6 +140,14 @@ class TransactionRepository @Inject constructor(
     suspend fun getTransactionByHash(transactionHash: String): TransactionEntity? =
         transactionDao.getTransactionByHash(transactionHash)
 
+    /** See [TransactionDao.findRecentExpensesByMerchant]. */
+    suspend fun findRecentExpensesByMerchant(
+        merchant: String,
+        since: java.time.LocalDateTime,
+        limit: Int = 5,
+    ): List<TransactionEntity> =
+        transactionDao.findRecentExpensesByMerchant(merchant, since, limit)
+
     suspend fun getTransactionByReference(reference: String): TransactionEntity? =
         transactionDao.getTransactionByReference(reference)
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
@@ -140,13 +140,14 @@ class TransactionRepository @Inject constructor(
     suspend fun getTransactionByHash(transactionHash: String): TransactionEntity? =
         transactionDao.getTransactionByHash(transactionHash)
 
-    /** See [TransactionDao.findRecentExpensesByMerchant]. */
-    suspend fun findRecentExpensesByMerchant(
+    /** See [TransactionDao.findRecentExpensesByMerchantAndAmount]. */
+    suspend fun findRecentExpensesByMerchantAndAmount(
         merchant: String,
+        amount: java.math.BigDecimal,
         since: java.time.LocalDateTime,
         limit: Int = 5,
     ): List<TransactionEntity> =
-        transactionDao.findRecentExpensesByMerchant(merchant, since, limit)
+        transactionDao.findRecentExpensesByMerchantAndAmount(merchant, amount, since, limit)
 
     suspend fun getTransactionByReference(reference: String): TransactionEntity? =
         transactionDao.getTransactionByReference(reference)

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/MarkSubscriptionPaidUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/MarkSubscriptionPaidUseCase.kt
@@ -68,6 +68,18 @@ class MarkSubscriptionPaidUseCase @Inject constructor(
             ?: return Result.SubscriptionNotFound
         val scheduled = sub.nextPaymentDate ?: return Result.NoScheduledDate
 
+        // Refuse a re-tap inside the same cycle window. Without this, a
+        // mistaken second tap would create another phantom for the now-
+        // future cycle AND advance the schedule a second time. The
+        // condition: lastPaidAt sits between (scheduled - billingCycle)
+        // and scheduled — i.e. it was set during this cycle.
+        val cycleStart = subscriptionRepository.advance(scheduled, sub.billingCycle, reverse = true)
+        sub.lastPaidAt?.let { lastPaid ->
+            if (!lastPaid.isBefore(cycleStart) && !lastPaid.isAfter(scheduled)) {
+                return Result.AlreadyMarked(nextPaymentDate = scheduled)
+            }
+        }
+
         val isIncome = sub.direction == SubscriptionDirection.INCOME
         val hash = if (isIncome) {
             "autopay-${sub.id}-$scheduled"
@@ -75,14 +87,12 @@ class MarkSubscriptionPaidUseCase @Inject constructor(
             "subpay-${sub.id}-$scheduled"
         }
 
+        // Hash-level guard catches the unlikely race where lastPaidAt
+        // wasn't yet written (crash between insert and markPaid).
         val existing = transactionRepository.getTransactionByHash(hash)
         if (existing != null) {
-            // Cycle already accounted for. Still advance the schedule —
-            // the user clearly thinks they need to mark this cycle done.
-            // (Without advancing, the subscription would stay "due" and
-            // keep prompting them. Advancing is the recovery path.)
             val nextDate = subscriptionRepository.advance(scheduled, sub.billingCycle)
-            subscriptionRepository.updateNextPaymentDate(sub.id, nextDate)
+            subscriptionRepository.markPaid(sub.id, paymentDate, nextDate)
             return Result.AlreadyMarked(nextDate)
         }
 
@@ -103,7 +113,7 @@ class MarkSubscriptionPaidUseCase @Inject constructor(
         val rowId = transactionRepository.insertTransaction(transaction)
 
         val nextDate = subscriptionRepository.advance(scheduled, sub.billingCycle)
-        subscriptionRepository.updateNextPaymentDate(sub.id, nextDate)
+        subscriptionRepository.markPaid(sub.id, paymentDate, nextDate)
 
         Log.i(
             TAG,
@@ -113,8 +123,6 @@ class MarkSubscriptionPaidUseCase @Inject constructor(
         return if (rowId != -1L) {
             Result.Created(transactionId = rowId, nextPaymentDate = nextDate)
         } else {
-            // Insert failed (unique-constraint race with autopay running at
-            // the same instant). Treat as already-marked — schedule advanced.
             Result.AlreadyMarked(nextDate)
         }
     }
@@ -131,8 +139,19 @@ class MarkSubscriptionPaidUseCase @Inject constructor(
             ?: return Result.SubscriptionNotFound
         val scheduled = sub.nextPaymentDate ?: return Result.NoScheduledDate
 
+        // Same-cycle re-tap guard (see [execute]).
+        val cycleStart = subscriptionRepository.advance(scheduled, sub.billingCycle, reverse = true)
+        sub.lastPaidAt?.let { lastPaid ->
+            if (!lastPaid.isBefore(cycleStart) && !lastPaid.isAfter(scheduled)) {
+                return Result.AlreadyMarked(nextPaymentDate = scheduled)
+            }
+        }
+
+        val linkedTxn = transactionRepository.getTransactionById(transactionId)
+        val paidAt = linkedTxn?.dateTime?.toLocalDate() ?: LocalDate.now()
+
         val nextDate = subscriptionRepository.advance(scheduled, sub.billingCycle)
-        subscriptionRepository.updateNextPaymentDate(sub.id, nextDate)
+        subscriptionRepository.markPaid(sub.id, paidAt, nextDate)
 
         Log.i(
             TAG,

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/MarkSubscriptionPaidUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/MarkSubscriptionPaidUseCase.kt
@@ -48,6 +48,13 @@ class MarkSubscriptionPaidUseCase @Inject constructor(
 
     sealed class Result {
         data class Created(val transactionId: Long, val nextPaymentDate: LocalDate) : Result()
+        /**
+         * User linked an existing bank-derived transaction to this cycle.
+         * No new phantom row inserted; schedule advanced. The linked
+         * transaction stays as-is so anything else (split, recategorise,
+         * delete) still works on it.
+         */
+        data class Linked(val transactionId: Long, val nextPaymentDate: LocalDate) : Result()
         data class AlreadyMarked(val nextPaymentDate: LocalDate) : Result()
         data object SubscriptionNotFound : Result()
         data object NoScheduledDate : Result()
@@ -110,6 +117,29 @@ class MarkSubscriptionPaidUseCase @Inject constructor(
             // the same instant). Treat as already-marked — schedule advanced.
             Result.AlreadyMarked(nextDate)
         }
+    }
+
+    /**
+     * Link an existing bank-derived transaction to this subscription's
+     * current cycle — used when an auto-pay charge already arrived via
+     * SMS and the user wants to acknowledge it as the cycle payment
+     * (avoiding a duplicate phantom row). Advances `nextPaymentDate` by
+     * the billing cycle; does NOT mutate the linked transaction itself.
+     */
+    suspend fun linkExisting(subscriptionId: Long, transactionId: Long): Result {
+        val sub = subscriptionRepository.getSubscriptionById(subscriptionId)
+            ?: return Result.SubscriptionNotFound
+        val scheduled = sub.nextPaymentDate ?: return Result.NoScheduledDate
+
+        val nextDate = subscriptionRepository.advance(scheduled, sub.billingCycle)
+        subscriptionRepository.updateNextPaymentDate(sub.id, nextDate)
+
+        Log.i(
+            TAG,
+            "Linked existing txn=$transactionId to sub=${sub.id} ${sub.merchantName} " +
+                "→ nextPaymentDate=$nextDate (no new transaction created)",
+        )
+        return Result.Linked(transactionId = transactionId, nextPaymentDate = nextDate)
     }
 
     private companion object {

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/MarkSubscriptionPaidUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/MarkSubscriptionPaidUseCase.kt
@@ -1,0 +1,118 @@
+package com.pennywiseai.tracker.domain.usecase
+
+import android.util.Log
+import com.pennywiseai.tracker.data.database.entity.SubscriptionDirection
+import com.pennywiseai.tracker.data.database.entity.TransactionEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionType
+import com.pennywiseai.tracker.data.repository.SubscriptionRepository
+import com.pennywiseai.tracker.data.repository.TransactionRepository
+import java.time.LocalDate
+import java.time.LocalDateTime
+import javax.inject.Inject
+
+/**
+ * User-initiated counterpart to [GenerateIncomeAutopayUseCase]: when the
+ * user manually confirms they paid (or received) a subscription this cycle,
+ * materialise the matching transaction and advance the subscription's
+ * `next_payment_date` by its billing cycle. Issue #412.
+ *
+ * Direction handling:
+ *  - EXPENSE — most expense subs auto-create a transaction from an SMS
+ *    (UPI mandate, card auto-debit). This use case covers the manual-pay
+ *    subset: cash, in-person card swipes, off-platform payments. Creates a
+ *    TransactionType.EXPENSE row.
+ *  - INCOME — already auto-created by GenerateIncomeAutopayUseCase on
+ *    schedule. User-initiated marks here let early-payers confirm before
+ *    the next scan; idempotent dedup ensures no double-count.
+ *
+ * Idempotency:
+ *  - EXPENSE rows use `"subpay-<subId>-<scheduledDate>"` as the transaction
+ *    hash, where `scheduledDate` is the subscription's CURRENT
+ *    `nextPaymentDate` (not the user-chosen payment date). Tapping mark-as-
+ *    paid twice for the same cycle dedup's via
+ *    [TransactionRepository.getTransactionByHash].
+ *  - INCOME rows use the SAME `"autopay-<subId>-<scheduledDate>"` shape as
+ *    the autopay use case so manual + auto can't double-fire on the same
+ *    cycle.
+ *
+ * The created transaction's `dateTime` is set to the user-chosen
+ * `paymentDate` (so the spend lands on the right day in reports). The
+ * subscription's `nextPaymentDate` is advanced by exactly one billing
+ * cycle from the previously-scheduled date (NOT from `paymentDate`) so
+ * cycle drift can't accumulate when the user pays a few days early/late.
+ */
+class MarkSubscriptionPaidUseCase @Inject constructor(
+    private val subscriptionRepository: SubscriptionRepository,
+    private val transactionRepository: TransactionRepository,
+) {
+
+    sealed class Result {
+        data class Created(val transactionId: Long, val nextPaymentDate: LocalDate) : Result()
+        data class AlreadyMarked(val nextPaymentDate: LocalDate) : Result()
+        data object SubscriptionNotFound : Result()
+        data object NoScheduledDate : Result()
+    }
+
+    suspend fun execute(
+        subscriptionId: Long,
+        paymentDate: LocalDate = LocalDate.now(),
+    ): Result {
+        val sub = subscriptionRepository.getSubscriptionById(subscriptionId)
+            ?: return Result.SubscriptionNotFound
+        val scheduled = sub.nextPaymentDate ?: return Result.NoScheduledDate
+
+        val isIncome = sub.direction == SubscriptionDirection.INCOME
+        val hash = if (isIncome) {
+            "autopay-${sub.id}-$scheduled"
+        } else {
+            "subpay-${sub.id}-$scheduled"
+        }
+
+        val existing = transactionRepository.getTransactionByHash(hash)
+        if (existing != null) {
+            // Cycle already accounted for. Still advance the schedule —
+            // the user clearly thinks they need to mark this cycle done.
+            // (Without advancing, the subscription would stay "due" and
+            // keep prompting them. Advancing is the recovery path.)
+            val nextDate = subscriptionRepository.advance(scheduled, sub.billingCycle)
+            subscriptionRepository.updateNextPaymentDate(sub.id, nextDate)
+            return Result.AlreadyMarked(nextDate)
+        }
+
+        val transaction = TransactionEntity(
+            amount = sub.amount,
+            merchantName = sub.merchantName,
+            category = sub.category ?: if (isIncome) "Income" else "Subscriptions",
+            transactionType = if (isIncome) TransactionType.INCOME else TransactionType.EXPENSE,
+            dateTime = paymentDate.atStartOfDay(),
+            description = if (isIncome) "Marked received" else "Marked paid",
+            bankName = sub.bankName,
+            currency = sub.currency,
+            transactionHash = hash,
+            isRecurring = true,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
+        )
+        val rowId = transactionRepository.insertTransaction(transaction)
+
+        val nextDate = subscriptionRepository.advance(scheduled, sub.billingCycle)
+        subscriptionRepository.updateNextPaymentDate(sub.id, nextDate)
+
+        Log.i(
+            TAG,
+            "Marked sub=${sub.id} ${sub.merchantName} paid on $paymentDate " +
+                "→ txn=$rowId, nextPaymentDate=$nextDate",
+        )
+        return if (rowId != -1L) {
+            Result.Created(transactionId = rowId, nextPaymentDate = nextDate)
+        } else {
+            // Insert failed (unique-constraint race with autopay running at
+            // the same instant). Treat as already-marked — schedule advanced.
+            Result.AlreadyMarked(nextDate)
+        }
+    }
+
+    private companion object {
+        const val TAG = "MarkSubscriptionPaid"
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/MarkSubscriptionPaidUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/MarkSubscriptionPaidUseCase.kt
@@ -68,14 +68,18 @@ class MarkSubscriptionPaidUseCase @Inject constructor(
             ?: return Result.SubscriptionNotFound
         val scheduled = sub.nextPaymentDate ?: return Result.NoScheduledDate
 
-        // Refuse a re-tap inside the same cycle window. Without this, a
-        // mistaken second tap would create another phantom for the now-
-        // future cycle AND advance the schedule a second time. The
-        // condition: lastPaidAt sits between (scheduled - billingCycle)
-        // and scheduled — i.e. it was set during this cycle.
-        val cycleStart = subscriptionRepository.advance(scheduled, sub.billingCycle, reverse = true)
+        // Same-cycle re-tap guard, anchored on TODAY not on the schedule.
+        // Earlier version anchored on the (sliding) schedule, which broke
+        // the moment we advanced it — lastPaidAt fell BEHIND the new cycle
+        // window so the guard stopped triggering and the user could keep
+        // tapping forever, marching the schedule forward each time.
+        //
+        // Real semantic: a subscription can't legitimately be paid twice
+        // within one billing cycle. So if today < lastPaidAt + 1 cycle,
+        // it's a re-tap of the cycle we just paid.
         sub.lastPaidAt?.let { lastPaid ->
-            if (!lastPaid.isBefore(cycleStart) && !lastPaid.isAfter(scheduled)) {
+            val nextLegitMark = subscriptionRepository.advance(lastPaid, sub.billingCycle)
+            if (LocalDate.now().isBefore(nextLegitMark)) {
                 return Result.AlreadyMarked(nextPaymentDate = scheduled)
             }
         }
@@ -139,10 +143,10 @@ class MarkSubscriptionPaidUseCase @Inject constructor(
             ?: return Result.SubscriptionNotFound
         val scheduled = sub.nextPaymentDate ?: return Result.NoScheduledDate
 
-        // Same-cycle re-tap guard (see [execute]).
-        val cycleStart = subscriptionRepository.advance(scheduled, sub.billingCycle, reverse = true)
+        // Same-cycle re-tap guard — see [execute] for the semantic.
         sub.lastPaidAt?.let { lastPaid ->
-            if (!lastPaid.isBefore(cycleStart) && !lastPaid.isAfter(scheduled)) {
+            val nextLegitMark = subscriptionRepository.advance(lastPaid, sub.billingCycle)
+            if (LocalDate.now().isBefore(nextLegitMark)) {
                 return Result.AlreadyMarked(nextPaymentDate = scheduled)
             }
         }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/MarkAsPaidSheet.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/MarkAsPaidSheet.kt
@@ -181,6 +181,47 @@ fun MarkAsPaidSheet(
             )
             Spacer(Modifier.height(Spacing.lg))
 
+            // Already-paid notice — shown when this cycle was marked paid
+            // already. Doesn't hide the rest of the sheet (user might want
+            // to see the history or hit a different date) but makes the
+            // status unambiguous so they don't double-tap.
+            val recentlyPaid = subscription.lastPaidAt?.let { lastPaid ->
+                val anchor = subscription.nextPaymentDate
+                anchor != null &&
+                    !lastPaid.isBefore(anchor.minusDays(35)) &&
+                    !lastPaid.isAfter(anchor)
+            } ?: false
+            if (recentlyPaid) {
+                androidx.compose.material3.Surface(
+                    shape = RoundedCornerShape(Dimensions.CornerRadius.large),
+                    color = MaterialTheme.colorScheme.secondaryContainer,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Row(
+                        modifier = Modifier.padding(
+                            horizontal = Dimensions.Padding.card,
+                            vertical = Spacing.md,
+                        ),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.CheckCircle,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                            modifier = Modifier.size(20.dp),
+                        )
+                        Spacer(Modifier.width(Spacing.sm))
+                        Text(
+                            text = "Already marked paid on ${subscription.lastPaidAt?.format(DateTimeFormatter.ofPattern("d MMM"))}",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                            fontWeight = FontWeight.Medium,
+                        )
+                    }
+                }
+                Spacer(Modifier.height(Spacing.lg))
+            }
+
             // Suggested-payment candidates (#412 follow-up). When the
             // subscription is on auto-pay, the bank SMS already created
             // EXPENSE rows for the merchant — tap one of these to link

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/MarkAsPaidSheet.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/MarkAsPaidSheet.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CalendarToday
+import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DatePicker
@@ -45,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.pennywiseai.tracker.data.database.entity.SubscriptionDirection
 import com.pennywiseai.tracker.data.database.entity.SubscriptionEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.ui.components.BrandIcon
 import com.pennywiseai.tracker.ui.theme.Dimensions
 import com.pennywiseai.tracker.ui.theme.Spacing
@@ -78,8 +80,10 @@ import java.time.format.DateTimeFormatter
 @Composable
 fun MarkAsPaidSheet(
     subscription: SubscriptionEntity,
+    candidates: List<TransactionEntity> = emptyList(),
     onDismiss: () -> Unit,
     onConfirm: (LocalDate) -> Unit,
+    onLinkExisting: (TransactionEntity) -> Unit = {},
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scope = rememberCoroutineScope()
@@ -99,6 +103,14 @@ fun MarkAsPaidSheet(
 
     val confirmAndDismiss: () -> Unit = {
         onConfirm(selectedDate)
+        scope.launch {
+            sheetState.hide()
+            onDismiss()
+        }
+    }
+
+    val linkAndDismiss: (TransactionEntity) -> Unit = { txn ->
+        onLinkExisting(txn)
         scope.launch {
             sheetState.hide()
             onDismiss()
@@ -168,6 +180,31 @@ fun MarkAsPaidSheet(
                 textAlign = TextAlign.Center,
             )
             Spacer(Modifier.height(Spacing.lg))
+
+            // Suggested-payment candidates (#412 follow-up). When the
+            // subscription is on auto-pay, the bank SMS already created
+            // EXPENSE rows for the merchant — tap one of these to link
+            // (advances the schedule, no duplicate phantom row created).
+            if (candidates.isNotEmpty()) {
+                Text(
+                    text = if (candidates.size == 1) {
+                        "Found 1 matching payment"
+                    } else {
+                        "Found ${candidates.size} matching payments"
+                    },
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(Spacing.sm))
+                Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                    candidates.forEach { txn ->
+                        CandidateCard(txn, onClick = { linkAndDismiss(txn) })
+                    }
+                }
+                Spacer(Modifier.height(Spacing.lg))
+                OrDivider()
+                Spacer(Modifier.height(Spacing.lg))
+            }
 
             // Date selector — chips for the common cases (today, yesterday)
             // + a "Pick date" option that defers to the system date picker.
@@ -245,6 +282,90 @@ fun MarkAsPaidSheet(
         ) {
             DatePicker(state = datePickerState)
         }
+    }
+}
+
+/**
+ * One suggested-payment card. Compact row: amount on the left (in expense
+ * tint to mirror the transactions list), merchant + relative date on the
+ * right. Tap = link this transaction as the cycle's payment.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CandidateCard(
+    txn: TransactionEntity,
+    onClick: () -> Unit,
+) {
+    val amountColor = if (androidx.compose.foundation.isSystemInDarkTheme()) expense_dark else expense_light
+    androidx.compose.material3.Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(Dimensions.CornerRadius.large),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(
+                horizontal = Dimensions.Padding.card,
+                vertical = Spacing.md,
+            ),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = CurrencyFormatter.formatCurrency(txn.amount, txn.currency),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = amountColor,
+                )
+                Text(
+                    text = relativeDate(txn.dateTime.toLocalDate()) +
+                        (txn.bankName?.let { " · $it" } ?: ""),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(
+                imageVector = Icons.Outlined.CheckCircle,
+                contentDescription = "Link this payment",
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+    }
+}
+
+/** "─── or mark today ───" divider sitting between the candidates list and the date selector. */
+@Composable
+private fun OrDivider() {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        androidx.compose.material3.HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color = MaterialTheme.colorScheme.outlineVariant,
+        )
+        Text(
+            text = "or mark today",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        androidx.compose.material3.HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color = MaterialTheme.colorScheme.outlineVariant,
+        )
+    }
+}
+
+private fun relativeDate(date: LocalDate): String {
+    val today = LocalDate.now()
+    val days = java.time.temporal.ChronoUnit.DAYS.between(date, today)
+    return when {
+        days == 0L -> "Today"
+        days == 1L -> "Yesterday"
+        days in 2..6 -> "$days days ago"
+        else -> date.format(DateTimeFormatter.ofPattern("d MMM"))
     }
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/MarkAsPaidSheet.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/MarkAsPaidSheet.kt
@@ -1,0 +1,342 @@
+package com.pennywiseai.tracker.presentation.subscriptions
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CalendarToday
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.pennywiseai.tracker.data.database.entity.SubscriptionDirection
+import com.pennywiseai.tracker.data.database.entity.SubscriptionEntity
+import com.pennywiseai.tracker.ui.components.BrandIcon
+import com.pennywiseai.tracker.ui.theme.Dimensions
+import com.pennywiseai.tracker.ui.theme.Spacing
+import com.pennywiseai.tracker.ui.theme.expense_dark
+import com.pennywiseai.tracker.ui.theme.expense_light
+import com.pennywiseai.tracker.ui.theme.income_dark
+import com.pennywiseai.tracker.ui.theme.income_light
+import com.pennywiseai.tracker.utils.CurrencyFormatter
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/**
+ * Bottom sheet for confirming a subscription payment / receipt (#412).
+ *
+ * Layout (top-down):
+ *   - drag handle (single dismiss affordance — no redundant X)
+ *   - eyebrow chip identifying the cadence ("MARK AS PAID" / "MARK AS RECEIVED")
+ *   - brand icon + merchant name (compact header row)
+ *   - hero amount — sized to the app's hero convention (headlineLarge Bold)
+ *   - "When did you pay?" with 3 date chips (Today / Yesterday / Pick…)
+ *   - CTA button with the amount baked into the label
+ *   - small disclaimer about the cycle being advanced
+ *
+ * Adapts to subscription direction:
+ *   - EXPENSE → expense palette + "Mark as paid"
+ *   - INCOME  → income (teal) palette + "Mark as received"
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MarkAsPaidSheet(
+    subscription: SubscriptionEntity,
+    onDismiss: () -> Unit,
+    onConfirm: (LocalDate) -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
+
+    val today = remember { LocalDate.now() }
+    var selectedDate by remember { mutableStateOf(today) }
+    var showDatePicker by remember { mutableStateOf(false) }
+
+    val isIncome = subscription.direction == SubscriptionDirection.INCOME
+    val amountColor = if (isIncome) {
+        if (androidx.compose.foundation.isSystemInDarkTheme()) income_dark else income_light
+    } else {
+        if (androidx.compose.foundation.isSystemInDarkTheme()) expense_dark else expense_light
+    }
+    val eyebrowText = if (isIncome) "MARK AS RECEIVED" else "MARK AS PAID"
+    val ctaPrefix = if (isIncome) "Mark received" else "Mark paid"
+
+    val confirmAndDismiss: () -> Unit = {
+        onConfirm(selectedDate)
+        scope.launch {
+            sheetState.hide()
+            onDismiss()
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        contentWindowInsets = { WindowInsets.navigationBars },
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    horizontal = Dimensions.Padding.content,
+                    vertical = Spacing.md,
+                ),
+        ) {
+            // Eyebrow chip — financial-document micro-typography matching
+            // the paywall sheet's pattern (gold there, primary here).
+            EyebrowChip(
+                text = eyebrowText,
+                isAccent = isIncome,
+            )
+            Spacer(Modifier.height(Spacing.md))
+
+            // Brand + merchant row
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                BrandIcon(
+                    merchantName = subscription.merchantName,
+                    size = 44.dp,
+                    showBackground = true,
+                )
+                Spacer(Modifier.width(Spacing.md))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = subscription.merchantName,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    subscription.category?.let { cat ->
+                        Text(
+                            text = cat,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+            Spacer(Modifier.height(Spacing.lg))
+
+            // Hero amount — typography carries the moment. headlineLarge
+            // matches the rest of the app's big-number convention
+            // (SummaryCardV2 uses the same size).
+            Text(
+                text = CurrencyFormatter.formatCurrency(subscription.amount, subscription.currency),
+                style = MaterialTheme.typography.headlineLarge,
+                fontWeight = FontWeight.Bold,
+                color = amountColor,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(Spacing.lg))
+
+            // Date selector — chips for the common cases (today, yesterday)
+            // + a "Pick date" option that defers to the system date picker.
+            Text(
+                text = "When?",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(Spacing.sm))
+            DateChips(
+                selected = selectedDate,
+                today = today,
+                onSelect = { selectedDate = it },
+                onPickDate = { showDatePicker = true },
+            )
+            Spacer(Modifier.height(Spacing.lg))
+
+            // CTA
+            Button(
+                onClick = confirmAndDismiss,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(Dimensions.Component.buttonHeight),
+                shape = RoundedCornerShape(Dimensions.CornerRadius.large),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                ),
+                contentPadding = PaddingValues(horizontal = Spacing.md),
+            ) {
+                Text(
+                    text = "$ctaPrefix · ${CurrencyFormatter.formatCurrency(subscription.amount, subscription.currency)}",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            Spacer(Modifier.height(Spacing.sm))
+
+            // Quiet helper about cycle behavior so the user understands
+            // why the subscription will "go away" from the due list.
+            Text(
+                text = if (isIncome) {
+                    "We'll log a ${subscription.currency} income and roll the schedule to the next cycle."
+                } else {
+                    "We'll log the expense and roll the schedule to the next cycle."
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(Spacing.sm))
+        }
+    }
+
+    if (showDatePicker) {
+        val datePickerState = rememberDatePickerState(
+            initialSelectedDateMillis = selectedDate.atStartOfDay(ZoneOffset.UTC)
+                .toInstant().toEpochMilli(),
+        )
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    datePickerState.selectedDateMillis?.let { millis ->
+                        selectedDate = java.time.Instant.ofEpochMilli(millis)
+                            .atZone(ZoneOffset.UTC).toLocalDate()
+                    }
+                    showDatePicker = false
+                }) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) { Text("Cancel") }
+            },
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+}
+
+/** Tiny letter-spaced uppercase label. Matches the paywall eyebrow pattern. */
+@Composable
+private fun EyebrowChip(text: String, isAccent: Boolean) {
+    val container = if (isAccent) {
+        MaterialTheme.colorScheme.secondaryContainer
+    } else {
+        MaterialTheme.colorScheme.surfaceContainerLow
+    }
+    val content = if (isAccent) {
+        MaterialTheme.colorScheme.onSecondaryContainer
+    } else {
+        MaterialTheme.colorScheme.primary
+    }
+    androidx.compose.material3.Surface(
+        color = container,
+        shape = RoundedCornerShape(50),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall.copy(
+                letterSpacing = 1.6.sp,
+                fontWeight = FontWeight.SemiBold,
+            ),
+            color = content,
+            modifier = Modifier.padding(horizontal = Spacing.md, vertical = 6.dp),
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DateChips(
+    selected: LocalDate,
+    today: LocalDate,
+    onSelect: (LocalDate) -> Unit,
+    onPickDate: () -> Unit,
+) {
+    val yesterday = today.minusDays(1)
+    val isToday = selected == today
+    val isYesterday = selected == yesterday
+    val isCustom = !isToday && !isYesterday
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        FilterChip(
+            selected = isToday,
+            onClick = { onSelect(today) },
+            label = { Text("Today") },
+            colors = FilterChipDefaults.filterChipColors(
+                selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            ),
+        )
+        FilterChip(
+            selected = isYesterday,
+            onClick = { onSelect(yesterday) },
+            label = { Text("Yesterday") },
+            colors = FilterChipDefaults.filterChipColors(
+                selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            ),
+        )
+        FilterChip(
+            selected = isCustom,
+            onClick = onPickDate,
+            label = {
+                Text(
+                    text = if (isCustom) {
+                        selected.format(DateTimeFormatter.ofPattern("MMM d"))
+                    } else {
+                        "Pick date"
+                    },
+                )
+            },
+            leadingIcon = if (isCustom) null else {
+                {
+                    Icon(
+                        imageVector = Icons.Outlined.CalendarToday,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+            },
+            colors = FilterChipDefaults.filterChipColors(
+                selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            ),
+        )
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/MarkAsPaidSheet.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/MarkAsPaidSheet.kt
@@ -80,6 +80,7 @@ import java.time.format.DateTimeFormatter
 @Composable
 fun MarkAsPaidSheet(
     subscription: SubscriptionEntity,
+    isPaidThisCycle: Boolean = false,
     candidates: List<TransactionEntity> = emptyList(),
     onDismiss: () -> Unit,
     onConfirm: (LocalDate) -> Unit,
@@ -182,16 +183,10 @@ fun MarkAsPaidSheet(
             Spacer(Modifier.height(Spacing.lg))
 
             // Already-paid notice — shown when this cycle was marked paid
-            // already. Doesn't hide the rest of the sheet (user might want
-            // to see the history or hit a different date) but makes the
-            // status unambiguous so they don't double-tap.
-            val recentlyPaid = subscription.lastPaidAt?.let { lastPaid ->
-                val anchor = subscription.nextPaymentDate
-                anchor != null &&
-                    !lastPaid.isBefore(anchor.minusDays(35)) &&
-                    !lastPaid.isAfter(anchor)
-            } ?: false
-            if (recentlyPaid) {
+            // already. Truth comes from the screen's VM (today-anchored
+            // cycle check), passed in via [isPaidThisCycle] so the sheet
+            // and row badge can't disagree.
+            if (isPaidThisCycle) {
                 androidx.compose.material3.Surface(
                     shape = RoundedCornerShape(Dimensions.CornerRadius.large),
                     color = MaterialTheme.colorScheme.secondaryContainer,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
@@ -64,6 +64,8 @@ fun SubscriptionsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
+    // Subscription currently being marked-as-paid. Null = sheet closed.
+    var markPaidTarget by remember { mutableStateOf<SubscriptionEntity?>(null) }
 
     // Scroll behaviors for collapsible TopAppBar
     val scrollBehaviorSmall = TopAppBarDefaults.pinnedScrollBehavior()
@@ -95,6 +97,15 @@ fun SubscriptionsScreen(
             if (result == SnackbarResult.ActionPerformed) {
                 viewModel.undoHide()
             }
+        }
+    }
+
+    // Mark-as-paid feedback snackbar (#412). The sheet itself closes
+    // optimistically; the VM publishes the outcome string here.
+    LaunchedEffect(uiState.markPaidMessage) {
+        uiState.markPaidMessage?.let { msg ->
+            snackbarHostState.showSnackbar(message = msg, duration = SnackbarDuration.Short)
+            viewModel.clearMarkPaidMessage()
         }
     }
 
@@ -201,6 +212,7 @@ fun SubscriptionsScreen(
                             subscription = subscription,
                             convertedAmount = uiState.convertedAmounts[subscription.id],
                             displayCurrency = uiState.displayCurrency,
+                            onTap = { markPaidTarget = subscription },
                             onHide = { viewModel.hideSubscription(subscription.id) },
                             onMarkAsEnded = { viewModel.markAsEnded(subscription.id) },
                             onEdit = { merchantName, amount, nextDate, category ->
@@ -255,6 +267,18 @@ fun SubscriptionsScreen(
                 }
             }
         }
+    }
+
+    // Mark-as-paid sheet (#412). Rendered at screen scope so a list item
+    // re-composition (snackbar, scroll) can't tear down the sheet.
+    markPaidTarget?.let { target ->
+        MarkAsPaidSheet(
+            subscription = target,
+            onDismiss = { markPaidTarget = null },
+            onConfirm = { paymentDate ->
+                viewModel.markAsPaid(target.id, paymentDate)
+            },
+        )
     }
 }
 
@@ -395,6 +419,7 @@ private fun SwipeableSubscriptionItem(
     subscription: SubscriptionEntity,
     convertedAmount: BigDecimal? = null,
     displayCurrency: String? = null,
+    onTap: () -> Unit = {},
     onHide: () -> Unit,
     onMarkAsEnded: () -> Unit = {},
     onEdit: (merchantName: String, amount: BigDecimal, nextDate: LocalDate?, category: String?) -> Unit = { _, _, _, _ -> },
@@ -449,9 +474,11 @@ private fun SwipeableSubscriptionItem(
                 PennyWiseCardV2(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clickable(enabled = !subscription.smsBody.isNullOrBlank()) {
-                            showSmsBody = !showSmsBody
-                        },
+                        // Tap = mark as paid (#412). Existing SMS-body expand
+                        // moved to the kebab menu's "View source" item so the
+                        // primary tap action is meaningful for ALL subs, not
+                        // only those that arrived via SMS.
+                        .clickable(onClick = onTap),
                     contentPadding = 0.dp
                 ) {
                     Row(
@@ -588,6 +615,24 @@ private fun SwipeableSubscriptionItem(
                                 expanded = showMenu,
                                 onDismissRequest = { showMenu = false }
                             ) {
+                                DropdownMenuItem(
+                                    text = { Text("Mark as paid") },
+                                    leadingIcon = { Icon(Icons.Default.CheckCircle, contentDescription = null) },
+                                    onClick = {
+                                        showMenu = false
+                                        onTap()
+                                    }
+                                )
+                                if (!subscription.smsBody.isNullOrBlank()) {
+                                    DropdownMenuItem(
+                                        text = { Text("View source") },
+                                        leadingIcon = { Icon(Icons.AutoMirrored.Filled.Chat, contentDescription = null) },
+                                        onClick = {
+                                            showMenu = false
+                                            showSmsBody = !showSmsBody
+                                        }
+                                    )
+                                }
                                 DropdownMenuItem(
                                     text = { Text("Edit") },
                                     leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
@@ -584,6 +584,46 @@ private fun SwipeableSubscriptionItem(
                                 }
                             }
 
+                            // "Paid Mar 15" badge — shown when this cycle has
+                            // already been marked. Inline filled-tonal pill so
+                            // users don't accidentally re-tap. Sits ABOVE the
+                            // category since payment state is more important
+                            // than the category label.
+                            val recentlyPaid = subscription.lastPaidAt?.let { lastPaid ->
+                                val cycleStart = run {
+                                    val anchor = subscription.nextPaymentDate ?: return@let false
+                                    // Compute cycle-start cheaply: 30 days back
+                                    // works for monthly+; for accurate cycle
+                                    // arithmetic we'd plumb the repo's
+                                    // advance() helper into the composable.
+                                    !lastPaid.isBefore(anchor.minusDays(35)) && !lastPaid.isAfter(anchor)
+                                }
+                                cycleStart == true
+                            } ?: false
+
+                            if (recentlyPaid) {
+                                Spacer(modifier = Modifier.height(2.dp))
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.CheckCircle,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(Dimensions.Icon.small),
+                                        tint = MaterialTheme.colorScheme.primary,
+                                    )
+                                    Text(
+                                        text = "Paid ${subscription.lastPaidAt?.format(DateTimeFormatter.ofPattern("MMM d"))}",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.primary,
+                                        fontWeight = FontWeight.Medium,
+                                        maxLines = 1,
+                                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                                    )
+                                }
+                            }
+
                             // Category — its own line. No bullet, no row
                             // sharing. Wraps if very long but won't break
                             // mid-word against a narrow column.

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
@@ -73,7 +73,7 @@ fun SubscriptionsScreen(
     }
     LaunchedEffect(markPaidTarget) {
         val target = markPaidTarget
-        markPaidCandidates = if (target != null) viewModel.candidatesFor(target.merchantName) else emptyList()
+        markPaidCandidates = if (target != null) viewModel.candidatesFor(target) else emptyList()
     }
 
     // Scroll behaviors for collapsible TopAppBar

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
@@ -66,6 +66,15 @@ fun SubscriptionsScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     // Subscription currently being marked-as-paid. Null = sheet closed.
     var markPaidTarget by remember { mutableStateOf<SubscriptionEntity?>(null) }
+    // Suggested-payment candidates resolved when target changes. Empty list
+    // = no recent SMS-derived matches (user falls through to date picker).
+    var markPaidCandidates by remember {
+        mutableStateOf<List<com.pennywiseai.tracker.data.database.entity.TransactionEntity>>(emptyList())
+    }
+    LaunchedEffect(markPaidTarget) {
+        val target = markPaidTarget
+        markPaidCandidates = if (target != null) viewModel.candidatesFor(target.merchantName) else emptyList()
+    }
 
     // Scroll behaviors for collapsible TopAppBar
     val scrollBehaviorSmall = TopAppBarDefaults.pinnedScrollBehavior()
@@ -274,9 +283,13 @@ fun SubscriptionsScreen(
     markPaidTarget?.let { target ->
         MarkAsPaidSheet(
             subscription = target,
+            candidates = markPaidCandidates,
             onDismiss = { markPaidTarget = null },
             onConfirm = { paymentDate ->
                 viewModel.markAsPaid(target.id, paymentDate)
+            },
+            onLinkExisting = { txn ->
+                viewModel.linkExistingTransaction(target.id, txn.id)
             },
         )
     }
@@ -509,11 +522,16 @@ private fun SwipeableSubscriptionItem(
                                 overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
                             )
                             
+                            // Due-date line — icon + relative-time copy. Single
+                            // line, ellipsised. Previously this row also tried to
+                            // fit the category, which wrapped mid-word
+                            // ("Entert\nainment") whenever the right column was
+                            // wide enough to be visible.
+                            Spacer(modifier = Modifier.height(2.dp))
                             Row(
-                                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                                horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
-                                // SMS indicator if available
                                 if (!subscription.smsBody.isNullOrBlank()) {
                                     Icon(
                                         imageVector = Icons.AutoMirrored.Filled.Chat,
@@ -523,33 +541,29 @@ private fun SwipeableSubscriptionItem(
                                     )
                                 }
 
-                                // Calculate the actual next payment date
                                 val today = LocalDate.now()
                                 val subscriptionDate = subscription.nextPaymentDate
-                                
-                                // Handle null date
                                 if (subscriptionDate == null) {
                                     Text(
-                                        text = "• No date set",
+                                        text = "No date set",
                                         style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        maxLines = 1,
+                                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                                     )
                                 } else {
-                                    // If the stored date is in the past, calculate the next occurrence
                                     var nextPaymentDate: LocalDate = subscriptionDate
                                     while (nextPaymentDate.isBefore(today) || nextPaymentDate.isEqual(today)) {
                                         nextPaymentDate = nextPaymentDate.plusMonths(1)
                                     }
-                                    
                                     val daysUntilNext = ChronoUnit.DAYS.between(today, nextPaymentDate)
-                                
+
                                     Icon(
                                         imageVector = Icons.Default.CalendarToday,
                                         contentDescription = null,
                                         modifier = Modifier.size(Dimensions.Icon.small),
                                         tint = MaterialTheme.colorScheme.onSurfaceVariant
                                     )
-                                    
                                     Text(
                                         text = when {
                                             daysUntilNext == 0L -> "Due today"
@@ -563,17 +577,24 @@ private fun SwipeableSubscriptionItem(
                                         color = when {
                                             daysUntilNext <= 3 -> MaterialTheme.colorScheme.error
                                             else -> MaterialTheme.colorScheme.onSurfaceVariant
-                                        }
+                                        },
+                                        maxLines = 1,
+                                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                                     )
                                 }
-                                
-                                subscription.category?.let { category ->
-                                    Text(
-                                        text = "• $category",
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                }
+                            }
+
+                            // Category — its own line. No bullet, no row
+                            // sharing. Wraps if very long but won't break
+                            // mid-word against a narrow column.
+                            subscription.category?.let { category ->
+                                Text(
+                                    text = category,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 1,
+                                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                                )
                             }
                         }
                         

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
@@ -220,6 +220,7 @@ fun SubscriptionsScreen(
                     ) {
                         SwipeableSubscriptionItem(
                             subscription = subscription,
+                            isPaidThisCycle = subscription.id in uiState.paidThisCycleIds,
                             convertedAmount = uiState.convertedAmounts[subscription.id],
                             displayCurrency = uiState.displayCurrency,
                             onTap = { markPaidTarget = subscription },
@@ -284,6 +285,7 @@ fun SubscriptionsScreen(
     markPaidTarget?.let { target ->
         MarkAsPaidSheet(
             subscription = target,
+            isPaidThisCycle = target.id in uiState.paidThisCycleIds,
             candidates = markPaidCandidates,
             onDismiss = { markPaidTarget = null },
             onConfirm = { paymentDate ->
@@ -444,6 +446,7 @@ private fun TotalSubscriptionsSummary(
 @Composable
 private fun SwipeableSubscriptionItem(
     subscription: SubscriptionEntity,
+    isPaidThisCycle: Boolean = false,
     convertedAmount: BigDecimal? = null,
     displayCurrency: String? = null,
     onTap: () -> Unit = {},
@@ -599,23 +602,12 @@ private fun SwipeableSubscriptionItem(
                             }
 
                             // "Paid Mar 15" badge — shown when this cycle has
-                            // already been marked. Inline filled-tonal pill so
-                            // users don't accidentally re-tap. Sits ABOVE the
-                            // category since payment state is more important
-                            // than the category label.
-                            val recentlyPaid = subscription.lastPaidAt?.let { lastPaid ->
-                                val cycleStart = run {
-                                    val anchor = subscription.nextPaymentDate ?: return@let false
-                                    // Compute cycle-start cheaply: 30 days back
-                                    // works for monthly+; for accurate cycle
-                                    // arithmetic we'd plumb the repo's
-                                    // advance() helper into the composable.
-                                    !lastPaid.isBefore(anchor.minusDays(35)) && !lastPaid.isAfter(anchor)
-                                }
-                                cycleStart == true
-                            } ?: false
-
-                            if (recentlyPaid) {
+                            // already been marked. Computed in the VM
+                            // (today-anchored cycle check, single source of
+                            // truth shared with the partition sort). Sits
+                            // ABOVE the category since payment state is more
+                            // important than the category label.
+                            if (isPaidThisCycle) {
                                 Spacer(modifier = Modifier.height(2.dp))
                                 Row(
                                     verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
@@ -192,6 +192,7 @@ fun SubscriptionsScreen(
                     TotalSubscriptionsSummary(
                         totalAmount = uiState.totalMonthlyAmount,
                         activeCount = uiState.activeSubscriptions.size,
+                        paidThisCycleCount = uiState.paidThisCycleCount,
                         currency = uiState.displayCurrency
                     )
                 }
@@ -407,9 +408,22 @@ private fun EndedSubscriptionItem(
 private fun TotalSubscriptionsSummary(
     totalAmount: BigDecimal,
     activeCount: Int,
+    paidThisCycleCount: Int = 0,
     currency: String? = null
 ) {
     val amountColor = if (!isSystemInDarkTheme()) expense_light else expense_dark
+    val pluralActive = if (activeCount != 1) "s" else ""
+
+    // Subtitle shape:
+    //   no paid yet  → "5 active subscriptions"
+    //   some paid    → "3 of 5 paid this cycle"
+    //   all paid     → "All 5 paid this cycle ✓"
+    val subtitle = when {
+        activeCount == 0 -> "No active subscriptions"
+        paidThisCycleCount == 0 -> "$activeCount active subscription$pluralActive"
+        paidThisCycleCount == activeCount -> "All $activeCount paid this cycle"
+        else -> "$paidThisCycleCount of $activeCount paid this cycle"
+    }
 
     SummaryCardV2(
         title = "Monthly Subscriptions",
@@ -418,7 +432,7 @@ private fun TotalSubscriptionsSummary(
         } else {
             totalAmount.toPlainString()
         },
-        subtitle = "$activeCount active subscription${if (activeCount != 1) "s" else ""}",
+        subtitle = subtitle,
         amountColor = amountColor,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.secondaryContainer

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
@@ -195,12 +195,21 @@ class SubscriptionsViewModel @Inject constructor(
      * SMS already created a transaction — we surface those here so the
      * user can link instead of creating a duplicate phantom.
      *
-     * Match window: last 30 days, exact (case-insensitive) merchant match,
-     * EXPENSE only, excluding phantoms we've already created.
+     * Matching: case-insensitive merchant exact + amount exact (±₹0.01)
+     * over the last 30 days, EXPENSE only, excluding phantoms we've
+     * created ourselves. Amount match is required — a one-off ₹789
+     * Netflix purchase shouldn't surface as a candidate for a ₹499 sub.
      */
-    suspend fun candidatesFor(merchant: String): List<com.pennywiseai.tracker.data.database.entity.TransactionEntity> {
+    suspend fun candidatesFor(
+        sub: SubscriptionEntity,
+    ): List<com.pennywiseai.tracker.data.database.entity.TransactionEntity> {
         val cutoff = java.time.LocalDate.now().minusDays(30).atStartOfDay()
-        return transactionRepository.findRecentExpensesByMerchant(merchant, cutoff, limit = 5)
+        return transactionRepository.findRecentExpensesByMerchantAndAmount(
+            merchant = sub.merchantName,
+            amount = sub.amount,
+            since = cutoff,
+            limit = 5,
+        )
     }
 
     /**

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
@@ -23,6 +23,7 @@ class SubscriptionsViewModel @Inject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val currencyConversionService: CurrencyConversionService,
     private val markSubscriptionPaidUseCase: MarkSubscriptionPaidUseCase,
+    private val transactionRepository: com.pennywiseai.tracker.data.repository.TransactionRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SubscriptionsUiState())
@@ -170,6 +171,8 @@ class SubscriptionsViewModel @Inject constructor(
             val message = when (result) {
                 is MarkSubscriptionPaidUseCase.Result.Created ->
                     "$merchant marked paid · next cycle on ${result.nextPaymentDate}"
+                is MarkSubscriptionPaidUseCase.Result.Linked ->
+                    "$merchant linked · next cycle on ${result.nextPaymentDate}"
                 is MarkSubscriptionPaidUseCase.Result.AlreadyMarked ->
                     "$merchant already marked this cycle · advanced to ${result.nextPaymentDate}"
                 MarkSubscriptionPaidUseCase.Result.NoScheduledDate ->
@@ -184,6 +187,42 @@ class SubscriptionsViewModel @Inject constructor(
     /** UI calls this after consuming the snackbar message. */
     fun clearMarkPaidMessage() {
         _uiState.value = _uiState.value.copy(markPaidMessage = null)
+    }
+
+    /**
+     * Suggested-payment candidates for the mark-as-paid sheet (#412
+     * follow-up). When an EXPENSE subscription is on auto-pay, the bank
+     * SMS already created a transaction — we surface those here so the
+     * user can link instead of creating a duplicate phantom.
+     *
+     * Match window: last 30 days, exact (case-insensitive) merchant match,
+     * EXPENSE only, excluding phantoms we've already created.
+     */
+    suspend fun candidatesFor(merchant: String): List<com.pennywiseai.tracker.data.database.entity.TransactionEntity> {
+        val cutoff = java.time.LocalDate.now().minusDays(30).atStartOfDay()
+        return transactionRepository.findRecentExpensesByMerchant(merchant, cutoff, limit = 5)
+    }
+
+    /**
+     * Link an existing bank-derived transaction as this subscription's
+     * current-cycle payment. Advances the schedule; doesn't duplicate.
+     */
+    fun linkExistingTransaction(subscriptionId: Long, transactionId: Long) {
+        viewModelScope.launch {
+            val result = markSubscriptionPaidUseCase.linkExisting(subscriptionId, transactionId)
+            val merchant = _uiState.value.activeSubscriptions.find { it.id == subscriptionId }?.merchantName
+                ?: "Subscription"
+            val message = when (result) {
+                is MarkSubscriptionPaidUseCase.Result.Linked ->
+                    "$merchant linked to existing payment · next cycle on ${result.nextPaymentDate}"
+                MarkSubscriptionPaidUseCase.Result.NoScheduledDate ->
+                    "Set a next-payment date on $merchant first"
+                MarkSubscriptionPaidUseCase.Result.SubscriptionNotFound ->
+                    "Couldn't find that subscription"
+                else -> "Linked"
+            }
+            _uiState.value = _uiState.value.copy(markPaidMessage = message)
+        }
     }
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
@@ -77,8 +77,31 @@ class SubscriptionsViewModel @Inject constructor(
                     emptyMap()
                 }
 
+                // Order the active list so "needs attention" rises to the
+                // top: unpaid-this-cycle subs first (sorted by next-payment
+                // date ascending, nulls last), recently-paid subs at the
+                // bottom (sorted by last-paid descending). Reduces the
+                // visual hunt for what still needs the user's attention.
+                val cycleStart: (com.pennywiseai.tracker.data.database.entity.SubscriptionEntity) -> java.time.LocalDate? = { sub ->
+                    sub.nextPaymentDate?.let { next ->
+                        subscriptionRepository.advance(next, sub.billingCycle, reverse = true)
+                    }
+                }
+                val isPaidThisCycle: (com.pennywiseai.tracker.data.database.entity.SubscriptionEntity) -> Boolean = { sub ->
+                    val anchor = sub.nextPaymentDate
+                    val start = cycleStart(sub)
+                    val paid = sub.lastPaidAt
+                    paid != null && anchor != null && start != null &&
+                        !paid.isBefore(start) && !paid.isAfter(anchor)
+                }
+                val (paid, unpaid) = subscriptions.partition(isPaidThisCycle)
+                val ordered = unpaid.sortedWith(
+                    compareBy(nullsLast()) { it.nextPaymentDate },
+                ) + paid.sortedByDescending { it.lastPaidAt }
+
                 _uiState.value = _uiState.value.copy(
-                    activeSubscriptions = subscriptions,
+                    activeSubscriptions = ordered,
+                    paidThisCycleCount = paid.size,
                     endedSubscriptions = endedSubscriptions,
                     totalMonthlyAmount = totalMonthlyAmount,
                     convertedAmounts = convertedAmounts,
@@ -237,6 +260,8 @@ class SubscriptionsViewModel @Inject constructor(
 
 data class SubscriptionsUiState(
     val activeSubscriptions: List<SubscriptionEntity> = emptyList(),
+    /** Count of subs in [activeSubscriptions] whose current cycle is paid. */
+    val paidThisCycleCount: Int = 0,
     val endedSubscriptions: List<SubscriptionEntity> = emptyList(),
     val totalMonthlyAmount: BigDecimal = BigDecimal.ZERO,
     val convertedAmounts: Map<Long, BigDecimal> = emptyMap(),

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
@@ -7,6 +7,7 @@ import com.pennywiseai.tracker.data.database.entity.SubscriptionEntity
 import com.pennywiseai.tracker.data.database.entity.SubscriptionState
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.repository.SubscriptionRepository
+import com.pennywiseai.tracker.domain.usecase.MarkSubscriptionPaidUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -20,7 +21,8 @@ import javax.inject.Inject
 class SubscriptionsViewModel @Inject constructor(
     private val subscriptionRepository: SubscriptionRepository,
     private val userPreferencesRepository: UserPreferencesRepository,
-    private val currencyConversionService: CurrencyConversionService
+    private val currencyConversionService: CurrencyConversionService,
+    private val markSubscriptionPaidUseCase: MarkSubscriptionPaidUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SubscriptionsUiState())
@@ -154,6 +156,35 @@ class SubscriptionsViewModel @Inject constructor(
             subscriptionRepository.deleteSubscription(subscriptionId)
         }
     }
+
+    /**
+     * #412 — user-initiated "mark as paid" (or "mark as received" for
+     * income-direction subscriptions). Creates the transaction + advances
+     * the schedule, then publishes a snackbar message the UI consumes.
+     */
+    fun markAsPaid(subscriptionId: Long, paymentDate: java.time.LocalDate) {
+        viewModelScope.launch {
+            val result = markSubscriptionPaidUseCase.execute(subscriptionId, paymentDate)
+            val merchant = _uiState.value.activeSubscriptions.find { it.id == subscriptionId }?.merchantName
+                ?: "Subscription"
+            val message = when (result) {
+                is MarkSubscriptionPaidUseCase.Result.Created ->
+                    "$merchant marked paid · next cycle on ${result.nextPaymentDate}"
+                is MarkSubscriptionPaidUseCase.Result.AlreadyMarked ->
+                    "$merchant already marked this cycle · advanced to ${result.nextPaymentDate}"
+                MarkSubscriptionPaidUseCase.Result.NoScheduledDate ->
+                    "Set a next-payment date on $merchant first"
+                MarkSubscriptionPaidUseCase.Result.SubscriptionNotFound ->
+                    "Couldn't find that subscription"
+            }
+            _uiState.value = _uiState.value.copy(markPaidMessage = message)
+        }
+    }
+
+    /** UI calls this after consuming the snackbar message. */
+    fun clearMarkPaidMessage() {
+        _uiState.value = _uiState.value.copy(markPaidMessage = null)
+    }
 }
 
 data class SubscriptionsUiState(
@@ -165,5 +196,7 @@ data class SubscriptionsUiState(
     val isUnifiedMode: Boolean = false,
     val isLoading: Boolean = true,
     val lastHiddenSubscription: SubscriptionEntity? = null,
-    val lastEndedSubscription: SubscriptionEntity? = null
+    val lastEndedSubscription: SubscriptionEntity? = null,
+    /** Snackbar text after a mark-as-paid action; cleared by [SubscriptionsViewModel.clearMarkPaidMessage]. */
+    val markPaidMessage: String? = null,
 )

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
@@ -80,27 +80,29 @@ class SubscriptionsViewModel @Inject constructor(
                 // Order the active list so "needs attention" rises to the
                 // top: unpaid-this-cycle subs first (sorted by next-payment
                 // date ascending, nulls last), recently-paid subs at the
-                // bottom (sorted by last-paid descending). Reduces the
-                // visual hunt for what still needs the user's attention.
-                val cycleStart: (com.pennywiseai.tracker.data.database.entity.SubscriptionEntity) -> java.time.LocalDate? = { sub ->
-                    sub.nextPaymentDate?.let { next ->
-                        subscriptionRepository.advance(next, sub.billingCycle, reverse = true)
-                    }
-                }
+                // bottom (sorted by last-paid descending).
+                //
+                // Today-anchored cycle check (NOT schedule-anchored — the
+                // schedule slides forward every time we advance, which used
+                // to break this guard once any sub had been marked once).
+                // Semantic: a sub is "paid this cycle" if today is still
+                // within one billing cycle of lastPaidAt.
+                val today = java.time.LocalDate.now()
                 val isPaidThisCycle: (com.pennywiseai.tracker.data.database.entity.SubscriptionEntity) -> Boolean = { sub ->
-                    val anchor = sub.nextPaymentDate
-                    val start = cycleStart(sub)
-                    val paid = sub.lastPaidAt
-                    paid != null && anchor != null && start != null &&
-                        !paid.isBefore(start) && !paid.isAfter(anchor)
+                    sub.lastPaidAt?.let { lastPaid ->
+                        val nextLegitMark = subscriptionRepository.advance(lastPaid, sub.billingCycle)
+                        today.isBefore(nextLegitMark)
+                    } ?: false
                 }
                 val (paid, unpaid) = subscriptions.partition(isPaidThisCycle)
                 val ordered = unpaid.sortedWith(
                     compareBy(nullsLast()) { it.nextPaymentDate },
                 ) + paid.sortedByDescending { it.lastPaidAt }
+                val paidIds = paid.map { it.id }.toSet()
 
                 _uiState.value = _uiState.value.copy(
                     activeSubscriptions = ordered,
+                    paidThisCycleIds = paidIds,
                     paidThisCycleCount = paid.size,
                     endedSubscriptions = endedSubscriptions,
                     totalMonthlyAmount = totalMonthlyAmount,
@@ -260,6 +262,8 @@ class SubscriptionsViewModel @Inject constructor(
 
 data class SubscriptionsUiState(
     val activeSubscriptions: List<SubscriptionEntity> = emptyList(),
+    /** IDs of subs in [activeSubscriptions] whose current cycle is paid — used to drive the row badge. */
+    val paidThisCycleIds: Set<Long> = emptySet(),
     /** Count of subs in [activeSubscriptions] whose current cycle is paid. */
     val paidThisCycleCount: Int = 0,
     val endedSubscriptions: List<SubscriptionEntity> = emptyList(),


### PR DESCRIPTION
Closes #412 (shreyes-shalgar's request).

## What the issue asked for

> When I go in subscriptions page and tap on any subscription it should prompt me 'Is the subscription paid' and if I select yes it should create a transaction out of it.

## What this PR does

- **Tap a subscription** → opens a Material 3 bottom sheet with brand icon, merchant name, amount (in the app's hero typography), 3 date chips (Today / Yesterday / Pick…), and a single CTA.
- **Confirm** → creates the matching transaction + advances `next_payment_date` by one billing cycle.
- **Existing SMS-body expand** moved from card-tap to the kebab menu under "View source" (only shown when `smsBody` is present). The primary tap is now meaningful for ALL subs, not just SMS-derived ones.

## Why user-initiated (not auto)

Mirrors the income-autopay split from #371 / v2.15.56:

| Direction | How transactions land |
|---|---|
| **INCOME** (wallet top-ups, salary, allowance) | Auto-created on schedule by `GenerateIncomeAutopayUseCase` (#371) — no SMS to drive it. |
| **EXPENSE auto-pay** (UPI mandate, card auto-debit, EMI) | Already auto-creates from the bank's SMS. Full auto here would double-count. |
| **EXPENSE manual-pay** (cash, in-person card, off-platform) | No SMS. This PR covers it — user taps to confirm. |

## Idempotency

- EXPENSE rows hash as `subpay-<subId>-<scheduledDate>`
- INCOME rows share `autopay-<subId>-<scheduledDate>` with `GenerateIncomeAutopayUseCase` so manual + scheduled can't fire twice for the same cycle
- The hash uses the subscription's stored `scheduledDate`, NOT the user's chosen payment date — so tapping twice for the same cycle dedups regardless of when the user actually paid
- Schedule advances from the previously-scheduled date (NOT `paymentDate`), preventing cycle drift when paying early/late

## UI

```
┌─────────────────────────────────────┐
│              ─                       │  drag handle
│                                     │
│   MARK AS PAID                       │  primary eyebrow chip
│                                     │
│  [icon] Netflix                      │  brand + merchant + category
│         Entertainment                │
│                                     │
│          ₹499                        │  headlineLarge Bold, expense_dark
│                                     │
│   When?                              │  label
│   [Today] [Yesterday] [Pick date]   │  filter chips
│                                     │
│  ┌───────────────────────────────┐  │
│  │   Mark paid · ₹499            │  │  56dp CTA
│  └───────────────────────────────┘  │
│   We'll log the expense and roll    │  small disclaimer
│   the schedule to the next cycle.   │
└─────────────────────────────────────┘
```

INCOME variant: gold-ish secondaryContainer eyebrow, teal amount color, "Mark received" / "MARK AS RECEIVED" labels.

## Test plan

- [ ] Tap an active expense subscription → sheet opens with correct brand/amount/category
- [ ] Date chips: Today → selects today, Yesterday → selects yesterday, Pick → opens DatePickerDialog
- [ ] Confirm → snackbar shows "X marked paid · next cycle on YYYY-MM-DD", transaction appears in Transactions, subscription's next-payment-date advanced by one billing cycle
- [ ] Confirm twice for the same cycle → second confirm shows "X already marked this cycle · advanced to YYYY-MM-DD" (idempotent, schedule still advances)
- [ ] Tap an income subscription (direction=INCOME) → sheet shows "MARK AS RECEIVED" + teal amount
- [ ] Tap a subscription with `smsBody == null` → sheet still opens (previous behavior would no-op the click)
- [ ] Kebab → "View source" → expands SMS body (existing behavior, just relocated)
- [ ] Kebab → "Mark as paid" → opens the same sheet as tap (redundant path for discoverability)
- [ ] Edit / End / Delete kebab actions unchanged
- [ ] Swipe-to-hide unchanged
- [ ] F-Droid flavor: same behavior (no billing dependency touched)

Closes #412