### PR TITLE
feat(accounts): per-account currency selection (+ NGN)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
@@ -123,6 +123,9 @@ class UserPreferencesRepository @Inject constructor(
         val PROFILE_BACKGROUND_COLOR = intPreferencesKey("profile_background_color")
         val HAS_COMPLETED_ONBOARDING = booleanPreferencesKey("has_completed_onboarding")
         val MAIN_ACCOUNT_KEY = stringPreferencesKey("main_account_key")
+        // True once the user explicitly picks a currency in the Settings selector.
+        // While true, the main-account-derived currency must not override their choice.
+        val BASE_CURRENCY_USER_SET = booleanPreferencesKey("base_currency_user_set")
 
         // UPI VPA → contact name lookup (opt-in; gated by READ_CONTACTS).
         val USE_CONTACTS_FOR_VPA = booleanPreferencesKey("use_contacts_for_vpa")
@@ -567,9 +570,27 @@ class UserPreferencesRepository @Inject constructor(
         }
     }
 
+    /**
+     * Explicit base-currency choice from the Settings currency selector. Marks the
+     * currency as user-set so the main account can no longer override it.
+     */
     suspend fun updateBaseCurrency(currency: String) {
         context.dataStore.edit { preferences ->
             preferences[PreferencesKeys.BASE_CURRENCY] = currency
+            preferences[PreferencesKeys.BASE_CURRENCY_USER_SET] = true
+        }
+    }
+
+    /**
+     * Sets the base currency derived from the user's main account, but only if the
+     * user hasn't explicitly chosen one via the Settings currency selector. The
+     * explicit selector always wins.
+     */
+    suspend fun applyMainAccountCurrency(currency: String) {
+        context.dataStore.edit { preferences ->
+            if (preferences[PreferencesKeys.BASE_CURRENCY_USER_SET] != true) {
+                preferences[PreferencesKeys.BASE_CURRENCY] = currency
+            }
         }
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/AccountDetailViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/AccountDetailViewModel.kt
@@ -61,8 +61,12 @@ class AccountDetailViewModel @Inject constructor(
                 selectedDateRange,
                 transactionRepository.getTransactionsByAccount(bankName, accountLast4),
                 userPreferencesRepository.unifiedCurrencyMode,
-                userPreferencesRepository.displayCurrency
-            ) { dateRange, allTransactions, isUnified, displayCurrency ->
+                userPreferencesRepository.displayCurrency,
+                // Include the balance flow so editing the account's currency (which writes
+                // a new balance row, not a transaction) re-emits and updates the displayed
+                // currency live, even while this screen is already open.
+                accountBalanceRepository.getLatestBalanceFlow(bankName, accountLast4)
+            ) { dateRange, allTransactions, isUnified, displayCurrency, latestBalance ->
                 val (startDate, endDate) = getDateRangeValues(dateRange)
 
                 val filteredTransactions = if (dateRange == DateRange.ALL_TIME) {
@@ -75,7 +79,7 @@ class AccountDetailViewModel @Inject constructor(
                 }
 
                 // Use display currency when unified, otherwise account's primary currency
-                val targetCurrency = if (isUnified) displayCurrency else getPrimaryCurrencyForAccount(bankName)
+                val targetCurrency = if (isUnified) displayCurrency else primaryCurrencyForAccount(latestBalance)
                 val hasMultipleCurrencies = filteredTransactions
                     .map { it.currency }
                     .distinct()
@@ -251,13 +255,14 @@ class AccountDetailViewModel @Inject constructor(
         return billed to unbilled
     }
 
-    private suspend fun getPrimaryCurrencyForAccount(bankName: String): String {
-        val latest = accountBalanceRepository.getLatestBalance(bankName, accountLast4)
-        // Manual accounts store the currency the user chose — trust it. SMS-tracked
-        // accounts fall back to the bank parser's currency (their stored currency may
-        // be the INR default even for a non-INR bank).
-        return if (latest?.sourceType == "MANUAL") {
-            latest.currency
+    // Derives the account's display currency from its latest balance row. Manual
+    // accounts store the currency the user chose — trust it. SMS-tracked accounts fall
+    // back to the bank parser's currency (their stored currency may be the INR default
+    // even for a non-INR bank). Pure function of the flowed balance so the caller stays
+    // reactive to currency edits.
+    private fun primaryCurrencyForAccount(latestBalance: AccountBalanceEntity?): String {
+        return if (latestBalance?.sourceType == "MANUAL") {
+            latestBalance.currency
         } else {
             CurrencyFormatter.getBankBaseCurrency(bankName)
         }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/AccountDetailViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/AccountDetailViewModel.kt
@@ -255,17 +255,14 @@ class AccountDetailViewModel @Inject constructor(
         return billed to unbilled
     }
 
-    // Derives the account's display currency from its latest balance row. Manual
-    // accounts store the currency the user chose — trust it. SMS-tracked accounts fall
-    // back to the bank parser's currency (their stored currency may be the INR default
-    // even for a non-INR bank). Pure function of the flowed balance so the caller stays
-    // reactive to currency edits.
+    // Derives the account's display currency from its latest balance row. Pure function
+    // of the flowed balance so the caller stays reactive to currency edits.
     private fun primaryCurrencyForAccount(latestBalance: AccountBalanceEntity?): String {
-        return if (latestBalance?.sourceType == "MANUAL") {
-            latestBalance.currency
-        } else {
-            CurrencyFormatter.getBankBaseCurrency(bankName)
-        }
+        return CurrencyFormatter.resolveAccountCurrency(
+            sourceType = latestBalance?.sourceType,
+            storedCurrency = latestBalance?.currency ?: "INR",
+            bankName = bankName
+        )
     }
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/AccountDetailViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/AccountDetailViewModel.kt
@@ -251,8 +251,16 @@ class AccountDetailViewModel @Inject constructor(
         return billed to unbilled
     }
 
-    private fun getPrimaryCurrencyForAccount(bankName: String): String {
-        return CurrencyFormatter.getBankBaseCurrency(bankName)
+    private suspend fun getPrimaryCurrencyForAccount(bankName: String): String {
+        val latest = accountBalanceRepository.getLatestBalance(bankName, accountLast4)
+        // Manual accounts store the currency the user chose — trust it. SMS-tracked
+        // accounts fall back to the bank parser's currency (their stored currency may
+        // be the INR default even for a non-INR bank).
+        return if (latest?.sourceType == "MANUAL") {
+            latest.currency
+        } else {
+            CurrencyFormatter.getBankBaseCurrency(bankName)
+        }
     }
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/AddAccountScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/AddAccountScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.pennywiseai.tracker.ui.components.CustomTitleTopAppBar
 import com.pennywiseai.tracker.ui.components.cards.PennyWiseCardV2
+import com.pennywiseai.tracker.utils.CurrencyFormatter
 import com.pennywiseai.tracker.ui.theme.Dimensions
 import com.pennywiseai.tracker.ui.theme.Spacing
 import dev.chrisbanes.haze.HazeState
@@ -38,6 +39,7 @@ fun AddAccountScreen(
 ) {
     val formState by viewModel.formState.collectAsState()
     var showTypeDropdown by remember { mutableStateOf(false) }
+    var showCurrencyDropdown by remember { mutableStateOf(false) }
 
     val scrollBehaviorSmall = TopAppBarDefaults.pinnedScrollBehavior()
     val scrollBehaviorLarge = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
@@ -200,6 +202,41 @@ fun AddAccountScreen(
                                     },
                                     contentDescription = null
                                 )
+                            }
+                        )
+                    }
+                }
+            }
+
+            // Currency
+            ExposedDropdownMenuBox(
+                expanded = showCurrencyDropdown,
+                onExpandedChange = { showCurrencyDropdown = it }
+            ) {
+                TextField(
+                    value = "${formState.currency}  ${CurrencyFormatter.getCurrencySymbol(formState.currency)}",
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Currency", fontWeight = FontWeight.SemiBold) },
+                    trailingIcon = { Icon(Icons.Rounded.KeyboardArrowDown, contentDescription = null) },
+                    leadingIcon = { Icon(Icons.Default.Payments, contentDescription = null) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true),
+                    shape = acctFullShape,
+                    colors = acctColors
+                )
+
+                ExposedDropdownMenu(
+                    expanded = showCurrencyDropdown,
+                    onDismissRequest = { showCurrencyDropdown = false }
+                ) {
+                    CurrencyFormatter.getSupportedCurrencies().sorted().forEach { code ->
+                        DropdownMenuItem(
+                            text = { Text("$code   ${CurrencyFormatter.getCurrencySymbol(code)}") },
+                            onClick = {
+                                viewModel.updateCurrency(code)
+                                showCurrencyDropdown = false
                             }
                         )
                     }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
@@ -509,14 +509,15 @@ fun ManageAccountsScreen(
                 showEditDialog = false
                 accountToEdit = null
             },
-            onConfirm = { newBankName, newBalance, newCreditLimit ->
+            onConfirm = { newBankName, newBalance, newCreditLimit, newCurrency ->
                 viewModel.editAccount(
                     oldBankName = accountToEdit!!.bankName,
                     accountLast4 = accountToEdit!!.accountLast4,
                     newBankName = newBankName,
                     newBalance = newBalance,
                     newCreditLimit = newCreditLimit,
-                    isCreditCard = accountToEdit!!.isCreditCard
+                    isCreditCard = accountToEdit!!.isCreditCard,
+                    newCurrency = newCurrency
                 )
                 showEditDialog = false
                 accountToEdit = null
@@ -1932,11 +1933,13 @@ private fun DeleteAccountConfirmDialog(
 private fun EditAccountDialog(
     account: com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity,
     onDismiss: () -> Unit,
-    onConfirm: (bankName: String, balance: BigDecimal, creditLimit: BigDecimal?) -> Unit
+    onConfirm: (bankName: String, balance: BigDecimal, creditLimit: BigDecimal?, currency: String) -> Unit
 ) {
     var bankNameText by remember { mutableStateOf(account.bankName) }
     var balanceText by remember { mutableStateOf(account.balance.toString()) }
     var creditLimitText by remember { mutableStateOf(account.creditLimit?.toString() ?: "") }
+    var currencyText by remember { mutableStateOf(account.currency) }
+    var showCurrencyMenu by remember { mutableStateOf(false) }
     var isValid by remember { mutableStateOf(false) }
 
     LaunchedEffect(bankNameText, balanceText, creditLimitText) {
@@ -2000,6 +2003,51 @@ private fun EditAccountDialog(
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth()
                 )
+
+                // Currency (editable — lets an existing account switch currency)
+                Column {
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { showCurrencyMenu = true },
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+                        )
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = Spacing.md, vertical = Spacing.sm),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "Currency",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Text(
+                                text = "$currencyText   ${CurrencyFormatter.getCurrencySymbol(currencyText)}",
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.Medium
+                            )
+                        }
+                    }
+                    DropdownMenu(
+                        expanded = showCurrencyMenu,
+                        onDismissRequest = { showCurrencyMenu = false }
+                    ) {
+                        CurrencyFormatter.getSupportedCurrencies().sorted().forEach { code ->
+                            DropdownMenuItem(
+                                text = { Text("$code   ${CurrencyFormatter.getCurrencySymbol(code)}") },
+                                onClick = {
+                                    currencyText = code
+                                    showCurrencyMenu = false
+                                }
+                            )
+                        }
+                    }
+                }
 
                 if (account.isCreditCard) {
                     // Outstanding Balance (Credit Card)
@@ -2121,7 +2169,7 @@ private fun EditAccountDialog(
                     val creditLimit = if (account.isCreditCard) {
                         creditLimitText.toBigDecimalOrNull()
                     } else null
-                    onConfirm(bankNameText, balance, creditLimit)
+                    onConfirm(bankNameText, balance, creditLimit, currencyText)
                 },
                 enabled = isValid
             ) {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
@@ -1018,7 +1018,16 @@ private fun AccountItem(
                     horizontalAlignment = Alignment.End
                 ) {
                     Text(
-                        text = CurrencyFormatter.formatCurrency(account.balance, account.currency),
+                        text = CurrencyFormatter.formatCurrency(
+                            account.balance,
+                            // Resolve so the list matches Account Detail — SMS-tracked
+                            // non-INR accounts show their parser currency, not stored INR.
+                            CurrencyFormatter.resolveAccountCurrency(
+                                sourceType = account.sourceType,
+                                storedCurrency = account.currency,
+                                bankName = account.bankName
+                            )
+                        ),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold,
                         color = MaterialTheme.colorScheme.primary
@@ -1938,7 +1947,19 @@ private fun EditAccountDialog(
     var bankNameText by remember { mutableStateOf(account.bankName) }
     var balanceText by remember { mutableStateOf(account.balance.toString()) }
     var creditLimitText by remember { mutableStateOf(account.creditLimit?.toString() ?: "") }
-    var currencyText by remember { mutableStateOf(account.currency) }
+    // Pre-fill with the *resolved* currency (what the account actually displays), not
+    // the raw stored value — an SMS-tracked non-INR account stores the INR default but
+    // shows the parser currency. Seeding from the raw value would let an unrelated edit
+    // silently lock the account to INR.
+    var currencyText by remember {
+        mutableStateOf(
+            CurrencyFormatter.resolveAccountCurrency(
+                sourceType = account.sourceType,
+                storedCurrency = account.currency,
+                bankName = account.bankName
+            )
+        )
+    }
     var showCurrencyMenu by remember { mutableStateOf(false) }
     var isValid by remember { mutableStateOf(false) }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
@@ -252,7 +252,16 @@ class ManageAccountsViewModel @Inject constructor(
                     balance = newBalance,
                     creditLimit = latestBalance?.creditLimit,
                     isCreditCard = latestBalance?.isCreditCard ?: false,
-                    currency = latestBalance?.currency ?: "INR",
+                    // Reinserted rows are stamped MANUAL (so a rescan won't purge a
+                    // user-edited balance), but that makes resolveAccountCurrency trust
+                    // the stored value. Resolve it first so an SMS-tracked non-INR
+                    // account keeps its parser currency instead of flipping to the
+                    // stored INR default. See [CurrencyFormatter.resolveAccountCurrency].
+                    currency = CurrencyFormatter.resolveAccountCurrency(
+                        sourceType = latestBalance?.sourceType,
+                        storedCurrency = latestBalance?.currency ?: "INR",
+                        bankName = bankName
+                    ),
                     accountType = latestBalance?.accountType,
                     profileId = latestBalance?.profileId ?: ProfileEntity.PERSONAL_ID,
                     alias = latestBalance?.alias,
@@ -275,7 +284,13 @@ class ManageAccountsViewModel @Inject constructor(
                     creditLimit = newLimit,
                     timestamp = LocalDateTime.now(),
                     isCreditCard = true,
-                    currency = latestBalance?.currency ?: "INR",
+                    // Keep the resolved currency (see updateAccountBalance) so stamping
+                    // MANUAL doesn't flip an SMS-tracked non-INR card to stored INR.
+                    currency = CurrencyFormatter.resolveAccountCurrency(
+                        sourceType = latestBalance?.sourceType,
+                        storedCurrency = latestBalance?.currency ?: "INR",
+                        bankName = bankName
+                    ),
                     accountType = latestBalance?.accountType,
                     profileId = latestBalance?.profileId ?: ProfileEntity.PERSONAL_ID,
                     alias = latestBalance?.alias,
@@ -730,7 +745,13 @@ class ManageAccountsViewModel @Inject constructor(
                         creditLimit = newCreditLimit,
                         timestamp = LocalDateTime.now(),
                         isCreditCard = isCreditCard,
-                        currency = newCurrency ?: latestBalance?.currency ?: "INR",
+                        // Honor an explicit currency edit; otherwise resolve so stamping
+                        // MANUAL doesn't flip an SMS-tracked non-INR account to stored INR.
+                        currency = newCurrency ?: CurrencyFormatter.resolveAccountCurrency(
+                            sourceType = latestBalance?.sourceType,
+                            storedCurrency = latestBalance?.currency ?: "INR",
+                            bankName = newBankName
+                        ),
                         accountType = latestBalance?.accountType,
                         profileId = latestBalance?.profileId ?: ProfileEntity.PERSONAL_ID,
                         alias = latestBalance?.alias,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
@@ -38,6 +38,7 @@ data class AccountFormState(
     val balance: String = "",
     val creditLimit: String = "",
     val accountType: AccountType = AccountType.SAVINGS,
+    val currency: String = "INR",
     val isValid: Boolean = false,
     val errorMessage: String? = null
 )
@@ -63,6 +64,7 @@ class ManageAccountsViewModel @Inject constructor(
     private val cardRepository: CardRepository,
     private val transactionRepository: com.pennywiseai.tracker.data.repository.TransactionRepository,
     private val database: com.pennywiseai.tracker.data.database.PennyWiseDatabase,
+    private val userPreferencesRepository: com.pennywiseai.tracker.data.preferences.UserPreferencesRepository,
     entitlementGate: com.pennywiseai.tracker.billing.EntitlementGate,
 ) : ViewModel() {
 
@@ -84,10 +86,22 @@ class ManageAccountsViewModel @Inject constructor(
     private val _pendingProfileReassign = MutableStateFlow<PendingProfileReassign?>(null)
     val pendingProfileReassign: StateFlow<PendingProfileReassign?> = _pendingProfileReassign.asStateFlow()
     
+    /** User's base currency — the default for a new manual account. */
+    private var baseCurrency: String = "INR"
+
     init {
         loadAccounts()
         loadHiddenAccounts()
         loadCards()
+        viewModelScope.launch {
+            baseCurrency = userPreferencesRepository.baseCurrency.first()
+            // Seed the (still-empty) add form with the base currency.
+            _formState.update { if (it.bankName.isBlank()) it.copy(currency = baseCurrency) else it }
+        }
+    }
+
+    fun updateCurrency(currency: String) {
+        _formState.update { it.copy(currency = currency) }
     }
     
     private fun loadAccounts() {
@@ -216,12 +230,13 @@ class ManageAccountsViewModel @Inject constructor(
                     timestamp = LocalDateTime.now(),
                     isCreditCard = (state.accountType == AccountType.CREDIT),
                     accountType = state.accountType.toDatabaseString(),
+                    currency = state.currency,
                     sourceType = "MANUAL"
                 )
             )
-            
-            // Clear form
-            _formState.value = AccountFormState()
+
+            // Clear form (keep the base currency as the next default)
+            _formState.value = AccountFormState(currency = baseCurrency)
         }
     }
     
@@ -682,7 +697,8 @@ class ManageAccountsViewModel @Inject constructor(
         newBankName: String,
         newBalance: BigDecimal,
         newCreditLimit: BigDecimal?,
-        isCreditCard: Boolean
+        isCreditCard: Boolean,
+        newCurrency: String? = null
     ) {
         viewModelScope.launch {
             try {
@@ -714,7 +730,7 @@ class ManageAccountsViewModel @Inject constructor(
                         creditLimit = newCreditLimit,
                         timestamp = LocalDateTime.now(),
                         isCreditCard = isCreditCard,
-                        currency = latestBalance?.currency ?: "INR",
+                        currency = newCurrency ?: latestBalance?.currency ?: "INR",
                         accountType = latestBalance?.accountType,
                         profileId = latestBalance?.profileId ?: ProfileEntity.PERSONAL_ID,
                         alias = latestBalance?.alias,

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/onboarding/OnBoardingViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/onboarding/OnBoardingViewModel.kt
@@ -13,6 +13,7 @@ import com.pennywiseai.tracker.data.manager.SmsScanManager
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.ui.components.AvatarHelper
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
+import com.pennywiseai.tracker.utils.CurrencyFormatter
 import com.pennywiseai.tracker.worker.OptimizedSmsReaderWorker
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -274,6 +275,21 @@ class OnBoardingViewModel @Inject constructor(
             }
             if (state.selectedAccountKey != null) {
                 userPreferencesRepository.updateMainAccountKey(state.selectedAccountKey)
+                // The main account defines the user's default currency. Manual accounts
+                // store the currency the user chose; SMS-tracked accounts fall back to the
+                // bank parser's currency (their stored value may be the INR default even
+                // for a non-INR bank).
+                val mainAccount = state.accounts.firstOrNull {
+                    "${it.bankName}_${it.accountLast4}" == state.selectedAccountKey
+                }
+                if (mainAccount != null) {
+                    val currency = if (mainAccount.sourceType == "MANUAL") {
+                        mainAccount.currency
+                    } else {
+                        CurrencyFormatter.getBankBaseCurrency(mainAccount.bankName)
+                    }
+                    userPreferencesRepository.updateBaseCurrency(currency)
+                }
             }
             userPreferencesRepository.updateHasCompletedOnboarding(true)
             _uiState.update { it.copy(isCompleting = false) }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/onboarding/OnBoardingViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/onboarding/OnBoardingViewModel.kt
@@ -283,12 +283,13 @@ class OnBoardingViewModel @Inject constructor(
                     "${it.bankName}_${it.accountLast4}" == state.selectedAccountKey
                 }
                 if (mainAccount != null) {
-                    val currency = if (mainAccount.sourceType == "MANUAL") {
-                        mainAccount.currency
-                    } else {
-                        CurrencyFormatter.getBankBaseCurrency(mainAccount.bankName)
-                    }
-                    userPreferencesRepository.updateBaseCurrency(currency)
+                    val currency = CurrencyFormatter.resolveAccountCurrency(
+                        sourceType = mainAccount.sourceType,
+                        storedCurrency = mainAccount.currency,
+                        bankName = mainAccount.bankName
+                    )
+                    // Won't override a currency the user explicitly picked in Settings.
+                    userPreferencesRepository.applyMainAccountCurrency(currency)
                 }
             }
             userPreferencesRepository.updateHasCompletedOnboarding(true)

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -106,6 +106,8 @@ fun SettingsScreen(
     val unifiedCurrencyMode by settingsViewModel.unifiedCurrencyMode.collectAsStateWithLifecycle(initialValue = false)
     val displayCurrency by settingsViewModel.displayCurrency.collectAsStateWithLifecycle(initialValue = "")
     val availableCurrencies by settingsViewModel.availableCurrencies.collectAsStateWithLifecycle()
+    val accounts by settingsViewModel.accounts.collectAsStateWithLifecycle()
+    val mainAccountKey by settingsViewModel.mainAccountKey.collectAsStateWithLifecycle()
     val useContactsForVpa by settingsViewModel.useContactsForVpa.collectAsStateWithLifecycle(initialValue = false)
     val isProEntitled by settingsViewModel.isProEntitled.collectAsStateWithLifecycle()
     var showUpgradeSheet by remember { mutableStateOf(false) }
@@ -122,6 +124,7 @@ fun SettingsScreen(
     var showTimeoutDialog by remember { mutableStateOf(false) }
     var showDisplayCurrencyDialog by remember { mutableStateOf(false) }
     var showCurrencyDropdown by remember { mutableStateOf(false) }
+    var showMainAccountDropdown by remember { mutableStateOf(false) }
     val permissionUiState by permissionViewModel.uiState.collectAsStateWithLifecycle()
     val hasNotificationAccess = permissionUiState.hasNotificationAccess
     val context = LocalContext.current
@@ -261,7 +264,7 @@ fun SettingsScreen(
                     currentValue = "${CurrencyFormatter.getCurrencySymbol(baseCurrency)} $baseCurrency",
                     expanded = showCurrencyDropdown,
                     onExpandedChange = { showCurrencyDropdown = it },
-                    position = ItemPosition.BOTTOM
+                    position = if (accounts.isNotEmpty()) ItemPosition.MIDDLE else ItemPosition.BOTTOM
                 ) {
                     availableCurrencies.forEach { currency ->
                         DropdownMenuItem(
@@ -282,6 +285,51 @@ fun SettingsScreen(
                                 }
                             } else null
                         )
+                    }
+                }
+
+                // Main account → sets the default currency (unless explicitly chosen above).
+                if (accounts.isNotEmpty()) {
+                    val mainAccount = accounts.firstOrNull {
+                        "${it.bankName}_${it.accountLast4}" == mainAccountKey
+                    }
+                    SettingsDropdownItem(
+                        icon = Icons.Default.AccountBalanceWallet,
+                        iconBgColor = purple_light,
+                        iconTint = purple_dark,
+                        title = "Main Account",
+                        subtitle = "Sets your default currency",
+                        currentValue = mainAccount?.let { acc ->
+                            val name = acc.alias?.takeIf { it.isNotBlank() } ?: acc.bankName
+                            if (acc.accountLast4.isNotBlank()) "$name ••${acc.accountLast4}" else name
+                        } ?: "Not set",
+                        expanded = showMainAccountDropdown,
+                        onExpandedChange = { showMainAccountDropdown = it },
+                        position = ItemPosition.BOTTOM
+                    ) {
+                        accounts.forEach { account ->
+                            val name = account.alias?.takeIf { it.isNotBlank() } ?: account.bankName
+                            val label = if (account.accountLast4.isNotBlank()) {
+                                "$name ••${account.accountLast4}"
+                            } else name
+                            val key = "${account.bankName}_${account.accountLast4}"
+                            DropdownMenuItem(
+                                text = { Text(label) },
+                                onClick = {
+                                    settingsViewModel.setMainAccount(account)
+                                    showMainAccountDropdown = false
+                                },
+                                leadingIcon = if (key == mainAccountKey) {
+                                    {
+                                        Icon(
+                                            Icons.Default.Check,
+                                            contentDescription = null,
+                                            tint = MaterialTheme.colorScheme.primary
+                                        )
+                                    }
+                                } else null
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -26,7 +26,10 @@ import com.pennywiseai.tracker.data.backup.BackupImporter
 import com.pennywiseai.tracker.data.backup.ExportResult
 import com.pennywiseai.tracker.data.backup.ImportResult
 import com.pennywiseai.tracker.data.backup.ImportStrategy
+import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
+import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
+import com.pennywiseai.tracker.utils.CurrencyFormatter
 import com.pennywiseai.tracker.utils.CurrencyUtils
 import com.pennywiseai.tracker.utils.SmsReportUrlBuilder
 import android.content.Intent
@@ -48,6 +51,7 @@ class SettingsViewModel @Inject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val unrecognizedSmsRepository: UnrecognizedSmsRepository,
     private val transactionRepository: TransactionRepository,
+    private val accountBalanceRepository: AccountBalanceRepository,
     private val backupExporter: BackupExporter,
     private val backupImporter: BackupImporter,
     private val contactsResolver: com.pennywiseai.tracker.data.contacts.ContactsResolver,
@@ -109,6 +113,23 @@ class SettingsViewModel @Inject constructor(
     
     // Base currency state
     val baseCurrency = userPreferencesRepository.baseCurrency
+
+    // Main account selection (drives the default currency unless overridden above).
+    val accounts: StateFlow<List<AccountBalanceEntity>> =
+        accountBalanceRepository.getAllLatestBalances()
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = emptyList()
+            )
+
+    val mainAccountKey: StateFlow<String?> = userPreferencesRepository.userPreferences
+        .map { it.mainAccountKey }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = null
+        )
     
     // Unrecognized SMS state
     val unreportedSmsCount = unrecognizedSmsRepository.getUnreportedCount()
@@ -599,6 +620,24 @@ class SettingsViewModel @Inject constructor(
     fun updateBaseCurrency(currency: String) {
         viewModelScope.launch {
             userPreferencesRepository.updateBaseCurrency(currency)
+        }
+    }
+
+    /**
+     * Sets the main account and derives the default currency from it — unless the user
+     * has already picked a currency explicitly, in which case that choice is kept.
+     */
+    fun setMainAccount(account: AccountBalanceEntity) {
+        viewModelScope.launch {
+            userPreferencesRepository.updateMainAccountKey(
+                "${account.bankName}_${account.accountLast4}"
+            )
+            val currency = CurrencyFormatter.resolveAccountCurrency(
+                sourceType = account.sourceType,
+                storedCurrency = account.currency,
+                bankName = account.bankName
+            )
+            userPreferencesRepository.applyMainAccountCurrency(currency)
         }
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
@@ -162,6 +162,25 @@ object CurrencyFormatter {
     }
 
     /**
+     * Resolves the effective currency for an account. Manual accounts store the
+     * currency the user chose — trust it. SMS-tracked accounts fall back to the bank
+     * parser's currency (their stored value may be the INR default even for a non-INR
+     * bank). Shared by Account Detail, onboarding, and Settings so the rule stays
+     * consistent everywhere.
+     */
+    fun resolveAccountCurrency(
+        sourceType: String?,
+        storedCurrency: String,
+        bankName: String?
+    ): String {
+        return if (sourceType == "MANUAL") {
+            storedCurrency
+        } else {
+            getBankBaseCurrency(bankName)
+        }
+    }
+
+    /**
      * Gets the base currency for a bank using the BankParserFactory
      * Returns INR as default for unknown banks
      */

--- a/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
@@ -35,7 +35,8 @@ object CurrencyFormatter {
         "THB" to "฿",
         "MYR" to "RM",
         "KWD" to "KD",
-        "KRW" to "₩"
+        "KRW" to "₩",
+        "NGN" to "₦"
     )
 
     /**
@@ -60,7 +61,8 @@ object CurrencyFormatter {
         "THB" to Locale.Builder().setLanguage("th").setRegion("TH").build(),
         "MYR" to Locale.Builder().setLanguage("ms").setRegion("MY").build(),
         "KWD" to Locale.Builder().setLanguage("en").setRegion("KW").build(),
-        "KRW" to Locale.KOREA
+        "KRW" to Locale.KOREA,
+        "NGN" to Locale.Builder().setLanguage("en").setRegion("NG").build()
     )
 
     /**

--- a/app/src/test/java/com/pennywiseai/tracker/utils/CurrencyFormatterTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/utils/CurrencyFormatterTest.kt
@@ -1,0 +1,61 @@
+package com.pennywiseai.tracker.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Guards [CurrencyFormatter.resolveAccountCurrency], the rule that decides whether an
+ * account's currency comes from its stored value or its bank parser.
+ *
+ * Regression: account reinserts (edit / update balance) stamp source_type = MANUAL so a
+ * rescan won't purge them. That made resolveAccountCurrency trust the stored currency,
+ * which for an SMS-tracked non-INR account is the INR default — silently flipping the
+ * displayed currency. The reinsert paths now write the *resolved* currency, so these
+ * cases must stay stable.
+ */
+class CurrencyFormatterTest {
+
+    @Test
+    fun `manual account trusts its stored currency`() {
+        // A user-created account stores the currency it was created with — even when it
+        // differs from the bank parser's default.
+        assertEquals(
+            "NGN",
+            CurrencyFormatter.resolveAccountCurrency(
+                sourceType = "MANUAL",
+                storedCurrency = "NGN",
+                bankName = "Cash"
+            )
+        )
+    }
+
+    @Test
+    fun `sms-tracked non-INR account ignores stored INR default and uses parser currency`() {
+        // The core regression: an SMS-tracked UAE account stores the INR default but must
+        // display its parser currency (AED). Both the null and "TRANSACTION" source types
+        // (what SMS rows carry) must resolve to the parser value.
+        listOf(null, "TRANSACTION", "SMS_BALANCE", "CARD_LINK").forEach { sourceType ->
+            assertEquals(
+                "source_type=$sourceType should fall back to the bank parser currency",
+                "AED",
+                CurrencyFormatter.resolveAccountCurrency(
+                    sourceType = sourceType,
+                    storedCurrency = "INR",
+                    bankName = "Liv Bank"
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `sms-tracked account on an unknown bank defaults to INR`() {
+        assertEquals(
+            "INR",
+            CurrencyFormatter.resolveAccountCurrency(
+                sourceType = null,
+                storedCurrency = "INR",
+                bankName = "Totally Unknown Bank"
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Problem
Manual/cash accounts were hard-locked to **INR** — there was no way to pick a currency on create or edit, so non-INR users always saw ₹ even after entering a foreign-currency amount.

Fixes a cluster:
- Closes #468 — manual account amount always treated/shown as INR
- Closes #471 — currency forced to INR on account creation
- Closes #464 — (enhancement) change currency on create/edit
- Closes #462 — add Nigerian Naira (NGN)

## Changes
- **Add Account**: a **Currency** dropdown (defaults to the user's base currency).
- **Edit Account**: an editable **Currency** row (so existing INR accounts can switch).
- Threaded `currency` through `AccountFormState` → `addAccount`/`editAccount` → `AccountBalanceEntity.currency`.
- **AccountDetailViewModel**: a MANUAL account now uses its **stored** currency instead of inferring INR from a (non-existent) bank parser.
- Added **NGN (₦)** to `CurrencyFormatter` (symbol + locale).
- No schema change — the `currency` column already existed; display paths already used `account.currency`.

## Verified on emulator
Created a **GTBank** account with **NGN** → list shows **₦50,000** (not ₹); the edit dialog shows and lets you change the currency.

| Add (currency picker, NGN) | Result |
|---|---|
| Currency dropdown lists NGN ₦, picked it | Account renders **₦50,000** |

## Notes / out of scope
- A separate cluster (#469/#470 cash-account balance not recomputing on past-dated add / delete) and #465 (account-number row layout) are tracked separately — happy to take those next.