### PR TITLE
feat(budgets): type-aware budgets — track a transaction type, not just a category

### DIFF
--- a/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/52.json
+++ b/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/52.json
@@ -1,0 +1,1759 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 52,
+    "identityHash": "e0450e161c8ec2f78f3e0c4ae4c63fd7",
+    "entities": [
+      {
+        "tableName": "transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` TEXT NOT NULL, `merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `transaction_type` TEXT NOT NULL, `date_time` TEXT NOT NULL, `description` TEXT, `sms_body` TEXT, `bank_name` TEXT, `sms_sender` TEXT, `account_number` TEXT, `balance_after` TEXT, `transaction_hash` TEXT NOT NULL DEFAULT '', `is_recurring` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `excluded_from_analytics` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `from_account` TEXT, `to_account` TEXT, `reference` TEXT, `loan_id` INTEGER DEFAULT NULL, `loan_contribution` TEXT DEFAULT NULL, `receipt_path` TEXT DEFAULT NULL, `budget_category` TEXT DEFAULT NULL, `budget_impact_type` TEXT DEFAULT NULL, `group_id` INTEGER DEFAULT NULL, `profile_id` INTEGER DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionType",
+            "columnName": "transaction_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateTime",
+            "columnName": "date_time",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsSender",
+            "columnName": "sms_sender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountNumber",
+            "columnName": "account_number",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "balanceAfter",
+            "columnName": "balance_after",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "transactionHash",
+            "columnName": "transaction_hash",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isRecurring",
+            "columnName": "is_recurring",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "excludedFromAnalytics",
+            "columnName": "excluded_from_analytics",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "fromAccount",
+            "columnName": "from_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toAccount",
+            "columnName": "to_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "loanId",
+            "columnName": "loan_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "loanContribution",
+            "columnName": "loan_contribution",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "receiptPath",
+            "columnName": "receipt_path",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetCategory",
+            "columnName": "budget_category",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetImpactType",
+            "columnName": "budget_impact_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "group_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transactions_transaction_hash",
+            "unique": true,
+            "columnNames": [
+              "transaction_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_transactions_transaction_hash` ON `${TABLE_NAME}` (`transaction_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `merchant_name` TEXT NOT NULL, `amount` TEXT NOT NULL, `next_payment_date` TEXT, `state` TEXT NOT NULL, `bank_name` TEXT, `umn` TEXT, `category` TEXT, `sms_body` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `direction` TEXT NOT NULL DEFAULT 'EXPENSE', `billing_cycle` TEXT NOT NULL DEFAULT 'Monthly', `last_paid_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextPaymentDate",
+            "columnName": "next_payment_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umn",
+            "columnName": "umn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'EXPENSE'"
+          },
+          {
+            "fieldPath": "billingCycle",
+            "columnName": "billing_cycle",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Monthly'"
+          },
+          {
+            "fieldPath": "lastPaidAt",
+            "columnName": "last_paid_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `message` TEXT NOT NULL, `isUser` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `isSystemPrompt` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUser",
+            "columnName": "isUser",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemPrompt",
+            "columnName": "isSystemPrompt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "merchant_mappings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`merchant_name`))",
+        "fields": [
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "merchant_name"
+          ]
+        }
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `color` TEXT NOT NULL, `is_system` INTEGER NOT NULL, `is_income` INTEGER NOT NULL, `display_order` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIncome",
+            "columnName": "is_income",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_categories_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_categories_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "account_balances",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT NOT NULL, `balance` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `transaction_id` INTEGER, `credit_limit` TEXT, `is_credit_card` INTEGER NOT NULL DEFAULT 0, `sms_source` TEXT, `source_type` TEXT, `account_type` TEXT, `created_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `statement_day` INTEGER DEFAULT NULL, `profile_id` INTEGER NOT NULL DEFAULT 1, `alias` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "creditLimit",
+            "columnName": "credit_limit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isCreditCard",
+            "columnName": "is_credit_card",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "smsSource",
+            "columnName": "sms_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "source_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountType",
+            "columnName": "account_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "statementDay",
+            "columnName": "statement_day",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_account_balances_bank_name_account_last4_timestamp",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "account_last4",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4_timestamp` ON `${TABLE_NAME}` (`bank_name`, `account_last4`, `timestamp`)"
+          },
+          {
+            "name": "index_account_balances_bank_name_account_last4",
+            "unique": false,
+            "columnNames": [
+              "bank_name",
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4` ON `${TABLE_NAME}` (`bank_name`, `account_last4`)"
+          },
+          {
+            "name": "index_account_balances_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "unrecognized_sms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sender` TEXT NOT NULL, `sms_body` TEXT NOT NULL, `received_at` TEXT NOT NULL, `reported` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receivedAt",
+            "columnName": "received_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reported",
+            "columnName": "reported",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_unrecognized_sms_sender_sms_body",
+            "unique": true,
+            "columnNames": [
+              "sender",
+              "sms_body"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_unrecognized_sms_sender_sms_body` ON `${TABLE_NAME}` (`sender`, `sms_body`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `card_last4` TEXT NOT NULL, `card_type` TEXT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT, `nickname` TEXT, `is_active` INTEGER NOT NULL DEFAULT 1, `last_balance` TEXT, `last_balance_source` TEXT, `last_balance_date` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardLast4",
+            "columnName": "card_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardType",
+            "columnName": "card_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastBalance",
+            "columnName": "last_balance",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceSource",
+            "columnName": "last_balance_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceDate",
+            "columnName": "last_balance_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cards_bank_name_card_last4",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cards_bank_name_card_last4` ON `${TABLE_NAME}` (`bank_name`, `card_last4`)"
+          },
+          {
+            "name": "index_cards_card_last4",
+            "unique": false,
+            "columnNames": [
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_card_last4` ON `${TABLE_NAME}` (`card_last4`)"
+          },
+          {
+            "name": "index_cards_account_last4",
+            "unique": false,
+            "columnNames": [
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_account_last4` ON `${TABLE_NAME}` (`account_last4`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `conditions` TEXT NOT NULL, `actions` TEXT NOT NULL, `is_active` INTEGER NOT NULL, `is_system_template` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conditions",
+            "columnName": "conditions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actions",
+            "columnName": "actions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemTemplate",
+            "columnName": "is_system_template",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_rules_priority_is_active",
+            "unique": false,
+            "columnNames": [
+              "priority",
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_priority_is_active` ON `${TABLE_NAME}` (`priority`, `is_active`)"
+          },
+          {
+            "name": "index_transaction_rules_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "rule_applications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `rule_id` TEXT NOT NULL, `rule_name` TEXT NOT NULL, `transaction_id` TEXT NOT NULL, `fields_modified` TEXT NOT NULL, `applied_at` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`rule_id`) REFERENCES `transaction_rules`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "rule_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleName",
+            "columnName": "rule_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fieldsModified",
+            "columnName": "fields_modified",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedAt",
+            "columnName": "applied_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rule_applications_rule_id",
+            "unique": false,
+            "columnNames": [
+              "rule_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_rule_id` ON `${TABLE_NAME}` (`rule_id`)"
+          },
+          {
+            "name": "index_rule_applications_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          },
+          {
+            "name": "index_rule_applications_applied_at",
+            "unique": false,
+            "columnNames": [
+              "applied_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_applied_at` ON `${TABLE_NAME}` (`applied_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transaction_rules",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "rule_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "exchange_rates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `from_currency` TEXT NOT NULL, `to_currency` TEXT NOT NULL, `rate` TEXT NOT NULL, `provider` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `updated_at_unix` INTEGER NOT NULL DEFAULT 0, `expires_at` TEXT NOT NULL, `expires_at_unix` INTEGER NOT NULL DEFAULT 0, `is_custom_rate` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCurrency",
+            "columnName": "from_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCurrency",
+            "columnName": "to_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtUnix",
+            "columnName": "updated_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expires_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAtUnix",
+            "columnName": "expires_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isCustomRate",
+            "columnName": "is_custom_rate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_exchange_rates_from_currency_to_currency",
+            "unique": true,
+            "columnNames": [
+              "from_currency",
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_exchange_rates_from_currency_to_currency` ON `${TABLE_NAME}` (`from_currency`, `to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_from_currency",
+            "unique": false,
+            "columnNames": [
+              "from_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_from_currency` ON `${TABLE_NAME}` (`from_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_to_currency",
+            "unique": false,
+            "columnNames": [
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_to_currency` ON `${TABLE_NAME}` (`to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          },
+          {
+            "name": "index_exchange_rates_expires_at_unix",
+            "unique": false,
+            "columnNames": [
+              "expires_at_unix"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_expires_at_unix` ON `${TABLE_NAME}` (`expires_at_unix`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `period_type` TEXT NOT NULL, `start_date` TEXT NOT NULL, `end_date` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `is_active` INTEGER NOT NULL DEFAULT 1, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "periodType",
+            "columnName": "period_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budgets_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_budgets_is_active",
+            "unique": false,
+            "columnNames": [
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_is_active` ON `${TABLE_NAME}` (`is_active`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budget_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL DEFAULT '0', `match_type` TEXT DEFAULT NULL, FOREIGN KEY(`budget_id`) REFERENCES `budgets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          },
+          {
+            "fieldPath": "matchType",
+            "columnName": "match_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budget_categories_budget_id",
+            "unique": false,
+            "columnNames": [
+              "budget_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budget_categories_budget_id` ON `${TABLE_NAME}` (`budget_id`)"
+          },
+          {
+            "name": "index_budget_categories_budget_id_category_name",
+            "unique": true,
+            "columnNames": [
+              "budget_id",
+              "category_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_budget_categories_budget_id_category_name` ON `${TABLE_NAME}` (`budget_id`, `category_name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "budgets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "budget_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "budget_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `budget_name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetName",
+            "columnName": "budget_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "budget_category_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL, `match_type` TEXT DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchType",
+            "columnName": "match_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "transaction_splits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `transaction_id` INTEGER NOT NULL, `category` TEXT NOT NULL, `amount` TEXT NOT NULL, `created_at` TEXT NOT NULL, FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_splits_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_splits_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bank_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `package_name` TEXT NOT NULL, `sender_alias` TEXT NOT NULL, `message_body` TEXT NOT NULL, `message_hash` TEXT NOT NULL, `posted_at` TEXT NOT NULL, `processed` INTEGER NOT NULL, `transaction_id` INTEGER, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderAlias",
+            "columnName": "sender_alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageBody",
+            "columnName": "message_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageHash",
+            "columnName": "message_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postedAt",
+            "columnName": "posted_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "processed",
+            "columnName": "processed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bank_notifications_package_name_message_hash",
+            "unique": true,
+            "columnNames": [
+              "package_name",
+              "message_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_bank_notifications_package_name_message_hash` ON `${TABLE_NAME}` (`package_name`, `message_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "loans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `person_name` TEXT NOT NULL, `direction` TEXT NOT NULL, `original_amount` TEXT NOT NULL, `remaining_amount` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `status` TEXT NOT NULL DEFAULT 'ACTIVE', `note` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `settled_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personName",
+            "columnName": "person_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalAmount",
+            "columnName": "original_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remainingAmount",
+            "columnName": "remaining_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'ACTIVE'"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settledAt",
+            "columnName": "settled_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_loans_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_loans_person_name",
+            "unique": false,
+            "columnNames": [
+              "person_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_person_name` ON `${TABLE_NAME}` (`person_name`)"
+          },
+          {
+            "name": "index_loans_created_at",
+            "unique": false,
+            "columnNames": [
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_created_at` ON `${TABLE_NAME}` (`created_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `note` TEXT DEFAULT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_groups_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_groups_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `color_hex` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorHex",
+            "columnName": "color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e0450e161c8ec2f78f3e0c4ae4c63fd7')"
+    ]
+  }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
@@ -57,7 +57,7 @@ import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
  * that needs to record the version it was exported against. Bump this in lock-
  * step with any schema change.
  */
-const val SCHEMA_VERSION = 51
+const val SCHEMA_VERSION = 52
 
 /**
  * The PennyWise Room database.
@@ -498,6 +498,20 @@ abstract class PennyWiseDatabase : RoomDatabase() {
             }
         }
 
+        val MIGRATION_51_52 = object : Migration(51, 52) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // Type-aware budgets: a budget bucket can now track a transaction
+                // TYPE (match_type set) instead of a category name.
+                db.execSQL("ALTER TABLE `budget_categories` ADD COLUMN `match_type` TEXT DEFAULT NULL")
+                db.execSQL("ALTER TABLE `budget_category_month_snapshots` ADD COLUMN `match_type` TEXT DEFAULT NULL")
+                // Auto-upgrade existing "Investments" category buckets to track the
+                // INVESTMENT type directly, so investments count regardless of how
+                // each transaction was categorised (and stop leaking into Spending).
+                db.execSQL("UPDATE `budget_categories` SET `match_type` = 'INVESTMENT' WHERE `category_name` = 'Investments'")
+                db.execSQL("UPDATE `budget_category_month_snapshots` SET `match_type` = 'INVESTMENT' WHERE `category_name` = 'Investments'")
+            }
+        }
+
         val MIGRATION_38_39 = object : Migration(38, 39) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 // Add receipt_path to transactions if missing
@@ -549,6 +563,7 @@ abstract class PennyWiseDatabase : RoomDatabase() {
             MIGRATION_48_49,
             MIGRATION_49_50,
             MIGRATION_50_51,
+            MIGRATION_51_52,
         )
     }
     

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/BudgetCategoryEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/BudgetCategoryEntity.kt
@@ -38,5 +38,15 @@ data class BudgetCategoryEntity(
 
     @ColumnInfo(name = "budget_amount", defaultValue = "0")
     @Contextual
-    val budgetAmount: BigDecimal = BigDecimal.ZERO
+    val budgetAmount: BigDecimal = BigDecimal.ZERO,
+
+    /**
+     * When null, this bucket tracks transactions whose `category` equals
+     * [categoryName] (the original, category-driven behaviour). When set to a
+     * [TransactionType] name (e.g. "INVESTMENT"), it instead tracks every
+     * transaction of that type regardless of category, and [categoryName] is
+     * just the display label. This is what makes a budget "type-aware".
+     */
+    @ColumnInfo(name = "match_type", defaultValue = "NULL")
+    val matchType: String? = null
 )

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/BudgetCategoryMonthSnapshotEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/BudgetCategoryMonthSnapshotEntity.kt
@@ -28,5 +28,9 @@ data class BudgetCategoryMonthSnapshotEntity(
 
     @ColumnInfo(name = "budget_amount")
     @Contextual
-    val budgetAmount: BigDecimal
+    val budgetAmount: BigDecimal,
+
+    /** Mirror of [BudgetCategoryEntity.matchType] captured at snapshot time. */
+    @ColumnInfo(name = "match_type", defaultValue = "NULL")
+    val matchType: String? = null
 )

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupModels.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupModels.kt
@@ -5,6 +5,18 @@ import com.pennywiseai.tracker.data.database.entity.BudgetWithCategories
 import com.pennywiseai.tracker.data.database.entity.TransactionWithSplits
 import java.math.BigDecimal
 
+/**
+ * One bucket a budget group tracks when creating/updating it. A category bucket
+ * has `matchType == null` and is matched by [name] against transaction category;
+ * a type bucket sets [matchType] to a `TransactionType.name` (e.g. "INVESTMENT")
+ * and is matched by transaction type, with [name] used only as the display label.
+ */
+data class BudgetBucketInput(
+    val name: String,
+    val amount: BigDecimal,
+    val matchType: String? = null
+)
+
 data class BudgetCategorySpending(
     val categoryName: String,
     val budgetAmount: BigDecimal,

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
@@ -50,12 +50,12 @@ class BudgetGroupRepository @Inject constructor(
         groupType: BudgetGroupType,
         color: String,
         currency: String,
-        categories: List<Pair<String, BigDecimal>> = emptyList(),
+        buckets: List<BudgetBucketInput> = emptyList(),
         displayOrder: Int = -1,
         limitAmount: BigDecimal? = null
     ): Long {
         val resolvedDisplayOrder = if (displayOrder < 0) budgetDao.getMaxDisplayOrder() + 1 else displayOrder
-        val totalAmount = limitAmount ?: categories.fold(BigDecimal.ZERO) { acc, (_, amount) -> acc + amount }
+        val totalAmount = limitAmount ?: buckets.fold(BigDecimal.ZERO) { acc, b -> acc + b.amount }
         val now = LocalDate.now()
         val yearMonth = YearMonth.from(now)
 
@@ -67,7 +67,7 @@ class BudgetGroupRepository @Inject constructor(
             endDate = yearMonth.atEndOfMonth(),
             currency = currency,
             isActive = true,
-            includeAllCategories = categories.isEmpty(),
+            includeAllCategories = buckets.isEmpty(),
             color = color,
             groupType = groupType,
             displayOrder = resolvedDisplayOrder,
@@ -77,12 +77,13 @@ class BudgetGroupRepository @Inject constructor(
 
         val budgetId = budgetDao.insertBudget(budget)
 
-        if (categories.isNotEmpty()) {
-            val categoryEntities = categories.map { (categoryName, amount) ->
+        if (buckets.isNotEmpty()) {
+            val categoryEntities = buckets.map { b ->
                 BudgetCategoryEntity(
                     budgetId = budgetId,
-                    categoryName = categoryName,
-                    budgetAmount = amount
+                    categoryName = b.name,
+                    budgetAmount = b.amount,
+                    matchType = b.matchType
                 )
             }
             budgetDao.insertBudgetCategories(categoryEntities)
@@ -97,12 +98,12 @@ class BudgetGroupRepository @Inject constructor(
         name: String,
         groupType: BudgetGroupType,
         color: String,
-        categories: List<Pair<String, BigDecimal>>,
+        buckets: List<BudgetBucketInput>,
         currency: String? = null,
         limitAmount: BigDecimal? = null
     ) {
         val existing = budgetDao.getBudgetById(budgetId) ?: return
-        val totalAmount = limitAmount ?: categories.fold(BigDecimal.ZERO) { acc, (_, amount) -> acc + amount }
+        val totalAmount = limitAmount ?: buckets.fold(BigDecimal.ZERO) { acc, b -> acc + b.amount }
 
         budgetDao.updateBudget(
             existing.copy(
@@ -111,18 +112,19 @@ class BudgetGroupRepository @Inject constructor(
                 color = color,
                 currency = currency ?: existing.currency,
                 limitAmount = totalAmount,
-                includeAllCategories = categories.isEmpty(),
+                includeAllCategories = buckets.isEmpty(),
                 updatedAt = LocalDateTime.now()
             )
         )
 
         budgetDao.deleteCategoriesForBudget(budgetId)
-        if (categories.isNotEmpty()) {
-            val categoryEntities = categories.map { (categoryName, amount) ->
+        if (buckets.isNotEmpty()) {
+            val categoryEntities = buckets.map { b ->
                 BudgetCategoryEntity(
                     budgetId = budgetId,
-                    categoryName = categoryName,
-                    budgetAmount = amount
+                    categoryName = b.name,
+                    budgetAmount = b.amount,
+                    matchType = b.matchType
                 )
             }
             budgetDao.insertBudgetCategories(categoryEntities)
@@ -190,7 +192,8 @@ class BudgetGroupRepository @Inject constructor(
                     year = year,
                     month = month,
                     categoryName = cat.categoryName,
-                    budgetAmount = cat.budgetAmount
+                    budgetAmount = cat.budgetAmount,
+                    matchType = cat.matchType
                 )
             }
         }.flatten()
@@ -215,7 +218,8 @@ class BudgetGroupRepository @Inject constructor(
                     BudgetCategoryEntity(
                         budgetId = gs.budgetId,
                         categoryName = cs.categoryName,
-                        budgetAmount = cs.budgetAmount
+                        budgetAmount = cs.budgetAmount,
+                        matchType = cs.matchType
                     )
                 }
             BudgetWithCategories(
@@ -347,7 +351,7 @@ class BudgetGroupRepository @Inject constructor(
         // Single-currency: amounts are already in the requested currency, so the
         // converter lambdas are identities. The unified-currency caller in
         // BudgetGroupsViewModel injects real conversion via the same helper.
-        val (categoryAmounts, categoryLimitBoosts) = aggregateBudgetCategorySpending(
+        val (categoryAmounts, categoryLimitBoosts, typeAmounts) = aggregateBudgetCategorySpending(
             transactions = allTransactions,
             convertSplit = { _, amount -> amount },
             convertIncome = { tx -> tx.amount }
@@ -359,6 +363,7 @@ class BudgetGroupRepository @Inject constructor(
         // Helper: build per-group daily cumulative spending from transactions matching category names
         fun buildGroupPace(
             categoryNames: Set<String>?,  // null = all categories
+            matchTypes: Set<String>,      // transaction-type buckets in this group
             groupBudget: BigDecimal
         ): Pair<List<Double>, List<Double>> {
             val effectiveDays = daysElapsed.coerceAtMost(daysInMonth)
@@ -367,12 +372,17 @@ class BudgetGroupRepository @Inject constructor(
             val dailyAmounts = DoubleArray(daysInMonth)
             allTransactions.forEach { txWithSplits ->
                 val tx = txWithSplits.transaction
-                if (tx.transactionType != TransactionType.INCOME &&
-                    tx.transactionType != TransactionType.TRANSFER &&
-                    tx.transactionType != TransactionType.INVESTMENT &&
-                    tx.loanId == null
-                ) {
-                    val day = tx.dateTime.dayOfMonth.coerceIn(1, daysInMonth)
+                if (tx.transactionType == TransactionType.INCOME ||
+                    tx.transactionType == TransactionType.TRANSFER ||
+                    tx.loanId != null
+                ) return@forEach
+                val day = tx.dateTime.dayOfMonth.coerceIn(1, daysInMonth)
+                if (tx.transactionType.name in matchTypes) {
+                    // Claimed by a type bucket in this group (e.g. INVESTMENT).
+                    dailyAmounts[day - 1] += tx.amount.toDouble()
+                } else if (tx.transactionType !in BUDGET_TYPE_BUCKETS) {
+                    // Category routing for expenses/credit. Type-bucket-eligible
+                    // transactions (investments) never fall through to categories.
                     if (categoryNames == null) {
                         dailyAmounts[day - 1] += tx.amount.toDouble()
                     } else {
@@ -427,7 +437,7 @@ class BudgetGroupRepository @Inject constructor(
                 val dailyAllowance = if (daysRemaining > 0 && remaining > BigDecimal.ZERO) {
                     remaining.divide(BigDecimal(daysRemaining), 0, RoundingMode.HALF_UP)
                 } else BigDecimal.ZERO
-                val (cumSpending, budgetPace) = buildGroupPace(null, totalBudget)
+                val (cumSpending, budgetPace) = buildGroupPace(null, emptySet(), totalBudget)
 
                 BudgetGroupSpending(
                     group = group,
@@ -446,8 +456,16 @@ class BudgetGroupRepository @Inject constructor(
             } else {
                 // Normal case: track specific categories
                 val catSpending = group.categories.map { cat ->
-                    val actual = categoryAmounts[cat.categoryName] ?: BigDecimal.ZERO
-                    val effectiveBudget = cat.budgetAmount + (categoryLimitBoosts[cat.categoryName] ?: BigDecimal.ZERO)
+                    // Type buckets read per-type spend; category buckets read
+                    // per-category spend (with any Extra-budget income boost).
+                    val actual = if (cat.matchType != null) {
+                        typeAmounts[cat.matchType] ?: BigDecimal.ZERO
+                    } else {
+                        categoryAmounts[cat.categoryName] ?: BigDecimal.ZERO
+                    }
+                    val boost = if (cat.matchType != null) BigDecimal.ZERO
+                        else categoryLimitBoosts[cat.categoryName] ?: BigDecimal.ZERO
+                    val effectiveBudget = cat.budgetAmount + boost
                     val pctUsed = if (effectiveBudget > BigDecimal.ZERO) {
                         percentOf(actual, effectiveBudget)
                     } else 0f
@@ -478,8 +496,10 @@ class BudgetGroupRepository @Inject constructor(
                 val dailyAllowance = if (daysRemaining > 0 && remaining > BigDecimal.ZERO) {
                     remaining.divide(BigDecimal(daysRemaining), 0, RoundingMode.HALF_UP)
                 } else BigDecimal.ZERO
-                val catNames = group.categories.map { it.categoryName }.toSet()
-                val (cumSpending, budgetPace) = buildGroupPace(catNames, totalBudget)
+                val catNames = group.categories.filter { it.matchType == null }
+                    .map { it.categoryName }.toSet()
+                val matchTypes = group.categories.mapNotNull { it.matchType }.toSet()
+                val (cumSpending, budgetPace) = buildGroupPace(catNames, matchTypes, totalBudget)
 
                 BudgetGroupSpending(
                     group = group,
@@ -553,15 +573,15 @@ class BudgetGroupRepository @Inject constructor(
             groupType = BudgetGroupType.LIMIT,
             color = "#1565C0",
             currency = baseCurrency,
-            categories = listOf(
-                "Food & Dining" to amount(5000),
-                "Groceries" to amount(8000),
-                "Shopping" to amount(3000),
-                "Entertainment" to amount(2000),
-                "Personal Care" to amount(1000),
-                "Transportation" to amount(3000),
-                "Travel" to amount(5000),
-                "Others" to amount(3000)
+            buckets = listOf(
+                BudgetBucketInput("Food & Dining", amount(5000)),
+                BudgetBucketInput("Groceries", amount(8000)),
+                BudgetBucketInput("Shopping", amount(3000)),
+                BudgetBucketInput("Entertainment", amount(2000)),
+                BudgetBucketInput("Personal Care", amount(1000)),
+                BudgetBucketInput("Transportation", amount(3000)),
+                BudgetBucketInput("Travel", amount(5000)),
+                BudgetBucketInput("Others", amount(3000))
             ),
             displayOrder = 0
         )
@@ -572,24 +592,29 @@ class BudgetGroupRepository @Inject constructor(
             groupType = BudgetGroupType.EXPECTED,
             color = "#4CAF50",
             currency = baseCurrency,
-            categories = listOf(
-                "Bills & Utilities" to amount(5000),
-                "Mobile" to amount(500),
-                "Insurance" to amount(2000),
-                "Education" to amount(3000)
+            buckets = listOf(
+                BudgetBucketInput("Bills & Utilities", amount(5000)),
+                BudgetBucketInput("Mobile", amount(500)),
+                BudgetBucketInput("Insurance", amount(2000)),
+                BudgetBucketInput("Education", amount(3000))
             ),
             displayOrder = 1
         )
 
-        // Group 3: Investments (TARGET) - savings goals
+        // Group 3: Investments (TARGET) — tracks the INVESTMENT transaction type
+        // directly, so every investment counts regardless of its category and
+        // nothing leaks into Spending.
         createGroup(
             name = "Investments",
             groupType = BudgetGroupType.TARGET,
             color = "#00D09C",
             currency = baseCurrency,
-            categories = listOf(
-                "Investments" to amount(10000),
-                "Banking" to amount(5000)
+            buckets = listOf(
+                BudgetBucketInput(
+                    name = "Investments",
+                    amount = amount(15000),
+                    matchType = TransactionType.INVESTMENT.name
+                )
             ),
             displayOrder = 2
         )
@@ -626,14 +651,25 @@ class BudgetGroupRepository @Inject constructor(
          */
         data class CategoryAggregation(
             val categoryAmounts: Map<String, BigDecimal>,
-            val categoryLimitBoosts: Map<String, BigDecimal>
+            val categoryLimitBoosts: Map<String, BigDecimal>,
+            // Spend per transaction TYPE (key = TransactionType.name, e.g.
+            // "INVESTMENT"), for budget buckets that track a type instead of a
+            // category. INVESTMENT outflows route here, never into categoryAmounts,
+            // so they only count toward a type bucket and never leak into a
+            // category/Spending budget. Third field → existing 2-arg destructuring
+            // still compiles.
+            val typeAmounts: Map<String, BigDecimal> = emptyMap()
         )
+
+        /** Transaction types that can back a budget "type bucket". */
+        val BUDGET_TYPE_BUCKETS = setOf(TransactionType.INVESTMENT)
 
         /**
          * Single source of truth for the per-category aggregation used on the
          * Budgets screen. Walks `transactions` and:
-         *  - sums non-INCOME / non-TRANSFER / non-INVESTMENT split amounts into
-         *    `categoryAmounts` (key=category name, "Others" when blank);
+         *  - sums non-INCOME / non-TRANSFER split amounts into `categoryAmounts`
+         *    (key=category name, "Others" when blank), EXCEPT type-bucket-eligible
+         *    types (INVESTMENT) which go to `typeAmounts` keyed by type name;
          *  - for INCOME txns with a `budgetCategory`, subtracts DEDUCT_SPENT
          *    (Refund) amounts from `categoryAmounts` (floored at zero) and
          *    accumulates ADD_TO_LIMIT (Extra budget) amounts into
@@ -650,13 +686,19 @@ class BudgetGroupRepository @Inject constructor(
             convertIncome: suspend (TransactionEntity) -> BigDecimal
         ): CategoryAggregation {
             val categoryAmounts = mutableMapOf<String, BigDecimal>()
+            val typeAmounts = mutableMapOf<String, BigDecimal>()
             for (txWithSplits in transactions) {
                 val type = txWithSplits.transaction.transactionType
-                if (type == TransactionType.INCOME ||
-                    type == TransactionType.TRANSFER ||
-                    type == TransactionType.INVESTMENT
-                ) continue
+                if (type == TransactionType.INCOME || type == TransactionType.TRANSFER) continue
                 val fromCurrency = txWithSplits.transaction.currency
+                if (type in BUDGET_TYPE_BUCKETS) {
+                    // Route the whole amount to its type bucket, ignoring category —
+                    // so it counts only toward a type-tracking budget and never
+                    // contributes to a category (Spending) budget.
+                    val converted = convertSplit(fromCurrency, txWithSplits.transaction.amount)
+                    typeAmounts[type.name] = (typeAmounts[type.name] ?: BigDecimal.ZERO) + converted
+                    continue
+                }
                 for ((category, amount) in txWithSplits.getAmountByCategory()) {
                     val categoryName = category.ifEmpty { "Others" }
                     val converted = convertSplit(fromCurrency, amount)
@@ -684,7 +726,7 @@ class BudgetGroupRepository @Inject constructor(
                 }
             }
 
-            return CategoryAggregation(categoryAmounts, categoryLimitBoosts)
+            return CategoryAggregation(categoryAmounts, categoryLimitBoosts, typeAmounts)
         }
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupEditScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupEditScreen.kt
@@ -276,7 +276,8 @@ fun BudgetGroupEditScreen(
                             FilledTonalButton(
                                 onClick = { showAddCategoryDropdown = true },
                                 modifier = Modifier.fillMaxWidth(),
-                                enabled = uiState.availableCategories.isNotEmpty(),
+                                enabled = uiState.availableCategories.isNotEmpty() ||
+                                    uiState.availableTypeBuckets.isNotEmpty(),
                                 shape = RoundedCornerShape(Dimensions.CornerRadius.medium)
                             ) {
                                 Icon(
@@ -315,6 +316,35 @@ fun BudgetGroupEditScreen(
                                         },
                                         onClick = {
                                             viewModel.addCategory(categoryName)
+                                            showAddCategoryDropdown = false
+                                        }
+                                    )
+                                }
+                                // Transaction-type buckets (e.g. Investments) —
+                                // track a whole transaction type, not a category.
+                                uiState.availableTypeBuckets.forEach { option ->
+                                    DropdownMenuItem(
+                                        text = {
+                                            Row(
+                                                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                                                verticalAlignment = Alignment.CenterVertically
+                                            ) {
+                                                val catInfo = CategoryMapping.categories[option.displayName]
+                                                    ?: CategoryMapping.categories["Others"]!!
+                                                Box(
+                                                    modifier = Modifier
+                                                        .size(32.dp)
+                                                        .clip(CircleShape)
+                                                        .background(catInfo.color.copy(alpha = 0.15f)),
+                                                    contentAlignment = Alignment.Center
+                                                ) {
+                                                    CategoryIcon(category = option.displayName, size = 18.dp)
+                                                }
+                                                Text("${option.displayName} (all)")
+                                            }
+                                        },
+                                        onClick = {
+                                            viewModel.addTypeBucket(option)
                                             showAddCategoryDropdown = false
                                         }
                                     )

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupEditViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupEditViewModel.kt
@@ -46,6 +46,7 @@ data class BudgetGroupEditUiState(
     val availableCategories: List<String> = emptyList(),
     val availableTypeBuckets: List<TypeBucketOption> = emptyList(),
     val categorySpending: Map<String, BigDecimal> = emptyMap(),
+    val typeSpending: Map<String, BigDecimal> = emptyMap(),
     val currency: String = "INR",
     val availableCurrencies: List<String> = emptyList(),
     val isLoading: Boolean = true,
@@ -86,9 +87,19 @@ class BudgetGroupEditViewModel @Inject constructor(
             val endDate = yearMonth.atEndOfMonth().atTime(23, 59, 59)
 
             val transactions = transactionSplitDao.getTransactionsWithSplitsFiltered(startDate, endDate, currency).first()
+            // Mirror the main budget screen's routing: type-bucket-eligible
+            // outflows (INVESTMENT) are summed per type, everything else per
+            // category. Keeps the edit screen's "current spending" hint accurate
+            // for a type bucket whose transactions aren't all tagged "Investments".
             val categorySpending = mutableMapOf<String, BigDecimal>()
+            val typeSpending = mutableMapOf<String, BigDecimal>()
             transactions.forEach { txWithSplits ->
-                if (txWithSplits.transaction.transactionType != TransactionType.INCOME) {
+                val type = txWithSplits.transaction.transactionType
+                if (type == TransactionType.INCOME || type == TransactionType.TRANSFER) return@forEach
+                if (type in BudgetGroupRepository.BUDGET_TYPE_BUCKETS) {
+                    typeSpending[type.name] = (typeSpending[type.name] ?: BigDecimal.ZERO) +
+                        txWithSplits.transaction.amount
+                } else {
                     txWithSplits.getAmountByCategory().forEach { (category, amount) ->
                         val categoryName = category.ifEmpty { "Others" }
                         categorySpending[categoryName] = (categorySpending[categoryName] ?: BigDecimal.ZERO) + amount
@@ -104,7 +115,11 @@ class BudgetGroupEditViewModel @Inject constructor(
                         CategoryBudgetItem(
                             categoryName = it.categoryName,
                             amount = it.budgetAmount,
-                            currentSpending = categorySpending[it.categoryName] ?: BigDecimal.ZERO,
+                            currentSpending = if (it.matchType != null) {
+                                typeSpending[it.matchType] ?: BigDecimal.ZERO
+                            } else {
+                                categorySpending[it.categoryName] ?: BigDecimal.ZERO
+                            },
                             matchType = it.matchType
                         )
                     }
@@ -114,6 +129,7 @@ class BudgetGroupEditViewModel @Inject constructor(
                         overallAmount = if (group.budget.limitAmount.compareTo(BigDecimal.ZERO) == 0) "" else group.budget.limitAmount.toPlainString(),
                         categories = assignedCategories,
                         categorySpending = categorySpending,
+                        typeSpending = typeSpending,
                         currency = group.budget.currency,
                         availableCurrencies = currencies,
                         isLoading = false
@@ -124,6 +140,7 @@ class BudgetGroupEditViewModel @Inject constructor(
                     name = "Monthly Budget",
                     currency = currency,
                     categorySpending = categorySpending,
+                    typeSpending = typeSpending,
                     availableCurrencies = currencies,
                     isLoading = false
                 )
@@ -161,7 +178,7 @@ class BudgetGroupEditViewModel @Inject constructor(
             CategoryBudgetItem(
                 categoryName = option.displayName,
                 amount = BigDecimal.ZERO,
-                currentSpending = BigDecimal.ZERO,
+                currentSpending = _uiState.value.typeSpending[option.typeName] ?: BigDecimal.ZERO,
                 matchType = option.typeName
             )
         )

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupEditViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupEditViewModel.kt
@@ -8,6 +8,7 @@ import com.pennywiseai.tracker.data.database.dao.TransactionSplitDao
 import com.pennywiseai.tracker.data.database.entity.BudgetGroupType
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
+import com.pennywiseai.tracker.data.repository.BudgetBucketInput
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository
 import com.pennywiseai.tracker.data.repository.CategoryRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -26,7 +27,15 @@ import javax.inject.Inject
 data class CategoryBudgetItem(
     val categoryName: String,
     val amount: BigDecimal,
-    val currentSpending: BigDecimal = BigDecimal.ZERO
+    val currentSpending: BigDecimal = BigDecimal.ZERO,
+    /** Non-null → this row is a transaction-type bucket (e.g. "INVESTMENT"). */
+    val matchType: String? = null
+)
+
+/** A trackable transaction-type bucket offered in the add-bucket menu. */
+data class TypeBucketOption(
+    val typeName: String,
+    val displayName: String
 )
 
 data class BudgetGroupEditUiState(
@@ -35,6 +44,7 @@ data class BudgetGroupEditUiState(
     val overallAmount: String = "",
     val categories: List<CategoryBudgetItem> = emptyList(),
     val availableCategories: List<String> = emptyList(),
+    val availableTypeBuckets: List<TypeBucketOption> = emptyList(),
     val categorySpending: Map<String, BigDecimal> = emptyMap(),
     val currency: String = "INR",
     val availableCurrencies: List<String> = emptyList(),
@@ -94,7 +104,8 @@ class BudgetGroupEditViewModel @Inject constructor(
                         CategoryBudgetItem(
                             categoryName = it.categoryName,
                             amount = it.budgetAmount,
-                            currentSpending = categorySpending[it.categoryName] ?: BigDecimal.ZERO
+                            currentSpending = categorySpending[it.categoryName] ?: BigDecimal.ZERO,
+                            matchType = it.matchType
                         )
                     }
                     _uiState.value = BudgetGroupEditUiState(
@@ -125,13 +136,39 @@ class BudgetGroupEditViewModel @Inject constructor(
     private fun loadAvailableCategories() {
         viewModelScope.launch {
             categoryRepository.getExpenseCategories().collect { expenseCategories ->
-                val currentCategoryNames = _uiState.value.categories.map { it.categoryName }
+                val current = _uiState.value.categories
+                val currentNames = current.map { it.categoryName }
+                // A type bucket's display label (e.g. "Investments") is offered as a
+                // type bucket, not a category — so hide those category names to avoid
+                // the (budget_id, category_name) unique-index collision.
+                val typeLabels = ALL_TYPE_BUCKETS.map { it.displayName }
                 val available = expenseCategories
                     .map { it.name }
-                    .filter { it !in currentCategoryNames }
-                _uiState.value = _uiState.value.copy(availableCategories = available)
+                    .filter { it !in currentNames && it !in typeLabels }
+                _uiState.value = _uiState.value.copy(
+                    availableCategories = available,
+                    availableTypeBuckets = ALL_TYPE_BUCKETS.filter { opt ->
+                        current.none { it.matchType == opt.typeName }
+                    }
+                )
             }
         }
+    }
+
+    fun addTypeBucket(option: TypeBucketOption) {
+        val current = _uiState.value.categories.toMutableList()
+        current.add(
+            CategoryBudgetItem(
+                categoryName = option.displayName,
+                amount = BigDecimal.ZERO,
+                currentSpending = BigDecimal.ZERO,
+                matchType = option.typeName
+            )
+        )
+        _uiState.value = _uiState.value.copy(
+            categories = current,
+            availableTypeBuckets = _uiState.value.availableTypeBuckets - option
+        )
     }
 
     fun updateName(name: String) {
@@ -160,10 +197,19 @@ class BudgetGroupEditViewModel @Inject constructor(
 
     fun removeCategory(categoryName: String) {
         val current = _uiState.value.categories.toMutableList()
+        val removed = current.firstOrNull { it.categoryName == categoryName }
         current.removeAll { it.categoryName == categoryName }
+        val restoredType = removed?.matchType?.let { mt -> ALL_TYPE_BUCKETS.firstOrNull { it.typeName == mt } }
         _uiState.value = _uiState.value.copy(
             categories = current,
-            availableCategories = _uiState.value.availableCategories + categoryName
+            // Restore a removed category to the picker; a removed type bucket goes
+            // back to the type-bucket options instead.
+            availableCategories = if (removed?.matchType == null) {
+                _uiState.value.availableCategories + categoryName
+            } else _uiState.value.availableCategories,
+            availableTypeBuckets = if (restoredType != null) {
+                _uiState.value.availableTypeBuckets + restoredType
+            } else _uiState.value.availableTypeBuckets
         )
     }
 
@@ -183,7 +229,9 @@ class BudgetGroupEditViewModel @Inject constructor(
         _uiState.value = state.copy(isSaving = true)
 
         viewModelScope.launch {
-            val categories = state.categories.map { it.categoryName to it.amount }
+            val buckets = state.categories.map {
+                BudgetBucketInput(name = it.categoryName, amount = it.amount, matchType = it.matchType)
+            }
             val defaultColor = "#1565C0"
 
             if (state.groupId != null && state.groupId > 0) {
@@ -192,7 +240,7 @@ class BudgetGroupEditViewModel @Inject constructor(
                     name = state.name,
                     groupType = BudgetGroupType.LIMIT,
                     color = defaultColor,
-                    categories = categories,
+                    buckets = buckets,
                     currency = state.currency,
                     limitAmount = overallAmount
                 )
@@ -201,8 +249,8 @@ class BudgetGroupEditViewModel @Inject constructor(
                     name = state.name,
                     groupType = BudgetGroupType.LIMIT,
                     color = defaultColor,
+                    buckets = buckets,
                     currency = state.currency,
-                    categories = categories,
                     limitAmount = overallAmount
                 )
             }
@@ -219,5 +267,12 @@ class BudgetGroupEditViewModel @Inject constructor(
             com.pennywiseai.tracker.widget.BudgetWidgetUpdateWorker.enqueueOneShot(context)
             _uiState.value = _uiState.value.copy(saveComplete = true)
         }
+    }
+
+    companion object {
+        /** Transaction-type buckets a budget can track (display order). */
+        private val ALL_TYPE_BUCKETS = listOf(
+            TypeBucketOption(TransactionType.INVESTMENT.name, "Investments")
+        )
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
@@ -134,7 +134,7 @@ class BudgetGroupsViewModel @Inject constructor(
         // single-currency path so Refund (DEDUCT_SPENT) and Extra budget
         // (ADD_TO_LIMIT) take effect here too. The converters project each
         // amount into the display currency before aggregation.
-        val (categoryAmounts, categoryLimitBoosts) = aggregateBudgetCategorySpending(
+        val (categoryAmounts, categoryLimitBoosts, typeAmounts) = aggregateBudgetCategorySpending(
             transactions = raw.allTransactions,
             convertSplit = { fromCurrency, amount ->
                 currencyConversionService.convertAmount(amount, fromCurrency, displayCurrency)
@@ -164,6 +164,20 @@ class BudgetGroupsViewModel @Inject constructor(
             ConvertedTxDay(day, catAmounts)
         }
 
+        // Type-bucket transactions (e.g. INVESTMENT) for the pace chart, keyed by
+        // transaction type. Routed separately from categories so a type bucket's
+        // "Actual" line reflects its type, not any category.
+        data class ConvertedTypeDay(val day: Int, val typeName: String, val amount: Double)
+        val convertedTypeDays = raw.allTransactions.mapNotNull { txWithSplits ->
+            val tx = txWithSplits.transaction
+            if (tx.transactionType !in BudgetGroupRepository.BUDGET_TYPE_BUCKETS || tx.loanId != null) {
+                return@mapNotNull null
+            }
+            val day = tx.dateTime.dayOfMonth.coerceIn(1, daysInMonth)
+            val amt = currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency).toDouble()
+            ConvertedTypeDay(day, tx.transactionType.name, amt)
+        }
+
         // Pre-convert Refund (DEDUCT_SPENT) income amounts on the day they occurred
         // so the pace chart subtracts them in lockstep with the displayed "actual".
         data class ConvertedRefundDay(val day: Int, val category: String, val amount: Double)
@@ -179,6 +193,7 @@ class BudgetGroupsViewModel @Inject constructor(
 
         fun buildGroupPaceUnified(
             categoryNames: Set<String>?,
+            matchTypes: Set<String>,
             groupBudget: BigDecimal
         ): Pair<List<Double>, List<Double>> {
             if (effectiveDays < 1) return emptyList<Double>() to emptyList()
@@ -191,6 +206,9 @@ class BudgetGroupsViewModel @Inject constructor(
                         if (cat in categoryNames) dailyAmounts[txDay.day - 1] += amount
                     }
                 }
+            }
+            convertedTypeDays.forEach { typeDay ->
+                if (typeDay.typeName in matchTypes) dailyAmounts[typeDay.day - 1] += typeDay.amount
             }
             convertedRefundDays.forEach { refundDay ->
                 if (categoryNames == null || refundDay.category in categoryNames) {
@@ -216,9 +234,15 @@ class BudgetGroupsViewModel @Inject constructor(
         val groupSpendingList = raw.budgetsWithCategories.map { group ->
             val isTrackingAll = group.categories.isEmpty()
             val catSpending = group.categories.map { cat ->
-                val actual = categoryAmounts[cat.categoryName] ?: BigDecimal.ZERO
+                val actual = if (cat.matchType != null) {
+                    typeAmounts[cat.matchType] ?: BigDecimal.ZERO
+                } else {
+                    categoryAmounts[cat.categoryName] ?: BigDecimal.ZERO
+                }
                 val convertedBudget = currencyConversionService.convertAmount(cat.budgetAmount, baseCurrency, displayCurrency)
-                val effectiveBudget = convertedBudget + (categoryLimitBoosts[cat.categoryName] ?: BigDecimal.ZERO)
+                val boost = if (cat.matchType != null) BigDecimal.ZERO
+                    else categoryLimitBoosts[cat.categoryName] ?: BigDecimal.ZERO
+                val effectiveBudget = convertedBudget + boost
                 val pctUsed = if (effectiveBudget > BigDecimal.ZERO) {
                     (actual.toFloat() / effectiveBudget.toFloat() * 100f).coerceAtLeast(0f)
                 } else 0f
@@ -258,8 +282,10 @@ class BudgetGroupsViewModel @Inject constructor(
                 remaining.divide(BigDecimal(raw.daysRemaining), 0, RoundingMode.HALF_UP)
             } else BigDecimal.ZERO
 
-            val catNames = if (isTrackingAll) null else group.categories.map { it.categoryName }.toSet()
-            val (cumSpending, budgetPace) = buildGroupPaceUnified(catNames, totalBudget)
+            val catNames = if (isTrackingAll) null
+                else group.categories.filter { it.matchType == null }.map { it.categoryName }.toSet()
+            val matchTypes = group.categories.mapNotNull { it.matchType }.toSet()
+            val (cumSpending, budgetPace) = buildGroupPaceUnified(catNames, matchTypes, totalBudget)
 
             BudgetGroupSpending(
                 group = group,

--- a/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
@@ -86,7 +86,7 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
                     { fromCurrency, amount ->
                         currencyConversionService.convertAmount(amount, fromCurrency, displayCurrency)
                     }
-                val (categoryAmounts, categoryLimitBoosts) = aggregateBudgetCategorySpending(
+                val (categoryAmounts, categoryLimitBoosts, typeAmounts) = aggregateBudgetCategorySpending(
                     transactions = raw.allTransactions,
                     convertSplit = convertSplit,
                     convertIncome = { tx ->
@@ -114,11 +114,15 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
                 val groupSpendingList = raw.budgetsWithCategories.map { group ->
                     val isTrackingAll = group.categories.isEmpty()
                     val catSpending = group.categories.map { cat ->
-                        val actual = categoryAmounts[cat.categoryName] ?: BigDecimal.ZERO
+                        val actual = if (cat.matchType != null) {
+                            typeAmounts[cat.matchType] ?: BigDecimal.ZERO
+                        } else {
+                            categoryAmounts[cat.categoryName] ?: BigDecimal.ZERO
+                        }
                         val convertedBudget = currencyConversionService.convertAmount(cat.budgetAmount, baseCurrency, displayCurrency)
-                        val effectiveBudget = convertedBudget +
-                            (categoryLimitBoosts[cat.categoryName] ?: BigDecimal.ZERO)
-                        BudgetCategorySpending(cat.categoryName, effectiveBudget, actual, 0f, BigDecimal.ZERO)
+                        val boost = if (cat.matchType != null) BigDecimal.ZERO
+                            else categoryLimitBoosts[cat.categoryName] ?: BigDecimal.ZERO
+                        BudgetCategorySpending(cat.categoryName, convertedBudget + boost, actual, 0f, BigDecimal.ZERO)
                     }
                     val convertedGroupLimit = currencyConversionService.convertAmount(
                         group.budget.limitAmount, baseCurrency, displayCurrency

--- a/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
@@ -172,7 +172,7 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
 
                 // Previous month savings for delta — same aggregator, same currency
                 // converters, so the delta isn't skewed by stale logic on either side.
-                val (prevCategoryAmounts, _) = aggregateBudgetCategorySpending(
+                val (prevCategoryAmounts, _, prevTypeAmounts) = aggregateBudgetCategorySpending(
                     transactions = raw.prevTransactions,
                     convertSplit = convertSplit,
                     convertIncome = { tx ->
@@ -180,15 +180,20 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
                     }
                 )
 
-                val limitCategoryNames = raw.budgetsWithCategories
+                // Split LIMIT-group buckets into category vs type buckets so the
+                // previous-month spend picks up type-bucket amounts too (they live
+                // in prevTypeAmounts, not prevCategoryAmounts).
+                val limitBuckets = raw.budgetsWithCategories
                     .filter { it.budget.groupType == BudgetGroupType.LIMIT }
-                    .map { it.categories }
-                    .flatten()
-                    .map { it.categoryName }
-                    .toSet()
+                    .flatMap { it.categories }
+                val limitCategoryNames = limitBuckets.filter { it.matchType == null }
+                    .map { it.categoryName }.toSet()
+                val limitMatchTypes = limitBuckets.mapNotNull { it.matchType }.toSet()
 
                 val prevLimitSpent = limitCategoryNames.fold(BigDecimal.ZERO) { acc, catName ->
                     acc + (prevCategoryAmounts[catName] ?: BigDecimal.ZERO)
+                } + limitMatchTypes.fold(BigDecimal.ZERO) { acc, t ->
+                    acc + (prevTypeAmounts[t] ?: BigDecimal.ZERO)
                 }
 
                 var prevIncome = BigDecimal.ZERO


### PR DESCRIPTION
## Why
Budgets were **category-only**. "Budget my investments" could only be expressed via a category named "Investments" that shadowed the `INVESTMENT` transaction *type* — a design flaw. Consequences: an investment tagged "Others" leaked into the Spending budget, and an expense tagged "Investments" counted as an investment.

**This supersedes #457**, which worked around the flaw by force-categorising every investment to "Investments" (+ a backfill + Add/Edit/parser category hacks). This PR fixes the root: budgets can track a transaction **type** directly.

## What
- **Schema:** `budget_categories.match_type` (nullable; also on `budget_category_month_snapshots`).
  - `null` → category bucket (match by category name — unchanged).
  - `"INVESTMENT"` → **type bucket** (match by transaction type; `category_name` is just the display label).
- **Aggregation:** INVESTMENT outflows route into per-**type** totals, never into category totals — so they count **only** toward a type bucket and **never leak** into a category/Spending budget. Updated across single-currency, unified-currency, the pace "Actual" line, and the budget widget.
- **`MIGRATION_51_52`:** adds the column and **auto-upgrades** existing "Investments" category buckets to `INVESTMENT` type buckets — current users are fixed with no action.
- **Smart defaults:** the "Investments" group is now one `INVESTMENT` type bucket.
- **Edit UI:** the add-bucket menu offers "Investments (all)" as a type bucket; type buckets load/save with their `match_type`.

## Result (no more workarounds)
No auto-categorization, no category-forcing migration, no Add/Edit/parser hacks. An investment counts by type regardless of how it was categorised.

## Verified on emulator
Migration applied cleanly (`user_version=52`, `match_type` present, existing Investments bucket auto-upgraded). With an `INVESTMENT` txn categorised **"Others"** + an `INVESTMENT` txn categorised "Investments":
- **Investments** budget: **₹7,500 / ₹15,000 (50%)** — both counted by type.
- **Spending** budget: **₹500** — the "Others" investment did **not** leak in.

## Backup
`match_type` is nullable with a Kotlin default → backward/forward compatible; `BackupSchemaGuardTest` passes.

Closes #457 (replaced by this).