### PR TITLE
feat(parser): eMola + Millennium BIM (Mozambique)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -62,6 +62,8 @@ object BankParserFactory {
         CBEBankParser(),  // Commercial Bank of Ethiopia
         AltanaFCUParser(),  // Altana Federal Credit Union (USA) — must precede EverestBank, which greedily claims numeric senders
         StandardBankMozambiqueParser(),  // Standard Bank Mozambique — must precede EverestBank (shortcode 7832265 is a 7-digit numeric sender)
+        EMolaParser(),  // eMola (Mozambique)
+        MillenniumBimParser(),  // Millennium BIM (Mozambique)
         EverestBankParser(),  // Everest Bank (Nepal)
         BancolombiaParser(),  // Bancolombia (Colombia)
         MashreqBankParser(),  // Mashreq Bank (UAE)

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/EMolaParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/EMolaParser.kt
@@ -1,6 +1,5 @@
 package com.pennywiseai.parser.core.bank
 
-import com.pennywiseai.parser.core.ParsedTransaction
 import com.pennywiseai.parser.core.TransactionType
 import java.math.BigDecimal
 

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/EMolaParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/EMolaParser.kt
@@ -1,0 +1,126 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for eMola (Mozambique) SMS messages (English).
+ *
+ * Amounts use US-style formatting (thousands separator ',', decimal '.'),
+ * e.g. "3,123.45". Currency is written as "MT" which maps to MZN.
+ * Dates are DD/MM/YYYY and times HH:MM:SS.
+ *
+ * Supported formats:
+ * - Outgoing transfer (EXPENSE):
+ *   "Transaction ID PP260530.0934.w91238. You transfered 100.00MT to 871234566, name: John Doe at 09:34:45 on 30/05/2026. Fee: 0.00MT. Your account balance is 3,123.45MT. ..."
+ * - Incoming transfer (INCOME):
+ *   "Transaction ID: PP260603.0854.K00983. You received 123.45MT from 871234567, name: JOHN DOE at 08:54:09 on 03/06/2026. Content: campo. Your account balance is 1,234.56MT. ..."
+ * - Agent withdrawal (EXPENSE):
+ *   "Transaction ID: CO260528.1806.W15992. You withdrew 50.00MT in the Agent with code ID 123456, Name JOHN DOE at 18:06:25 on 28/05/2026. Fee: 3.00 MT. Your account balance is 1,234.23MT. ..."
+ *
+ * Note: "transfered" is the spelling used in the app's SMS.
+ */
+class EMolaParser : BankParser() {
+
+    override fun getBankName() = "eMola"
+
+    override fun getCurrency() = "MZN"
+
+    override fun canHandle(sender: String): Boolean {
+        return sender.equals("eMola", ignoreCase = true)
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+        return lower.contains("you transfered") ||
+                lower.contains("you received") ||
+                lower.contains("you withdrew")
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // Amount follows the action verb, e.g. "transfered 100.00MT",
+        // "received 123.45MT", "withdrew 50.00MT".
+        val pattern = Regex(
+            """(?:transfered|received|withdrew)\s+([0-9,]+\.[0-9]{2})\s*MT""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            return parseUsAmount(match.groupValues[1])
+        }
+        return null
+    }
+
+    private fun parseUsAmount(raw: String): BigDecimal? {
+        val normalized = raw.replace(",", "")
+        return try {
+            BigDecimal(normalized)
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lower = message.lowercase()
+        return when {
+            lower.contains("you transfered") -> TransactionType.EXPENSE
+            lower.contains("you withdrew") -> TransactionType.EXPENSE
+            lower.contains("you received") -> TransactionType.INCOME
+            else -> null
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // Counterparty name after "name:" for transfers/receipts.
+        // e.g. "to 871234566, name: John Doe at 09:34:45"
+        val namePattern = Regex(
+            """name:\s*([^,]+?)\s+at\s+\d{2}:\d{2}:\d{2}""",
+            RegexOption.IGNORE_CASE
+        )
+        namePattern.find(message)?.let { match ->
+            val merchant = match.groupValues[1].trim()
+            if (isValidMerchantName(merchant)) {
+                return merchant
+            }
+        }
+
+        // Agent withdrawal: "Name JOHN DOE at 18:06:25"
+        val agentPattern = Regex(
+            """Name\s+([^,]+?)\s+at\s+\d{2}:\d{2}:\d{2}""",
+            RegexOption.IGNORE_CASE
+        )
+        agentPattern.find(message)?.let { match ->
+            val merchant = match.groupValues[1].trim()
+            if (isValidMerchantName(merchant)) {
+                return merchant
+            }
+        }
+        return null
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        // "Your account balance is 3,123.45MT."
+        val pattern = Regex(
+            """account\s+balance\s+is\s+([0-9,]+\.[0-9]{2})\s*MT""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            return parseUsAmount(match.groupValues[1])
+        }
+        return null
+    }
+
+    override fun extractReference(message: String): String? {
+        // "Transaction ID PP260530.0934.w91238." or "Transaction ID: PP260603.0854.K00983."
+        val pattern = Regex(
+            """Transaction\s+ID:?\s*([A-Za-z0-9.]+)""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            return match.groupValues[1].trim().trimEnd('.')
+        }
+        return null
+    }
+
+    override fun extractAccountLast4(message: String): String? = null
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MillenniumBimParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MillenniumBimParser.kt
@@ -1,0 +1,88 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Millennium BIM (Mozambique) SMS messages (Portuguese).
+ *
+ * Amounts use a dot decimal separator (e.g. "1000.00") and currency "MZN".
+ * Dates are DD/MM/YY, times HH:MM (24h).
+ *
+ * Supported formats:
+ * - Debit (EXPENSE):
+ *   "A conta 123456789 foi debitada no valor de 50.00 MZN as 10:14 do dia 31/05/26. Em caso de duvida, ligue 8003500. Millennium bim"
+ * - Credit (INCOME):
+ *   "A conta 123456789 recebeu o valor de 1000.00 MZN as 12:16 do dia 26/04/26. Em  caso de duvida, ligue 8003500. Millennium bim"
+ * - Debit with commission/fee:
+ *   "A conta 123456789 foi debitada no valor de 1000.00 MZN as 12:25 do dia 27/01/26, comissao 30.00 MZN. Em caso de duvida, ligue 8003500. Millennium bim"
+ *
+ * Portuguese keys:
+ * - "foi debitada" = debit  (EXPENSE)
+ * - "recebeu"      = credit (INCOME)
+ * - "no valor de X MZN" = amount
+ * - "comissao X MZN"    = fee (when present)
+ * - "A conta NNN"       = account number
+ *
+ * These messages have no merchant and no balance — that is expected.
+ * Only the "foi debitada / recebeu" formats are handled; anything else returns null.
+ */
+class MillenniumBimParser : BankParser() {
+
+    override fun getBankName() = "Millennium BIM"
+
+    override fun getCurrency() = "MZN"
+
+    override fun canHandle(sender: String): Boolean {
+        return sender.equals("Mbim", ignoreCase = true)
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+        return lower.contains("foi debitada") || lower.contains("recebeu o valor")
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // "no valor de 50.00 MZN" (debit) or "o valor de 1000.00 MZN" (credit)
+        val pattern = Regex(
+            """\bvalor\s+de\s+([0-9]+\.[0-9]{2})\s*MZN""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            return try {
+                BigDecimal(match.groupValues[1])
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+        return null
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lower = message.lowercase()
+        return when {
+            lower.contains("foi debitada") -> TransactionType.EXPENSE
+            lower.contains("recebeu o valor") -> TransactionType.INCOME
+            else -> null
+        }
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        // "A conta 123456789 ..."
+        val pattern = Regex(
+            """A\s+conta\s+(\d+)""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            return extractLast4Digits(match.groupValues[1])
+        }
+        return null
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? = null
+
+    override fun extractBalance(message: String): BigDecimal? = null
+
+    override fun extractReference(message: String): String? = null
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MillenniumBimParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MillenniumBimParser.kt
@@ -1,6 +1,5 @@
 package com.pennywiseai.parser.core.bank
 
-import com.pennywiseai.parser.core.ParsedTransaction
 import com.pennywiseai.parser.core.TransactionType
 import java.math.BigDecimal
 

--- a/parser-core/src/test/kotlin/TestEMolaParser.kt
+++ b/parser-core/src/test/kotlin/TestEMolaParser.kt
@@ -1,0 +1,75 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.*
+import java.math.BigDecimal
+
+class EMolaParserTest {
+    @TestFactory
+    fun `emola parser handles common cases`(): List<DynamicTest> {
+        val parser = EMolaParser()
+
+        val cases = listOf(
+            ParserTestCase(
+                name = "Outgoing transfer - expense",
+                message = "Transaction ID PP260530.0934.w91238. You transfered 100.00MT to 871234566, name: John Doe at 09:34:45 on 30/05/2026. Fee: 0.00MT. Your account balance is 3,123.45MT. Content: . In case of doubt, please call 100. Thank you!",
+                sender = "eMola",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("100.00"),
+                    currency = "MZN",
+                    type = TransactionType.EXPENSE,
+                    merchant = "John Doe",
+                    reference = "PP260530.0934.w91238",
+                    balance = BigDecimal("3123.45")
+                )
+            ),
+            ParserTestCase(
+                name = "Incoming transfer - income",
+                message = "Transaction ID: PP260603.0854.K00983. You received 123.45MT from 871234567, name: JOHN DOE at 08:54:09 on 03/06/2026. Content: campo. Your account balance is 1,234.56MT. In case of doubt, please call 100. Thank you!",
+                sender = "eMola",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("123.45"),
+                    currency = "MZN",
+                    type = TransactionType.INCOME,
+                    merchant = "JOHN DOE",
+                    reference = "PP260603.0854.K00983",
+                    balance = BigDecimal("1234.56")
+                )
+            ),
+            ParserTestCase(
+                name = "Agent withdrawal - expense",
+                message = "Transaction ID: CO260528.1806.W15992. You withdrew 50.00MT in the Agent with code ID 123456, Name JOHN DOE at 18:06:25 on 28/05/2026. Fee: 3.00 MT. Your account balance is 1,234.23MT. In case of doubt, please call 100. Thank you!",
+                sender = "eMola",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("50.00"),
+                    currency = "MZN",
+                    type = TransactionType.EXPENSE,
+                    merchant = "JOHN DOE",
+                    reference = "CO260528.1806.W15992",
+                    balance = BigDecimal("1234.23")
+                )
+            )
+        )
+
+        val handleChecks = listOf(
+            "eMola" to true,
+            "EMOLA" to true,
+            "STDBank" to false,
+            "Mbim" to false,
+            "UNKNOWN" to false
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases, handleChecks, "eMola Parser")
+    }
+
+    @Test
+    fun `factory routes eMola sender to this parser`() {
+        Assertions.assertTrue(
+            BankParserFactory.getParser("eMola") is EMolaParser,
+            "eMola should route to EMolaParser"
+        )
+    }
+}

--- a/parser-core/src/test/kotlin/TestMillenniumBimParser.kt
+++ b/parser-core/src/test/kotlin/TestMillenniumBimParser.kt
@@ -1,0 +1,69 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.*
+import java.math.BigDecimal
+
+class MillenniumBimParserTest {
+    @TestFactory
+    fun `millennium bim parser handles common cases`(): List<DynamicTest> {
+        val parser = MillenniumBimParser()
+
+        val cases = listOf(
+            ParserTestCase(
+                name = "Debit - expense",
+                message = "A conta 123456789 foi debitada no valor de 50.00 MZN as 10:14 do dia 31/05/26. Em caso de duvida, ligue 8003500. Millennium bim",
+                sender = "Mbim",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("50.00"),
+                    currency = "MZN",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "6789"
+                )
+            ),
+            ParserTestCase(
+                name = "Credit - income",
+                message = "A conta 123456789 recebeu o valor de 1000.00 MZN as 12:16 do dia 26/04/26. Em  caso de duvida, ligue 8003500. Millennium bim",
+                sender = "Mbim",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1000.00"),
+                    currency = "MZN",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "6789"
+                )
+            ),
+            ParserTestCase(
+                name = "Debit with commission - expense",
+                message = "A conta 123456789 foi debitada no valor de 1000.00 MZN as 12:25 do dia 27/01/26, comissao 30.00 MZN. Em caso de duvida, ligue 8003500. Millennium bim",
+                sender = "Mbim",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1000.00"),
+                    currency = "MZN",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "6789"
+                )
+            )
+        )
+
+        val handleChecks = listOf(
+            "Mbim" to true,
+            "MBIM" to true,
+            "STDBank" to false,
+            "eMola" to false,
+            "UNKNOWN" to false
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases, handleChecks, "Millennium BIM Parser")
+    }
+
+    @Test
+    fun `factory routes Mbim sender to this parser`() {
+        Assertions.assertTrue(
+            BankParserFactory.getParser("Mbim") is MillenniumBimParser,
+            "Mbim should route to MillenniumBimParser"
+        )
+    }
+}


### PR DESCRIPTION
Adds **Mozambique** as a supported country with two MZN parsers (parser-core), each with `ParserTestUtils` tests; full `:parser-core:jvmTest` green.

### eMola — `#429` (READY)
- Sender `eMola`, English, US number format (`3,123.45`), currency `MT`→MZN.
- Handles outgoing transfer (expense), received (income), agent withdrawal (expense); extracts amount, counterparty merchant, balance, reference.

### Millennium BIM — partially `#430`
- Sender `Mbim`, Portuguese, dot-decimal, `DD/MM/YY`.
- Handles `foi debitada` (expense), `recebeu` (income), and `comissao` fee; account last-4 from `A conta NNN`.
- These SMS carry no merchant/balance (expected). **Card / ATM / international formats aren't covered yet** — the reporter ticked them but gave no samples; I'll request those and extend.

Both `canHandle` checks verified not to collide with the existing Standard Bank Mozambique or M-PESA parsers.