### PR TITLE
feat(accounts): filter + group by account in Transactions & Analytics (#421)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/common/Filters.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/common/Filters.kt
@@ -98,7 +98,9 @@ fun buildProfileAccountKeys(accounts: List<AccountBalanceEntity>): Map<Long, Set
 /**
  * Filters transactions by the selected account.
  *
- * An account is identified by the key `"${bankName}_${accountNumber}"`.
+ * An account is identified by the key `"${bankName}_${accountNumber}"`. A
+ * transaction's `accountNumber` holds the same last-4 digits as an account's
+ * `accountLast4`, so this key matches [AccountOption.key] from [accountOptions].
  *
  * @param accountKey null/blank means "All accounts" (no filtering)
  */

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/common/Filters.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/common/Filters.kt
@@ -96,6 +96,52 @@ fun buildProfileAccountKeys(accounts: List<AccountBalanceEntity>): Map<Long, Set
 }
 
 /**
+ * Filters transactions by the selected account.
+ *
+ * An account is identified by the key `"${bankName}_${accountNumber}"`.
+ *
+ * @param accountKey null/blank means "All accounts" (no filtering)
+ */
+fun filterTransactionsByAccount(
+    transactions: List<TransactionEntity>,
+    accountKey: String?
+): List<TransactionEntity> {
+    if (accountKey.isNullOrBlank()) return transactions
+    return transactions.filter { tx ->
+        "${tx.bankName}_${tx.accountNumber}" == accountKey
+    }
+}
+
+/**
+ * A pickable account option for the account filter dropdown.
+ *
+ * @param key the account key `"${bankName}_${accountLast4}"`
+ * @param label the display label (alias if set, else "$bankName ••$accountLast4")
+ */
+data class AccountOption(
+    val key: String,
+    val label: String
+)
+
+/**
+ * Builds the list of [AccountOption]s for the account picker from account balances.
+ *
+ * The label prefers the account [AccountBalanceEntity.alias] when non-blank,
+ * otherwise falls back to "$bankName ••$accountLast4". Deduped by key.
+ */
+fun accountOptions(accounts: List<AccountBalanceEntity>): List<AccountOption> {
+    return accounts
+        .map { account ->
+            val key = "${account.bankName}_${account.accountLast4}"
+            val alias = account.alias?.takeIf { it.isNotBlank() }
+            val label = alias ?: "${account.bankName} ••${account.accountLast4}"
+            AccountOption(key = key, label = label)
+        }
+        .distinctBy { it.key }
+        .sortedBy { it.label.lowercase() }
+}
+
+/**
  * Filters account balances by profile.
  *
  * @param selectedProfileId null means "All profiles" (no filtering)

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.automirrored.filled.TrendingUp
 import androidx.compose.material.icons.rounded.MoreHoriz
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.outlined.AccountBalance
+import androidx.compose.material.icons.outlined.AccountBalanceWallet
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.LaunchedEffect
@@ -107,6 +108,8 @@ fun TransactionsScreen(
     val selectedProfileId by viewModel.selectedProfileId.collectAsState()
     val profiles by viewModel.profiles.collectAsState()
     val profileAccountKeys by viewModel.profileAccountKeys.collectAsState()
+    val accountFilter by viewModel.accountFilter.collectAsState()
+    val accountOptions by viewModel.accountOptions.collectAsState()
 
     // Bulk-edit selection (#369)
     val selectedIds by viewModel.selectedIds.collectAsState()
@@ -130,7 +133,8 @@ fun TransactionsScreen(
     var showPeriodMenu by remember { mutableStateOf(false) }
     var showTypeMenu by remember { mutableStateOf(false) }
     var showMoreFiltersMenu by remember { mutableStateOf(false) }
-    
+    var showAccountMenu by remember { mutableStateOf(false) }
+
     // Focus management for search field
     val searchFocusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -149,6 +153,7 @@ fun TransactionsScreen(
         categoriesFilter != null ||
         transactionTypeFilter != TransactionTypeFilter.ALL ||
         selectedProfileId != null ||
+        accountFilter != null ||
         hasCurrencyFilter ||
         customDateRange != null
 
@@ -359,12 +364,15 @@ fun TransactionsScreen(
             showPeriodMenu = showPeriodMenu,
             showTypeMenu = showTypeMenu,
             showMoreFiltersMenu = showMoreFiltersMenu,
-            collapsed = collapseTransactionHeader && !showPeriodMenu && !showTypeMenu && !showMoreFiltersMenu,
+            showAccountMenu = showAccountMenu,
+            collapsed = collapseTransactionHeader && !showPeriodMenu && !showTypeMenu && !showMoreFiltersMenu && !showAccountMenu,
             sortOption = sortOption,
             timePeriods = timePeriods,
             availableCategories = availableCategories,
             profiles = profiles,
             selectedProfileId = selectedProfileId,
+            accountOptions = accountOptions,
+            accountFilter = accountFilter,
             onSearchQueryChange = viewModel::updateSearchQuery,
             onSortClick = { showSortMenu = true },
             onSortDismiss = { showSortMenu = false },
@@ -403,6 +411,13 @@ fun TransactionsScreen(
                 view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
                 viewModel.setSelectedProfile(profileId)
                 showMoreFiltersMenu = false
+            },
+            onAccountClick = { showAccountMenu = true },
+            onAccountDismiss = { showAccountMenu = false },
+            onAccountSelected = { accountKey ->
+                view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+                viewModel.setAccountFilter(accountKey)
+                showAccountMenu = false
             },
             onResetFilters = viewModel::resetFilters,
             focusRequester = searchFocusRequester,
@@ -804,12 +819,15 @@ private fun TransactionFilterHeader(
     showPeriodMenu: Boolean,
     showTypeMenu: Boolean,
     showMoreFiltersMenu: Boolean,
+    showAccountMenu: Boolean,
     collapsed: Boolean,
     sortOption: SortOption,
     timePeriods: List<TimePeriod>,
     availableCategories: List<String>,
     profiles: List<ProfileEntity>,
     selectedProfileId: Long?,
+    accountOptions: List<com.pennywiseai.tracker.presentation.common.AccountOption>,
+    accountFilter: String?,
     onSearchQueryChange: (String) -> Unit,
     onSortClick: () -> Unit,
     onSortDismiss: () -> Unit,
@@ -824,6 +842,9 @@ private fun TransactionFilterHeader(
     onMoreFiltersDismiss: () -> Unit,
     onCategorySelected: (String?) -> Unit,
     onProfileSelected: (Long?) -> Unit,
+    onAccountClick: () -> Unit,
+    onAccountDismiss: () -> Unit,
+    onAccountSelected: (String?) -> Unit,
     onResetFilters: () -> Unit,
     focusRequester: FocusRequester,
     modifier: Modifier = Modifier
@@ -1057,6 +1078,51 @@ private fun TransactionFilterHeader(
                                     },
                                     onClick = { onProfileSelected(profile.id) }
                                 )
+                            }
+                        }
+                    }
+                }
+
+                if (accountOptions.isNotEmpty()) {
+                    item {
+                        Box {
+                            val selectedAccountLabel =
+                                accountOptions.firstOrNull { it.key == accountFilter }?.label
+                            ExpressiveFilterChip(
+                                selected = accountFilter != null,
+                                text = selectedAccountLabel ?: "Account",
+                                icon = Icons.Outlined.AccountBalanceWallet,
+                                onClick = onAccountClick
+                            )
+
+                            DropdownMenu(
+                                expanded = showAccountMenu,
+                                onDismissRequest = onAccountDismiss
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text("All accounts") },
+                                    leadingIcon = {
+                                        if (accountFilter == null) {
+                                            Icon(Icons.Default.Check, contentDescription = null)
+                                        } else {
+                                            Icon(Icons.Outlined.AccountBalanceWallet, contentDescription = null)
+                                        }
+                                    },
+                                    onClick = { onAccountSelected(null) }
+                                )
+                                accountOptions.forEach { option ->
+                                    DropdownMenuItem(
+                                        text = { Text(option.label, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                                        leadingIcon = {
+                                            if (accountFilter == option.key) {
+                                                Icon(Icons.Default.Check, contentDescription = null)
+                                            } else {
+                                                Icon(Icons.Outlined.AccountBalanceWallet, contentDescription = null)
+                                            }
+                                        },
+                                        onClick = { onAccountSelected(option.key) }
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -14,7 +14,10 @@ import com.pennywiseai.tracker.presentation.common.TransactionTypeFilter
 import com.pennywiseai.tracker.presentation.common.getDateRangeForPeriod
 import com.pennywiseai.tracker.presentation.common.CurrencyGroupedTotals
 import com.pennywiseai.tracker.presentation.common.CurrencyTotals
+import com.pennywiseai.tracker.presentation.common.AccountOption
+import com.pennywiseai.tracker.presentation.common.accountOptions
 import com.pennywiseai.tracker.presentation.common.buildProfileAccountKeys
+import com.pennywiseai.tracker.presentation.common.filterTransactionsByAccount
 import com.pennywiseai.tracker.presentation.common.filterTransactionsByProfile
 import com.pennywiseai.tracker.core.Constants
 import com.pennywiseai.tracker.data.currency.CurrencyConversionService
@@ -68,6 +71,16 @@ class TransactionsViewModel @Inject constructor(
 
     private val _profileAccountKeys = MutableStateFlow<Map<Long, Set<String>>>(emptyMap())
     val profileAccountKeys: StateFlow<Map<Long, Set<String>>> = _profileAccountKeys.asStateFlow()
+
+    // Account filter — null means "All accounts". Key is "bankName_accountLast4".
+    private val _accountFilter = MutableStateFlow<String?>(null)
+    val accountFilter: StateFlow<String?> = _accountFilter.asStateFlow()
+
+    // Pickable account options for the account filter dropdown (alias-preferred labels).
+    val accountOptions: StateFlow<List<AccountOption>> =
+        accountBalanceRepository.getAllLatestBalances()
+            .map { accountOptions(it) }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     val profiles: StateFlow<List<ProfileEntity>> = profileRepository.observeAllProfiles()
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
@@ -561,6 +574,7 @@ class TransactionsViewModel @Inject constructor(
             transactionTypeFilter.map { "typeFilter" },
             _selectedProfileId.map { "profileFilter" },
             _profileAccountKeys.map { "profileAccountKeys" },
+            _accountFilter.map { "accountFilter" },
             selectedCurrency.map { "currency" },
             _isUnifiedMode.map { "unifiedMode" },
             sortOption.map { "sort" },
@@ -577,12 +591,16 @@ class TransactionsViewModel @Inject constructor(
                 val isUnified = _isUnifiedMode.value
 
                 val profileId = _selectedProfileId.value
+                val accountKey = _accountFilter.value
 
                 // Get filtered transactions (without currency filter first)
                 getFilteredTransactions(query, period, category, categories, typeFilter)
                     .collect { allTransactions ->
-                        // Apply profile filter
-                        val transactions = filterByProfile(allTransactions, profileId)
+                        // Apply profile filter, then account filter
+                        val transactions = filterTransactionsByAccount(
+                            filterByProfile(allTransactions, profileId),
+                            accountKey
+                        )
                         if (isUnified) {
                             // Show all transactions regardless of currency
                             emit(sortTransactions(transactions, sort))
@@ -683,6 +701,11 @@ class TransactionsViewModel @Inject constructor(
     fun setTransactionTypeFilter(filter: TransactionTypeFilter) {
         _transactionTypeFilter.value = filter
     }
+
+    /** Sets the account filter; null clears it ("All accounts"). */
+    fun setAccountFilter(accountKey: String?) {
+        _accountFilter.value = accountKey
+    }
     
     fun setSelectedProfile(profileId: Long?) {
         _selectedProfileId.value = profileId
@@ -764,6 +787,7 @@ class TransactionsViewModel @Inject constructor(
         clearCustomDateRange()
         selectPeriod(TimePeriod.THIS_MONTH)
         setTransactionTypeFilter(TransactionTypeFilter.ALL)
+        setAccountFilter(null)
         _selectedProfileId.value = null  // reset local state only; does not update the shared DataStore preference
         setSortOption(SortOption.DATE_NEWEST)
         if (!_isUnifiedMode.value) {

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsScreen.kt
@@ -78,6 +78,8 @@ fun AnalyticsScreen(
     val categoryFilter by viewModel.categoryFilter.collectAsStateWithLifecycle()
     val selectedProfileId by viewModel.selectedProfileId.collectAsStateWithLifecycle()
     val profiles by viewModel.profiles.collectAsStateWithLifecycle()
+    val accountFilter by viewModel.accountFilter.collectAsStateWithLifecycle()
+    val accountOptions by viewModel.accountOptions.collectAsStateWithLifecycle()
     var showDateRangePicker by rememberSaveable { mutableStateOf(false) }
     var categoryViewType by rememberSaveable { mutableStateOf(CategoryViewType.CHART) }
     var showChartTypeSelector by remember { mutableStateOf(false) }
@@ -86,6 +88,7 @@ fun AnalyticsScreen(
     var showCurrencyMenu by remember { mutableStateOf(false) }
     var showCategoryMenu by remember { mutableStateOf(false) }
     var showProfileMenu by remember { mutableStateOf(false) }
+    var showAccountMenu by remember { mutableStateOf(false) }
 
     // Remember scroll position across navigation
     val listState = rememberSaveable(saver = LazyListState.Saver) {
@@ -106,6 +109,7 @@ fun AnalyticsScreen(
             customDateRange != null ||
             transactionTypeFilter != TransactionTypeFilter.EXPENSE ||
             categoryFilter != null ||
+            accountFilter != null ||
             hasCurrencyFilter
 
     // Scroll behaviors for collapsible TopAppBar
@@ -154,11 +158,14 @@ fun AnalyticsScreen(
                 availableCategories = uiState.availableCategories,
                 profiles = profiles,
                 selectedProfileId = selectedProfileId,
+                accountOptions = accountOptions,
+                accountFilter = accountFilter,
                 showPeriodMenu = showPeriodMenu,
                 showTypeMenu = showTypeMenu,
                 showCurrencyMenu = showCurrencyMenu,
                 showCategoryMenu = showCategoryMenu,
                 showProfileMenu = showProfileMenu,
+                showAccountMenu = showAccountMenu,
                 hasActiveFilter = hasActiveAnalyticsFilter,
                 onPeriodClick = { showPeriodMenu = true },
                 onPeriodDismiss = { showPeriodMenu = false },
@@ -198,10 +205,17 @@ fun AnalyticsScreen(
                     viewModel.selectProfile(profileId)
                     showProfileMenu = false
                 },
+                onAccountClick = { showAccountMenu = true },
+                onAccountDismiss = { showAccountMenu = false },
+                onAccountSelected = { accountKey ->
+                    viewModel.setAccountFilter(accountKey)
+                    showAccountMenu = false
+                },
                 onResetFilters = {
                     viewModel.selectPeriod(TimePeriod.THIS_MONTH)
                     viewModel.setTransactionTypeFilter(TransactionTypeFilter.EXPENSE)
                     viewModel.clearCategoryFilter()
+                    viewModel.setAccountFilter(null)
                     if (!isUnifiedMode && primaryVisibleCurrency.isNotBlank()) {
                         viewModel.selectCurrency(primaryVisibleCurrency)
                     }
@@ -209,6 +223,7 @@ fun AnalyticsScreen(
                     showTypeMenu = false
                     showCurrencyMenu = false
                     showCategoryMenu = false
+                    showAccountMenu = false
                 }
             )
         }
@@ -443,6 +458,28 @@ fun AnalyticsScreen(
         }
 
 
+        // By Account Section
+        if (uiState.accountBreakdown.isNotEmpty()) {
+            item {
+                SectionHeaderV2(
+                    title = "By Account"
+                )
+            }
+
+            item {
+                ExpandableList(
+                    items = uiState.accountBreakdown,
+                    visibleItemCount = 3,
+                    modifier = Modifier.fillMaxWidth()
+                ) { account ->
+                    AccountBreakdownListItem(
+                        account = account,
+                        currency = selectedCurrency
+                    )
+                }
+            }
+        }
+
         // Empty state
         if (uiState.topMerchants.isEmpty() && uiState.categoryBreakdown.isEmpty() && !uiState.isLoading) {
             item {
@@ -478,11 +515,14 @@ private fun AnalyticsFilterBar(
     availableCategories: List<String>,
     profiles: List<ProfileEntity>,
     selectedProfileId: Long?,
+    accountOptions: List<com.pennywiseai.tracker.presentation.common.AccountOption>,
+    accountFilter: String?,
     showPeriodMenu: Boolean,
     showTypeMenu: Boolean,
     showCurrencyMenu: Boolean,
     showCategoryMenu: Boolean,
     showProfileMenu: Boolean,
+    showAccountMenu: Boolean,
     hasActiveFilter: Boolean,
     onPeriodClick: () -> Unit,
     onPeriodDismiss: () -> Unit,
@@ -499,6 +539,9 @@ private fun AnalyticsFilterBar(
     onProfileClick: () -> Unit,
     onProfileDismiss: () -> Unit,
     onProfileSelected: (Long?) -> Unit,
+    onAccountClick: () -> Unit,
+    onAccountDismiss: () -> Unit,
+    onAccountSelected: (String?) -> Unit,
     onResetFilters: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -712,6 +755,60 @@ private fun AnalyticsFilterBar(
                 }
             }
         }
+
+        if (accountOptions.isNotEmpty()) {
+            item {
+                val selectedAccountLabel =
+                    accountOptions.firstOrNull { it.key == accountFilter }?.label
+                Box {
+                    ExpressiveFilterChip(
+                        colors = analyticsFilterChipColors(),
+                        border = analyticsFilterChipBorder(selected = accountFilter != null),
+                        selected = accountFilter != null,
+                        text = selectedAccountLabel ?: "Account",
+                        icon = Icons.Default.AccountBalanceWallet,
+                        onClick = onAccountClick
+                    )
+
+                    DropdownMenu(
+                        expanded = showAccountMenu,
+                        onDismissRequest = onAccountDismiss,
+                        shape = MaterialTheme.shapes.large
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("All accounts") },
+                            leadingIcon = {
+                                if (accountFilter == null) {
+                                    Icon(Icons.Default.Check, contentDescription = null)
+                                } else {
+                                    Icon(Icons.Default.AccountBalanceWallet, contentDescription = null)
+                                }
+                            },
+                            onClick = { onAccountSelected(null) }
+                        )
+                        accountOptions.forEach { option ->
+                            DropdownMenuItem(
+                                text = {
+                                    Text(
+                                        option.label,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                },
+                                leadingIcon = {
+                                    if (accountFilter == option.key) {
+                                        Icon(Icons.Default.Check, contentDescription = null)
+                                    } else {
+                                        Icon(Icons.Default.AccountBalanceWallet, contentDescription = null)
+                                    }
+                                },
+                                onClick = { onAccountSelected(option.key) }
+                            )
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -797,6 +894,42 @@ private fun MerchantListItem(
         subtitle = subtitle,
         amount = CurrencyFormatter.formatCurrency(merchant.amount, currency),
         onClick = onClick
+    )
+}
+
+@Composable
+private fun AccountBreakdownListItem(
+    account: AccountBreakdownData,
+    currency: String
+) {
+    ListItemCardV2(
+        leadingContent = {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.AccountBalanceWallet,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+        },
+        title = account.label,
+        subtitle = "${account.transactionCount} " +
+            if (account.transactionCount == 1) "transaction" else "transactions",
+        amount = CurrencyFormatter.formatCurrency(account.amount, currency),
+        trailingContent = {
+            Text(
+                text = "${account.percentage.toInt()}%",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
     )
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -13,6 +13,8 @@ import com.pennywiseai.tracker.data.repository.TransactionRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import com.pennywiseai.tracker.presentation.common.TimePeriod
 import com.pennywiseai.tracker.presentation.common.TransactionTypeFilter
+import com.pennywiseai.tracker.presentation.common.AccountOption
+import com.pennywiseai.tracker.presentation.common.accountOptions
 import com.pennywiseai.tracker.presentation.common.buildProfileAccountKeys
 import com.pennywiseai.tracker.presentation.common.filterTransactionsByProfile
 import com.pennywiseai.tracker.presentation.common.getDateRangeForPeriod
@@ -63,6 +65,16 @@ class AnalyticsViewModel @Inject constructor(
 
     private val _categoryFilter = MutableStateFlow<String?>(null)
     val categoryFilter: StateFlow<String?> = _categoryFilter.asStateFlow()
+
+    // Account filter — null means "All accounts". Key is "bankName_accountLast4".
+    private val _accountFilter = MutableStateFlow<String?>(null)
+    val accountFilter: StateFlow<String?> = _accountFilter.asStateFlow()
+
+    // Pickable account options for the account filter dropdown (alias-preferred labels).
+    val accountOptions: StateFlow<List<AccountOption>> =
+        accountBalanceRepository.getAllLatestBalances()
+            .map { accountOptions(it) }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     private val _isUnifiedMode = MutableStateFlow(false)
     val isUnifiedMode: StateFlow<Boolean> = _isUnifiedMode.asStateFlow()
@@ -126,9 +138,20 @@ class AnalyticsViewModel @Inject constructor(
         customDateRange,
         _transactionTypeFilter,
         _selectedCurrency,
-        combine(_isUnifiedMode, _categoryFilter, selectedProfileId) { u, c, p -> Triple(u, c, p) }
-    ) { period, customRange, typeFilter, currency, (isUnified, catFilter, profileId) ->
-        FilterState(period, customRange, typeFilter, currency, isUnified, catFilter, profileId)
+        combine(_isUnifiedMode, _categoryFilter, selectedProfileId, _accountFilter) { u, c, p, a ->
+            UnifiedCatProfileAccount(u, c, p, a)
+        }
+    ) { period, customRange, typeFilter, currency, extra ->
+        FilterState(
+            period,
+            customRange,
+            typeFilter,
+            currency,
+            extra.isUnified,
+            extra.categoryFilter,
+            extra.profileId,
+            extra.accountFilter
+        )
     }.combine(accountBalanceRepository.getAllLatestBalances()) { fs, balances ->
         fs to balances
     }.flatMapLatest { (filterState, balances) ->
@@ -195,9 +218,13 @@ class AnalyticsViewModel @Inject constructor(
                         filterState.profileId,
                         profileKeys
                     ).mapTo(HashSet()) { it.id }
+                    val accountKey = filterState.accountFilter
                     return txs.filter { tw ->
+                        val txAccountKey =
+                            "${tw.transaction.bankName}_${tw.transaction.accountNumber}"
                         tw.transaction.id in keptIds &&
-                            "${tw.transaction.bankName}_${tw.transaction.accountNumber}" !in hidden
+                            txAccountKey !in hidden &&
+                            (accountKey.isNullOrBlank() || txAccountKey == accountKey)
                     }
                 }
 
@@ -306,6 +333,37 @@ class AnalyticsViewModel @Inject constructor(
                     .sortedByDescending { it.amount }
                     .take(10)
 
+                // Group by account — convert if unified. Labels prefer the alias
+                // (via accountOptions) and fall back to "$bankName ••$last4".
+                val accountLabels = accountOptions(balances).associate { it.key to it.label }
+                val accountBreakdown = filteredTransactions
+                    .groupBy { "${it.bankName}_${it.accountNumber}" }
+                    .entries
+                    .map { (accountKey, txns) ->
+                        val accountAmount = if (isUnified) {
+                            var sum = BigDecimal.ZERO
+                            for (tx in txns) {
+                                sum += currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                            }
+                            sum
+                        } else {
+                            txns.sumOf { it.amount.toDouble() }.toBigDecimal()
+                        }
+                        AccountBreakdownData(
+                            key = accountKey,
+                            label = accountLabels[accountKey] ?: run {
+                                val first = txns.first()
+                                "${first.bankName ?: "Unknown"} ••${first.accountNumber ?: "----"}"
+                            },
+                            amount = accountAmount,
+                            percentage = if (totalSpending > BigDecimal.ZERO) {
+                                (accountAmount.divide(totalSpending, 4, java.math.RoundingMode.HALF_UP) * BigDecimal(100)).toFloat()
+                            } else 0f,
+                            transactionCount = txns.size
+                        )
+                    }
+                    .sortedByDescending { it.amount }
+
                 // Calculate average amount
                 val averageAmount = if (filteredTransactions.isNotEmpty()) {
                     totalSpending.divide(BigDecimal(filteredTransactions.size), 2, java.math.RoundingMode.HALF_UP)
@@ -327,7 +385,8 @@ class AnalyticsViewModel @Inject constructor(
                     currency = displayCurrency,
                     isLoading = false,
                     spendingTrend = calculateSpendingTrend(filteredTransactions, dateRange.first, dateRange.second),
-                    availableCategories = allCategoryNames
+                    availableCategories = allCategoryNames,
+                    accountBreakdown = accountBreakdown
                 )
             }
         }
@@ -355,6 +414,11 @@ class AnalyticsViewModel @Inject constructor(
 
     fun clearCategoryFilter() {
         _categoryFilter.value = null
+    }
+
+    /** Sets the account filter; null clears it ("All accounts"). */
+    fun setAccountFilter(accountKey: String?) {
+        _accountFilter.value = accountKey
     }
 
     fun setChartType(type: ChartType) {
@@ -463,7 +527,19 @@ private data class FilterState(
     val currency: String,
     val isUnifiedMode: Boolean = false,
     val categoryFilter: String? = null,
-    val profileId: Long? = null
+    val profileId: Long? = null,
+    val accountFilter: String? = null
+)
+
+/**
+ * Helper tuple for combining the unified-mode, category, profile, and account
+ * filter flows (Kotlin's [combine] caps at a small arity).
+ */
+private data class UnifiedCatProfileAccount(
+    val isUnified: Boolean,
+    val categoryFilter: String?,
+    val profileId: Long?,
+    val accountFilter: String?
 )
 
 data class AnalyticsUiState(
@@ -477,7 +553,16 @@ data class AnalyticsUiState(
     val currency: String = "",
     val isLoading: Boolean = true,
     val spendingTrend: List<BalancePoint> = emptyList(),
-    val availableCategories: List<String> = emptyList()
+    val availableCategories: List<String> = emptyList(),
+    val accountBreakdown: List<AccountBreakdownData> = emptyList()
+)
+
+data class AccountBreakdownData(
+    val key: String,
+    val label: String,
+    val amount: BigDecimal,
+    val percentage: Float,
+    val transactionCount: Int
 )
 
 data class CategoryData(


### PR DESCRIPTION
Second half of #421 (account **aliases** are #439, which this is stacked on — retarget to main after #439 merges).

Clones the existing **profile-filter** pattern, so it threads through the same pipelines:
- **Filters.kt**: `filterTransactionsByAccount(txns, key)`, `AccountOption(key,label)`, `accountOptions(accounts)` (key `"bank_last4"`, **alias-preferred label**).
- **Transactions**: an Account filter chip (dropdown of accounts by alias) folded into the filter pipeline alongside category/profile.
- **Analytics**: an Account filter chip that scopes all metrics, plus a **"By Account" breakdown** (per-account total / % / count, alias labels) mirroring the category/merchant breakdowns.

No DB or backup changes (alias already exists).

**Verified live on emulator:**
- Account dropdown lists accounts by alias ("Salary Account", "something") + `bank ••last4`.
- Transactions list filters to the chosen account and **composes with the profile filter** (Salary Account=Business + Personal profile → correctly empty; Kotak ••1234 + Personal → its transactions).
- Analytics scopes to the account; "By Account" breakdown renders (1234 66%, something 32%, 7777 0%).

Closes #421 (together with #439).