### PR TITLE
fix(loans): allow unmarking a transaction as a loan (#444)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/LoanDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/LoanDao.kt
@@ -47,6 +47,9 @@ interface LoanDao {
     @Query("SELECT * FROM transactions WHERE loan_id = :loanId AND is_deleted = 0 ORDER BY date_time ASC LIMIT 1")
     suspend fun getOriginalTransactionForLoan(loanId: Long): TransactionEntity?
 
+    @Query("SELECT COUNT(*) FROM transactions WHERE loan_id = :loanId AND is_deleted = 0")
+    suspend fun countTransactionsForLoan(loanId: Long): Int
+
     @Query("""
         SELECT COALESCE(SUM(COALESCE(t.loan_contribution, t.amount)), 0) FROM transactions t
         WHERE t.loan_id = :loanId AND t.is_deleted = 0

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/LoanDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/LoanDao.kt
@@ -47,9 +47,6 @@ interface LoanDao {
     @Query("SELECT * FROM transactions WHERE loan_id = :loanId AND is_deleted = 0 ORDER BY date_time ASC LIMIT 1")
     suspend fun getOriginalTransactionForLoan(loanId: Long): TransactionEntity?
 
-    @Query("SELECT COUNT(*) FROM transactions WHERE loan_id = :loanId AND is_deleted = 0")
-    suspend fun countTransactionsForLoan(loanId: Long): Int
-
     @Query("""
         SELECT COALESCE(SUM(COALESCE(t.loan_contribution, t.amount)), 0) FROM transactions t
         WHERE t.loan_id = :loanId AND t.is_deleted = 0

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/LoanDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/LoanDao.kt
@@ -99,13 +99,13 @@ interface LoanDao {
         endDate: LocalDateTime
     ): Flow<List<LoanEntity>>
 
-    @Query("UPDATE transactions SET loan_id = NULL WHERE id = :transactionId")
+    @Query("UPDATE transactions SET loan_id = NULL, loan_contribution = NULL WHERE id = :transactionId")
     suspend fun unlinkTransaction(transactionId: Long)
 
     @Query("UPDATE transactions SET loan_id = :loanId WHERE id = :transactionId")
     suspend fun linkTransaction(transactionId: Long, loanId: Long)
 
-    @Query("UPDATE transactions SET loan_id = NULL WHERE loan_id = :loanId")
+    @Query("UPDATE transactions SET loan_id = NULL, loan_contribution = NULL WHERE loan_id = :loanId")
     suspend fun unlinkAllTransactions(loanId: Long)
 
     @Query("""

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/LoanRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/LoanRepository.kt
@@ -174,22 +174,24 @@ class LoanRepository @Inject constructor(
 
     suspend fun unlinkTransaction(transactionId: Long, loanId: Long) {
         loanDao.unlinkTransaction(transactionId)
-        // If this was the last transaction on the loan, the loan is now empty —
-        // delete it so it doesn't linger with no entries (issue #444).
-        if (loanDao.countTransactionsForLoan(loanId) == 0) {
+        val loan = loanDao.getLoanById(loanId) ?: return
+        // Recompute the principal from the remaining CONTRIBUTION transactions
+        // (the loan's own direction: LENT->EXPENSE, BORROWED->INCOME). Repayments
+        // are the opposite type and don't count toward principal.
+        val contributionType = if (loan.direction == LoanDirection.LENT) "EXPENSE" else "INCOME"
+        val remainingPrincipal = loanDao.getTotalRepaidByType(loanId, contributionType)
+        if (remainingPrincipal.compareTo(BigDecimal.ZERO) == 0) {
+            // No principal left — the loan is meaningless. Delete it; deleteLoan's
+            // unlinkAllTransactions also detaches any leftover repayment rows so
+            // they aren't stranded on a zeroed-out, auto-settled loan
+            // (issue #444 / Greptile #445). Covers the sole-transaction case too.
             deleteLoan(loanId)
         } else {
-            // Reduce the principal to match the remaining contributions, so
-            // unlinking a source transaction from a multi-entry loan doesn't
-            // leave an inflated originalAmount/remaining (#445). Contributions are
-            // the transactions in the loan's own direction (LENT->EXPENSE,
-            // BORROWED->INCOME); repayments are handled by recalculateRemaining.
-            loanDao.getLoanById(loanId)?.let { loan ->
-                val contributionType = if (loan.direction == LoanDirection.LENT) "EXPENSE" else "INCOME"
-                val newOriginal = loanDao.getTotalRepaidByType(loanId, contributionType)
-                if (loan.originalAmount.compareTo(newOriginal) != 0) {
-                    loanDao.updateLoan(loan.copy(originalAmount = newOriginal, updatedAt = LocalDateTime.now()))
-                }
+            // Multi-entry loan with contributions remaining: shrink the principal
+            // to match, so unlinking a source transaction doesn't leave an
+            // inflated originalAmount/remaining.
+            if (loan.originalAmount.compareTo(remainingPrincipal) != 0) {
+                loanDao.updateLoan(loan.copy(originalAmount = remainingPrincipal, updatedAt = LocalDateTime.now()))
             }
             recalculateRemaining(loanId)
         }

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/LoanRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/LoanRepository.kt
@@ -174,7 +174,13 @@ class LoanRepository @Inject constructor(
 
     suspend fun unlinkTransaction(transactionId: Long, loanId: Long) {
         loanDao.unlinkTransaction(transactionId)
-        recalculateRemaining(loanId)
+        // If this was the last transaction on the loan, the loan is now empty —
+        // delete it so it doesn't linger with no entries (issue #444).
+        if (loanDao.countTransactionsForLoan(loanId) == 0) {
+            deleteLoan(loanId)
+        } else {
+            recalculateRemaining(loanId)
+        }
     }
 
     suspend fun updateOriginalAmount(loanId: Long, newAmount: BigDecimal) {

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/LoanRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/LoanRepository.kt
@@ -179,6 +179,18 @@ class LoanRepository @Inject constructor(
         if (loanDao.countTransactionsForLoan(loanId) == 0) {
             deleteLoan(loanId)
         } else {
+            // Reduce the principal to match the remaining contributions, so
+            // unlinking a source transaction from a multi-entry loan doesn't
+            // leave an inflated originalAmount/remaining (#445). Contributions are
+            // the transactions in the loan's own direction (LENT->EXPENSE,
+            // BORROWED->INCOME); repayments are handled by recalculateRemaining.
+            loanDao.getLoanById(loanId)?.let { loan ->
+                val contributionType = if (loan.direction == LoanDirection.LENT) "EXPENSE" else "INCOME"
+                val newOriginal = loanDao.getTotalRepaidByType(loanId, contributionType)
+                if (loan.originalAmount.compareTo(newOriginal) != 0) {
+                    loanDao.updateLoan(loan.copy(originalAmount = newOriginal, updatedAt = LocalDateTime.now()))
+                }
+            }
             recalculateRemaining(loanId)
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailScreen.kt
@@ -51,6 +51,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.pennywiseai.tracker.data.database.entity.BudgetImpactType
@@ -135,6 +137,7 @@ fun TransactionDetailScreen(
     // Loan state
     val loan by viewModel.loan.collectAsStateWithLifecycle()
     val showMarkAsLoanSheet by viewModel.showMarkAsLoanSheet.collectAsStateWithLifecycle()
+    var showUnmarkLoanConfirm by remember { mutableStateOf(false) }
     val recentPersonNames by viewModel.recentPersonNames.collectAsStateWithLifecycle()
 // Account profile state
     val accountProfileId by viewModel.accountProfileId.collectAsStateWithLifecycle()
@@ -171,7 +174,9 @@ fun TransactionDetailScreen(
         }
     }
     
-    LaunchedEffect(transactionId) {
+    // Reload on every resume so external changes — e.g. the linked loan being
+    // deleted from the Loan screen — are reflected when returning here (#444).
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         viewModel.loadTransaction(transactionId)
     }
     
@@ -327,6 +332,7 @@ fun TransactionDetailScreen(
                 hasSplits = hasSplits,
                 loan = loan,
                 onNavigateToLoanDetail = onNavigateToLoanDetail,
+                onUnmarkLoanClick = { showUnmarkLoanConfirm = true },
                 accountProfileId = accountProfileId,
                 hazeState = hazeState,
                 modifier = Modifier.padding(paddingValues)
@@ -397,6 +403,29 @@ fun TransactionDetailScreen(
         )
     }
 
+    // Unmark-as-loan confirmation (#444)
+    if (showUnmarkLoanConfirm) {
+        AlertDialog(
+            onDismissRequest = { showUnmarkLoanConfirm = false },
+            title = { Text("Unmark as loan?") },
+            text = {
+                Text(
+                    "This removes the loan link from this transaction. If no other " +
+                        "transactions are linked, the loan is deleted too."
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showUnmarkLoanConfirm = false
+                    viewModel.unlinkLoan()
+                }) { Text("Unmark") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showUnmarkLoanConfirm = false }) { Text("Cancel") }
+            }
+        )
+    }
+
     // Full-screen Receipt Dialog
     if (showFullScreenReceipt && receiptUri != null) {
         Dialog(
@@ -449,6 +478,7 @@ private fun TransactionDetailContent(
     hasSplits: Boolean,
     loan: LoanEntity?,
     onNavigateToLoanDetail: (Long) -> Unit,
+    onUnmarkLoanClick: () -> Unit,
     accountProfileId: Long?,
     hazeState: HazeState,
     modifier: Modifier = Modifier
@@ -495,6 +525,7 @@ private fun TransactionDetailContent(
                 hasSplits = hasSplits,
                 loan = loan,
                 onNavigateToLoanDetail = onNavigateToLoanDetail,
+                onUnmarkLoanClick = onUnmarkLoanClick,
                 accountProfileId = accountProfileId
             )
         }
@@ -513,6 +544,7 @@ private fun TransactionReceipt(
     hasSplits: Boolean,
     loan: LoanEntity?,
     onNavigateToLoanDetail: (Long) -> Unit,
+    onUnmarkLoanClick: () -> Unit,
     accountProfileId: Long? = null
 ) {
     val isDark = isSystemInDarkTheme()
@@ -626,31 +658,46 @@ private fun TransactionReceipt(
                 val loanColor = if (isDarkTheme) loan_dark else loan_light
                 Spacer(modifier = Modifier.height(Spacing.xs))
                 if (loan != null) {
-                    SuggestionChip(
-                        onClick = { onNavigateToLoanDetail(loan.id) },
-                        label = {
-                            Text(
-                                text = if (loan.direction == LoanDirection.LENT)
-                                    "Lent to ${loan.personName}" else "Borrowed from ${loan.personName}",
-                                style = MaterialTheme.typography.labelMedium,
-                                fontWeight = FontWeight.SemiBold
-                            )
-                        },
-                        icon = {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.xs)
+                    ) {
+                        SuggestionChip(
+                            onClick = { onNavigateToLoanDetail(loan.id) },
+                            label = {
+                                Text(
+                                    text = if (loan.direction == LoanDirection.LENT)
+                                        "Lent to ${loan.personName}" else "Borrowed from ${loan.personName}",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                            },
+                            icon = {
+                                Icon(
+                                    Icons.Default.SwapHoriz,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(Dimensions.Icon.small),
+                                    tint = loanColor
+                                )
+                            },
+                            colors = SuggestionChipDefaults.suggestionChipColors(
+                                containerColor = loanColor.copy(alpha = 0.12f),
+                                labelColor = loanColor,
+                                iconContentColor = loanColor
+                            ),
+                            border = null
+                        )
+                        // Unmark-as-loan (#444): removes the loan link; deletes the
+                        // loan too if no other transactions are linked.
+                        IconButton(onClick = onUnmarkLoanClick) {
                             Icon(
-                                Icons.Default.SwapHoriz,
-                                contentDescription = null,
+                                Icons.Default.Close,
+                                contentDescription = "Unmark as loan",
                                 modifier = Modifier.size(Dimensions.Icon.small),
-                                tint = loanColor
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
                             )
-                        },
-                        colors = SuggestionChipDefaults.suggestionChipColors(
-                            containerColor = loanColor.copy(alpha = 0.12f),
-                            labelColor = loanColor,
-                            iconContentColor = loanColor
-                        ),
-                        border = null
-                    )
+                        }
+                    }
                 } else {
                     SuggestionChip(
                         onClick = { viewModel.showMarkAsLoanSheet() },

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
@@ -224,7 +224,11 @@ class TransactionDetailViewModel @Inject constructor(
                 calculateConvertedAmount(it)
                 loadSplits(transactionId)
                 loadReceiptUri(it)
-                it.loanId?.let { id -> loadLoan(id) }
+                // Clear stale loan state when the (re)loaded transaction has no
+                // loan — e.g. the loan was deleted elsewhere and we reload on
+                // resume (#444). Otherwise the loan chip would persist.
+                val loanId = it.loanId
+                if (loanId != null) loadLoan(loanId) else _loan.value = null
                 _budgetImpactType.value = it.budgetImpactType
                 _budgetCategory.value = it.budgetCategory
                 loadAccountProfileId(it)


### PR DESCRIPTION
Fixes #444 — once a transaction was marked as a loan there was no way to undo it, and deleting the loan left the transaction still flagged.

**Changes**
- **Unmark action (was missing):** the loan chip now has an **"Unmark as loan" (×)** button + confirm dialog, wired to the existing-but-unwired `unlinkLoan()`. Callback threaded through `TransactionReceipt`.
- **Orphan cleanup (expected #2):** `LoanRepository.unlinkTransaction` deletes the loan when no transactions remain linked (new `LoanDao.countTransactionsForLoan`).
- **Stale refresh (expected #1):** the transaction detail reloads on `ON_RESUME`, so deleting the loan from the Loan screen is reflected on return (it was a one-shot load before).

**Verified live on emulator:** mark → "Borrowed from TestPerson" chip + × button; unmark → confirm → chip reverts to "Mark as loan"; DB shows the loan deleted (0 loans) and the transaction's `loan_id` cleared. Compiles clean.