### PR TITLE
feat(pro): home Pro-discovery surfaces + paywall support line

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
@@ -123,7 +123,7 @@ fun HomeScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val isProEntitled by viewModel.isProEntitled.collectAsState()
-    var showUpgradeSheet by remember { mutableStateOf(false) }
+    var showUpgradeSheet by rememberSaveable { mutableStateOf(false) }
     val deletedTransaction by viewModel.deletedTransaction.collectAsState()
     val smsScanWorkInfo by viewModel.smsScanWorkInfo.collectAsState()
     val activity = LocalActivity.current

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
@@ -31,6 +31,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
@@ -121,6 +122,8 @@ fun HomeScreen(
     onFabPositioned: (Rect) -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val isProEntitled by viewModel.isProEntitled.collectAsState()
+    var showUpgradeSheet by remember { mutableStateOf(false) }
     val deletedTransaction by viewModel.deletedTransaction.collectAsState()
     val smsScanWorkInfo by viewModel.smsScanWorkInfo.collectAsState()
     val activity = LocalActivity.current
@@ -251,6 +254,35 @@ fun HomeScreen(
                         modifier = Modifier.padding(end = 16.dp),
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
+                        // Subtle Pro discovery chip — yellow sparkle that ties
+                        // back to the Settings → PennyWise Pro entry. Hidden
+                        // for already-entitled users so it's never pushy.
+                        // Tap → opens the same UpgradeSheet as Settings.
+                        if (!isProEntitled) {
+                            Box(
+                                modifier = Modifier
+                                    .size(40.dp)
+                                    .clip(CircleShape)
+                                    .background(
+                                        color = com.pennywiseai.tracker.ui.theme.yellow_light,
+                                        shape = CircleShape,
+                                    )
+                                    .clickable(
+                                        onClick = { showUpgradeSheet = true },
+                                        interactionSource = remember { MutableInteractionSource() },
+                                        indication = null,
+                                    ),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.AutoAwesome,
+                                    contentDescription = "Upgrade to PennyWise Pro",
+                                    tint = com.pennywiseai.tracker.ui.theme.yellow_dark,
+                                    modifier = Modifier.size(20.dp),
+                                )
+                            }
+                        }
+
                         // Business/Personal filter dropdown
                         Box {
                             Box(
@@ -317,7 +349,9 @@ fun HomeScreen(
                         onMenuClick = { showMenuSheet = true },
                         profiles = uiState.profiles,
                         selectedProfileId = uiState.selectedProfileId,
-                        onProfileSelected = { viewModel.updateSelectedProfile(it) }
+                        onProfileSelected = { viewModel.updateSelectedProfile(it) },
+                        isProEntitled = isProEntitled,
+                        onUpgradeClick = { showUpgradeSheet = true }
                     )
                 }
             )
@@ -1027,6 +1061,14 @@ fun HomeScreen(
             }
         }
     }
+    }
+
+    // Pro upgrade sheet — triggered from the subtle ✨ chip in the top bar
+    // for free users; reuses the same composable Settings uses.
+    if (showUpgradeSheet) {
+        com.pennywiseai.tracker.presentation.paywall.UpgradeSheet(
+            onDismiss = { showUpgradeSheet = false },
+        )
     }
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -73,8 +73,15 @@ class HomeViewModel @Inject constructor(
     private val profileRepository: ProfileRepository,
     private val inAppUpdateManager: InAppUpdateManager,
     private val inAppReviewManager: InAppReviewManager,
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
+    entitlementGate: com.pennywiseai.tracker.billing.EntitlementGate,
 ) : ViewModel() {
+
+    /**
+     * Drives the subtle Pro chip in the home top bar — hidden when the
+     * user is already entitled so we never push to existing buyers.
+     */
+    val isProEntitled: StateFlow<Boolean> = entitlementGate.isProEntitled
     
     private val sharedPrefs = context.getSharedPreferences("account_prefs", Context.MODE_PRIVATE)
     private val _uiState = MutableStateFlow(HomeUiState())

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/paywall/UpgradeSheet.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/paywall/UpgradeSheet.kt
@@ -29,10 +29,12 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -262,10 +264,44 @@ private fun UpgradeBody(
     IncludesBlock()
     Spacer(Modifier.height(Spacing.lg))
 
+    SupportNote()
+    Spacer(Modifier.height(Spacing.lg))
+
     TrustRow(
         liveCatalogEmpty = state.products.isEmpty() && !state.isLoading,
         onRestore = onRestore,
     )
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Support note — the emotional beat at the buy moment. Reminds the buyer
+// there's a real person behind the app and what their money actually funds.
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun SupportNote() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Dimensions.Padding.content)
+            .clip(RoundedCornerShape(Dimensions.CornerRadius.large))
+            .background(yellow_light)
+            .padding(Spacing.md),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.FavoriteBorder,
+            contentDescription = null,
+            tint = yellow_dark,
+            modifier = Modifier.size(Dimensions.Icon.medium),
+        )
+        Text(
+            text = "Built by a solo dev — your upgrade funds what's next. Thank you.",
+            style = MaterialTheme.typography.bodySmall,
+            color = Color(0xFF3A2B00),
+        )
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/GreetingCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/GreetingCard.kt
@@ -29,13 +29,18 @@ import com.pennywiseai.tracker.data.database.entity.ProfileEntity
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.pennywiseai.tracker.ui.theme.Dimensions
 import com.pennywiseai.tracker.ui.theme.Spacing
+import com.pennywiseai.tracker.ui.theme.yellow_dark
 import coil.compose.AsyncImage
 import java.time.LocalDate
 import java.time.LocalTime
@@ -51,7 +56,9 @@ fun GreetingCard(
     onMenuClick: () -> Unit = {},
     profiles: List<ProfileEntity> = emptyList(),
     selectedProfileId: Long? = null,
-    onProfileSelected: (Long?) -> Unit = {}
+    onProfileSelected: (Long?) -> Unit = {},
+    isProEntitled: Boolean = false,
+    onUpgradeClick: () -> Unit = {}
 ) {
     val today = LocalDate.now()
     val subtitle = remember(today) {
@@ -87,13 +94,33 @@ fun GreetingCard(
             .padding(horizontal = Dimensions.Padding.content, vertical = Spacing.xs),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        // Profile Avatar
+        // Profile Avatar wrapped in a "membership ring" — the only Pro signal,
+        // no pill, no label. Solid gold = Pro member; dashed gold = free user
+        // (reads as "not yet filled / tap to unlock"). For free users tapping
+        // opens the upgrade sheet; Pro members tap through to settings.
+        val ringColor = yellow_dark
+        Box(
+            modifier = Modifier
+                .size(52.dp)
+                .drawBehind {
+                    val stroke = 2.dp.toPx()
+                    val dash = if (!isProEntitled) {
+                        PathEffect.dashPathEffect(floatArrayOf(stroke * 2.5f, stroke * 2f), 0f)
+                    } else null
+                    drawCircle(
+                        color = ringColor,
+                        radius = (size.minDimension - stroke) / 2f,
+                        style = Stroke(width = stroke, pathEffect = dash)
+                    )
+                }
+                .clickable(onClick = if (isProEntitled) onAvatarClick else onUpgradeClick),
+            contentAlignment = Alignment.Center
+        ) {
         Box(
             modifier = Modifier
                 .size(44.dp)
                 .clip(CircleShape)
-                .background(avatarBackground)
-                .clickable(onClick = onAvatarClick),
+                .background(avatarBackground),
             contentAlignment = Alignment.Center
         ) {
             val avatarResId = profileImageUri?.let { AvatarHelper.resolveAvatarDrawable(it) }
@@ -129,6 +156,7 @@ fun GreetingCard(
                 )
             }
         }
+        }
 
         Spacer(modifier = Modifier.width(Spacing.sm))
 
@@ -142,7 +170,9 @@ fun GreetingCard(
                 style = MaterialTheme.typography.titleMedium.copy(
                     fontWeight = FontWeight.SemiBold
                 ),
-                color = MaterialTheme.colorScheme.onBackground
+                color = MaterialTheme.colorScheme.onBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
             Text(
                 text = subtitle,
@@ -188,3 +218,4 @@ fun GreetingCard(
         }
     }
 }
+

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/GreetingCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/GreetingCard.kt
@@ -102,6 +102,9 @@ fun GreetingCard(
         Box(
             modifier = Modifier
                 .size(52.dp)
+                // Clip to a circle before clickable so the tap ripple stays
+                // within the ring instead of rendering as a square.
+                .clip(CircleShape)
                 .drawBehind {
                     val stroke = 2.dp.toPx()
                     val dash = if (!isProEntitled) {


### PR DESCRIPTION
## What

Makes **PennyWise Pro** discoverable for free users and rewarding for members, using the app's existing yellow Pro accent (`yellow_light` / `yellow_dark`) — no banners, gradients, or ad-like treatments.

### Changes
- **`GreetingCard`** — a gold *membership ring* around the home avatar:
  - **Free users** → a **dashed** gold ring (reads as "not yet unlocked"); tapping opens the `UpgradeSheet`.
  - **Pro members** → a **solid** gold ring (quiet status marker); tapping goes to settings.
  - The avatar reserves the ring slot in both states, so upgrading causes **no layout shift**.
- **`HomeScreen`** — wires `isProEntitled` into the greeting; keeps the subtle ✨ Pro chip in the collapsed top bar for free users.
- **`HomeViewModel`** — exposes `isProEntitled` from `EntitlementGate`.
- **`UpgradeSheet`** — adds a short *"built by a solo dev"* support line at the buy moment (after **Includes**, before the trust row).

## Why
The previous Pro entry points were easy to miss (the top-bar chip only appears when the bar is collapsed). These surfaces put a tasteful, on-brand nudge where free users actually look, give paying members a small reward, and add an honest support beat exactly where someone decides to buy.

## Design notes
Iterated from louder concepts (gradient "Go Pro" pill, in-feed support card) down to the restrained ring + one-line paywall note, to stay consistent with the app's minimal Material 3 look.

## Testing
Built and verified both states live on an emulator (`standardDebug`):
- Free user: dashed ring → opens upgrade sheet with the support line.
- Pro user (entitlement temporarily forced for preview, reverted): solid ring.

## Not included
Pre-existing unrelated working-tree changes (PlayBillingGateway discount diagnostics, release changelogs/script, planning docs) were intentionally left out of this PR.