### PR TITLE
feat(accounts): make Balance History a real page, not a modal

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/BalanceHistoryScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/BalanceHistoryScreen.kt
@@ -19,7 +19,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.pennywiseai.tracker.ui.components.CustomTitleTopAppBar
 import androidx.compose.foundation.text.KeyboardOptions
 import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.ui.components.PennyWiseEmptyState
@@ -29,16 +34,17 @@ import com.pennywiseai.tracker.utils.CurrencyFormatter
 import java.math.BigDecimal
 import java.time.format.DateTimeFormatter
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Suppress("DEPRECATION")
 @Composable
-fun BalanceHistoryDialog(
-    bankName: String,
-    accountLast4: String,
-    balanceHistory: List<AccountBalanceEntity>,
-    onDismiss: () -> Unit,
-    onDeleteBalance: (Long) -> Unit,
-    onUpdateBalance: (Long, BigDecimal) -> Unit
+fun BalanceHistoryScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: BalanceHistoryViewModel = hiltViewModel()
 ) {
+    val balanceHistory by viewModel.history.collectAsStateWithLifecycle()
+    val bankName = viewModel.bankName
+    val accountLast4 = viewModel.accountLast4
+
     // Get the primary currency for this account
     val accountPrimaryCurrency = remember(bankName) {
         CurrencyFormatter.getBankBaseCurrency(bankName)
@@ -48,39 +54,39 @@ fun BalanceHistoryDialog(
     var showDeleteConfirmation by remember { mutableStateOf<Long?>(null) }
     var expandedSources by remember { mutableStateOf<Set<Long>>(emptySet()) }
     val clipboard = LocalClipboardManager.current
+
+    val scrollBehaviorSmall = TopAppBarDefaults.pinnedScrollBehavior()
+    val scrollBehaviorLarge = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     
-    Dialog(onDismissRequest = onDismiss) {
-        PennyWiseCardV2(
-            modifier = Modifier
-                .fillMaxWidth(0.95f)
-                .fillMaxHeight(0.8f),
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surface
-            ),
-            contentPadding = Dimensions.Padding.content
-        ) {
-                // Header
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Column {
-                        Text(
-                            text = "Balance History",
-                            style = MaterialTheme.typography.titleLarge,
-                            fontWeight = FontWeight.Bold
-                        )
-                        Text(
-                            text = "$bankName ••$accountLast4",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    IconButton(onClick = onDismiss) {
-                        Icon(Icons.Default.Close, contentDescription = "Close")
+    Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehaviorLarge.nestedScrollConnection),
+        containerColor = Color.Transparent,
+        topBar = {
+            CustomTitleTopAppBar(
+                scrollBehaviorSmall = scrollBehaviorSmall,
+                scrollBehaviorLarge = scrollBehaviorLarge,
+                title = "Balance History",
+                hasBackButton = true,
+                hasActionButton = false,
+                navigationContent = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = Dimensions.Padding.content)
+        ) {
+                Text(
+                    text = "$bankName ••$accountLast4",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
                 
                 Spacer(modifier = Modifier.height(Spacing.md))
                 
@@ -124,7 +130,7 @@ fun BalanceHistoryDialog(
                                 },
                                 onSaveEdit = {
                                     editingValue.toBigDecimalOrNull()?.let { newBalance ->
-                                        onUpdateBalance(balance.id, newBalance)
+                                        viewModel.updateBalance(balance.id, newBalance)
                                         editingId = null
                                         editingValue = ""
                                     }
@@ -165,7 +171,7 @@ fun BalanceHistoryDialog(
             confirmButton = {
                 TextButton(
                     onClick = {
-                        onDeleteBalance(balanceId)
+                        viewModel.deleteBalance(balanceId)
                         showDeleteConfirmation = null
                     }
                 ) {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/BalanceHistoryScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/BalanceHistoryScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.pennywiseai.tracker.ui.components.CustomTitleTopAppBar
 import androidx.compose.foundation.text.KeyboardOptions

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/BalanceHistoryViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/BalanceHistoryViewModel.kt
@@ -1,0 +1,60 @@
+package com.pennywiseai.tracker.presentation.accounts
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
+import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.math.BigDecimal
+import javax.inject.Inject
+
+/**
+ * Backs the full-page [BalanceHistoryScreen]. Reads the account (bankName +
+ * accountLast4) from the navigation route and exposes its balance snapshots,
+ * mirroring the load/update/delete logic that used to live in
+ * [ManageAccountsViewModel] when balance history was a dialog.
+ */
+@HiltViewModel
+class BalanceHistoryViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val accountBalanceRepository: AccountBalanceRepository
+) : ViewModel() {
+
+    val bankName: String = savedStateHandle.get<String>("bankName") ?: ""
+    val accountLast4: String = savedStateHandle.get<String>("accountLast4") ?: ""
+
+    private val _history = MutableStateFlow<List<AccountBalanceEntity>>(emptyList())
+    val history: StateFlow<List<AccountBalanceEntity>> = _history.asStateFlow()
+
+    init {
+        reload()
+    }
+
+    private fun reload() {
+        viewModelScope.launch {
+            _history.value = accountBalanceRepository.getBalanceHistoryForAccount(bankName, accountLast4)
+        }
+    }
+
+    fun updateBalance(id: Long, newBalance: BigDecimal) {
+        viewModelScope.launch {
+            accountBalanceRepository.updateBalanceById(id, newBalance)
+            reload()
+        }
+    }
+
+    fun deleteBalance(id: Long) {
+        viewModelScope.launch {
+            // Never delete the only record — the account's latest balance must survive.
+            if (accountBalanceRepository.getBalanceCountForAccount(bankName, accountLast4) > 1) {
+                accountBalanceRepository.deleteBalanceById(id)
+                reload()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
@@ -43,14 +43,13 @@ import com.pennywiseai.tracker.data.database.entity.ProfileEntity
 fun ManageAccountsScreen(
     onNavigateBack: () -> Unit,
     onNavigateToAddAccount: () -> Unit,
+    onNavigateToBalanceHistory: (bankName: String, accountLast4: String) -> Unit,
     viewModel: ManageAccountsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
     var showUpdateDialog by remember { mutableStateOf(false) }
     var selectedAccount by remember { mutableStateOf<Pair<String, String>?>(null) }
     var selectedAccountEntity by remember { mutableStateOf<com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity?>(null) }
-    var showHistoryDialog by remember { mutableStateOf(false) }
-    var historyAccount by remember { mutableStateOf<Pair<String, String>?>(null) }
     var showDeleteConfirmDialog by remember { mutableStateOf(false) }
     var accountToDelete by remember { mutableStateOf<Pair<String, String>?>(null) }
     var showHiddenAccounts by remember { mutableStateOf(false) }
@@ -233,9 +232,7 @@ fun ManageAccountsScreen(
                                 showUpdateDialog = true
                             },
                             onViewHistory = {
-                                historyAccount = account.bankName to account.accountLast4
-                                viewModel.loadBalanceHistory(account.bankName, account.accountLast4)
-                                showHistoryDialog = true
+                                onNavigateToBalanceHistory(account.bankName, account.accountLast4)
                             },
                             onUnlinkCard = { cardId ->
                                 viewModel.unlinkCard(cardId)
@@ -302,9 +299,7 @@ fun ManageAccountsScreen(
                                 showUpdateDialog = true
                             },
                             onViewHistory = {
-                                historyAccount = card.bankName to card.accountLast4
-                                viewModel.loadBalanceHistory(card.bankName, card.accountLast4)
-                                showHistoryDialog = true
+                                onNavigateToBalanceHistory(card.bankName, card.accountLast4)
                             },
                             onDeleteAccount = {
                                 accountToDelete = card.bankName to card.accountLast4
@@ -382,9 +377,7 @@ fun ManageAccountsScreen(
                                     showUpdateDialog = true
                                 },
                                 onViewHistory = {
-                                    historyAccount = account.bankName to account.accountLast4
-                                    viewModel.loadBalanceHistory(account.bankName, account.accountLast4)
-                                    showHistoryDialog = true
+                                    onNavigateToBalanceHistory(account.bankName, account.accountLast4)
                                 },
                                 onUnlinkCard = { cardId ->
                                     viewModel.unlinkCard(cardId)
@@ -420,9 +413,7 @@ fun ManageAccountsScreen(
                                     showUpdateDialog = true
                                 },
                                 onViewHistory = {
-                                    historyAccount = card.bankName to card.accountLast4
-                                    viewModel.loadBalanceHistory(card.bankName, card.accountLast4)
-                                    showHistoryDialog = true
+                                    onNavigateToBalanceHistory(card.bankName, card.accountLast4)
                                 },
                                 onDeleteAccount = {
                                     accountToDelete = card.bankName to card.accountLast4
@@ -493,26 +484,6 @@ fun ManageAccountsScreen(
         }
     }
     
-    // Balance History Dialog
-    if (showHistoryDialog && historyAccount != null) {
-        BalanceHistoryDialog(
-            bankName = historyAccount!!.first,
-            accountLast4 = historyAccount!!.second,
-            balanceHistory = uiState.balanceHistory,
-            onDismiss = {
-                showHistoryDialog = false
-                historyAccount = null
-                viewModel.clearBalanceHistory()
-            },
-            onDeleteBalance = { id ->
-                viewModel.deleteBalanceRecord(id, historyAccount!!.first, historyAccount!!.second)
-            },
-            onUpdateBalance = { id, newBalance ->
-                viewModel.updateBalanceRecord(id, newBalance, historyAccount!!.first, historyAccount!!.second)
-            }
-        )
-    }
-
     // Delete Account Confirmation Dialog
     if (showDeleteConfirmDialog && accountToDelete != null) {
         DeleteAccountConfirmDialog(

--- a/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
@@ -511,6 +511,28 @@ fun MainScreen(
                                 navController.navigate("add_account") {
                                     launchSingleTop = true
                                 }
+                            },
+                            onNavigateToBalanceHistory = { bankName, accountLast4 ->
+                                navController.navigate(
+                                    "balance_history/${android.net.Uri.encode(bankName)}/${android.net.Uri.encode(accountLast4)}"
+                                ) {
+                                    launchSingleTop = true
+                                }
+                            }
+                        )
+                    }
+                )
+
+                composable(
+                    route = "balance_history/{bankName}/{accountLast4}",
+                    arguments = listOf(
+                        androidx.navigation.navArgument("bankName") { type = androidx.navigation.NavType.StringType },
+                        androidx.navigation.navArgument("accountLast4") { type = androidx.navigation.NavType.StringType }
+                    ),
+                    content = { _: NavBackStackEntry ->
+                        com.pennywiseai.tracker.presentation.accounts.BalanceHistoryScreen(
+                            onNavigateBack = {
+                                navController.safePopBackStack()
                             }
                         )
                     }


### PR DESCRIPTION
Balance History opened as a (full-screen) **`Dialog`** — a modal: scrim behind, floats over the dimmed Accounts screen, no back-stack entry. This converts it into a genuine **navigation page**.

## Change
- **`BalanceHistoryScreen`** (renamed from `BalanceHistoryDialog`) now renders with `Scaffold` + `CustomTitleTopAppBar` + a back arrow → `navController.safePopBackStack()` — the same pattern as `AddAccountScreen`/`FAQScreen` and every other settings sub-screen.
- **`BalanceHistoryViewModel`** (new) reads `bankName`/`accountLast4` from the route via `SavedStateHandle` and owns load/update/delete (moved off `ManageAccountsViewModel`), mirroring `AccountDetailViewModel`.
- Route `balance_history/{bankName}/{accountLast4}` registered in `MainScreen`; nav args URL-encoded (bank names have spaces).
- `ManageAccountsScreen` navigates via `onNavigateToBalanceHistory` instead of toggling a dialog; the dialog block + its state are removed.

By construction it is now a back-stack destination, not a modal.

## Verification
- `:app:compileStandardDebugKotlin` clean.
- App runs; SMS scan + account creation confirmed on the emulator.
- ⚠️ I did **not** capture a final screenshot of the page end-to-end — see note.

## Note for reviewer
This branch is off `main` (schema v50). PR #454 bumps schema to **v51**, so an emulator that already ran a #454 build has a v51 DB and this v50 build hits a Room downgrade crash (test-env artifact, not a code bug). When both land, this should be rebased onto a `main` that includes #454. No schema change here.