### PR TITLE
chore(app): set app name to "PennyWise AI - Expense Tracker"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Pennywise AI Tracker</string>
+    <string name="app_name">PennyWise AI - Expense Tracker</string>
     <string name="widget_name_budget">Budget Overview</string>
     <string name="widget_description_budget">Shows your monthly budget progress, savings, and daily allowance at a glance.</string>
     <string name="widget_loading">Loading widget…</string>


### PR DESCRIPTION
Sets `app_name` (the `android:label`) to **PennyWise AI - Expense Tracker** — fixes the casing (`Pennywise` → `PennyWise`) and uses the full product name.

F-Droid derives **AutoName** from the built APK's label on the next build, so this updates the F-Droid listing name the recommended way — instead of overriding it with a `Name:` field in fdroiddata metadata (per review feedback on fdroiddata!40241).

Note: this also becomes the home-screen launcher label.