### PR TITLE
fix(transactions): exclude loans from spend/income totals (#483)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -1148,8 +1148,12 @@ class TransactionsViewModel @Inject constructor(
     }
     
     private fun calculateCurrencyGroupedTotals(transactions: List<TransactionEntity>): CurrencyGroupedTotals {
-        // Group transactions by currency
-        val transactionsByCurrency = transactions.groupBy { it.currency }
+        // Loan disbursements/repayments still appear in the list (it's the full ledger)
+        // but must not count toward the period's Income/Expense/etc. totals — they're
+        // tracked in the Loans feature. Matches the Home/Analytics convention.
+        val transactionsByCurrency = transactions
+            .filter { it.loanId == null }
+            .groupBy { it.currency }
 
         val totalsByCurrency = transactionsByCurrency.mapValues { (currency, currencyTransactions) ->
             // A "Refund" (INCOME + DEDUCT_SPENT) is the reversal of a previous

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -1151,9 +1151,8 @@ class TransactionsViewModel @Inject constructor(
         // Loan disbursements/repayments still appear in the list (it's the full ledger)
         // but must not count toward the period's Income/Expense/etc. totals — they're
         // tracked in the Loans feature. Matches the Home/Analytics convention.
-        val transactionsByCurrency = transactions
-            .filter { it.loanId == null }
-            .groupBy { it.currency }
+        val nonLoanTransactions = transactions.filter { it.loanId == null }
+        val transactionsByCurrency = nonLoanTransactions.groupBy { it.currency }
 
         val totalsByCurrency = transactionsByCurrency.mapValues { (currency, currencyTransactions) ->
             // A "Refund" (INCOME + DEDUCT_SPENT) is the reversal of a previous
@@ -1218,7 +1217,7 @@ class TransactionsViewModel @Inject constructor(
         return CurrencyGroupedTotals(
             totalsByCurrency = totalsByCurrency,
             availableCurrencies = filteredAvailableCurrencies,
-            transactionCount = transactions.size
+            transactionCount = nonLoanTransactions.size
         )
     }
     

--- a/app/src/main/java/com/pennywiseai/tracker/widget/RecentTransactionsWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/RecentTransactionsWidgetUpdateWorker.kt
@@ -80,6 +80,9 @@ class RecentTransactionsWidgetUpdateWorker @AssistedInject constructor(
                 .first()
 
             val totalSpent = allTransactions
+                // Loan disbursements/repayments are tracked in the Loans feature, not
+                // spending — exclude them, matching Home/Analytics.
+                .filter { it.loanId == null }
                 .filter { it.transactionType == TransactionType.EXPENSE || it.transactionType == TransactionType.CREDIT || it.transactionType == TransactionType.INVESTMENT }
                 .fold(BigDecimal.ZERO) { acc, tx ->
                     val amount = if (!tx.currency.equals(targetCurrency, ignoreCase = true)) {


### PR DESCRIPTION
Loan disbursements/repayments (`loanId != null`) were counted as expenses and income in two aggregations that missed the established `loanId == null` convention used by Home and Analytics.

## Changes
- **`TransactionsViewModel.calculateCurrencyGroupedTotals`** — the Transactions screen's "This Month" Income/Expense/Credit/Transfer/Investment summary. The ledger list still shows loan rows; only the **totals** now exclude them.
- **`RecentTransactionsWidgetUpdateWorker`** — the home-screen widget's "spent this month".

## Verification (emulator)
1. Added two $expenses (Coffee $100, John $500) → Transactions "Expenses" = **$600**.
2. Marked John ($500) as a loan (Lent).
3. Transactions "Expenses" dropped to **$100**, Net **-$100** — and "John -$500" still appears in the list.


## Notes / open questions
- The Transactions **list** still shows loan rows (it's the full ledger); only totals exclude them. Say the word if loan rows should also be hidden from the list when filtered to a type.
- The widget still lumps `INVESTMENT` into "spent" (pre-existing, unrelated to loans) — left as-is.

Closes #483
