### PR TITLE
feat(accounts): bulk-apply an account's profile to existing transactions (#420)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
@@ -144,6 +144,12 @@ interface TransactionDao {
     @Query("SELECT COUNT(*) FROM transactions WHERE merchant_name = :merchantName AND id != :excludeId")
     suspend fun getTransactionCountForMerchant(merchantName: String, excludeId: Long): Int
 
+    @Query("SELECT COUNT(*) FROM transactions WHERE bank_name = :bankName AND account_number = :accountLast4 AND is_deleted = 0 AND profile_id IS NOT NULL AND profile_id != :profileId")
+    suspend fun countExplicitProfileMismatchForAccount(bankName: String, accountLast4: String, profileId: Long): Int
+
+    @Query("UPDATE transactions SET profile_id = :profileId, updated_at = :updatedAt WHERE bank_name = :bankName AND account_number = :accountLast4 AND is_deleted = 0 AND profile_id IS NOT NULL AND profile_id != :profileId")
+    suspend fun setProfileForAccountTransactions(bankName: String, accountLast4: String, profileId: Long, updatedAt: LocalDateTime): Int
+
     @Query("SELECT DISTINCT currency FROM transactions WHERE is_deleted = 0 ORDER BY currency")
     fun getAllCurrencies(): Flow<List<String>>
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
@@ -204,6 +204,27 @@ class TransactionRepository @Inject constructor(
     suspend fun getOtherTransactionCountForMerchant(merchantName: String, excludeId: Long): Int {
         return transactionDao.getTransactionCountForMerchant(merchantName, excludeId)
     }
+
+    suspend fun countExplicitProfileMismatchForAccount(
+        bankName: String,
+        accountLast4: String,
+        profileId: Long
+    ): Int {
+        return transactionDao.countExplicitProfileMismatchForAccount(bankName, accountLast4, profileId)
+    }
+
+    suspend fun setProfileForAccountTransactions(
+        bankName: String,
+        accountLast4: String,
+        profileId: Long
+    ): Int {
+        return transactionDao.setProfileForAccountTransactions(
+            bankName,
+            accountLast4,
+            profileId,
+            LocalDateTime.now()
+        )
+    }
     
     // Additional methods for Home screen
     data class MonthlyBreakdown(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
@@ -61,6 +61,7 @@ fun ManageAccountsScreen(
     var showMergeSheet by remember { mutableStateOf(false) }
     val isProEntitled by viewModel.isProEntitled.collectAsState()
     var showUpgradeSheet by remember { mutableStateOf(false) }
+    val pendingProfileReassign by viewModel.pendingProfileReassign.collectAsState()
 
     val scrollBehaviorSmall = TopAppBarDefaults.pinnedScrollBehavior()
     val scrollBehaviorLarge = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
@@ -564,6 +565,31 @@ fun ManageAccountsScreen(
     if (showUpgradeSheet) {
         com.pennywiseai.tracker.presentation.paywall.UpgradeSheet(
             onDismiss = { showUpgradeSheet = false },
+        )
+    }
+
+    // Offer to move existing transactions that carry an explicit, mismatched
+    // profile after the account's profile changes (#420).
+    pendingProfileReassign?.let { pending ->
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissPendingProfileReassign() },
+            title = { Text("Move existing transactions?") },
+            text = {
+                Text(
+                    "${pending.transactionCount} transaction(s) from this account are set to a " +
+                        "different profile. Move them to the new profile too?"
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { viewModel.applyPendingProfileReassign() }) {
+                    Text("Move them")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.dismissPendingProfileReassign() }) {
+                    Text("Keep as is")
+                }
+            }
         )
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
@@ -613,22 +613,27 @@ class ManageAccountsViewModel @Inject constructor(
 
     fun setAccountProfile(bankName: String, accountLast4: String, profileId: Long) {
         viewModelScope.launch {
-            accountBalanceRepository.setAccountProfile(bankName, accountLast4, profileId)
+            try {
+                accountBalanceRepository.setAccountProfile(bankName, accountLast4, profileId)
 
-            // Offer to move EXISTING transactions that carry an explicit, mismatched
-            // profile (NULL/dynamic ones already follow the account, so they're left alone).
-            val count = transactionRepository.countExplicitProfileMismatchForAccount(
-                bankName,
-                accountLast4,
-                profileId
-            )
-            if (count > 0) {
-                _pendingProfileReassign.value = PendingProfileReassign(
-                    bankName = bankName,
-                    accountLast4 = accountLast4,
-                    profileId = profileId,
-                    transactionCount = count
+                // Offer to move EXISTING transactions that carry an explicit, mismatched
+                // profile (NULL/dynamic ones already follow the account, so they're left alone).
+                val count = transactionRepository.countExplicitProfileMismatchForAccount(
+                    bankName,
+                    accountLast4,
+                    profileId
                 )
+                if (count > 0) {
+                    _pendingProfileReassign.value = PendingProfileReassign(
+                        bankName = bankName,
+                        accountLast4 = accountLast4,
+                        profileId = profileId,
+                        transactionCount = count
+                    )
+                }
+            } catch (e: Exception) {
+                android.util.Log.e("ManageAccountsViewModel", "Failed to set account profile", e)
+                _uiState.update { it.copy(errorMessage = "Failed to update account profile: ${e.message}") }
             }
         }
     }
@@ -640,6 +645,7 @@ class ManageAccountsViewModel @Inject constructor(
                 transactionRepository.setProfileForAccountTransactions(p.bankName, p.accountLast4, p.profileId)
             } catch (e: Exception) {
                 android.util.Log.e("ManageAccountsViewModel", "Failed to reassign account transactions", e)
+                _uiState.update { it.copy(errorMessage = "Failed to move transactions: ${e.message}") }
             } finally {
                 // Always clear the prompt so the dialog can't get stuck open if
                 // the update throws.

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
@@ -634,10 +634,17 @@ class ManageAccountsViewModel @Inject constructor(
     }
 
     fun applyPendingProfileReassign() {
+        val p = _pendingProfileReassign.value ?: return
         viewModelScope.launch {
-            val p = _pendingProfileReassign.value ?: return@launch
-            transactionRepository.setProfileForAccountTransactions(p.bankName, p.accountLast4, p.profileId)
-            _pendingProfileReassign.value = null
+            try {
+                transactionRepository.setProfileForAccountTransactions(p.bankName, p.accountLast4, p.profileId)
+            } catch (e: Exception) {
+                android.util.Log.e("ManageAccountsViewModel", "Failed to reassign account transactions", e)
+            } finally {
+                // Always clear the prompt so the dialog can't get stuck open if
+                // the update throws.
+                _pendingProfileReassign.value = null
+            }
         }
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
@@ -49,6 +49,13 @@ enum class AccountType {
     CASH
 }
 
+data class PendingProfileReassign(
+    val bankName: String,
+    val accountLast4: String,
+    val profileId: Long,
+    val transactionCount: Int
+)
+
 @HiltViewModel
 class ManageAccountsViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -73,6 +80,9 @@ class ManageAccountsViewModel @Inject constructor(
     
     private val _formState = MutableStateFlow(AccountFormState())
     val formState: StateFlow<AccountFormState> = _formState.asStateFlow()
+
+    private val _pendingProfileReassign = MutableStateFlow<PendingProfileReassign?>(null)
+    val pendingProfileReassign: StateFlow<PendingProfileReassign?> = _pendingProfileReassign.asStateFlow()
     
     init {
         loadAccounts()
@@ -604,7 +614,35 @@ class ManageAccountsViewModel @Inject constructor(
     fun setAccountProfile(bankName: String, accountLast4: String, profileId: Long) {
         viewModelScope.launch {
             accountBalanceRepository.setAccountProfile(bankName, accountLast4, profileId)
+
+            // Offer to move EXISTING transactions that carry an explicit, mismatched
+            // profile (NULL/dynamic ones already follow the account, so they're left alone).
+            val count = transactionRepository.countExplicitProfileMismatchForAccount(
+                bankName,
+                accountLast4,
+                profileId
+            )
+            if (count > 0) {
+                _pendingProfileReassign.value = PendingProfileReassign(
+                    bankName = bankName,
+                    accountLast4 = accountLast4,
+                    profileId = profileId,
+                    transactionCount = count
+                )
+            }
         }
+    }
+
+    fun applyPendingProfileReassign() {
+        viewModelScope.launch {
+            val p = _pendingProfileReassign.value ?: return@launch
+            transactionRepository.setProfileForAccountTransactions(p.bankName, p.accountLast4, p.profileId)
+            _pendingProfileReassign.value = null
+        }
+    }
+
+    fun dismissPendingProfileReassign() {
+        _pendingProfileReassign.value = null
     }
 
     fun editAccount(


### PR DESCRIPTION
Closes #420

From a user's feedback: after classifying an account as Business, existing transactions didn't follow — they had to reclassify them one by one.

## What
After you change an account's profile in **Manage Accounts**, if any of that account's transactions carry an **explicit, mismatched** profile, a confirmation dialog offers to move them all:

> **Move existing transactions?**
> N transaction(s) from this account are set to a different profile. Move them to the new profile too? — **Move them** / **Keep as is**

## Why "explicit mismatch only"
A transaction inherits its account's profile **dynamically** when its `profile_id` is `NULL`, so those already follow the account change. The real pain is transactions with an explicit override (e.g. an old "Personal") that *don't* follow. So the count and bulk-update are scoped to `profile_id IS NOT NULL AND profile_id != :profileId` — NULL/dynamic rows are never touched.

## Changes
- **TransactionDao** — `countExplicitProfileMismatchForAccount(...)` and `setProfileForAccountTransactions(...)` (UPDATE scoped as above; stamps `updated_at`). No schema change → no migration.
- **TransactionRepository** — passthroughs (`update` uses `LocalDateTime.now()`).
- **ManageAccountsViewModel** — `setAccountProfile` now counts explicit mismatches and raises a `pendingProfileReassign` prompt; `apply`/`dismiss` actions.
- **ManageAccountsScreen** — confirmation `AlertDialog` wired to the prompt.

## Verification
- Compiles clean (`:app:compileStandardDebugKotlin`).
- Manage Accounts loads with the new VM/DAO wiring on the emulator — no crash/DI break.
- The dialog only triggers when explicit mismatches exist (by design). I did **not** stage that exact data state on the emulator to capture the dialog live — `sqlite3` isn't available there and seeding it via the UI is multi-step — so the dialog wiring is verified by review against the existing AlertDialog pattern, not a live screenshot. Happy to do a full data-seeded UI demo if you'd like.