### PR TITLE
fix(ui): stop top-bar action icons overlapping in expanded state

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/CustomTitleTopAppBar.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/CustomTitleTopAppBar.kt
@@ -204,7 +204,12 @@ private fun LargerTopAppBar(
                 enter = fadeIn() + scaleIn(),
                 exit = fadeOut() + scaleOut()
             ) {
-                actionContent()
+                // Lay multiple actions (e.g. Edit + overflow) out horizontally. The
+                // visibility wrapper renders into a Box, not a RowScope, so without
+                // this Row the icons stack on top of each other in the expanded bar.
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    actionContent()
+                }
             }
         },
         collapsedHeight = TopAppBarDefaults.LargeAppBarCollapsedHeight,


### PR DESCRIPTION
## Problem
On screens with more than one top-bar action (e.g. Transaction Details: **Edit** pencil + **⋮** overflow), the icons **overlapped** in the expanded large app bar and only separated after scrolling collapsed the bar. The overflow drew on top of Edit, making Edit effectively unreachable.

## Cause
`LargerTopAppBar` routed `actionContent()` through a single `BlurredAnimatedVisibility`, whose content lambda is a `Box`, not Material's `actions` `RowScope`. So multiple action buttons stacked instead of sitting side by side. The collapsed `RegularTopAppBar` calls `actionContent()` directly in the `RowScope`, which is why it looked fine once scrolled.

## Fix
Wrap `actionContent()` in a `Row` inside the visibility wrapper. Single-action screens are unaffected.

## Verification (emulator)
Transaction Details expanded bar now shows Edit `[1016,216][1088,288]` and More actions `[1160,216][1232,288]` cleanly side by side; both tap independently.