### PR TITLE
fix(crowdin): GITHUB_TOKEN for PR + correct Play locale codes

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -32,6 +32,9 @@ jobs:
           upload_sources: true
           upload_translations: false
           download_translations: true
+          # Only pull fully-translated files, so we never publish English copy
+          # in a non-English store listing.
+          skip_untranslated_files: true
           localization_branch_name: l10n/crowdin
           create_pull_request: true
           pull_request_title: 'i18n: new Play Store metadata translations'

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -39,5 +39,7 @@ jobs:
           pull_request_base_branch_name: main
           commit_message: 'i18n: update Play Store metadata translations'
         env:
+          # Auto-provided by GitHub Actions — needed to open the translations PR.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -19,14 +19,22 @@ preserve_hierarchy: true
 # Only Play-supported codes here; enabling a language in the Crowdin project
 # that maps to an unsupported folder will make `fastlane supply` reject it.
 #   Priority: Hindi (India is ~87% of the install base) then Arabic (UAE+Saudi).
+#   Crowdin's default %locale% over-regionalizes some languages (e.g. sw-KE,
+#   th-TH) which Play REJECTS — Play wants bare `sw` / `th`. Every entry below is
+#   the exact Google Play listing code (verified against fastlane's ALL_LANGUAGES).
 languages_mapping:
   locale:
-    hi: hi-IN     # Hindi  -> India
-    ar: ar        # Arabic -> UAE / Saudi
-    # --- uncomment as you expand (all Play-supported) ---
-    # ru: ru-RU   # Russian
-    # cs: cs-CZ   # Czech
-    # sw: sw      # Swahili (Kenya/Tanzania)
+    hi: hi-IN     # Hindi      -> India
+    ar: ar        # Arabic     -> UAE / Saudi / Egypt
+    th: th        # Thai       -> Thailand   (NOT th-TH)
+    sw: sw        # Swahili    -> Kenya / Tanzania (NOT sw-KE)
+    ne: ne-NP     # Nepali     -> Nepal
+    ru: ru-RU     # Russian    -> Russia / Belarus
+    be: be        # Belarusian -> Belarus
+    cs: cs-CZ     # Czech      -> Czechia
+    fa: fa        # Persian    -> Iran
+    am: am        # Amharic    -> Ethiopia
+    es: es-419    # Spanish    -> Latin America (Colombia)
 
 files:
   - source: /fastlane/metadata/android/en-US/title.txt


### PR DESCRIPTION
Two fixes after the first real Crowdin run (auth + download worked, PR creation failed).

1. **GITHUB_TOKEN** — pass the auto-provided token into the Crowdin step so it can open the translations PR (`Either 'GITHUB_TOKEN' or 'GH_TOKEN' must be set`). `permissions: pull-requests: write` already set.

2. **Play locale codes** — Crowdin's `%locale%` over-regionalizes some languages (`sw-KE`, `th-TH`) which Google Play **rejects**. `languages_mapping` now pins the exact Play listing code for every PennyWise market (`sw`, `th`, `hi-IN`, `ar`, `ru-RU`, `ne-NP`, `cs-CZ`, `be`, `fa`, `am`, `es-419`), verified against fastlane's `ALL_LANGUAGES`.

3. **skip_untranslated_files** — so a half-translated language never publishes English copy inside a non-English listing.