### PR TITLE
feat(parser-core): add support for Mellat Bank SMS parsing

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -96,6 +96,7 @@ object BankParserFactory {
         DashenBankParser(),  // Dashen Bank (Ethiopia)
         FaysalBankParser(),  // Faysal Bank (Pakistan)
         MelliBankParser(),  // Melli Bank (Iran)
+        MellatBankParser(), // Mellat Bank (Iran)
         ParsianBankParser(),  // Parsian Bank (Iran)
         BangkokBankParser(),  // Bangkok Bank (Thailand)
         KasikornBankParser(),  // Kasikorn Bank (Thailand)

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MellatBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MellatBankParser.kt
@@ -1,0 +1,101 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Mellat Bank parser for Iranian banking SMS messages.
+ * Only handles deposit and withdrawal messages, ignoring OTPs and other notifications.
+ */
+class MellatBankParser : BaseIranianBankParser() {
+
+    private val pattern1 = Regex(
+        """^حساب\d+\s+(برداشت|واریز)([0-9,]+)\s+مانده([0-9,]+)\s+\d{2}/\d{2}/\d{2}-\d{2}:\d{2}""",
+        RegexOption.MULTILINE
+    )
+    private val pattern2 = Regex(
+        """^واریز سود کوتاه مدت\s+حساب\d+\s+مبلغ([0-9,]+)\s+\d{2}/\d{2}/\d{2}""",
+        RegexOption.MULTILINE
+    )
+    private val accountPattern = Regex("""حساب\s*(\d+)""")
+
+    override fun getBankName(): String = "Mellat Bank"
+
+    override fun canHandle(sender: String): Boolean {
+        val upperSender = sender.uppercase()
+        val mellatSenders = setOf(
+            "BANK MELLAT",
+            "BANKMELLAT",
+            "MELLAT",
+            "MELLATBANK",
+            "MELLAT BANK"
+        )
+        return upperSender in mellatSenders
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val trimmed = message.trim()
+        return pattern1.containsMatchIn(trimmed) || pattern2.containsMatchIn(trimmed)
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        val trimmed = message.trim()
+        pattern1.find(trimmed)?.let { match ->
+            val amountStr = match.groupValues[2].replace(",", "")
+            return try {
+                BigDecimal(amountStr)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+        pattern2.find(trimmed)?.let { match ->
+            val amountStr = match.groupValues[1].replace(",", "")
+            return try {
+                BigDecimal(amountStr)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+        return null
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val trimmed = message.trim()
+        pattern1.find(trimmed)?.let { match ->
+            val typeStr = match.groupValues[1]
+            return if (typeStr == "برداشت") {
+                TransactionType.EXPENSE
+            } else {
+                TransactionType.INCOME
+            }
+        }
+        if (pattern2.containsMatchIn(trimmed)) {
+            return TransactionType.INCOME
+        }
+        return null
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        accountPattern.find(message)?.let { match ->
+            val fullAccount = match.groupValues[1]
+            if (fullAccount.length >= 4) {
+                return fullAccount.takeLast(4)
+            }
+            return fullAccount
+        }
+        return null
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        val trimmed = message.trim()
+        pattern1.find(trimmed)?.let { match ->
+            val balanceStr = match.groupValues[3].replace(",", "")
+            return try {
+                BigDecimal(balanceStr)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+        return null
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MellatBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MellatBankParser.kt
@@ -10,11 +10,11 @@ import java.math.BigDecimal
 class MellatBankParser : BaseIranianBankParser() {
 
     private val pattern1 = Regex(
-        """^حساب\d+\s+(برداشت|واریز)([0-9,]+)\s+مانده([0-9,]+)\s+\d{2}/\d{2}/\d{2}-\d{2}:\d{2}""",
+        """^حساب\d+\s+(برداشت|واریز)\s*([0-9,]+)\s+مانده\s*([0-9,]+)\s+\d{2}/\d{2}/\d{2}-\d{2}:\d{2}""",
         RegexOption.MULTILINE
     )
     private val pattern2 = Regex(
-        """^واریز سود کوتاه مدت\s+حساب\d+\s+مبلغ([0-9,]+)\s+\d{2}/\d{2}/\d{2}""",
+        """^واریز سود کوتاه مدت\s+حساب\d+\s+مبلغ\s*([0-9,]+)\s+\d{2}/\d{2}/\d{2}""",
         RegexOption.MULTILINE
     )
     private val accountPattern = Regex("""حساب\s*(\d+)""")
@@ -62,11 +62,10 @@ class MellatBankParser : BaseIranianBankParser() {
     override fun extractTransactionType(message: String): TransactionType? {
         val trimmed = message.trim()
         pattern1.find(trimmed)?.let { match ->
-            val typeStr = match.groupValues[1]
-            return if (typeStr == "برداشت") {
-                TransactionType.EXPENSE
-            } else {
-                TransactionType.INCOME
+            return when (match.groupValues[1]) {
+                "برداشت" -> TransactionType.EXPENSE
+                "واریز" -> TransactionType.INCOME
+                else -> null
             }
         }
         if (pattern2.containsMatchIn(trimmed)) {

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/MellatBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/MellatBankParserTest.kt
@@ -34,6 +34,23 @@ class MellatBankParserTest {
                 )
             ),
             ParserTestCase(
+                name = "Mellat Bank withdrawal with spaced amounts",
+                message = """
+                    حساب1234567890
+                    برداشت 1,250,000
+                    مانده 18,750,000
+                    04/04/21-21:40
+                """.trimIndent(),
+                sender = "Bank Mellat",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1250000"),
+                    currency = "IRR",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "7890",
+                    balance = BigDecimal("18750000")
+                )
+            ),
+            ParserTestCase(
                 name = "Mellat Bank deposit transaction",
                 message = """
                     حساب1234567890

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/MellatBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/MellatBankParserTest.kt
@@ -1,0 +1,162 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import com.pennywiseai.parser.core.test.SimpleTestCase
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class MellatBankParserTest {
+
+    private val parser = MellatBankParser()
+
+    @TestFactory
+    fun `mellat bank parser handles key paths`(): List<DynamicTest> {
+        val cases = listOf(
+            ParserTestCase(
+                name = "Mellat Bank withdrawal transaction",
+                message = """
+                    حساب1234567890
+                    برداشت1,250,000
+                    مانده18,750,000
+                    04/04/21-21:40
+                """.trimIndent(),
+                sender = "Bank Mellat",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1250000"),
+                    currency = "IRR",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "7890",
+                    balance = BigDecimal("18750000")
+                )
+            ),
+            ParserTestCase(
+                name = "Mellat Bank deposit transaction",
+                message = """
+                    حساب1234567890
+                    واریز2,500,000
+                    مانده21,250,000
+                    04/07/15-08:42
+                """.trimIndent(),
+                sender = "Bank Mellat",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2500000"),
+                    currency = "IRR",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "7890",
+                    balance = BigDecimal("21250000")
+                )
+            ),
+            ParserTestCase(
+                name = "Mellat Bank short term interest deposit transaction",
+                message = """
+                    واریز سود کوتاه مدت
+                    حساب1234567890
+                    مبلغ45,670
+                    04/06/02
+                """.trimIndent(),
+                sender = "Bank Mellat",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("45670"),
+                    currency = "IRR",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "7890",
+                    balance = null
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            Pair("Bank Mellat", true),
+            Pair("BANKMELLAT", true),
+            Pair("MELLAT BANK", true),
+            Pair("MELLAT", true),
+            Pair("MELLATBANK", true),
+            Pair("OTHER", false)
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases, handleCases)
+    }
+
+    @TestFactory
+    fun `mellat bank parser ignores non-transaction messages`(): List<DynamicTest> {
+        val ignoredMessages = listOf(
+            "OTP verification",
+            """
+                هشدار
+                مشتری گرامی  شما درحال برداشت مبلغ 100,000,000 ریال از حساب خود جهت انتقال وجه پایا  به شبای IR990000000000000000000000 به نام IR990000000000000000000000# می باشید. 
+                توجه نمایید كه عدد محرمانه: 1234567 یكباررمز شما جهت تایید انتقال وجه پایا  می باشد.
+            """.trimIndent(),
+            """
+                مشتری گرامی
+                سلام؛
+                جشنواره حساب های قرض الحسنه پس انداز بانک ملت تا پایان شهریور تمدید شد.
+                1404 جایزه نقدی 250 میلیون تومانی
+                4404 جایزه نقدی 25 میلیون تومانی و هزاران جایزه نقدی دیگر
+                بانک ملت، تجربه ای متمایز
+            """.trimIndent(),
+            """
+                به سامانه بانكداری اینترنتی ملت خوش آمدید
+                  1404/07/12
+                07:49
+            """.trimIndent(),
+            """
+                انتقال به کارت
+                603799*1234
+                مبلغ 1,000,000
+                رمز پویا 12345
+            """.trimIndent()
+        )
+
+        return ignoredMessages.map { msg ->
+            DynamicTest.dynamicTest("Should ignore: ${msg.take(30)}...") {
+                org.junit.jupiter.api.Assertions.assertNull(parser.parse(msg, "Bank Mellat", System.currentTimeMillis()))
+            }
+        }
+    }
+
+    @TestFactory
+    fun `factory resolves mellat bank`(): List<DynamicTest> {
+        val cases = listOf(
+            SimpleTestCase(
+                bankName = "Mellat Bank",
+                sender = "Bank Mellat",
+                currency = "IRR",
+                message = """
+                    حساب1234567890
+                    برداشت1,250,000
+                    مانده18,750,000
+                    04/04/21-21:40
+                """.trimIndent(),
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1250000"),
+                    currency = "IRR",
+                    type = TransactionType.EXPENSE
+                ),
+                shouldHandle = true
+            ),
+            SimpleTestCase(
+                bankName = "Mellat Bank",
+                sender = "BANKMELLAT",
+                currency = "IRR",
+                message = """
+                    حساب1234567890
+                    واریز2,500,000
+                    مانده21,250,000
+                    04/07/15-08:42
+                """.trimIndent(),
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2500000"),
+                    currency = "IRR",
+                    type = TransactionType.INCOME
+                ),
+                shouldHandle = true
+            )
+        )
+
+        return ParserTestUtils.runFactoryTestSuite(cases, "Mellat Bank factory tests")
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for parsing SMS transaction notifications from Mellat Bank (Iran). 
The parser extracts the transaction type (Deposit/Withdrawal), transaction amount (in IRR), and the last 4 digits of the account number. It specifically ignores non-transaction messages like OTP verification codes, security alerts, and promotional advertisements.

## Type of change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Code improvement (no behavior change)
- [ ] perf: Performance improvement
- [ ] style: Formatting (no behavior change)
- [x] test: Add/update tests
- [ ] chore/ci: Build or CI changes

## Screenshots/Recordings (optional)

N/A (Backend parser logic)

## How to test

1. Run the Mellat Bank parser unit tests to verify parsing rules:
   ```bash
   ./gradlew :parser-core:jvmTest --tests "com.pennywiseai.parser.core.bank.MellatBankParserTest"
