### PR TITLE
feat(analytics): account scoping — exclude hidden accounts + profile filter (#418, #419)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.pennywiseai.tracker.data.database.entity.ProfileEntity
 import com.pennywiseai.tracker.presentation.common.TimePeriod
 import com.pennywiseai.tracker.presentation.common.TransactionTypeFilter
 import com.pennywiseai.tracker.ui.components.*
@@ -75,6 +76,8 @@ fun AnalyticsScreen(
     val isUnifiedMode by viewModel.isUnifiedMode.collectAsStateWithLifecycle()
     val chartType by viewModel.selectedChartType.collectAsStateWithLifecycle()
     val categoryFilter by viewModel.categoryFilter.collectAsStateWithLifecycle()
+    val selectedProfileId by viewModel.selectedProfileId.collectAsStateWithLifecycle()
+    val profiles by viewModel.profiles.collectAsStateWithLifecycle()
     var showDateRangePicker by rememberSaveable { mutableStateOf(false) }
     var categoryViewType by rememberSaveable { mutableStateOf(CategoryViewType.CHART) }
     var showChartTypeSelector by remember { mutableStateOf(false) }
@@ -82,6 +85,7 @@ fun AnalyticsScreen(
     var showTypeMenu by remember { mutableStateOf(false) }
     var showCurrencyMenu by remember { mutableStateOf(false) }
     var showCategoryMenu by remember { mutableStateOf(false) }
+    var showProfileMenu by remember { mutableStateOf(false) }
 
     // Remember scroll position across navigation
     val listState = rememberSaveable(saver = LazyListState.Saver) {
@@ -148,10 +152,13 @@ fun AnalyticsScreen(
                 isUnifiedMode = isUnifiedMode,
                 categoryFilter = categoryFilter,
                 availableCategories = uiState.availableCategories,
+                profiles = profiles,
+                selectedProfileId = selectedProfileId,
                 showPeriodMenu = showPeriodMenu,
                 showTypeMenu = showTypeMenu,
                 showCurrencyMenu = showCurrencyMenu,
                 showCategoryMenu = showCategoryMenu,
+                showProfileMenu = showProfileMenu,
                 hasActiveFilter = hasActiveAnalyticsFilter,
                 onPeriodClick = { showPeriodMenu = true },
                 onPeriodDismiss = { showPeriodMenu = false },
@@ -184,6 +191,12 @@ fun AnalyticsScreen(
                         viewModel.setCategoryFilter(category)
                     }
                     showCategoryMenu = false
+                },
+                onProfileClick = { showProfileMenu = true },
+                onProfileDismiss = { showProfileMenu = false },
+                onProfileSelected = { profileId ->
+                    viewModel.selectProfile(profileId)
+                    showProfileMenu = false
                 },
                 onResetFilters = {
                     viewModel.selectPeriod(TimePeriod.THIS_MONTH)
@@ -463,10 +476,13 @@ private fun AnalyticsFilterBar(
     isUnifiedMode: Boolean,
     categoryFilter: String?,
     availableCategories: List<String>,
+    profiles: List<ProfileEntity>,
+    selectedProfileId: Long?,
     showPeriodMenu: Boolean,
     showTypeMenu: Boolean,
     showCurrencyMenu: Boolean,
     showCategoryMenu: Boolean,
+    showProfileMenu: Boolean,
     hasActiveFilter: Boolean,
     onPeriodClick: () -> Unit,
     onPeriodDismiss: () -> Unit,
@@ -480,6 +496,9 @@ private fun AnalyticsFilterBar(
     onCategoryClick: () -> Unit,
     onCategoryDismiss: () -> Unit,
     onCategorySelected: (String?) -> Unit,
+    onProfileClick: () -> Unit,
+    onProfileDismiss: () -> Unit,
+    onProfileSelected: (Long?) -> Unit,
     onResetFilters: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -504,6 +523,30 @@ private fun AnalyticsFilterBar(
                         leadingIconContentColor = MaterialTheme.colorScheme.error
                     )
                 )
+            }
+        }
+
+        if (profiles.isNotEmpty()) {
+            item {
+                val selectedProfileLabel = profiles.find { it.id == selectedProfileId }?.name
+                Box {
+                    ExpressiveFilterChip(
+                        colors = analyticsFilterChipColors(),
+                        border = analyticsFilterChipBorder(selected = selectedProfileId != null),
+                        selected = selectedProfileId != null,
+                        text = selectedProfileLabel ?: "All Accounts",
+                        icon = profileFilterIcon(profiles, selectedProfileId),
+                        onClick = onProfileClick
+                    )
+
+                    ProfileFilterDropdown(
+                        expanded = showProfileMenu,
+                        profiles = profiles,
+                        selectedProfileId = selectedProfileId,
+                        onProfileSelected = onProfileSelected,
+                        onDismiss = onProfileDismiss
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -1,14 +1,20 @@
 package com.pennywiseai.tracker.ui.screens.analytics
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.data.currency.CurrencyConversionService
+import com.pennywiseai.tracker.data.database.entity.ProfileEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionWithSplits
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
+import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
+import com.pennywiseai.tracker.data.repository.ProfileRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import com.pennywiseai.tracker.presentation.common.TimePeriod
 import com.pennywiseai.tracker.presentation.common.TransactionTypeFilter
+import com.pennywiseai.tracker.presentation.common.buildProfileAccountKeys
+import com.pennywiseai.tracker.presentation.common.filterTransactionsByProfile
 import com.pennywiseai.tracker.presentation.common.getDateRangeForPeriod
 import com.pennywiseai.tracker.utils.CurrencyUtils
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -26,11 +32,25 @@ enum class ChartType { LINE, BAR, HEATMAP }
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class AnalyticsViewModel @Inject constructor(
+    @dagger.hilt.android.qualifiers.ApplicationContext private val context: Context,
     private val transactionRepository: TransactionRepository,
     private val userPreferencesRepository: UserPreferencesRepository,
     private val currencyConversionService: CurrencyConversionService,
+    private val accountBalanceRepository: AccountBalanceRepository,
+    private val profileRepository: ProfileRepository,
     private val savedStateHandle: androidx.lifecycle.SavedStateHandle
 ) : ViewModel() {
+
+    // Profile filter — reuses the global Home profile selection so the two stay in sync.
+    val selectedProfileId: StateFlow<Long?> = userPreferencesRepository.selectedProfileId
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    val profiles: StateFlow<List<ProfileEntity>> = profileRepository.observeAllProfiles()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    fun selectProfile(id: Long?) {
+        viewModelScope.launch { userPreferencesRepository.updateSelectedProfileId(id) }
+    }
     
     private val _selectedPeriod = MutableStateFlow(TimePeriod.THIS_MONTH)
     val selectedPeriod: StateFlow<TimePeriod> = _selectedPeriod.asStateFlow()
@@ -106,10 +126,12 @@ class AnalyticsViewModel @Inject constructor(
         customDateRange,
         _transactionTypeFilter,
         _selectedCurrency,
-        combine(_isUnifiedMode, _categoryFilter) { a, b -> a to b }
-    ) { period, customRange, typeFilter, currency, (isUnified, catFilter) ->
-        FilterState(period, customRange, typeFilter, currency, isUnified, catFilter)
-    }.flatMapLatest { filterState ->
+        combine(_isUnifiedMode, _categoryFilter, selectedProfileId) { u, c, p -> Triple(u, c, p) }
+    ) { period, customRange, typeFilter, currency, (isUnified, catFilter, profileId) ->
+        FilterState(period, customRange, typeFilter, currency, isUnified, catFilter, profileId)
+    }.combine(accountBalanceRepository.getAllLatestBalances()) { fs, balances ->
+        fs to balances
+    }.flatMapLatest { (filterState, balances) ->
         // Determine date range based on selected period
         val dateRange = if (filterState.period == TimePeriod.CUSTOM) {
             val customRange = filterState.customRange
@@ -160,19 +182,38 @@ class AnalyticsViewModel @Inject constructor(
                     TransactionTypeFilter.INVESTMENT -> com.pennywiseai.tracker.data.database.entity.TransactionType.INVESTMENT
                 }
 
+                // Scope a loaded transaction list to the selected profile and exclude
+                // hidden accounts (mirrors the Home screen's account scoping).
+                fun scopeTransactions(
+                    txs: List<TransactionWithSplits>
+                ): List<TransactionWithSplits> {
+                    val hidden = context.getSharedPreferences("account_prefs", Context.MODE_PRIVATE)
+                        .getStringSet("hidden_accounts", emptySet()) ?: emptySet()
+                    val profileKeys = buildProfileAccountKeys(balances)
+                    val keptIds = filterTransactionsByProfile(
+                        txs.map { it.transaction },
+                        filterState.profileId,
+                        profileKeys
+                    ).mapTo(HashSet()) { it.id }
+                    return txs.filter { tw ->
+                        tw.transaction.id in keptIds &&
+                            "${tw.transaction.bankName}_${tw.transaction.accountNumber}" !in hidden
+                    }
+                }
+
                 // Load transactions with splits for proper category breakdown
                 if (filterState.isUnifiedMode) {
                     // Unified mode: load ALL currencies
                     transactionRepository.getTransactionsWithSplitsFiltered(
                         startDate = dateRange.first,
                         endDate = dateRange.second
-                    ).map { txs -> Triple(txs, dbTransactionType, true) }
+                    ).map { txs -> Triple(scopeTransactions(txs), dbTransactionType, true) }
                 } else {
                     transactionRepository.getTransactionsWithSplitsFiltered(
                         startDate = dateRange.first,
                         endDate = dateRange.second,
                         currency = filterState.currency
-                    ).map { txs -> Triple(txs, dbTransactionType, false) }
+                    ).map { txs -> Triple(scopeTransactions(txs), dbTransactionType, false) }
                 }
             }.mapLatest { (allTransactionsWithSplits, transactionTypeFilter, isUnified) ->
                 // Filter by transaction type in memory (splits are already loaded)
@@ -421,7 +462,8 @@ private data class FilterState(
     val typeFilter: TransactionTypeFilter,
     val currency: String,
     val isUnifiedMode: Boolean = false,
-    val categoryFilter: String? = null
+    val categoryFilter: String? = null,
+    val profileId: Long? = null
 )
 
 data class AnalyticsUiState(


### PR DESCRIPTION
Fixes #418 · Closes #419

From a user's feedback: a finance professional whose work/business transactions clutter their reports. The Analytics screen had **no concept of account scoping** — hidden accounts still counted, and there was no profile filter.

## Changes
- **#418 (bug):** Analytics now excludes **hidden accounts** (the `account_prefs/hidden_accounts` set) from every total, category/merchant breakdown, and trend — matching how Home already filters them. Previously a hidden business account still leaked into all analytics.
- **#419 (feature):** Added a **profile filter chip** (All Accounts / Personal / Business / custom profiles) to the Analytics filter bar, reusing the Home plumbing:
  - global `userPreferencesRepository.selectedProfileId` (consistent with Home — selecting a profile applies everywhere)
  - the existing `ProfileFilterDropdown` + `profileFilterIcon`
  - the shared `buildProfileAccountKeys` / `filterTransactionsByProfile` helpers

## Implementation
Both apply through a single `scopeTransactions()` step in the `AnalyticsViewModel` reactive pipeline, in **both** the unified and per-currency branches. Account balances are folded into the flow (`.combine(getAllLatestBalances())`) so profile→account keys stay reactive. The profile selection is intentionally **not** part of the analytics "Clear filters" reset, since it's a global scope shared with Home.

## Verification (emulator)
- The profile chip renders as the first filter chip and opens the dropdown (All / Personal / Business).
- Selecting **Personal** → ₹7,134 (all test txns are personal); **Business** → ₹0; **All** → ₹7,134 — confirming the filter scopes the aggregates. Hidden-account exclusion runs through the same proven path.

Screenshots available on request.

## Follow-ups (separate issues filed)
#420 (bulk reassign account→profile), #421 (account aliases + group-by-account), #422 (report builder/pivot).