### PR TITLE
feat(parser-core): add Emirates Islamic (UAE) SMS parsing

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -56,6 +56,7 @@ object BankParserFactory {
         ADCBParser(),  // Abu Dhabi Commercial Bank (UAE)
         FABParser(),  // First Abu Dhabi Bank (UAE)
         EmiratesNBDParser(),  // Emirates NBD Bank (UAE)
+        EmiratesIslamicParser(),  // Emirates Islamic Bank (UAE)
         LivBankParser(),  // Liv Bank (UAE)
         CitiBankParser(),  // Citi Bank (USA)
         DiscoverCardParser(),  // Discover Card (USA)

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/EmiratesIslamicParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/EmiratesIslamicParser.kt
@@ -1,0 +1,149 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Emirates Islamic Bank (UAE) transactions.
+ * Inherits from UAEBankParser for AED / multi-currency support.
+ *
+ * Sender is "EI SMS" for all messages. Handles debit/credit card purchases,
+ * ATM withdrawals, telegraphic transfers, online banking transfers, credit
+ * card payments and salary deposits.
+ *
+ * Sample formats (masked):
+ *  - Debit/Credit Card Purchase ... Card Ending: 1234 ... At: <merchant> ... Amount: AED 12.34
+ *  - Telegraphic Transfer Deducted/Received ... Account: 123XXX12XXX12 ... Amount: AED 12.00
+ *  - Payment towards Credit Card ... From Account: 12345XXXXX123 ... Amount: AED 1,123.12
+ *  - ATM Withdrawal ... Debit Card Ending: 1234 ... Amount: AED 123.00
+ *  - Salary Deposited Account: 123XXX12XXX12 ... Amount: AED 123,123.12
+ */
+class EmiratesIslamicParser : UAEBankParser() {
+
+    override fun getBankName() = "Emirates Islamic"
+
+    override fun canHandle(sender: String): Boolean {
+        // Sender is "EI SMS"; normalize by uppercasing and stripping spaces.
+        // Match the exact "EISMS" token and the full bank name, but never a bare
+        // two-letter "EI" substring (far too broad; would steal other banks' SMS).
+        val normalizedSender = sender.uppercase().replace(Regex("\\s+"), "")
+        return normalizedSender == "EISMS" ||
+                normalizedSender == "EMIRATESISLAMIC" ||
+                normalizedSender == "EMIRATESISLAMICBANK"
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lowerMessage = message.lowercase()
+
+        // Skip OTP / verification messages.
+        if (lowerMessage.contains("otp") ||
+            lowerMessage.contains("one time password") ||
+            lowerMessage.contains("verification code")
+        ) {
+            return false
+        }
+
+        // Credit Card payment receipt (sample #5) is a confirmation/duplicate of the
+        // "Payment towards Credit Card" debit (sample #3). We classify it as a
+        // NON-transaction and return null here to avoid double-counting the payment.
+        if (lowerMessage.contains("confirm receipt of your payment")) {
+            return false
+        }
+
+        // Emirates Islamic transaction indicators.
+        val transactionKeywords = listOf(
+            "debit card purchase",
+            "credit card purchase",
+            "payment towards credit card",
+            "telegraphic transfer",
+            "atm withdrawal",
+            "online banking transfer",
+            "salary deposited",
+            "deducted",
+            "received",
+            "deposited"
+        )
+        return transactionKeywords.any { lowerMessage.contains(it) }
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lowerMessage = message.lowercase()
+
+        return when {
+            // Income: incoming telegraphic transfers and salary deposits.
+            lowerMessage.contains("telegraphic transfer received") -> TransactionType.INCOME
+            lowerMessage.contains("salary deposited") -> TransactionType.INCOME
+
+            // Expenses: card purchases (per issue, credit card purchases are EXPENSE too),
+            // ATM withdrawals, outgoing transfers and credit-card payments.
+            lowerMessage.contains("credit card purchase") -> TransactionType.EXPENSE
+            lowerMessage.contains("debit card purchase") -> TransactionType.EXPENSE
+            lowerMessage.contains("atm withdrawal") -> TransactionType.EXPENSE
+            lowerMessage.contains("payment towards credit card") -> TransactionType.EXPENSE
+            lowerMessage.contains("telegraphic transfer deducted") -> TransactionType.EXPENSE
+            lowerMessage.contains("online banking transfer") -> TransactionType.EXPENSE
+
+            else -> super.extractTransactionType(message)
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // Card purchases use "At: <merchant>" on its own line.
+        val atPattern = Regex("""At:\s*(.+?)(?:\r?\n|$)""", RegexOption.IGNORE_CASE)
+        atPattern.find(message)?.let { match ->
+            val merchant = match.groupValues[1].trim()
+            if (merchant.isNotEmpty()) {
+                return cleanMerchantName(merchant)
+            }
+        }
+
+        // ATM withdrawals use "From: <location>" on its own line.
+        if (message.contains("ATM Withdrawal", ignoreCase = true)) {
+            val fromPattern = Regex("""From:\s*(.+?)(?:\r?\n|$)""", RegexOption.IGNORE_CASE)
+            fromPattern.find(message)?.let { match ->
+                val location = match.groupValues[1].trim()
+                if (location.isNotEmpty()) {
+                    return "ATM Withdrawal: ${cleanMerchantName(location)}"
+                }
+            }
+            return "ATM Withdrawal"
+        }
+
+        return super.extractMerchant(message, sender)
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        // Prefer the card number when present: "Card Ending: 1234" / "Debit Card Ending: 1234".
+        val cardEndingPattern = Regex("""Card Ending:\s*(\d{3,})""", RegexOption.IGNORE_CASE)
+        cardEndingPattern.find(message)?.let { match ->
+            extractLast4Digits(match.groupValues[1])?.let { return it }
+        }
+
+        // Otherwise use the trailing digits of the masked account number, e.g.
+        // "Account: 123XXX12XXX12" or "From Account: 12345XXXXX123".
+        val accountPattern = Regex("""Account:\s*([X\d]+)""", RegexOption.IGNORE_CASE)
+        accountPattern.find(message)?.let { match ->
+            extractLast4Digits(match.groupValues[1])?.let { return it }
+        }
+
+        return super.extractAccountLast4(message)
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        // "Available Balance: AED 12,123.12" and credit-card "Available Limit: AED 123,123.12".
+        val balancePattern = Regex(
+            """Available\s+(?:Balance|Limit):\s*([A-Z]{3})\s+([0-9,]+(?:\.\d{2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        balancePattern.find(message)?.let { match ->
+            val balanceStr = match.groupValues[2].replace(",", "")
+            return try {
+                BigDecimal(balanceStr)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+
+        return super.extractBalance(message)
+    }
+}

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/EmiratesIslamicParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/EmiratesIslamicParserTest.kt
@@ -178,6 +178,75 @@ class EmiratesIslamicParserTest {
         return ParserTestUtils.runTestSuite(parser, cases, handleChecks, "Emirates Islamic Bank Parser")
     }
 
+    /**
+     * International / foreign-currency transactions. UAE banks report the
+     * transaction in the spend currency (e.g. USD/EUR) while the account's
+     * Available Balance stays in AED. The parser should surface the spend
+     * currency + amount, and read the AED balance unchanged.
+     */
+    @TestFactory
+    fun `emirates islamic parser handles foreign currency`(): List<DynamicTest> {
+        val cases = listOf(
+            // International debit card purchase billed in USD.
+            ParserTestCase(
+                name = "Debit Card Purchase in USD",
+                message = """
+                    Debit Card Purchase
+                    Card Ending: 1111
+                    At: AMAZON.COM, USA
+                    Amount: USD 50.00
+                    Date: 21/12/2024 20:18
+                    Available Balance: AED 12,123.12
+                """.trimIndent(),
+                sender = "EI SMS",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("50.00"),
+                    currency = "USD",
+                    type = TransactionType.EXPENSE,
+                    merchant = "AMAZON.COM, USA",
+                    accountLast4 = "1111",
+                    balance = BigDecimal("12123.12")
+                )
+            ),
+            // International credit card purchase billed in EUR (uses "Available Limit").
+            ParserTestCase(
+                name = "Credit Card Purchase in EUR",
+                message = """
+                    Credit Card Purchase
+                    Card Ending: 1234
+                    At: ZARA, MADRID
+                    Amount: EUR 20.00
+                    Date: 21/12/2024, 20:12
+                    Available Limit: AED 5,000.00
+                """.trimIndent(),
+                sender = "EI SMS",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("20.00"),
+                    currency = "EUR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "ZARA, MADRID",
+                    accountLast4 = "1234",
+                    balance = BigDecimal("5000.00")
+                )
+            ),
+            // Inbound telegraphic transfer received in GBP.
+            ParserTestCase(
+                name = "Telegraphic Transfer Received in GBP",
+                message = "Telegraphic Transfer Received To Account: 123XXX12XXX12 Amount: GBP 100.00 Date: 21/12/2024 00:12 Available Balance: AED 123,123.12",
+                sender = "EI SMS",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("100.00"),
+                    currency = "GBP",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "1212",
+                    balance = BigDecimal("123123.12")
+                )
+            )
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases, emptyList(), "Emirates Islamic foreign-currency")
+    }
+
     @TestFactory
     fun `factory resolves emirates islamic`(): List<DynamicTest> {
         val cases = listOf(

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/EmiratesIslamicParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/EmiratesIslamicParserTest.kt
@@ -1,0 +1,207 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import com.pennywiseai.parser.core.test.SimpleTestCase
+import org.junit.jupiter.api.*
+import java.math.BigDecimal
+
+class EmiratesIslamicParserTest {
+
+    private val parser = EmiratesIslamicParser()
+
+    @TestFactory
+    fun `emirates islamic parser handles all sample types`(): List<DynamicTest> {
+        val cases = listOf(
+            // Sample 1: Debit Card Purchase
+            ParserTestCase(
+                name = "Debit Card Purchase",
+                message = """
+                    Debit Card Purchase
+                    Card Ending: 1111
+                    At: talabat.com, DUBAI
+                    Amount: AED 12.34
+                    Date: 21/12/2024 20:18
+                    Available Balance: AED 12,123.12
+                """.trimIndent(),
+                sender = "EI SMS",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("12.34"),
+                    currency = "AED",
+                    type = TransactionType.EXPENSE,
+                    merchant = "talabat.com, DUBAI",
+                    accountLast4 = "1111",
+                    balance = BigDecimal("12123.12")
+                )
+            ),
+            // Sample 2: Telegraphic Transfer Deducted (outgoing) -> EXPENSE
+            ParserTestCase(
+                name = "Telegraphic Transfer Deducted",
+                message = "Telegraphic Transfer Deducted From Account: 123XXX12XXX12  Amount: AED 12.00 Date: 21/12/2024 20:18 Available Balance: AED 12,123.12",
+                sender = "EI SMS",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("12.00"),
+                    currency = "AED",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "1212",
+                    balance = BigDecimal("12123.12")
+                )
+            ),
+            // Sample 3: Payment towards Credit Card (money leaving account) -> EXPENSE
+            ParserTestCase(
+                name = "Payment towards Credit Card",
+                message = """
+                    Payment towards Credit Card
+                    From Account: 12345XXXXX123
+                    Amount: AED 1,123.12
+                    Date: 21/12/2024 12:34
+                    Available Balance: AED 12,123.12
+                """.trimIndent(),
+                sender = "EI SMS",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1123.12"),
+                    currency = "AED",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "5123",
+                    balance = BigDecimal("12123.12")
+                )
+            ),
+            // Sample 4: Credit Card Purchase -> EXPENSE (uses "Available Limit")
+            ParserTestCase(
+                name = "Credit Card Purchase",
+                message = """
+                    Credit Card Purchase
+                    Card Ending: 1234
+                    At: ROXY CINEMA - Dubai Hi, Dubai
+                    Amount: AED 123.00
+                    Date: 21/12/2024, 20:12
+                    Available Limit: AED 123,123.12
+                """.trimIndent(),
+                sender = "EI SMS",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("123.00"),
+                    currency = "AED",
+                    type = TransactionType.EXPENSE,
+                    merchant = "ROXY CINEMA - Dubai Hi, Dubai",
+                    accountLast4 = "1234",
+                    balance = BigDecimal("123123.12")
+                )
+            ),
+            // Sample 5: Credit Card payment receipt -> NON-transaction (return null)
+            ParserTestCase(
+                name = "Credit Card payment receipt (confirmation, not a transaction)",
+                message = "This is to confirm receipt of your payment of AED 123.00 towards your Credit Card starting with 123456  on 21/12/2024. Available limit is   AED 123,123.12.",
+                sender = "EI SMS",
+                shouldParse = false
+            ),
+            // Sample 6: ATM Withdrawal -> EXPENSE
+            ParserTestCase(
+                name = "ATM Withdrawal",
+                message = """
+                    ATM Withdrawal
+                    Debit Card Ending: 1234
+                    From: ABU DHABI UAEAE, ABU DHABI
+                    Amount: AED 123.00
+                    Date: 21/12/2024, 20:12
+                    Available Balance: AED 123.12
+                """.trimIndent(),
+                sender = "EI SMS",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("123.00"),
+                    currency = "AED",
+                    type = TransactionType.EXPENSE,
+                    merchant = "ATM Withdrawal: ABU DHABI UAEAE, ABU DHABI",
+                    accountLast4 = "1234",
+                    balance = BigDecimal("123.12")
+                )
+            ),
+            // Sample 7: Online Banking Transfer -> EXPENSE
+            ParserTestCase(
+                name = "Online Banking Transfer",
+                message = "Online Banking Transfer From Account: 123XXX12XXX12 Amount: AED 12,123.00 Date: 21/12/2024 20:12 Available Balance: AED 123,123.12",
+                sender = "EI SMS",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("12123.00"),
+                    currency = "AED",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "1212",
+                    balance = BigDecimal("123123.12")
+                )
+            ),
+            // Sample 8: Telegraphic Transfer Received -> INCOME
+            ParserTestCase(
+                name = "Telegraphic Transfer Received",
+                message = "Telegraphic Transfer Received To Account: 123XXX12XXX12 Amount: AED 12.00 Date: 21/12/2024 00:12 Available Balance: AED 123,123.12",
+                sender = "EI SMS",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("12.00"),
+                    currency = "AED",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "1212",
+                    balance = BigDecimal("123123.12")
+                )
+            ),
+            // Sample 9: Salary Deposited -> INCOME
+            ParserTestCase(
+                name = "Salary Deposited",
+                message = "Salary Deposited Account: 123XXX12XXX12 Amount: AED 123,123.12 Date: 21/12/2024 22:44 Available Balance: AED 123,123.12",
+                sender = "EI SMS",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("123123.12"),
+                    currency = "AED",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "1212",
+                    balance = BigDecimal("123123.12")
+                )
+            ),
+            // Non-transaction: OTP -> return null
+            ParserTestCase(
+                name = "OTP message is not a transaction",
+                message = "Your OTP for Emirates Islamic online banking is 123456. Do not share it with anyone.",
+                sender = "EI SMS",
+                shouldParse = false
+            )
+        )
+
+        val handleChecks = listOf(
+            "EI SMS" to true,
+            "EISMS" to true,
+            "OTHER" to false,
+            "EMIRATESNBD" to false,
+            "ENBD" to false,
+            "ADCB" to false,
+            "EI" to false
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases, handleChecks, "Emirates Islamic Bank Parser")
+    }
+
+    @TestFactory
+    fun `factory resolves emirates islamic`(): List<DynamicTest> {
+        val cases = listOf(
+            SimpleTestCase(
+                bankName = "Emirates Islamic",
+                sender = "EI SMS",
+                currency = "AED",
+                message = """
+                    Debit Card Purchase
+                    Card Ending: 1111
+                    At: talabat.com, DUBAI
+                    Amount: AED 12.34
+                    Date: 21/12/2024 20:18
+                    Available Balance: AED 12,123.12
+                """.trimIndent(),
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("12.34"),
+                    currency = "AED",
+                    type = TransactionType.EXPENSE
+                ),
+                shouldHandle = true
+            )
+        )
+
+        return ParserTestUtils.runFactoryTestSuite(cases, "Factory smoke tests")
+    }
+}


### PR DESCRIPTION
Closes #443.

## Summary
Adds a parser for **Emirates Islamic** (UAE), extending `UAEBankParser` (AED). Sender is `EI SMS`.

Handles all 9 sample types from the issue:
- Debit Card Purchase, Credit Card Purchase → EXPENSE (merchant from `At:`)
- ATM Withdrawal → EXPENSE
- Telegraphic Transfer Deducted / Online Banking Transfer / Payment towards Credit Card → EXPENSE
- Telegraphic Transfer Received / Salary Deposited → INCOME
- Credit-card **payment receipt** ("confirm receipt of your payment") → treated as a **non-transaction** (returns null) since it duplicates the "Payment towards Credit Card" debit, so the payment isn't double-counted.

Account last4 comes from `Card Ending:` when present, else the trailing digits of the masked `Account:` number. Balance reads both `Available Balance:` and credit-card `Available Limit:`.

## Sender safety
`canHandle` matches `EISMS` / `EMIRATESISLAMIC` only — never a bare two-letter `EI` substring — so it does not collide with Emirates NBD (`ENBD`) or ADCB. Verified by handle-checks + a factory-resolution test.

## Tests
`ParserTestUtils`-based JUnit5 suite: 9 sample types + OTP non-transaction + handle-checks (including false for `EMIRATESNBD`/`ADCB`) + factory resolution. Full `:parser-core:jvmTest` suite is green (no coexistence regression).

## How to test
```bash
./gradlew :parser-core:jvmTest --tests "com.pennywiseai.parser.core.bank.EmiratesIslamicParserTest"
```