### PR TITLE
fix(accounts): Unlinked Cards text wrapping one character per line

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
@@ -1570,16 +1570,16 @@ private fun OrphanedCardItem(
         )
     ) {
         Column(modifier = Modifier.padding(Dimensions.Padding.content)) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.CreditCard,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary
-                    )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Default.CreditCard,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = "${card.bankName} ••${card.cardLast4}",
@@ -1615,55 +1615,55 @@ private fun OrphanedCardItem(
                     }
                 }
             }
-            
-                Spacer(modifier = Modifier.height(Spacing.sm))
 
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(Spacing.xs)
+            Spacer(modifier = Modifier.height(Spacing.sm))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(Spacing.xs)
+            ) {
+                OutlinedButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = { showLinkDialog = true }
                 ) {
-                    OutlinedButton(
-                        modifier = Modifier.weight(1f),
-                        onClick = { showLinkDialog = true }
-                    ) {
-                        Icon(
-                            Icons.Default.Link,
-                            contentDescription = null,
-                            modifier = Modifier.size(Dimensions.Icon.small)
-                        )
-                        Spacer(modifier = Modifier.width(Spacing.xs))
-                        Text("Link")
-                    }
-
-                    OutlinedButton(
-                        modifier = Modifier.weight(1f),
-                        onClick = { showEditDialog = true }
-                    ) {
-                        Icon(
-                            Icons.Default.Edit,
-                            contentDescription = null,
-                            modifier = Modifier.size(Dimensions.Icon.small)
-                        )
-                        Spacer(modifier = Modifier.width(Spacing.xs))
-                        Text("Edit")
-                    }
-
-                    OutlinedButton(
-                        modifier = Modifier.weight(1f),
-                        onClick = { onDeleteCard(card.id) },
-                        colors = ButtonDefaults.outlinedButtonColors(
-                            contentColor = MaterialTheme.colorScheme.error
-                        )
-                    ) {
-                        Icon(
-                            Icons.Default.Delete,
-                            contentDescription = null,
-                            modifier = Modifier.size(Dimensions.Icon.small)
-                        )
-                        Spacer(modifier = Modifier.width(Spacing.xs))
-                        Text("Delete")
-                    }
+                    Icon(
+                        Icons.Default.Link,
+                        contentDescription = null,
+                        modifier = Modifier.size(Dimensions.Icon.small)
+                    )
+                    Spacer(modifier = Modifier.width(Spacing.xs))
+                    Text("Link")
                 }
+
+                OutlinedButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = { showEditDialog = true }
+                ) {
+                    Icon(
+                        Icons.Default.Edit,
+                        contentDescription = null,
+                        modifier = Modifier.size(Dimensions.Icon.small)
+                    )
+                    Spacer(modifier = Modifier.width(Spacing.xs))
+                    Text("Edit")
+                }
+
+                OutlinedButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = { onDeleteCard(card.id) },
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error
+                    )
+                ) {
+                    Icon(
+                        Icons.Default.Delete,
+                        contentDescription = null,
+                        modifier = Modifier.size(Dimensions.Icon.small)
+                    )
+                    Spacer(modifier = Modifier.width(Spacing.xs))
+                    Text("Delete")
+                }
+            }
         }
     }
     

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
@@ -1569,18 +1569,11 @@ private fun OrphanedCardItem(
             containerColor = MaterialTheme.colorScheme.surfaceVariant
         )
     ) {
-        Column {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(Dimensions.Padding.content),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
+        Column(modifier = Modifier.padding(Dimensions.Padding.content)) {
                 Row(
+                    modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.weight(1f)
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
                     Icon(
                         imageVector = Icons.Default.CreditCard,
@@ -1623,10 +1616,14 @@ private fun OrphanedCardItem(
                 }
             }
             
+                Spacer(modifier = Modifier.height(Spacing.sm))
+
                 Row(
+                    modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(Spacing.xs)
                 ) {
                     OutlinedButton(
+                        modifier = Modifier.weight(1f),
                         onClick = { showLinkDialog = true }
                     ) {
                         Icon(
@@ -1639,6 +1636,7 @@ private fun OrphanedCardItem(
                     }
 
                     OutlinedButton(
+                        modifier = Modifier.weight(1f),
                         onClick = { showEditDialog = true }
                     ) {
                         Icon(
@@ -1651,6 +1649,7 @@ private fun OrphanedCardItem(
                     }
 
                     OutlinedButton(
+                        modifier = Modifier.weight(1f),
                         onClick = { onDeleteCard(card.id) },
                         colors = ButtonDefaults.outlinedButtonColors(
                             contentColor = MaterialTheme.colorScheme.error
@@ -1665,7 +1664,6 @@ private fun OrphanedCardItem(
                         Text("Delete")
                     }
                 }
-            }
         }
     }
     


### PR DESCRIPTION
On the **Accounts → Unlinked Cards** section, each card rendered its text vertically — one character per line.

## Cause
`OrphanedCardItem` placed the three action buttons (Link / Edit / Delete) **beside** the info column inside a `Row(horizontalArrangement = SpaceBetween)`. The buttons row was unweighted, so it took its full intrinsic width and the weighted text column was starved to ~0 width → the bank name / balance / SMS text wrapped a single character per line.

## Fix
Restructure `OrphanedCardItem` so actions sit **below** the info instead of beside it:
- Info row (icon + text column) gets the full card width.
- Action buttons move to their own full-width row, each with `Modifier.weight(1f)` so the three buttons split the width evenly and always fit.

No behavior change — same buttons, same actions, just a layout fix. Compiles clean (`:app:compileStandardDebugKotlin`).

## Before / After
- Before: `H\nD\nF\nC\n…` (one char per line)
- After: `HDFC Bank ••1101` / `Debit Card (Unlinked)` / `Last Balance: ₹8,60,40…` on normal lines, with `[ Link ] [ Edit ] [ Delete ]` below.