### PR TITLE
Local Play upload (fastlane supply) + Crowdin glossary/style guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ deploy.sh
 
 # VSCode build files
 parser-core/bin/*
+
+# Local Play service-account key (used by scripts/upload-play.sh)
+play-store-key.json
+*play-store*.json

--- a/crowdin/glossary.csv
+++ b/crowdin/glossary.csv
@@ -1,0 +1,11 @@
+Term,Description
+PennyWise AI,Brand name. Do NOT translate — always keep "PennyWise AI" in Latin script.
+PennyWise,Brand name. Do NOT translate — keep in Latin script.
+Pro,Product tier (PennyWise Pro). Do NOT translate — keep "Pro".
+SMS,Technical term. Keep as "SMS" — universally understood; do not expand or translate.
+AI,Keep as "AI" in Latin. Do not translate to a local word for artificial intelligence.
+on-device,The privacy hook. Translate the meaning naturally but keep it clearly "runs on your phone, not the cloud".
+open source,May be translated; keep the meaning. Leave the license name "AGPL" untranslated.
+AGPL,Software license name. Do NOT translate.
+Qwen,On-device AI model name. Do NOT translate.
+UPI,Indian payments rail. Do NOT translate — keep "UPI".

--- a/docs/store-localization.md
+++ b/docs/store-localization.md
@@ -69,3 +69,35 @@ crowdin download                # pull translations into fastlane folders
 
 > Tip: keep `title.txt` translations within 30 characters. Translators may keep
 > the "PennyWise AI" brand in Latin script and only localize "Expense Tracker".
+
+## Translation style guide (paste into the Crowdin project)
+
+Put this in **Crowdin → Settings → project description / translator instructions**
+so it shows to every translator and MT pass. It's the single biggest lever for
+not getting stiff, robotic translations.
+
+> **Voice:** write the way real people in this market *speak*, not formal/literary
+> language. For Hindi specifically, use everyday conversational Hindi in
+> Devanagari and **keep the English loanwords people actually say** — "SMS",
+> "bank", "app", "budget", "AI". Avoid Sanskritized/government-form Hindi.
+>
+> **Always keep in Latin / untranslated:** `PennyWise AI`, `PennyWise`, `Pro`,
+> `SMS`, `AI`, `AGPL`, `Qwen`, `UPI`, currency symbols (₹ $ AED …) and numbers.
+>
+> **Length:** the app **title** must stay ≤ 30 characters and the **short
+> description** ≤ 80. If a literal translation is too long, shorten the meaning —
+> don't exceed the limit.
+>
+> **Tone:** benefit-first and friendly, same as the English ("auto-reads your
+> bank SMS", "private, on-device"). Don't translate word-for-word; translate the
+> *promise*.
+
+### Glossary
+
+Import [`crowdin/glossary.csv`](../crowdin/glossary.csv) under **Crowdin →
+Glossaries → Upload**. It lists the do-not-translate terms above with notes, so
+they surface inline while translating and Crowdin's QA flags it if they get
+changed.
+
+> Note: this only governs the **store listing** copy. The in-app UI is still
+> English-only until its strings are extracted into resources.

--- a/scripts/upload-play.sh
+++ b/scripts/upload-play.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# Local Google Play uploader via `fastlane supply` — no CI minutes.
+# Run it AFTER scripts/release.sh has built the .aab locally.
+#
+# Modes:
+#   ./scripts/upload-play.sh release [--dry-run]   # AAB + release notes (default)
+#   ./scripts/upload-play.sh listing [--dry-run]   # screenshots + store text only
+#
+#   release  -> uploads the built AAB and its release notes
+#               (fastlane/metadata/android/en-US/changelogs/<versionCode>.txt).
+#               Does NOT touch screenshots/description, so it can't clobber a
+#               listing you edit by hand. Leaves the release as a DRAFT to review
+#               and roll out in Play Console.
+#   listing  -> uploads title/short/full description + phone & tablet
+#               screenshots + feature graphic from fastlane/metadata. No binary.
+#               Use this to push refreshed screenshots instead of dragging files
+#               into Play Console.
+#
+# Setup (one time):
+#   gem install fastlane
+#   Put your Play service-account JSON somewhere local and point to it:
+#     export PLAY_JSON_KEY=/absolute/path/to/play-store-key.json
+#   (default looked-up path: ./play-store-key.json — git-ignored)
+#
+# Optional env overrides:
+#   PLAY_TRACK   (default: production)   PLAY_STATUS (default: draft)
+
+set -e
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+
+MODE="${1:-release}"
+DRY=""
+[ "$2" = "--dry-run" ] || [ "$1" = "--dry-run" ] && DRY="--validate_only true"
+[ "$1" = "--dry-run" ] && MODE="release"
+
+PACKAGE="com.pennywiseai.tracker"
+JSON_KEY="${PLAY_JSON_KEY:-play-store-key.json}"
+TRACK="${PLAY_TRACK:-production}"
+STATUS="${PLAY_STATUS:-draft}"
+META_PATH="fastlane/metadata/android"
+
+# --- preflight ---
+if ! command -v fastlane >/dev/null 2>&1; then
+  echo -e "${RED}❌ fastlane not found. Install it:  gem install fastlane${NC}"; exit 1
+fi
+if [ ! -f "$JSON_KEY" ]; then
+  echo -e "${RED}❌ Play service-account key not found at: $JSON_KEY${NC}"
+  echo -e "${YELLOW}   Set PLAY_JSON_KEY=/path/to/play-store-key.json${NC}"; exit 1
+fi
+
+case "$MODE" in
+  release)
+    VERSION=$(grep 'versionName = ' app/build.gradle.kts | sed 's/.*"\(.*\)".*/\1/')
+    AAB="app/build/outputs/bundle/standardRelease/PennyWise-v${VERSION}.aab"
+    [ -f "$AAB" ] || AAB=$(ls app/build/outputs/bundle/standardRelease/*.aab 2>/dev/null | head -1)
+    if [ -z "$AAB" ] || [ ! -f "$AAB" ]; then
+      echo -e "${RED}❌ No .aab found. Build it first (release.sh -> 'Build Play Store Bundle').${NC}"; exit 1
+    fi
+    echo -e "${GREEN}⬆️  Uploading AAB + release notes${NC}  (track=$TRACK status=$STATUS)"
+    echo "   $AAB"
+    fastlane supply \
+      --package_name "$PACKAGE" \
+      --json_key "$JSON_KEY" \
+      --aab "$AAB" \
+      --track "$TRACK" \
+      --release_status "$STATUS" \
+      --skip_upload_metadata true \
+      --skip_upload_images true \
+      --skip_upload_screenshots true \
+      $DRY
+    echo -e "${GREEN}✅ Done.${NC} ${YELLOW}Left as a DRAFT — review & roll out in Play Console.${NC}"
+    ;;
+  listing)
+    echo -e "${GREEN}⬆️  Uploading store listing (text + screenshots + feature graphic)${NC}"
+    fastlane supply \
+      --package_name "$PACKAGE" \
+      --json_key "$JSON_KEY" \
+      --track "$TRACK" \
+      --metadata_path "$META_PATH" \
+      --skip_upload_aab true \
+      --skip_upload_apk true \
+      --skip_upload_changelogs true \
+      $DRY
+    echo -e "${GREEN}✅ Listing pushed.${NC} ${YELLOW}Store-listing changes go to Google review.${NC}"
+    ;;
+  *)
+    echo "Usage: $0 [release|listing] [--dry-run]"; exit 1 ;;
+esac

--- a/scripts/upload-play.sh
+++ b/scripts/upload-play.sh
@@ -30,10 +30,16 @@ set -e
 
 GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
 
-MODE="${1:-release}"
+# Parse args in any order: mode (release|listing) and optional --dry-run.
+MODE="release"
 DRY=""
-[ "$2" = "--dry-run" ] || [ "$1" = "--dry-run" ] && DRY="--validate_only true"
-[ "$1" = "--dry-run" ] && MODE="release"
+for arg in "$@"; do
+  case "$arg" in
+    release|listing) MODE="$arg" ;;
+    --dry-run)       DRY="--validate_only true" ;;
+    *) echo "Unknown arg: $arg"; echo "Usage: $0 [release|listing] [--dry-run]"; exit 1 ;;
+  esac
+done
 
 PACKAGE="com.pennywiseai.tracker"
 JSON_KEY="${PLAY_JSON_KEY:-play-store-key.json}"


### PR DESCRIPTION
Two things, both keeping CI cost at zero (no Actions — you build the AAB locally).

## Local Play uploader — `scripts/upload-play.sh`
Replaces the manual "upload AAB + copy-paste release notes" step with `fastlane supply`, run locally after `release.sh` builds the bundle:
- `./scripts/upload-play.sh release` → uploads the built **AAB + release notes** (reads `changelogs/<versionCode>.txt`). Leaves it a **draft** to review/roll-out in Console. Skips listing text/images so it can't clobber a hand-edited listing.
- `./scripts/upload-play.sh listing` → pushes **screenshots + descriptions + feature graphic** from `fastlane/metadata` (no binary) — so you stop dragging files into Console.
- `--dry-run` on either to validate first.
- Service-account key path via `PLAY_JSON_KEY` (default `./play-store-key.json`, git-ignored).

## Crowdin quality
- `crowdin/glossary.csv` — do-not-translate terms (PennyWise AI, SMS, AI, Pro, AGPL, Qwen, UPI) to import in Crowdin → Glossaries.
- `docs/store-localization.md` — a translator style guide (natural conversational Hindi, keep English loanwords, brand in Latin) to paste into the Crowdin project so you don't get stiff/robotic Hindi.

No release.sh changes (your local edits there are untouched).