### PR TITLE
feat(parser): M-Pesa Mozambique + content-aware dispatch (#425)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsTransactionProcessor.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsTransactionProcessor.kt
@@ -67,14 +67,16 @@ class SmsTransactionProcessor @Inject constructor(
         timestamp: Long
     ): ProcessingResult {
         try {
-            // Get the appropriate parser for this sender
-            val parser = BankParserFactory.getParser(sender)
-            if (parser == null) {
+            // Some senders are shared by multiple parsers (e.g. M-Pesa
+            // Kenya/Tanzania/Mozambique all use "M-Pesa"), so try every parser
+            // that handles this sender and use the first whose content parses.
+            val parsers = BankParserFactory.getParsers(sender)
+            if (parsers.isEmpty()) {
                 return ProcessingResult(false, reason = "No parser found for sender: $sender")
             }
 
             // Parse the SMS
-            val parsedTransaction = parser.parse(body, sender, timestamp)
+            val parsedTransaction = parsers.firstNotNullOfOrNull { it.parse(body, sender, timestamp) }
             if (parsedTransaction == null) {
                 return ProcessingResult(false, reason = "Could not parse transaction from SMS")
             }

--- a/app/src/main/java/com/pennywiseai/tracker/receiver/SmsBroadcastReceiver.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/receiver/SmsBroadcastReceiver.kt
@@ -106,8 +106,10 @@ class SmsBroadcastReceiver : BroadcastReceiver() {
                     // Show notification if app is not in foreground
                     if (!isAppInForeground(context)) {
                         // Get transaction details for notification
-                        val parser = com.pennywiseai.parser.core.bank.BankParserFactory.getParser(sender)
-                        val parsedTransaction = parser?.parse(body, sender, timestamp)
+                        // Content-aware dispatch (same as processAndSaveTransaction) so
+                        // shared-sender banks (M-Pesa KE/TZ/MZ) re-parse with the right parser.
+                        val parsedTransaction = com.pennywiseai.parser.core.bank.BankParserFactory
+                            .parse(body, sender, timestamp)
 
                         if (parsedTransaction != null) {
                             // Get entry point to access repository

--- a/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
@@ -130,10 +130,10 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
     private lateinit var thirtyDaysAgo: LocalDateTime
 
     /** O(1) sender-to-parser lookup. Factory is only called once per unique sender string. */
-    private class ParserHolder(val parser: BankParser?)
+    private class ParserHolder(val parsers: List<BankParser>)
     private val parserCache = java.util.concurrent.ConcurrentHashMap<String, ParserHolder>(256)
-    private fun cachedParser(sender: String): BankParser? =
-        parserCache.computeIfAbsent(sender) { ParserHolder(BankParserFactory.getParser(sender)) }.parser
+    private fun cachedParsers(sender: String): List<BankParser> =
+        parserCache.computeIfAbsent(sender) { ParserHolder(BankParserFactory.getParsers(sender)) }.parsers
 
     /**
      * Merchant-name to custom category, preloaded once at scan start.
@@ -485,7 +485,8 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
         if (upper.endsWith("-P") || upper.endsWith("-G"))
             return ParseResult.Discard(sms)
 
-        val parser = cachedParser(sms.sender)
+        val parsers = cachedParsers(sms.sender)
+        val parser = parsers.firstOrNull()
             ?: return if (upper.endsWith("-T") || upper.endsWith("-S"))
                 ParseResult.StoreUnrecognized(sms)
             else
@@ -493,9 +494,12 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
 
         val isRecent = sms.timestamp.toLocalDateTime().isAfter(thirtyDaysAgo)
 
+        // Subscription/balance special-cases are bank-type specific; the primary
+        // parser is enough (shared-sender M-Pesa parsers aren't special-cased).
         checkSubscriptionOrBalance(parser, sms, isRecent)?.let { return it }
 
-        val parsed = parser.parse(sms.body, sms.sender, sms.timestamp)
+        // Shared senders (M-Pesa KE/TZ/MZ): first candidate whose content parses.
+        val parsed = parsers.firstNotNullOfOrNull { it.parse(sms.body, sms.sender, sms.timestamp) }
             ?: return ParseResult.Discard(sms)
 
         return ParseResult.Transaction(sms, parsed)

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -1,5 +1,7 @@
 package com.pennywiseai.parser.core.bank
 
+import com.pennywiseai.parser.core.ParsedTransaction
+
 /**
  * Factory for creating bank-specific parsers based on SMS sender.
  */
@@ -76,6 +78,7 @@ object BankParserFactory {
         ManjushreeFinanceParser(), // Manjushree Finance (Nepal)
         SiddharthaBankParser(),  // Siddhartha Bank Limited (Nepal)
         PrimeCommercialBankParser(),  // Prime Commercial Bank (Nepal)
+        MPesaMozambiqueParser(),  // M-Pesa Mozambique (must be before Tanzania & Kenya; gates on Portuguese "Confirmado" + "MT")
         MPesaTanzaniaParser(),  // M-Pesa Tanzania (must be before Kenya M-PESA)
         MPESAParser(),  // M-PESA (Kenya)
         SelcomPesaParser(),  // Selcom Pesa (Tanzania)
@@ -126,6 +129,21 @@ object BankParserFactory {
     fun getParser(sender: String): BankParser? {
         return parsers.firstOrNull { it.canHandle(sender) }
     }
+
+    /**
+     * Returns every parser whose canHandle matches the sender.
+     * Multiple parsers can share a sender (e.g. M-Pesa Kenya/Tanzania/Mozambique);
+     * content-aware dispatch in [parse] picks the right one.
+     */
+    fun getParsers(sender: String): List<BankParser> = parsers.filter { it.canHandle(sender) }
+
+    /**
+     * Content-aware dispatch: tries every canHandle-matching parser and returns the
+     * first non-null parse(). This un-shadows parsers that share a sender ID — each
+     * parser gates its own parse() by message content and returns null otherwise.
+     */
+    fun parse(smsBody: String, sender: String, timestamp: Long): ParsedTransaction? =
+        getParsers(sender).firstNotNullOfOrNull { it.parse(smsBody, sender, timestamp) }
 
     /**
      * Returns the bank parser for the given bank name.

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MPesaMozambiqueParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MPesaMozambiqueParser.kt
@@ -1,0 +1,200 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for M-Pesa Mozambique (Vodacom) mobile money SMS messages.
+ *
+ * Language: Portuguese. Currency: MZN (written "MT" in messages).
+ * Number format: US style (comma thousands, dot decimal e.g. 12,345.67). Dates D/M/YY.
+ *
+ * Handles formats like (names/numbers below are masked example values):
+ * - "Confirmado DF50KDFDHWK. Transferiste 1,234.56MT e a taxa foi de 1.23MT para 258841234567 - JOHNDOE ..."
+ * - "Confirmado DF36KCPECLC. Registamos uma operacao de compra no valor de 1,234.56MT ... na entidade EDM ..."
+ * - "Confirmado DF30KCJDIIA. Aos ... levantaste 1,234.56MT no agente 425300 - BENJAMIM FERAGE ..."
+ * - "Confirmado DEV6KB6GAUI. Depositaste o valor de 12,345.67MT no agente JOHN DOE ..."
+ * - "Confirmado DET0KAIXP5E. Recebeste 12,345.67MT de 123456 - SIMO ..."
+ *
+ * Gating: Mozambique messages start with "Confirmado" (Portuguese), whereas Kenya/Tanzania
+ * use "Confirmed" (English). parse()/isTransactionMessage are gated on "Confirmado" AND the
+ * presence of "MT", so Kenyan/Tanzanian SMS fall through to their parsers under the
+ * content-aware dispatch in BankParserFactory.
+ *
+ * Country: Mozambique
+ */
+class MPesaMozambiqueParser : BankParser() {
+
+    override fun getBankName() = "M-Pesa Mozambique"
+
+    override fun getCurrency() = "MZN"
+
+    override fun canHandle(sender: String): Boolean {
+        val normalizedSender = sender.uppercase()
+        // M-Pesa Mozambique uses the same sender ID; differentiation is by content.
+        return normalizedSender.contains("MPESA") ||
+                normalizedSender.contains("M-PESA") ||
+                normalizedSender == "MPESA" ||
+                normalizedSender == "M-PESA"
+    }
+
+    /**
+     * Only parse Mozambique M-Pesa messages: Portuguese "Confirmado" + "MT" currency token.
+     * Returning null lets Kenya/Tanzania parsers handle their own SMS under the dispatch.
+     */
+    override fun parse(smsBody: String, sender: String, timestamp: Long): ParsedTransaction? {
+        if (!isMozambiqueMessage(smsBody)) {
+            return null
+        }
+        return super.parse(smsBody, sender, timestamp)
+    }
+
+    private fun isMozambiqueMessage(message: String): Boolean {
+        return message.contains("Confirmado", ignoreCase = true) &&
+                message.contains("MT", ignoreCase = false)
+    }
+
+    private fun parseAmount(raw: String): BigDecimal? {
+        val amountStr = raw.replace(",", "")
+        return try {
+            BigDecimal(amountStr)
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // Purchase: "operacao de compra no valor de 1,234.56MT"
+        // Deposit: "Depositaste o valor de 12,345.67MT"
+        val valorPattern = Regex(
+            """no\s+valor\s+de\s+([0-9,]+(?:\.[0-9]{2})?)\s*MT""",
+            RegexOption.IGNORE_CASE
+        )
+        valorPattern.find(message)?.let { return parseAmount(it.groupValues[1]) }
+
+        val oValorPattern = Regex(
+            """o\s+valor\s+de\s+([0-9,]+(?:\.[0-9]{2})?)\s*MT""",
+            RegexOption.IGNORE_CASE
+        )
+        oValorPattern.find(message)?.let { return parseAmount(it.groupValues[1]) }
+
+        // Verb-led amounts: "Transferiste X MT", "levantaste X MT", "Recebeste X MT"
+        val verbPattern = Regex(
+            """(?:Transferiste|levantaste|Recebeste)\s+([0-9,]+(?:\.[0-9]{2})?)\s*MT""",
+            RegexOption.IGNORE_CASE
+        )
+        verbPattern.find(message)?.let { return parseAmount(it.groupValues[1]) }
+
+        return null
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lower = message.lowercase()
+        return when {
+            lower.contains("transferiste") -> TransactionType.EXPENSE
+            lower.contains("operacao de compra") -> TransactionType.EXPENSE
+            lower.contains("levantaste") -> TransactionType.EXPENSE
+            lower.contains("depositaste") -> TransactionType.INCOME
+            lower.contains("recebeste") -> TransactionType.INCOME
+            else -> null
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // Transfer: "para 258841234567 - JOHNDOE aos ..."
+        val paraPattern = Regex(
+            """para\s+\S+\s+-\s+(.+?)\s+aos\b""",
+            RegexOption.IGNORE_CASE
+        )
+        paraPattern.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(merchant)) return merchant
+        }
+
+        // Received: "de 123456 - SIMO aos ..."
+        val dePattern = Regex(
+            """\bde\s+\S+\s+-\s+(.+?)\s+aos\b""",
+            RegexOption.IGNORE_CASE
+        )
+        dePattern.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(merchant)) return merchant
+        }
+
+        // Withdrawal: "no agente 425300 - BENJAMIM FERAGE." (number + name)
+        val agenteNumNamePattern = Regex(
+            """no\s+agente\s+\S+\s+-\s+(.+?)(?:\.|\s+O\s+novo\s+saldo|\s+aos\b)""",
+            RegexOption.IGNORE_CASE
+        )
+        agenteNumNamePattern.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(merchant)) return merchant
+        }
+
+        // Deposit: "no agente JOHN DOE aos ..." (name only, no leading number/dash)
+        val agenteNamePattern = Regex(
+            """no\s+agente\s+(.+?)\s+aos\b""",
+            RegexOption.IGNORE_CASE
+        )
+        agenteNamePattern.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(merchant)) return merchant
+        }
+
+        // Purchase: "na entidade EDM com referencia ..."
+        val entidadePattern = Regex(
+            """na\s+entidade\s+(.+?)(?:\s+com\s+referencia|\s+aos\b)""",
+            RegexOption.IGNORE_CASE
+        )
+        entidadePattern.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(merchant)) return merchant
+        }
+
+        return null
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        // "novo saldo M-Pesa e de X MT" — tolerate extra/irregular spacing around words.
+        val balancePattern = Regex(
+            """novo\s+saldo\s+M-Pesa\s+e\s+de\s+([0-9,]+(?:\.[0-9]{2})?)\s*MT""",
+            RegexOption.IGNORE_CASE
+        )
+        balancePattern.find(message)?.let { return parseAmount(it.groupValues[1]) }
+        return null
+    }
+
+    override fun extractReference(message: String): String? {
+        // Reference is the code after "Confirmado " (e.g. DF50KDFDHWK).
+        val refPattern = Regex(
+            """Confirmado\s+([A-Z0-9]+)""",
+            RegexOption.IGNORE_CASE
+        )
+        refPattern.find(message)?.let { return it.groupValues[1] }
+        return null
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        if (!isMozambiqueMessage(message)) {
+            return false
+        }
+        val lower = message.lowercase()
+        val keywords = listOf(
+            "transferiste",
+            "operacao de compra",
+            "levantaste",
+            "depositaste",
+            "recebeste"
+        )
+        return keywords.any { lower.contains(it) }
+    }
+
+    override fun cleanMerchantName(merchant: String): String {
+        return merchant
+            .replace(Regex("""\s*\(.*?\)\s*$"""), "")  // Remove trailing parentheses
+            .replace(Regex("""\.\s*$"""), "")            // Remove trailing period
+            .replace(Regex("""\s*-\s*$"""), "")          // Remove trailing dash
+            .trim()
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MPesaMozambiqueParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MPesaMozambiqueParser.kt
@@ -34,9 +34,7 @@ class MPesaMozambiqueParser : BankParser() {
         val normalizedSender = sender.uppercase()
         // M-Pesa Mozambique uses the same sender ID; differentiation is by content.
         return normalizedSender.contains("MPESA") ||
-                normalizedSender.contains("M-PESA") ||
-                normalizedSender == "MPESA" ||
-                normalizedSender == "M-PESA"
+                normalizedSender.contains("M-PESA")
     }
 
     /**

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/MPesaMozambiqueParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/MPesaMozambiqueParserTest.kt
@@ -1,0 +1,131 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import java.math.BigDecimal
+
+/**
+ * Tests for M-Pesa Mozambique (Portuguese, MZN/"MT") parser, plus a coexistence
+ * test proving content-aware dispatch routes shared "M-Pesa" senders correctly.
+ *
+ * All names/numbers are masked example values — no real PII.
+ */
+class MPesaMozambiqueParserTest {
+
+    @TestFactory
+    fun `m-pesa mozambique parser handles common cases`(): List<DynamicTest> {
+        val parser = MPesaMozambiqueParser()
+
+        val cases = listOf(
+            ParserTestCase(
+                name = "Transfer out (EXPENSE)",
+                message = "Confirmado DF50KDFDHWK. Transferiste 1,234.56MT e a taxa foi de 1.23MT para 258841234567 - JOHNDOE aos 5/6/26 as 4:15 PM. O teu novo saldo M-Pesa e de 12,345.67MT. Continua a transferir SEM TAXAS de M-Pesa para M-Pesa. Em caso de duvida, liga 100.",
+                sender = "M-Pesa",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1234.56"),
+                    currency = "MZN",
+                    type = TransactionType.EXPENSE,
+                    merchant = "JOHNDOE",
+                    balance = BigDecimal("12345.67"),
+                    reference = "DF50KDFDHWK"
+                )
+            ),
+            ParserTestCase(
+                name = "Purchase at entity (EXPENSE)",
+                message = "Confirmado DF36KCPECLC. Registamos uma operacao de compra no valor de 1,234.56MT e a taxa foi de 0.00MT na entidade EDM com referencia  aos 3/6/26 as 10:37 PM. O teu novo saldo M-Pesa e de 1,234.56MT. Em caso de duvida, liga 100. M-Pesa e facil!",
+                sender = "M-Pesa",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1234.56"),
+                    currency = "MZN",
+                    type = TransactionType.EXPENSE,
+                    merchant = "EDM",
+                    balance = BigDecimal("1234.56"),
+                    reference = "DF36KCPECLC"
+                )
+            ),
+            ParserTestCase(
+                name = "Agent withdrawal (EXPENSE)",
+                message = "Confirmado DF30KCJDIIA. Aos 3/6/26  as 3:57 PM levantaste 1,234.56MT no agente 425300 - BENJAMIM FERAGE. O novo saldo M-Pesa e de 1,234.56MT e a taxa foi de 12.34MT. Em caso de duvida, liga 100. M-Pesa e facil!",
+                sender = "M-Pesa",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1234.56"),
+                    currency = "MZN",
+                    type = TransactionType.EXPENSE,
+                    merchant = "BENJAMIM FERAGE",
+                    balance = BigDecimal("1234.56"),
+                    reference = "DF30KCJDIIA"
+                )
+            ),
+            ParserTestCase(
+                name = "Deposit at agent (INCOME)",
+                message = "Confirmado DEV6KB6GAUI. Depositaste o valor de 12,345.67MT no agente JOHN DOE aos  31/5/26 as 12:04 PM. O teu novo saldo  M-Pesa e de 12,345.67MT. Aproveita e transfere SEM TAXAS de M-Pesa para M-Pesa. Em caso de duvida, liga 100.",
+                sender = "M-Pesa",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("12345.67"),
+                    currency = "MZN",
+                    type = TransactionType.INCOME,
+                    merchant = "JOHN DOE",
+                    balance = BigDecimal("12345.67"),
+                    reference = "DEV6KB6GAUI"
+                )
+            ),
+            ParserTestCase(
+                name = "Received money (INCOME)",
+                message = "Confirmado DET0KAIXP5E. Recebeste  12,345.67MT de 123456 - SIMO aos 29/5/26  as 6:22 PM o novo saldo  M-Pesa e de 1,234.56MT. Aproveita e transfere SEM TAXAS de M-Pesa para M-Pesa. Em caso de duvida, liga 100.",
+                sender = "M-Pesa",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("12345.67"),
+                    currency = "MZN",
+                    type = TransactionType.INCOME,
+                    merchant = "SIMO",
+                    balance = BigDecimal("1234.56"),
+                    reference = "DET0KAIXP5E"
+                )
+            )
+        )
+
+        val handleChecks = listOf(
+            "M-Pesa" to true,
+            "MPESA" to true,
+            "UNKNOWN" to false
+        )
+
+        return ParserTestUtils.runTestSuite(
+            parser,
+            cases,
+            handleChecks,
+            "M-Pesa Mozambique Parser"
+        )
+    }
+
+    @Test
+    fun `dispatch routes shared M-Pesa sender to correct country parser`() {
+        val now = System.currentTimeMillis()
+
+        // (a) Mozambique — Portuguese "Confirmado" + MT -> MZN -> Mozambique
+        val mozMsg = "Confirmado DET0KAIXP5E. Recebeste  12,345.67MT de 123456 - SIMO aos 29/5/26  as 6:22 PM o novo saldo  M-Pesa e de 1,234.56MT. Aproveita e transfere SEM TAXAS de M-Pesa para M-Pesa. Em caso de duvida, liga 100."
+        val moz = BankParserFactory.parse(mozMsg, "M-Pesa", now)
+        assertNotNull(moz, "Mozambique message should parse")
+        assertEquals("M-Pesa Mozambique", moz!!.bankName)
+        assertEquals("MZN", moz.currency)
+
+        // (b) Tanzania — English "Confirmed" + TZS -> Tanzania
+        val tzMsg = "SGR1234567 Confirmed. You have received TZS 50,000.00 from JOHN DOE (255754XXXXXX) on 2025-05-12 at 10:30 AM. New M-Pesa balance is TZS 150,000.00."
+        val tz = BankParserFactory.parse(tzMsg, "M-PESA", now)
+        assertNotNull(tz, "Tanzania message should parse")
+        assertEquals("M-Pesa Tanzania", tz!!.bankName)
+        assertEquals("TZS", tz.currency)
+
+        // (c) Kenya — English "Confirmed" + Ksh -> Kenya (proves Tanzania no longer shadows Kenya)
+        val keMsg = "TJK6H7T3GA Confirmed. Ksh70.00 paid to person 1. on 20/10/24 at 4:21 PM.New M-PESA balance is Ksh123.12. Transaction cost, Ksh0.00. Amount you can transact within the day is 499,895.00."
+        val ke = BankParserFactory.parse(keMsg, "M-PESA", now)
+        assertNotNull(ke, "Kenya message should parse")
+        assertEquals("M-PESA", ke!!.bankName)
+        assertEquals("KES", ke.currency)
+    }
+}


### PR DESCRIPTION
Adds **M-Pesa Mozambique** and fixes the same-sender dispatch it requires.

### The dispatch fix (also repairs a latent Kenya bug)
M-Pesa Kenya/Tanzania/Mozambique all use the **"M-Pesa" sender**. `getParser` returned the *first* `canHandle` match with no fallthrough, so Tanzania (registered first) **shadowed Kenya** — a Kenyan SMS (no "TZS") made Tanzania's `parse()` return null and the SMS was dropped.

`BankParserFactory` now has:
```kotlin
fun getParsers(sender) = parsers.filter { it.canHandle(sender) }
fun parse(body, sender, ts) = getParsers(sender).firstNotNullOfOrNull { it.parse(body, sender, ts) }
```
Callers (`SmsTransactionProcessor.processAndSaveTransaction`, the worker's parse path) use it; the worker caches the candidate list per sender.

### M-Pesa Mozambique parser
Portuguese, MZN (`MT`). Handles transfer (`Transferiste`), purchase (`operacao de compra`), withdrawal (`levantaste`), deposit (`Depositaste`), received (`Recebeste`). Gated on **`Confirmado` + `MT`** (vs Kenya/Tanzania's English `Confirmed`) so their SMS fall through. Registered before Tanzania + Kenya.

### Verification
- ✅ Full `:parser-core:jvmTest` green — **1161 tests**, including a **coexistence test** that feeds MZN/TZS/Ksh SMS (all sender "M-Pesa") through `BankParserFactory.parse` and asserts each routes to the right country (proves Mozambique works **and** Kenya is un-shadowed).
- ✅ App compiles; both SMS callers wired to the new dispatch.
- ⚠️ In-app live SMS round-trip not completed — the emulator went into ANR mid-test (environment, not code). The unit-level routing proof is conclusive; happy to do the device round-trip once the emulator is healthy.

Closes #425.