### PR TITLE
feat(parser): Nigerian bank parsers — Access, Zenith, Keystone

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/AccessBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/AccessBankParser.kt
@@ -67,7 +67,9 @@ class AccessBankParser : BankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
-        val match = Regex("""(?i)Desc:\s*(.+)""").find(message) ?: return null
+        // Use [ \t]* (not \s*) so an empty "Desc:" line can't let the capture cross the
+        // newline and grab the following Date:/Avail Bal: line as the merchant.
+        val match = Regex("""(?i)Desc:[ \t]*(.+)""").find(message) ?: return null
         val desc = match.groupValues[1].trim()
         return desc.ifBlank { null }
     }

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/AccessBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/AccessBankParser.kt
@@ -1,0 +1,85 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Access Bank (Nigeria) SMS messages.
+ *
+ * Supported format (line-based):
+ * ```
+ * Debit
+ * Amt:NGN20,400.00
+ * Acc:146******325
+ * Desc:<description>
+ * Date:09/06/2026
+ * Avail Bal:NGN224,408.56
+ * Total:NGN2          (may be truncated — ignored)
+ * ```
+ * First line is "Debit" (EXPENSE) or "Credit" (INCOME).
+ *
+ * Sender: AccessBank
+ */
+class AccessBankParser : BankParser() {
+
+    override fun getBankName() = "Access Bank"
+
+    override fun getCurrency() = "NGN"
+
+    override fun canHandle(sender: String): Boolean {
+        return sender.uppercase().contains("ACCESSBANK")
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+        if (lower.contains("otp") || lower.contains("verification code")) {
+            return false
+        }
+        // Must look like the Access Bank line-based alert.
+        return Regex("""(?im)^\s*(debit|credit)\b""").containsMatchIn(message) &&
+                Regex("""(?i)Amt:\s*NGN""").containsMatchIn(message)
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        return when {
+            Regex("""(?im)^\s*debit\b""").containsMatchIn(message) -> TransactionType.EXPENSE
+            Regex("""(?im)^\s*credit\b""").containsMatchIn(message) -> TransactionType.INCOME
+            else -> null
+        }
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        val match = Regex("""(?i)Amt:\s*NGN\s*([0-9,]+(?:\.\d{1,2})?)""").find(message) ?: return null
+        return try {
+            BigDecimal(match.groupValues[1].replace(",", ""))
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        val match = Regex("""(?i)Avail\s*Bal:\s*NGN\s*([0-9,]+(?:\.\d{1,2})?)""").find(message) ?: return null
+        return try {
+            BigDecimal(match.groupValues[1].replace(",", ""))
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        val match = Regex("""(?i)Desc:\s*(.+)""").find(message) ?: return null
+        val desc = match.groupValues[1].trim()
+        return desc.ifBlank { null }
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        // Account is masked, e.g. "146******325" — use the trailing digit group.
+        val match = Regex("""(?i)Acc:\s*[0-9]*\*+([0-9]+)""").find(message)
+        if (match != null) {
+            return extractLast4Digits(match.groupValues[1])
+        }
+        // Fallback: unmasked account number.
+        val plain = Regex("""(?i)Acc:\s*([0-9]+)""").find(message) ?: return null
+        return extractLast4Digits(plain.groupValues[1])
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -122,7 +122,10 @@ object BankParserFactory {
         BankMuscatParser(),  // Bank Muscat (Oman)
         GreaterBankParser(),  // Greater Bank (India)
         BPCEParser(),  // BPCE (France)
-        SampathBankParser()  // Sampath Bank (Sri Lanka)
+        SampathBankParser(),  // Sampath Bank (Sri Lanka)
+        AccessBankParser(),  // Access Bank (Nigeria)
+        ZenithBankParser(),  // Zenith Bank (Nigeria)
+        KeystoneBankParser()  // Keystone Bank (Nigeria)
         // Add more bank parsers here as we implement them
     )
 

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KeystoneBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KeystoneBankParser.kt
@@ -68,7 +68,9 @@ class KeystoneBankParser : BankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
-        val match = Regex("""(?i)Desc:\s*(.+)""").find(message) ?: return null
+        // Use [ \t]* (not \s*) so an empty "Desc:" line can't let the capture cross the
+        // newline and grab the following Date:/Bal: line as the merchant.
+        val match = Regex("""(?i)Desc:[ \t]*(.+)""").find(message) ?: return null
         val desc = match.groupValues[1].trim()
         return desc.ifBlank { null }
     }

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KeystoneBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KeystoneBankParser.kt
@@ -1,0 +1,84 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Keystone Bank (Nigeria) SMS messages.
+ *
+ * Supported format (line-based):
+ * ```
+ * Debit!                                  (or Credit!)
+ * Acct:602****370
+ * Amt:NGN-57,000.00                       (debit carries a leading minus)
+ * Desc:<description>
+ * Date:26-05-2026 0:0
+ * Bal:NGN1,929.24
+ * Download Keymobile bit.ly/31MJj1s       (promo — ignored)
+ * ```
+ *
+ * Sender: KEYSTONE
+ */
+class KeystoneBankParser : BankParser() {
+
+    override fun getBankName() = "Keystone Bank"
+
+    override fun getCurrency() = "NGN"
+
+    override fun canHandle(sender: String): Boolean {
+        return sender.uppercase().contains("KEYSTONE")
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+        if (lower.contains("otp") || lower.contains("verification code")) {
+            return false
+        }
+        return Regex("""(?im)^\s*(debit|credit)!""").containsMatchIn(message) &&
+                Regex("""(?i)Amt:\s*NGN""").containsMatchIn(message)
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        return when {
+            Regex("""(?im)^\s*debit!""").containsMatchIn(message) -> TransactionType.EXPENSE
+            Regex("""(?im)^\s*credit!""").containsMatchIn(message) -> TransactionType.INCOME
+            // Fallback to the sign on the amount line.
+            Regex("""(?i)Amt:\s*NGN\s*-""").containsMatchIn(message) -> TransactionType.EXPENSE
+            else -> null
+        }
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // Strip the leading minus when present; we only need the magnitude.
+        val match = Regex("""(?i)Amt:\s*NGN\s*-?\s*([0-9,]+(?:\.\d{1,2})?)""").find(message) ?: return null
+        return try {
+            BigDecimal(match.groupValues[1].replace(",", ""))
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        val match = Regex("""(?i)Bal:\s*NGN\s*([0-9,]+(?:\.\d{1,2})?)""").find(message) ?: return null
+        return try {
+            BigDecimal(match.groupValues[1].replace(",", ""))
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        val match = Regex("""(?i)Desc:\s*(.+)""").find(message) ?: return null
+        val desc = match.groupValues[1].trim()
+        return desc.ifBlank { null }
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        val match = Regex("""(?i)Acct:\s*[0-9]*\*+([0-9]+)""").find(message)
+        if (match != null) {
+            return extractLast4Digits(match.groupValues[1])
+        }
+        val plain = Regex("""(?i)Acct:\s*([0-9]+)""").find(message) ?: return null
+        return extractLast4Digits(plain.groupValues[1])
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ZenithBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ZenithBankParser.kt
@@ -65,10 +65,14 @@ class ZenithBankParser : BankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
-        // Description is the line between the DT line and the amount line.
+        // Narration sits on the line between the DT: timestamp and the amount line.
+        // When a message has no narration line, this regex would otherwise capture the
+        // amount/balance/promo line — guard against persisting those as the merchant.
         val match = Regex("""(?im)^DT:.*\n(.+)""").find(message) ?: return null
         val desc = match.groupValues[1].trim()
-        return desc.ifBlank { null }
+        if (desc.isBlank()) return null
+        val isNonNarration = Regex("""(?i)^((DR|CR)\s*Amt:|Bal:|Dial\b)""").containsMatchIn(desc)
+        return if (isNonNarration) null else desc
     }
 
     override fun extractAccountLast4(message: String): String? {

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ZenithBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ZenithBankParser.kt
@@ -65,14 +65,15 @@ class ZenithBankParser : BankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
-        // Narration sits on the line between the DT: timestamp and the amount line.
-        // When a message has no narration line, this regex would otherwise capture the
-        // amount/balance/promo line — guard against persisting those as the merchant.
-        val match = Regex("""(?im)^DT:.*\n(.+)""").find(message) ?: return null
+        // Narration is the line directly above the amount line. Anchor on the amount
+        // line (always present) and take the preceding line — when a message has no
+        // narration, that line is the DT:/Acct: header, which we treat as "no merchant"
+        // instead of persisting a header/amount line.
+        val match = Regex("""(?im)^(.+)\r?\n\s*(?:DR|CR)\s*Amt:""").find(message) ?: return null
         val desc = match.groupValues[1].trim()
         if (desc.isBlank()) return null
-        val isNonNarration = Regex("""(?i)^((DR|CR)\s*Amt:|Bal:|Dial\b)""").containsMatchIn(desc)
-        return if (isNonNarration) null else desc
+        if (Regex("""(?i)^(DT:|Acct:)""").containsMatchIn(desc)) return null
+        return desc
     }
 
     override fun extractAccountLast4(message: String): String? {

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ZenithBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ZenithBankParser.kt
@@ -1,0 +1,82 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Zenith Bank (Nigeria) SMS messages.
+ *
+ * Supported format (line-based):
+ * ```
+ * Acct:421****577
+ * DT:09/06/2026 03:23:17 PM
+ * <description>
+ * DR Amt:650.00          (debit -> EXPENSE)  or  CR Amt:40,000.00 (credit -> INCOME)
+ * Bal:289.69
+ * Dial *966# for quick airtime/Data purchase   (promo — ignored)
+ * ```
+ * Amounts have no NGN prefix.
+ *
+ * Sender: ZENITHBANK
+ */
+class ZenithBankParser : BankParser() {
+
+    override fun getBankName() = "Zenith Bank"
+
+    override fun getCurrency() = "NGN"
+
+    override fun canHandle(sender: String): Boolean {
+        return sender.uppercase().contains("ZENITH")
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+        if (lower.contains("otp") || lower.contains("verification code")) {
+            return false
+        }
+        return Regex("""(?i)(?:DR|CR)\s*Amt:""").containsMatchIn(message) &&
+                Regex("""(?i)Acct:""").containsMatchIn(message)
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        return when {
+            Regex("""(?i)DR\s*Amt:""").containsMatchIn(message) -> TransactionType.EXPENSE
+            Regex("""(?i)CR\s*Amt:""").containsMatchIn(message) -> TransactionType.INCOME
+            else -> null
+        }
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        val match = Regex("""(?i)(?:DR|CR)\s*Amt:\s*([0-9,]+(?:\.\d{1,2})?)""").find(message) ?: return null
+        return try {
+            BigDecimal(match.groupValues[1].replace(",", ""))
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        val match = Regex("""(?i)Bal:\s*([0-9,]+(?:\.\d{1,2})?)""").find(message) ?: return null
+        return try {
+            BigDecimal(match.groupValues[1].replace(",", ""))
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // Description is the line between the DT line and the amount line.
+        val match = Regex("""(?im)^DT:.*\n(.+)""").find(message) ?: return null
+        val desc = match.groupValues[1].trim()
+        return desc.ifBlank { null }
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        val match = Regex("""(?i)Acct:\s*[0-9]*\*+([0-9]+)""").find(message)
+        if (match != null) {
+            return extractLast4Digits(match.groupValues[1])
+        }
+        val plain = Regex("""(?i)Acct:\s*([0-9]+)""").find(message) ?: return null
+        return extractLast4Digits(plain.groupValues[1])
+    }
+}

--- a/parser-core/src/test/kotlin/TestAccessBankParser.kt
+++ b/parser-core/src/test/kotlin/TestAccessBankParser.kt
@@ -1,0 +1,75 @@
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.bank.AccessBankParser
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.*
+import java.math.BigDecimal
+
+class AccessBankParserTest {
+
+    @TestFactory
+    fun `access bank parser handles common cases`(): List<DynamicTest> {
+        val parser = AccessBankParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "Debit transaction (EXPENSE)",
+                message = """
+                    Debit
+                    Amt:NGN20,400.00
+                    Acc:146******325
+                    Desc:179AMHY2616000hU/MOBILE TRF TO PAY/ POS /ABDULHADI  HAMISU
+                    Date:09/06/2026
+                    Avail Bal:NGN224,408.56
+                    Total:NGN2
+                """.trimIndent(),
+                sender = "AccessBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("20400.00"),
+                    currency = "NGN",
+                    type = TransactionType.EXPENSE,
+                    merchant = "179AMHY2616000hU/MOBILE TRF TO PAY/ POS /ABDULHADI  HAMISU",
+                    accountLast4 = "325",
+                    balance = BigDecimal("224408.56")
+                )
+            ),
+            ParserTestCase(
+                name = "Credit transaction (INCOME)",
+                message = """
+                    Credit
+                    Amt:NGN260,000.00
+                    Acc:146******325
+                    Desc:179NIPL2616000QZ/Paystack/CowrywiseCowrywise Financial Tech
+                    Date:09/06/2026
+                    Avail Bal:NGN260,000.38
+                    Total:N
+                """.trimIndent(),
+                sender = "AccessBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("260000.00"),
+                    currency = "NGN",
+                    type = TransactionType.INCOME,
+                    merchant = "179NIPL2616000QZ/Paystack/CowrywiseCowrywise Financial Tech",
+                    accountLast4 = "325",
+                    balance = BigDecimal("260000.38")
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            "AccessBank" to true,
+            "AD-ACCESSBANK-S" to true,
+            "ZENITHBANK" to false,
+            "HDFC" to false,
+            "" to false
+        )
+
+        return ParserTestUtils.runTestSuite(
+            parser = parser,
+            testCases = testCases,
+            handleCases = handleCases,
+            suiteName = "Access Bank Parser Suite"
+        )
+    }
+}

--- a/parser-core/src/test/kotlin/TestAccessBankParser.kt
+++ b/parser-core/src/test/kotlin/TestAccessBankParser.kt
@@ -72,4 +72,24 @@ class AccessBankParserTest {
             suiteName = "Access Bank Parser Suite"
         )
     }
+
+    @Test
+    fun `empty Desc field yields a null merchant, not the next line`() {
+        val parser = AccessBankParser()
+        val message = """
+            Debit
+            Amt:NGN20,400.00
+            Acc:146******325
+            Desc:
+            Date:09/06/2026
+            Avail Bal:NGN224,408.56
+        """.trimIndent()
+
+        val parsed = parser.parse(message, "AccessBank", 0L)
+        Assertions.assertNotNull(parsed, "Message should still parse")
+        Assertions.assertNull(
+            parsed!!.merchant,
+            "An empty Desc: must not capture the following Date:/Avail Bal: line"
+        )
+    }
 }

--- a/parser-core/src/test/kotlin/TestKeystoneBankParser.kt
+++ b/parser-core/src/test/kotlin/TestKeystoneBankParser.kt
@@ -1,0 +1,75 @@
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.bank.KeystoneBankParser
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.*
+import java.math.BigDecimal
+
+class KeystoneBankParserTest {
+
+    @TestFactory
+    fun `keystone bank parser handles common cases`(): List<DynamicTest> {
+        val parser = KeystoneBankParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "Debit transaction (EXPENSE)",
+                message = """
+                    Debit!
+                    Acct:602****370
+                    Amt:NGN-57,000.00
+                    Desc:TRF IFO WILSPLENDOR LIMITED FRM OBA
+                    Date:26-05-2026 0:0
+                    Bal:NGN1,929.24
+                    Download Keymobile bit.ly/31MJj1s
+                """.trimIndent(),
+                sender = "KEYSTONE",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("57000.00"),
+                    currency = "NGN",
+                    type = TransactionType.EXPENSE,
+                    merchant = "TRF IFO WILSPLENDOR LIMITED FRM OBA",
+                    accountLast4 = "370",
+                    balance = BigDecimal("1929.24")
+                )
+            ),
+            ParserTestCase(
+                name = "Credit transaction (INCOME)",
+                message = """
+                    Credit!
+                    Acct:602****370
+                    Amt:NGN3,000.00
+                    Desc:NXG :MOBILE TRF TO KSB  OBAYUWANA C
+                    Date:26-05-2026 0:0
+                    Bal:NGN59,030.84
+                    Download Keymobile bit.ly/31MJj1s
+                """.trimIndent(),
+                sender = "KEYSTONE",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("3000.00"),
+                    currency = "NGN",
+                    type = TransactionType.INCOME,
+                    merchant = "NXG :MOBILE TRF TO KSB  OBAYUWANA C",
+                    accountLast4 = "370",
+                    balance = BigDecimal("59030.84")
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            "KEYSTONE" to true,
+            "AD-KEYSTONE-S" to true,
+            "ZENITHBANK" to false,
+            "HDFC" to false,
+            "" to false
+        )
+
+        return ParserTestUtils.runTestSuite(
+            parser = parser,
+            testCases = testCases,
+            handleCases = handleCases,
+            suiteName = "Keystone Bank Parser Suite"
+        )
+    }
+}

--- a/parser-core/src/test/kotlin/TestKeystoneBankParser.kt
+++ b/parser-core/src/test/kotlin/TestKeystoneBankParser.kt
@@ -72,4 +72,24 @@ class KeystoneBankParserTest {
             suiteName = "Keystone Bank Parser Suite"
         )
     }
+
+    @Test
+    fun `empty Desc field yields a null merchant, not the next line`() {
+        val parser = KeystoneBankParser()
+        val message = """
+            Debit!
+            Acct:602****370
+            Amt:NGN-57,000.00
+            Desc:
+            Date:26-05-2026 0:0
+            Bal:NGN1,929.24
+        """.trimIndent()
+
+        val parsed = parser.parse(message, "KEYSTONE", 0L)
+        Assertions.assertNotNull(parsed, "Message should still parse")
+        Assertions.assertNull(
+            parsed!!.merchant,
+            "An empty Desc: must not capture the following Date:/Bal: line"
+        )
+    }
 }

--- a/parser-core/src/test/kotlin/TestZenithBankParser.kt
+++ b/parser-core/src/test/kotlin/TestZenithBankParser.kt
@@ -52,6 +52,26 @@ class ZenithBankParserTest {
                     accountLast4 = "577",
                     balance = BigDecimal("40277.08")
                 )
+            ),
+            ParserTestCase(
+                name = "Debit without a narration line still parses amount/type/balance",
+                message = """
+                    Acct:421****577
+                    DT:09/06/2026 03:23:17 PM
+                    DR Amt:650.00
+                    Bal:289.69
+                    Dial *966# for quick airtime/Data purchase
+                """.trimIndent(),
+                sender = "ZENITHBANK",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("650.00"),
+                    currency = "NGN",
+                    type = TransactionType.EXPENSE,
+                    // merchant intentionally unasserted here; the null guarantee is
+                    // checked directly in `no narration line yields a null merchant`.
+                    accountLast4 = "577",
+                    balance = BigDecimal("289.69")
+                )
             )
         )
 
@@ -68,6 +88,25 @@ class ZenithBankParserTest {
             testCases = testCases,
             handleCases = handleCases,
             suiteName = "Zenith Bank Parser Suite"
+        )
+    }
+
+    @Test
+    fun `no narration line yields a null merchant, not the amount line`() {
+        val parser = ZenithBankParser()
+        val message = """
+            Acct:421****577
+            DT:09/06/2026 03:23:17 PM
+            DR Amt:650.00
+            Bal:289.69
+            Dial *966# for quick airtime/Data purchase
+        """.trimIndent()
+
+        val parsed = parser.parse(message, "ZENITHBANK", 0L)
+        Assertions.assertNotNull(parsed, "Message should still parse")
+        Assertions.assertNull(
+            parsed!!.merchant,
+            "Without a narration line the merchant must be null, not the amount line"
         )
     }
 }

--- a/parser-core/src/test/kotlin/TestZenithBankParser.kt
+++ b/parser-core/src/test/kotlin/TestZenithBankParser.kt
@@ -1,0 +1,73 @@
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.bank.ZenithBankParser
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.*
+import java.math.BigDecimal
+
+class ZenithBankParserTest {
+
+    @TestFactory
+    fun `zenith bank parser handles common cases`(): List<DynamicTest> {
+        val parser = ZenithBankParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "Debit transaction (EXPENSE)",
+                message = """
+                    Acct:421****577
+                    DT:09/06/2026 03:23:17 PM
+                    CIP/CR/MOB/OLIVER TWIST LOKOGO
+                    DR Amt:650.00
+                    Bal:289.69
+                    Dial *966# for quick airtime/Data purchase
+                """.trimIndent(),
+                sender = "ZENITHBANK",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("650.00"),
+                    currency = "NGN",
+                    type = TransactionType.EXPENSE,
+                    merchant = "CIP/CR/MOB/OLIVER TWIST LOKOGO",
+                    accountLast4 = "577",
+                    balance = BigDecimal("289.69")
+                )
+            ),
+            ParserTestCase(
+                name = "Credit transaction (INCOME)",
+                message = """
+                    Acct:421****577
+                    DT:24/05/2026 08:05:26 AM
+                    ETI NXG  MOBILE TRF TO ZIB  CO
+                    CR Amt:40,000.00
+                    Bal:40,277.08
+                    Dial *966# for quick airtime/Data purchase
+                """.trimIndent(),
+                sender = "ZENITHBANK",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("40000.00"),
+                    currency = "NGN",
+                    type = TransactionType.INCOME,
+                    merchant = "ETI NXG  MOBILE TRF TO ZIB  CO",
+                    accountLast4 = "577",
+                    balance = BigDecimal("40277.08")
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            "ZENITHBANK" to true,
+            "AD-ZENITH-S" to true,
+            "AccessBank" to false,
+            "HDFC" to false,
+            "" to false
+        )
+
+        return ParserTestUtils.runTestSuite(
+            parser = parser,
+            testCases = testCases,
+            handleCases = handleCases,
+            suiteName = "Zenith Bank Parser Suite"
+        )
+    }
+}


### PR DESCRIPTION
Adds the first Nigerian (NGN) bank SMS parsers. Pairs well with the per-account NGN currency support just merged in #474.

## Parsers
| Bank | Sender | Issue | Format notes |
|------|--------|-------|--------------|
| Access Bank | `AccessBank` | #459 | `Debit/Credit` first line, `Amt:NGN…`, `Avail Bal:NGN…`, `Desc:…` |
| Zenith Bank | `ZENITHBANK` | #460 | `DR Amt:/CR Amt:` (no NGN prefix), `Bal:…`, `DT:` datetime |
| Keystone Bank | `KEYSTONE` | #461 | `Debit!/Credit!`, `Amt:NGN-…` (minus on debit), `Bal:NGN…` |

All three extend `BankParser()` directly (not Indian/UAE base) and override `getCurrency() = "NGN"`.

## Tests
- 7 JUnit 5 tests per parser (2 debit/credit parse cases + 5 `canHandle` checks) via `ParserTestUtils`.
- Full `:parser-core:jvmTest` green: **1238 tests, 0 failures** across 98 classes.

## Notes
- Sample account numbers are masked to 3 trailing digits, so `accountLast4` stores 3 digits (base helper accepts ≥3; auto-upgrades to 4 if a future sample exposes more).
- Merchant/description is preserved verbatim from the `Desc:`/narration line, since these formats pack transfer narration there rather than a clean merchant name.

Closes #459
Closes #460
Closes #461