### PR TITLE
feat(parser): CRDB Bank (Tanzania) + TZS currency

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
@@ -36,7 +36,8 @@ object CurrencyFormatter {
         "MYR" to "RM",
         "KWD" to "KD",
         "KRW" to "₩",
-        "NGN" to "₦"
+        "NGN" to "₦",
+        "TZS" to "TSh"
     )
 
     /**
@@ -62,7 +63,8 @@ object CurrencyFormatter {
         "MYR" to Locale.Builder().setLanguage("ms").setRegion("MY").build(),
         "KWD" to Locale.Builder().setLanguage("en").setRegion("KW").build(),
         "KRW" to Locale.KOREA,
-        "NGN" to Locale.Builder().setLanguage("en").setRegion("NG").build()
+        "NGN" to Locale.Builder().setLanguage("en").setRegion("NG").build(),
+        "TZS" to Locale.Builder().setLanguage("en").setRegion("TZ").build()
     )
 
     /**

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -85,6 +85,7 @@ object BankParserFactory {
         MPesaTanzaniaParser(),  // M-Pesa Tanzania (must be before Kenya M-PESA)
         MPESAParser(),  // M-PESA (Kenya)
         SelcomPesaParser(),  // Selcom Pesa (Tanzania)
+        CrdbBankParser(),  // CRDB Bank (Tanzania) — bilingual Swahili/English, multi-currency cards
         TigoPesaParser(),  // Tigo Pesa / Mixx by Yas (Tanzania)
         CIBEgyptParser(),  // CIB - Commercial International Bank (Egypt)
         DhanlaxmiBankParser(),  // Dhanlaxmi Bank (India)

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CrdbBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CrdbBankParser.kt
@@ -1,0 +1,238 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for CRDB Bank (Tanzania).
+ *
+ * CRDB sends bilingual Swahili/English SMS across several transaction types.
+ * Default currency is Tanzanian Shilling (TZS), but some card payments are
+ * billed in a foreign currency (e.g. USD) while the balance stays in TZS.
+ * For those, the transaction amount/currency reflect the foreign spend and
+ * the balance reflects the TZS figure (see [parse]).
+ *
+ * Supported formats:
+ * - ATM withdrawal (English): "... has been withdrawn using a Card ... Balance is TZS ..."
+ * - Card payment / POS / online (English): "Paid:MERCHANT ... CCY 9.99 Card:... Bal:TZS..."
+ * - Mobile money send (Swahili): "Muamala umefanikiwa TZS40000 AIRTEL kwenda NAME phone"
+ * - Bill payment / utility (Swahili): "Malipo yamekamilika MERCHANT TZS 2000"
+ */
+class CrdbBankParser : BankParser() {
+
+    override fun getBankName() = "CRDB Bank"
+
+    override fun getCurrency() = "TZS"
+
+    override fun canHandle(sender: String): Boolean {
+        return sender.uppercase().contains("CRDB")
+    }
+
+    /**
+     * Override parse to surface per-transaction foreign currency.
+     *
+     * The base [extractAmount] already picks the spent amount (e.g. USD 9.99 for the
+     * Netflix card-payment form). Here we detect when that amount is billed in a
+     * non-TZS currency and copy it onto the transaction, while [extractBalance]
+     * keeps reporting the TZS balance figure.
+     */
+    override fun parse(smsBody: String, sender: String, timestamp: Long): ParsedTransaction? {
+        val transaction = super.parse(smsBody, sender, timestamp) ?: return null
+        val currency = extractCurrency(smsBody)
+        return if (currency != null && currency != getCurrency()) {
+            transaction.copy(currency = currency)
+        } else {
+            transaction
+        }
+    }
+
+    /**
+     * Detects the currency of the SPENT amount (not the balance).
+     *
+     * Card-payment form: "Paid:NETFLIX.COM, NL USD 9.99 Card:... Bal:TZS923041.06"
+     * The currency we want is the one immediately preceding the amount after "Paid:".
+     */
+    override fun extractCurrency(message: String): String? {
+        // Currency + amount right before "Card:" in the card-payment form.
+        val paidCurrency = Regex(
+            """Paid:.*?\b([A-Z]{3})\s*[0-9][0-9,]*(?:\.\d{1,2})?\s*Card:""",
+            RegexOption.IGNORE_CASE
+        )
+        paidCurrency.find(message)?.let { match ->
+            val code = match.groupValues[1].uppercase()
+            if (code.all { it.isLetter() }) return code
+        }
+        return null
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // Card-payment form: amount sits between the merchant and "Card:".
+        // e.g. "Paid:NETFLIX.COM, NL USD 9.99 Card:..." -> 9.99
+        val paidPattern = Regex(
+            """Paid:.*?\b[A-Z]{3}\s*([0-9][0-9,]*(?:\.\d{1,2})?)\s*Card:""",
+            RegexOption.IGNORE_CASE
+        )
+        paidPattern.find(message)?.let { match ->
+            parseAmount(match.groupValues[1])?.let { return it }
+        }
+
+        // "TZS 50000.00" (with space) or "TZS40000" (no space).
+        val tzsPattern = Regex(
+            """TZS\s*([0-9][0-9,]*(?:\.\d{1,2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        // Use the FIRST TZS amount that is not the balance.
+        for (match in tzsPattern.findAll(message)) {
+            // Skip the balance figure ("Balance is TZS ..." / "Bal:TZS...").
+            val precedingText = message.substring(0, match.range.first).takeLast(20).lowercase()
+            if (precedingText.contains("bal")) continue
+            parseAmount(match.groupValues[1])?.let { return it }
+        }
+
+        return super.extractAmount(message)
+    }
+
+    private fun parseAmount(raw: String): BigDecimal? {
+        val cleaned = raw.replace(",", "")
+        return try {
+            BigDecimal(cleaned)
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lower = message.lowercase()
+
+        return when {
+            // Outgoing money (Swahili + English).
+            lower.contains("withdrawn") -> TransactionType.EXPENSE          // ATM withdrawal
+            lower.contains("paid:") -> TransactionType.EXPENSE              // card payment
+            lower.contains("umefanikiwa kutuma") -> TransactionType.EXPENSE // send money
+            lower.contains("umetuma") -> TransactionType.EXPENSE            // sent
+            lower.contains("kwenda") -> TransactionType.EXPENSE             // "to" (transfer)
+            lower.contains("malipo yamekamilika") -> TransactionType.EXPENSE // payment completed
+            lower.contains("imelipwa") -> TransactionType.EXPENSE          // has been paid
+
+            // Incoming money (Swahili + English) — only on clear keywords.
+            lower.contains("umepokea") -> TransactionType.INCOME           // you received
+            lower.contains("received") -> TransactionType.INCOME
+            lower.contains("deposited") -> TransactionType.INCOME
+
+            // "Muamala umefanikiwa" alone (generic "transaction successful") defaults to expense,
+            // matching all provided send/payment samples.
+            lower.contains("muamala umefanikiwa") -> TransactionType.EXPENSE
+
+            else -> null
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // Card-payment form: "Paid:NETFLIX.COM, NL USD 9.99 Card:..."
+        // Merchant is everything after "Paid:" up to the currency+amount.
+        val paidMerchant = Regex(
+            """Paid:\s*(.+?)\s+[A-Z]{3}\s*[0-9]""",
+            RegexOption.IGNORE_CASE
+        )
+        paidMerchant.find(message)?.let { match ->
+            val merchant = match.groupValues[1].trim().trimEnd(',').trim()
+            if (merchant.isNotEmpty()) return merchant
+        }
+
+        // ATM withdrawal.
+        if (message.contains("withdrawn using a Card", ignoreCase = true)) {
+            return "ATM Withdrawal"
+        }
+
+        // Mobile money send (Swahili): "... kwenda NAME phonenumber".
+        // Recipient is the name after "kwenda" up to a trailing phone number.
+        val kwendaPattern = Regex(
+            """kwenda\s+(.+?)(?:\s+\d{6,})?$""",
+            RegexOption.IGNORE_CASE
+        )
+        kwendaPattern.find(message)?.let { match ->
+            val merchant = match.groupValues[1].trim()
+            if (merchant.isNotEmpty()) return merchant
+        }
+
+        // Bill payment / utility (Swahili): "Malipo yamekamilika TOTAL TZS 2000".
+        // Merchant is the text between the completion phrase and the amount.
+        val billPattern = Regex(
+            """Malipo yamekamilika\s+(.+?)\s+TZS""",
+            RegexOption.IGNORE_CASE
+        )
+        billPattern.find(message)?.let { match ->
+            val merchant = match.groupValues[1].trim()
+            if (merchant.isNotEmpty()) return merchant
+        }
+        if (message.contains("Malipo yamekamilika", ignoreCase = true)) {
+            return "Bill Payment"
+        }
+
+        return null
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        // "Balance is TZS 550070.90" or "Bal:TZS923041.06".
+        val patterns = listOf(
+            Regex("""Balance is\s+TZS\s*([0-9][0-9,]*(?:\.\d{1,2})?)""", RegexOption.IGNORE_CASE),
+            Regex("""Bal:\s*TZS\s*([0-9][0-9,]*(?:\.\d{1,2})?)""", RegexOption.IGNORE_CASE)
+        )
+        for (pattern in patterns) {
+            pattern.find(message)?.let { match ->
+                parseAmount(match.groupValues[1])?.let { return it }
+            }
+        }
+        return null
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        // Card number form: "Card 4232***0581" / "Card:4232***0581".
+        val cardPattern = Regex("""Card:?\s*([0-9*]{4,})""", RegexOption.IGNORE_CASE)
+        cardPattern.find(message)?.let { match ->
+            extractLast4Digits(match.groupValues[1])?.let { return it }
+        }
+
+        // Account-number labels (Swahili + English).
+        val accountPattern = Regex(
+            """(?:akaunti yako nambari|bank account|account|AC No\.?)[:\s]*([0-9*]{4,})""",
+            RegexOption.IGNORE_CASE
+        )
+        accountPattern.find(message)?.let { match ->
+            extractLast4Digits(match.groupValues[1])?.let { return it }
+        }
+
+        return null
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+
+        // Reject OTP / promotional noise.
+        if (lower.contains("otp") ||
+            lower.contains("one time password") ||
+            lower.contains("verification code") ||
+            lower.contains("namba ya siri")
+        ) {
+            return false
+        }
+
+        // Accept both English and Swahili transaction markers.
+        val markers = listOf(
+            "withdrawn",
+            "paid:",
+            "muamala umefanikiwa",
+            "umefanikiwa kutuma",
+            "umetuma",
+            "malipo yamekamilika",
+            "imelipwa",
+            "kwenda",
+            "umepokea",
+            "received",
+            "deposited"
+        )
+
+        return markers.any { lower.contains(it) }
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CrdbBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CrdbBankParser.kt
@@ -106,6 +106,13 @@ class CrdbBankParser : BankParser() {
         val lower = message.lowercase()
 
         return when {
+            // Incoming money (Swahili + English) — checked FIRST. A deposit/credit SMS
+            // commonly also contains outgoing words like "kwenda" ("to"), so the
+            // unambiguous income keywords must win over the weaker outgoing markers.
+            lower.contains("umepokea") -> TransactionType.INCOME           // you received
+            lower.contains("received") -> TransactionType.INCOME
+            lower.contains("deposited") -> TransactionType.INCOME
+
             // Outgoing money (Swahili + English).
             lower.contains("withdrawn") -> TransactionType.EXPENSE          // ATM withdrawal
             lower.contains("paid:") -> TransactionType.EXPENSE              // card payment
@@ -114,11 +121,6 @@ class CrdbBankParser : BankParser() {
             lower.contains("kwenda") -> TransactionType.EXPENSE             // "to" (transfer)
             lower.contains("malipo yamekamilika") -> TransactionType.EXPENSE // payment completed
             lower.contains("imelipwa") -> TransactionType.EXPENSE          // has been paid
-
-            // Incoming money (Swahili + English) — only on clear keywords.
-            lower.contains("umepokea") -> TransactionType.INCOME           // you received
-            lower.contains("received") -> TransactionType.INCOME
-            lower.contains("deposited") -> TransactionType.INCOME
 
             // "Muamala umefanikiwa" alone (generic "transaction successful") defaults to expense,
             // matching all provided send/payment samples.

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CrdbBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CrdbBankParser.kt
@@ -105,25 +105,31 @@ class CrdbBankParser : BankParser() {
     override fun extractTransactionType(message: String): TransactionType? {
         val lower = message.lowercase()
 
+        // Keywords are tiered by signal strength so weaker directional words ("kwenda",
+        // "received") can't override an unambiguous first-person verb. A deposit SMS may
+        // also contain "kwenda" ("to"), and a send confirmation may mention the recipient
+        // having "received" — the tiering resolves both correctly.
         return when {
-            // Incoming money (Swahili + English) — checked FIRST. A deposit/credit SMS
-            // commonly also contains outgoing words like "kwenda" ("to"), so the
-            // unambiguous income keywords must win over the weaker outgoing markers.
-            lower.contains("umepokea") -> TransactionType.INCOME           // you received
+            // Tier 1 — first-person, unambiguous direction.
+            lower.contains("umepokea") -> TransactionType.INCOME            // you received
+            lower.contains("umefanikiwa kutuma") -> TransactionType.EXPENSE // you sent
+            lower.contains("umetuma") -> TransactionType.EXPENSE            // you sent
+
+            // Tier 2 — strong action verbs.
+            lower.contains("withdrawn") -> TransactionType.EXPENSE          // ATM withdrawal
+            lower.contains("paid:") -> TransactionType.EXPENSE              // card payment
+            lower.contains("malipo yamekamilika") -> TransactionType.EXPENSE // payment completed
+            lower.contains("imelipwa") -> TransactionType.EXPENSE           // has been paid
+
+            // Tier 3 — weaker income hints.
             lower.contains("received") -> TransactionType.INCOME
             lower.contains("deposited") -> TransactionType.INCOME
 
-            // Outgoing money (Swahili + English).
-            lower.contains("withdrawn") -> TransactionType.EXPENSE          // ATM withdrawal
-            lower.contains("paid:") -> TransactionType.EXPENSE              // card payment
-            lower.contains("umefanikiwa kutuma") -> TransactionType.EXPENSE // send money
-            lower.contains("umetuma") -> TransactionType.EXPENSE            // sent
+            // Tier 4 — weak directional marker (only reached when nothing stronger matched).
             lower.contains("kwenda") -> TransactionType.EXPENSE             // "to" (transfer)
-            lower.contains("malipo yamekamilika") -> TransactionType.EXPENSE // payment completed
-            lower.contains("imelipwa") -> TransactionType.EXPENSE          // has been paid
 
-            // "Muamala umefanikiwa" alone (generic "transaction successful") defaults to expense,
-            // matching all provided send/payment samples.
+            // Fallback — generic "transaction successful", defaults to expense to match
+            // all provided send/payment samples.
             lower.contains("muamala umefanikiwa") -> TransactionType.EXPENSE
 
             else -> null

--- a/parser-core/src/test/kotlin/CrdbBankParserTest.kt
+++ b/parser-core/src/test/kotlin/CrdbBankParserTest.kt
@@ -1,0 +1,76 @@
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.bank.CrdbBankParser
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class CrdbBankParserTest {
+
+    @TestFactory
+    fun `crdb parser handles common cases`(): List<DynamicTest> {
+        val parser = CrdbBankParser()
+
+        val cases = listOf(
+            ParserTestCase(
+                name = "ATM withdrawal (English)",
+                message = "Dear NAME, TZS 50000.00 has been withdrawn using a Card 4232***0581 On 19.01.2511:53 Balance is TZS 550070.90",
+                sender = "CRDB BANK",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("50000.00"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "ATM Withdrawal",
+                    balance = BigDecimal("550070.90"),
+                    accountLast4 = "0581"
+                )
+            ),
+            ParserTestCase(
+                name = "Card payment foreign currency (USD)",
+                message = "Paid:NETFLIX.COM, NL USD 9.99 Card:4232***0581 Date:17.01.2517:39 Bal:TZS923041.06",
+                sender = "CRDB BANK",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("9.99"),
+                    currency = "USD",
+                    type = TransactionType.EXPENSE,
+                    merchant = "NETFLIX.COM, NL",
+                    balance = BigDecimal("923041.06"),
+                    accountLast4 = "0581"
+                )
+            ),
+            ParserTestCase(
+                name = "Mobile money send (Swahili)",
+                message = "Muamala umefanikiwa TZS40000 AIRTEL kwenda MSHAMU MSHAMU 255686621388",
+                sender = "CRDB BANK",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("40000"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "MSHAMU MSHAMU"
+                )
+            ),
+            ParserTestCase(
+                name = "Bill payment / utility (Swahili)",
+                message = "Malipo yamekamilika TOTAL TZS 2000",
+                sender = "CRDB BANK",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2000"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "TOTAL"
+                )
+            )
+        )
+
+        val handleChecks = listOf(
+            "CRDB BANK" to true,
+            "crdb" to true,
+            "MPESA" to false,
+            "UNKNOWN" to false
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases, handleChecks, "CRDB Bank Parser")
+    }
+}

--- a/parser-core/src/test/kotlin/CrdbBankParserTest.kt
+++ b/parser-core/src/test/kotlin/CrdbBankParserTest.kt
@@ -74,6 +74,20 @@ class CrdbBankParserTest {
                     type = TransactionType.INCOME,
                     balance = BigDecimal("200000.00")
                 )
+            ),
+            ParserTestCase(
+                // Tiering: a first-person send ("umetuma") must stay EXPENSE even when the
+                // message also mentions the recipient having "received" the funds. The
+                // strong sender verb outranks the weak income hint.
+                name = "Outgoing send mentioning recipient received (EXPENSE)",
+                message = "Umetuma TZS 30000.00 kwenda JANE DOE. JANE DOE has received the funds. Bal:TZS 50000.00",
+                sender = "CRDB BANK",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("30000.00"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    balance = BigDecimal("50000.00")
+                )
             )
         )
 

--- a/parser-core/src/test/kotlin/CrdbBankParserTest.kt
+++ b/parser-core/src/test/kotlin/CrdbBankParserTest.kt
@@ -61,6 +61,19 @@ class CrdbBankParserTest {
                     type = TransactionType.EXPENSE,
                     merchant = "TOTAL"
                 )
+            ),
+            ParserTestCase(
+                // Regression: a deposit ("umepokea") that also contains the outgoing word
+                // "kwenda" must classify as INCOME — income keywords are matched first.
+                name = "Incoming transfer with both umepokea and kwenda (INCOME)",
+                message = "Umepokea TZS 75000.00 kutoka JOHN DOE kwenda akaunti yako Balance is TZS 200000.00",
+                sender = "CRDB BANK",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("75000.00"),
+                    currency = "TZS",
+                    type = TransactionType.INCOME,
+                    balance = BigDecimal("200000.00")
+                )
             )
         )
 


### PR DESCRIPTION
Adds a CRDB Bank parser and Tanzanian Shilling (TZS) support.

## Parser (`parser-core`)
`CrdbBankParser` (sender `CRDB BANK`), extends `BankParser`, `getCurrency()="TZS"`. Handles bilingual Swahili/English alerts:

| Type | Marker | Example → result |
|------|--------|------------------|
| ATM withdrawal | `withdrawn using a Card` | `TZS 50000.00 … Balance is TZS 550070.90` → 50000 TZS, EXPENSE |
| Card / POS (foreign ccy) | `Paid:… Card:… Bal:TZS…` | `Paid:NETFLIX.COM, NL USD 9.99 …` → **9.99 USD**, bal 923041.06 TZS |
| Mobile money send | `Muamala umefanikiwa … kwenda` | `TZS40000 AIRTEL kwenda …` → 40000 TZS, EXPENSE |
| Bill payment | `Malipo yamekamilika` | `… TOTAL TZS 2000` → 2000 TZS, EXPENSE |

**Multi-currency:** `parse()` follows the `UAEBankParser` idiom — `super.parse()` then `.copy(currency=…)` when a non-TZS spend currency is detected. `extractAmount` prefers the `Paid:<CCY> amount` figure and skips the `Bal`-prefixed balance for TZS forms.

## App
`CurrencyFormatter`: added `TZS → TSh` symbol + `en-TZ` locale, so amounts format and TZS is selectable in the account currency picker.

## Tests
- 8 dynamic tests (4 sample parses incl. the USD-currency assertion + 4 canHandle checks).
- Full `:parser-core:jvmTest` green: **1225 tests, 0 failures**; app compiles.

## Notes for reporter
- No INCOME sample was provided — income is keyword-guarded (`umepokea`/`received`/`deposited`) but unverified against a real CRDB deposit SMS.
- Samples only carried card numbers (not bare account numbers), so the account-number label paths (`akaunti yako nambari:`, masked forms) are handled but untested by real data.

Closes #472