### PR TITLE
fix(accounts): derive manual/cash balance from transactions (#469, #470)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/AccountBalanceDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/AccountBalanceDao.kt
@@ -223,4 +223,43 @@ interface AccountBalanceDao {
 
     @Query("UPDATE account_balances SET alias = :alias WHERE bank_name = :bankName AND account_last4 = :accountLast4")
     suspend fun setAccountAlias(bankName: String, accountLast4: String, alias: String?): Int
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Manual/cash account balance recompute support.
+    //
+    // A manual account's displayed balance = opening + Σ(its transactions). The
+    // opening is stored in a single OPENING row at an early timestamp (so it never
+    // wins "latest by timestamp"); the displayed value lives in a single MANUAL row
+    // that recompute refreshes. See AccountBalanceRepository.recomputeManualBalance.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Query("""
+        SELECT * FROM account_balances
+        WHERE bank_name = :bankName AND account_last4 = :accountLast4
+        AND source_type = 'OPENING'
+        ORDER BY timestamp ASC
+        LIMIT 1
+    """)
+    suspend fun getOpeningRow(bankName: String, accountLast4: String): AccountBalanceEntity?
+
+    @Query("""
+        SELECT * FROM account_balances
+        WHERE bank_name = :bankName AND account_last4 = :accountLast4
+        AND source_type = 'MANUAL'
+        ORDER BY timestamp DESC
+        LIMIT 1
+    """)
+    suspend fun getManualCurrentRow(bankName: String, accountLast4: String): AccountBalanceEntity?
+
+    @Query("""
+        SELECT MIN(timestamp) FROM account_balances
+        WHERE bank_name = :bankName AND account_last4 = :accountLast4
+    """)
+    suspend fun getEarliestBalanceTimestamp(bankName: String, accountLast4: String): LocalDateTime?
+
+    @Query("UPDATE account_balances SET balance = :balance, timestamp = :timestamp WHERE id = :id")
+    suspend fun updateBalanceAndTimestampById(id: Long, balance: BigDecimal, timestamp: LocalDateTime)
+
+    @Query("UPDATE account_balances SET currency = :currency WHERE bank_name = :bankName AND account_last4 = :accountLast4")
+    suspend fun updateAccountCurrency(bankName: String, accountLast4: String, currency: String): Int
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/AccountBalanceDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/AccountBalanceDao.kt
@@ -175,7 +175,10 @@ interface AccountBalanceDao {
     """)
     fun getAccountCount(): Flow<Int>
     
-    @Query("DELETE FROM account_balances WHERE timestamp < :beforeDate")
+    // Never prune OPENING anchors — they carry an intentionally early timestamp (so
+    // they never win "latest"), which would otherwise make them the prime target of a
+    // timestamp-cutoff delete and silently break the derived manual-balance model.
+    @Query("DELETE FROM account_balances WHERE timestamp < :beforeDate AND (source_type IS NULL OR source_type != 'OPENING')")
     suspend fun deleteOldBalances(beforeDate: LocalDateTime): Int
     
     @Update

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/AccountBalanceDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/AccountBalanceDao.kt
@@ -265,4 +265,17 @@ interface AccountBalanceDao {
 
     @Query("UPDATE account_balances SET currency = :currency WHERE bank_name = :bankName AND account_last4 = :accountLast4")
     suspend fun updateAccountCurrency(bankName: String, accountLast4: String, currency: String): Int
+
+    /**
+     * Count of SMS-sourced balance rows for an account. Real bank SMS balances always
+     * carry a non-null `sms_source`, so a positive count means the account is
+     * SMS-tracked — used to keep the manual-balance recompute away from SMS accounts
+     * that merely had a one-off "Update balance" override.
+     */
+    @Query("""
+        SELECT COUNT(*) FROM account_balances
+        WHERE bank_name = :bankName AND account_last4 = :accountLast4
+        AND sms_source IS NOT NULL
+    """)
+    suspend fun countSmsSourcedBalances(bankName: String, accountLast4: String): Int
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
@@ -224,6 +224,23 @@ interface TransactionDao {
         bankName: String,
         accountLast4: String
     ): Flow<List<TransactionEntity>>
+
+    /**
+     * One-shot, strict-match transactions for an account — only rows explicitly
+     * assigned to (bankName, accountLast4), excluding the `account_number IS NULL`
+     * "any account at this bank" rows. Used to recompute a manual/cash account's
+     * balance as opening + Σ(transactions).
+     */
+    @Query("""
+        SELECT * FROM transactions
+        WHERE is_deleted = 0
+        AND bank_name = :bankName
+        AND account_number = :accountLast4
+    """)
+    suspend fun getTransactionsForAccountStrict(
+        bankName: String,
+        accountLast4: String
+    ): List<TransactionEntity>
     
     @Query("""
         SELECT * FROM transactions

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
@@ -241,6 +241,20 @@ interface TransactionDao {
         bankName: String,
         accountLast4: String
     ): List<TransactionEntity>
+
+    /**
+     * TRANSFER transactions touching an account on either side. Transfers are stored
+     * once with `from_account` / `to_account` (last-4 only, matching how the transfer
+     * balance shift resolves accounts), so a manual account's recompute must pull them
+     * by those columns — they don't carry the account in `account_number`.
+     */
+    @Query("""
+        SELECT * FROM transactions
+        WHERE is_deleted = 0
+        AND transaction_type = 'TRANSFER'
+        AND (from_account = :accountLast4 OR to_account = :accountLast4)
+    """)
+    suspend fun getTransfersForAccount(accountLast4: String): List<TransactionEntity>
     
     @Query("""
         SELECT * FROM transactions

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
@@ -280,12 +280,24 @@ class AccountBalanceRepository @Inject constructor(
         return accountBalanceDao.countSmsSourcedBalances(bankName, accountLast4) == 0
     }
 
-    /** Σ of an account's transactions, signed the same way balances move: INCOME +, everything else −. */
+    /**
+     * Σ of an account's transactions, signed the way balances move. Direct transactions
+     * (assigned via `account_number`): INCOME +, everything else −. TRANSFERs are handled
+     * separately by their `from_account`/`to_account` (money in when this account is the
+     * destination, out when it's the source) and excluded from the direct sum so they're
+     * never double-counted — a transfer *into* a manual account would otherwise be dropped.
+     */
     private suspend fun signedTransactionSum(bankName: String, accountLast4: String): BigDecimal {
-        return transactionDao.getTransactionsForAccountStrict(bankName, accountLast4)
+        var sum = transactionDao.getTransactionsForAccountStrict(bankName, accountLast4)
+            .filter { it.transactionType != TransactionType.TRANSFER }
             .fold(BigDecimal.ZERO) { acc, tx ->
                 if (tx.transactionType == TransactionType.INCOME) acc + tx.amount else acc - tx.amount
             }
+        for (tx in transactionDao.getTransfersForAccount(accountLast4)) {
+            if (tx.toAccount == accountLast4) sum += tx.amount
+            if (tx.fromAccount == accountLast4) sum -= tx.amount
+        }
+        return sum
     }
 
     /**

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
@@ -272,7 +272,12 @@ class AccountBalanceRepository @Inject constructor(
         // increases it), which the income-positive recompute would get backwards.
         accountBalanceDao.getOpeningRow(bankName, accountLast4)?.let { return !it.isCreditCard }
         val latest = accountBalanceDao.getLatestBalance(bankName, accountLast4) ?: return false
-        return latest.sourceType == SOURCE_MANUAL && !latest.isCreditCard
+        if (latest.sourceType != SOURCE_MANUAL || latest.isCreditCard) return false
+        // Legacy bridge for accounts created before the OPENING model: only treat them
+        // as manual if they have no SMS-sourced history. Without this, an SMS-tracked
+        // account that merely had a one-off "Update balance" override (latest row MANUAL)
+        // would be permanently reclassified as manual on its first write. (Greptile #487)
+        return accountBalanceDao.countSmsSourcedBalances(bankName, accountLast4) == 0
     }
 
     /** Σ of an account's transactions, signed the same way balances move: INCOME +, everything else −. */

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
@@ -350,6 +350,23 @@ class AccountBalanceRepository @Inject constructor(
         }
     }
 
+    /**
+     * Atomically applies the account-edit dialog's currency + balance changes for a
+     * manual account, so a failure can't leave the currency updated but the opening
+     * un-back-solved (a stale balance until the next mutation). (Greptile #487)
+     */
+    suspend fun updateManualBalanceAndCurrency(
+        bankName: String,
+        accountLast4: String,
+        currency: String,
+        targetBalance: BigDecimal
+    ) {
+        database.withTransaction {
+            accountBalanceDao.updateAccountCurrency(bankName, accountLast4, currency)
+            setManualCurrentBalance(bankName, accountLast4, targetBalance)
+        }
+    }
+
     /** Upserts the single MANUAL "current" row at `now` so it wins as the latest. */
     private suspend fun writeManualCurrentRow(
         bankName: String,

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
@@ -3,6 +3,7 @@ package com.pennywiseai.tracker.data.repository
 import androidx.room.withTransaction
 import com.pennywiseai.tracker.data.database.PennyWiseDatabase
 import com.pennywiseai.tracker.data.database.dao.AccountBalanceDao
+import com.pennywiseai.tracker.data.database.dao.TransactionDao
 import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.data.database.entity.ProfileEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
@@ -16,8 +17,13 @@ import javax.inject.Singleton
 @Singleton
 class AccountBalanceRepository @Inject constructor(
     private val accountBalanceDao: AccountBalanceDao,
+    private val transactionDao: TransactionDao,
     private val database: PennyWiseDatabase
 ) {
+    companion object {
+        const val SOURCE_OPENING = "OPENING"
+        const val SOURCE_MANUAL = "MANUAL"
+    }
     
     suspend fun insertBalance(balance: AccountBalanceEntity): Long {
         return accountBalanceDao.insertBalance(balance)
@@ -185,6 +191,10 @@ class AccountBalanceRepository @Inject constructor(
         return accountBalanceDao.setAccountAlias(bankName, accountLast4, alias)
     }
 
+    suspend fun updateAccountCurrency(bankName: String, accountLast4: String, currency: String): Int {
+        return accountBalanceDao.updateAccountCurrency(bankName, accountLast4, currency)
+    }
+
     /**
      * Atomically revert the balance impact of the [original] TRANSFER (if it was
      * one) and apply the [updated] TRANSFER's impact (if it is one) — wrapped in
@@ -235,6 +245,128 @@ class AccountBalanceRepository @Inject constructor(
                 timestamp = timestamp,
                 transactionId = transactionId,
                 sourceType = "TRANSACTION",
+                smsSource = null
+            )
+        )
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Manual / cash account balance = opening + Σ(its transactions).
+    //
+    // SMS-tracked accounts get their balance from the bank (each SMS reports the
+    // real figure), so these helpers only ever touch accounts the app recognises
+    // as manual. A manual account stores a stable OPENING row (at an early
+    // timestamp, so it never wins "latest by timestamp") plus a single MANUAL row
+    // that [recomputeManualBalance] keeps equal to opening + Σ(transactions).
+    // Because the balance is *derived*, retroactive changes — back-dated adds,
+    // deletes, edits — are handled by simply recomputing. (#469 / #470)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * An account is "manual" if it has an OPENING anchor, or (for accounts created
+     * before this model existed) its latest balance row is user-entered (MANUAL).
+     * SMS-tracked accounts never match.
+     */
+    suspend fun isManualAccount(bankName: String, accountLast4: String): Boolean {
+        // Credit cards are excluded — their balance is outstanding owed (spending
+        // increases it), which the income-positive recompute would get backwards.
+        accountBalanceDao.getOpeningRow(bankName, accountLast4)?.let { return !it.isCreditCard }
+        val latest = accountBalanceDao.getLatestBalance(bankName, accountLast4) ?: return false
+        return latest.sourceType == SOURCE_MANUAL && !latest.isCreditCard
+    }
+
+    /** Σ of an account's transactions, signed the same way balances move: INCOME +, everything else −. */
+    private suspend fun signedTransactionSum(bankName: String, accountLast4: String): BigDecimal {
+        return transactionDao.getTransactionsForAccountStrict(bankName, accountLast4)
+            .fold(BigDecimal.ZERO) { acc, tx ->
+                if (tx.transactionType == TransactionType.INCOME) acc + tx.amount else acc - tx.amount
+            }
+    }
+
+    /**
+     * Ensures a manual account has an OPENING anchor, deriving it once so the
+     * currently-displayed balance is preserved: opening = currentBalance − Σtxns.
+     * No-op if an anchor already exists or the account has no balance row yet.
+     */
+    suspend fun ensureManualOpening(bankName: String, accountLast4: String) {
+        if (accountBalanceDao.getOpeningRow(bankName, accountLast4) != null) return
+        if (!isManualAccount(bankName, accountLast4)) return
+        val latest = accountBalanceDao.getLatestBalance(bankName, accountLast4) ?: return
+        val sum = signedTransactionSum(bankName, accountLast4)
+        val earliest = accountBalanceDao.getEarliestBalanceTimestamp(bankName, accountLast4)
+            ?: latest.timestamp
+        accountBalanceDao.insertBalance(
+            latest.copy(
+                id = 0,
+                balance = latest.balance - sum,
+                timestamp = earliest.minusNanos(1),  // strictly before all history → never "latest"
+                transactionId = null,
+                sourceType = SOURCE_OPENING,
+                smsSource = null
+            )
+        )
+    }
+
+    /**
+     * Recomputes a manual account's displayed balance as opening + Σ(transactions)
+     * and writes it to the single MANUAL row (refreshed to "now" so it wins as the
+     * latest). Safe to call after any add / edit / delete of the account's
+     * transactions. No-op for non-manual accounts.
+     */
+    suspend fun recomputeManualBalance(bankName: String, accountLast4: String) {
+        if (!isManualAccount(bankName, accountLast4)) return
+        ensureManualOpening(bankName, accountLast4)
+        val opening = accountBalanceDao.getOpeningRow(bankName, accountLast4) ?: return
+        val current = opening.balance + signedTransactionSum(bankName, accountLast4)
+        val now = LocalDateTime.now()
+        val existing = accountBalanceDao.getManualCurrentRow(bankName, accountLast4)
+        if (existing != null) {
+            accountBalanceDao.updateBalanceAndTimestampById(existing.id, current, now)
+        } else {
+            accountBalanceDao.insertBalance(
+                opening.copy(id = 0, balance = current, timestamp = now, sourceType = SOURCE_MANUAL)
+            )
+        }
+    }
+
+    /**
+     * "Update balance" for a manual account (option-b semantics): the user types
+     * their *current* balance and we back-solve the opening (opening = target −
+     * Σtxns) so future transactions still adjust from there. Returns the resolved
+     * current balance.
+     */
+    suspend fun setManualCurrentBalance(bankName: String, accountLast4: String, target: BigDecimal) {
+        ensureManualOpening(bankName, accountLast4)
+        val opening = accountBalanceDao.getOpeningRow(bankName, accountLast4) ?: return
+        val newOpening = target - signedTransactionSum(bankName, accountLast4)
+        accountBalanceDao.updateBalanceById(opening.id, newOpening)
+        recomputeManualBalance(bankName, accountLast4)
+    }
+
+    /**
+     * Seeds a brand-new manual account: an OPENING anchor (at an early timestamp)
+     * plus its current MANUAL row, both equal to [openingBalance] since there are
+     * no transactions yet. [template] carries currency / accountType / alias / etc.
+     */
+    suspend fun seedManualAccount(template: AccountBalanceEntity, openingBalance: BigDecimal) {
+        val now = LocalDateTime.now()
+        accountBalanceDao.insertBalance(
+            template.copy(
+                id = 0,
+                balance = openingBalance,
+                timestamp = now.minusSeconds(1),
+                transactionId = null,
+                sourceType = SOURCE_OPENING,
+                smsSource = null
+            )
+        )
+        accountBalanceDao.insertBalance(
+            template.copy(
+                id = 0,
+                balance = openingBalance,
+                timestamp = now,
+                transactionId = null,
+                sourceType = SOURCE_MANUAL,
                 smsSource = null
             )
         )

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
@@ -291,20 +291,24 @@ class AccountBalanceRepository @Inject constructor(
     suspend fun ensureManualOpening(bankName: String, accountLast4: String) {
         if (accountBalanceDao.getOpeningRow(bankName, accountLast4) != null) return
         if (!isManualAccount(bankName, accountLast4)) return
-        val latest = accountBalanceDao.getLatestBalance(bankName, accountLast4) ?: return
-        val sum = signedTransactionSum(bankName, accountLast4)
-        val earliest = accountBalanceDao.getEarliestBalanceTimestamp(bankName, accountLast4)
-            ?: latest.timestamp
-        accountBalanceDao.insertBalance(
-            latest.copy(
-                id = 0,
-                balance = latest.balance - sum,
-                timestamp = earliest.minusNanos(1),  // strictly before all history → never "latest"
-                transactionId = null,
-                sourceType = SOURCE_OPENING,
-                smsSource = null
+        database.withTransaction {
+            // Re-check inside the transaction in case a concurrent call just created it.
+            if (accountBalanceDao.getOpeningRow(bankName, accountLast4) != null) return@withTransaction
+            val latest = accountBalanceDao.getLatestBalance(bankName, accountLast4) ?: return@withTransaction
+            val sum = signedTransactionSum(bankName, accountLast4)
+            val earliest = accountBalanceDao.getEarliestBalanceTimestamp(bankName, accountLast4)
+                ?: latest.timestamp
+            accountBalanceDao.insertBalance(
+                latest.copy(
+                    id = 0,
+                    balance = latest.balance - sum,
+                    timestamp = earliest.minusNanos(1),  // strictly before all history → never "latest"
+                    transactionId = null,
+                    sourceType = SOURCE_OPENING,
+                    smsSource = null
+                )
             )
-        )
+        }
     }
 
     /**
@@ -315,9 +319,39 @@ class AccountBalanceRepository @Inject constructor(
      */
     suspend fun recomputeManualBalance(bankName: String, accountLast4: String) {
         if (!isManualAccount(bankName, accountLast4)) return
-        ensureManualOpening(bankName, accountLast4)
-        val opening = accountBalanceDao.getOpeningRow(bankName, accountLast4) ?: return
-        val current = opening.balance + signedTransactionSum(bankName, accountLast4)
+        database.withTransaction {
+            ensureManualOpening(bankName, accountLast4)
+            val opening = accountBalanceDao.getOpeningRow(bankName, accountLast4) ?: return@withTransaction
+            val current = opening.balance + signedTransactionSum(bankName, accountLast4)
+            writeManualCurrentRow(bankName, accountLast4, opening, current)
+        }
+    }
+
+    /**
+     * "Update balance" for a manual account (option-b semantics): the user types
+     * their *current* balance and we back-solve the opening (opening = target −
+     * Σtxns) so future transactions still adjust from there.
+     */
+    suspend fun setManualCurrentBalance(bankName: String, accountLast4: String, target: BigDecimal) {
+        if (!isManualAccount(bankName, accountLast4)) return
+        database.withTransaction {
+            ensureManualOpening(bankName, accountLast4)
+            val opening = accountBalanceDao.getOpeningRow(bankName, accountLast4) ?: return@withTransaction
+            val sum = signedTransactionSum(bankName, accountLast4)
+            accountBalanceDao.updateBalanceById(opening.id, target - sum)
+            // current = (target − sum) + sum = target — write it directly instead of
+            // re-summing via recomputeManualBalance.
+            writeManualCurrentRow(bankName, accountLast4, opening, target)
+        }
+    }
+
+    /** Upserts the single MANUAL "current" row at `now` so it wins as the latest. */
+    private suspend fun writeManualCurrentRow(
+        bankName: String,
+        accountLast4: String,
+        opening: AccountBalanceEntity,
+        current: BigDecimal
+    ) {
         val now = LocalDateTime.now()
         val existing = accountBalanceDao.getManualCurrentRow(bankName, accountLast4)
         if (existing != null) {
@@ -330,45 +364,33 @@ class AccountBalanceRepository @Inject constructor(
     }
 
     /**
-     * "Update balance" for a manual account (option-b semantics): the user types
-     * their *current* balance and we back-solve the opening (opening = target −
-     * Σtxns) so future transactions still adjust from there. Returns the resolved
-     * current balance.
-     */
-    suspend fun setManualCurrentBalance(bankName: String, accountLast4: String, target: BigDecimal) {
-        ensureManualOpening(bankName, accountLast4)
-        val opening = accountBalanceDao.getOpeningRow(bankName, accountLast4) ?: return
-        val newOpening = target - signedTransactionSum(bankName, accountLast4)
-        accountBalanceDao.updateBalanceById(opening.id, newOpening)
-        recomputeManualBalance(bankName, accountLast4)
-    }
-
-    /**
      * Seeds a brand-new manual account: an OPENING anchor (at an early timestamp)
      * plus its current MANUAL row, both equal to [openingBalance] since there are
      * no transactions yet. [template] carries currency / accountType / alias / etc.
      */
     suspend fun seedManualAccount(template: AccountBalanceEntity, openingBalance: BigDecimal) {
         val now = LocalDateTime.now()
-        accountBalanceDao.insertBalance(
-            template.copy(
-                id = 0,
-                balance = openingBalance,
-                timestamp = now.minusSeconds(1),
-                transactionId = null,
-                sourceType = SOURCE_OPENING,
-                smsSource = null
+        database.withTransaction {
+            accountBalanceDao.insertBalance(
+                template.copy(
+                    id = 0,
+                    balance = openingBalance,
+                    timestamp = now.minusSeconds(1),
+                    transactionId = null,
+                    sourceType = SOURCE_OPENING,
+                    smsSource = null
+                )
             )
-        )
-        accountBalanceDao.insertBalance(
-            template.copy(
-                id = 0,
-                balance = openingBalance,
-                timestamp = now,
-                transactionId = null,
-                sourceType = SOURCE_MANUAL,
-                smsSource = null
+            accountBalanceDao.insertBalance(
+                template.copy(
+                    id = 0,
+                    balance = openingBalance,
+                    timestamp = now,
+                    transactionId = null,
+                    sourceType = SOURCE_MANUAL,
+                    smsSource = null
+                )
             )
-        )
+        }
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
@@ -64,6 +64,14 @@ class AddTransactionUseCase @Inject constructor(
             budgetImpactType = budgetImpactType
         )
 
+        // For manual/cash accounts, pin the opening anchor from the PRE-insert snapshot
+        // (balance − Σtxns) so the post-insert recompute reflects this new transaction.
+        // Establishing it after the insert would fold the new txn into the opening and
+        // the add would silently not move the balance. No-op for SMS accounts.
+        if (bankName != null && accountLast4 != null) {
+            accountBalanceRepository.ensureManualOpening(bankName, accountLast4)
+        }
+
         // Insert the transaction
         val transactionId = transactionRepository.insertTransaction(transaction)
 
@@ -107,6 +115,16 @@ class AddTransactionUseCase @Inject constructor(
         date: LocalDateTime,
         transactionId: Long
     ) {
+        // Manual/cash accounts derive their balance from their transactions, so a
+        // back-dated (or later edited) transaction must be reflected — recompute rather
+        // than writing a per-transaction delta snapshot stamped at the txn date (which a
+        // back-dated row hides from "latest"). The transaction is already persisted here,
+        // so the recompute sum includes it. (#469)
+        if (accountBalanceRepository.isManualAccount(bankName, accountLast4)) {
+            accountBalanceRepository.recomputeManualBalance(bankName, accountLast4)
+            return
+        }
+
         // Get current account balance
         val currentAccount = accountBalanceRepository.getLatestBalance(bankName, accountLast4)
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
@@ -221,19 +221,26 @@ class ManageAccountsViewModel @Inject constructor(
                 BigDecimal(state.creditLimit)
             } else null
             
-            accountBalanceRepository.insertBalance(
-                AccountBalanceEntity(
-                    bankName = state.bankName,
-                    accountLast4 = state.accountLast4,
-                    balance = BigDecimal(state.balance),
-                    creditLimit = creditLimit,
-                    timestamp = LocalDateTime.now(),
-                    isCreditCard = (state.accountType == AccountType.CREDIT),
-                    accountType = state.accountType.toDatabaseString(),
-                    currency = state.currency,
-                    sourceType = "MANUAL"
-                )
+            val isCredit = state.accountType == AccountType.CREDIT
+            val template = AccountBalanceEntity(
+                bankName = state.bankName,
+                accountLast4 = state.accountLast4,
+                balance = BigDecimal(state.balance),
+                creditLimit = creditLimit,
+                timestamp = LocalDateTime.now(),
+                isCreditCard = isCredit,
+                accountType = state.accountType.toDatabaseString(),
+                currency = state.currency,
+                sourceType = "MANUAL"
             )
+            if (isCredit) {
+                // Credit cards aren't recompute-managed — single snapshot as before.
+                accountBalanceRepository.insertBalance(template)
+            } else {
+                // Cash/regular manual account: seed an OPENING anchor + current row so
+                // its balance derives from opening + Σ(transactions) going forward.
+                accountBalanceRepository.seedManualAccount(template, BigDecimal(state.balance))
+            }
 
             // Clear form (keep the base currency as the next default)
             _formState.value = AccountFormState(currency = baseCurrency)
@@ -242,6 +249,14 @@ class ManageAccountsViewModel @Inject constructor(
     
     fun updateAccountBalance(bankName: String, accountLast4: String, newBalance: BigDecimal) {
         viewModelScope.launch {
+            // For a manual/cash account the balance is derived (opening + Σtxns). The
+            // user types their *current* balance, so back-solve the opening (option b)
+            // — future transactions still adjust from there.
+            if (accountBalanceRepository.isManualAccount(bankName, accountLast4)) {
+                accountBalanceRepository.setManualCurrentBalance(bankName, accountLast4, newBalance)
+                return@launch
+            }
+
             // Get the latest balance to preserve existing account properties
             val latestBalance = accountBalanceRepository.getLatestBalance(bankName, accountLast4)
 
@@ -735,29 +750,39 @@ class ManageAccountsViewModel @Inject constructor(
 
                 // Get existing balance to preserve profileId and other properties
                 val latestBalance = accountBalanceRepository.getLatestBalance(newBankName, accountLast4)
-
-                // Insert new balance record with updated values
-                accountBalanceRepository.insertBalance(
-                    AccountBalanceEntity(
-                        bankName = newBankName,
-                        accountLast4 = accountLast4,
-                        balance = newBalance,
-                        creditLimit = newCreditLimit,
-                        timestamp = LocalDateTime.now(),
-                        isCreditCard = isCreditCard,
-                        // Honor an explicit currency edit; otherwise resolve so stamping
-                        // MANUAL doesn't flip an SMS-tracked non-INR account to stored INR.
-                        currency = newCurrency ?: CurrencyFormatter.resolveAccountCurrency(
-                            sourceType = latestBalance?.sourceType,
-                            storedCurrency = latestBalance?.currency ?: "INR",
-                            bankName = newBankName
-                        ),
-                        accountType = latestBalance?.accountType,
-                        profileId = latestBalance?.profileId ?: ProfileEntity.PERSONAL_ID,
-                        alias = latestBalance?.alias,
-                        sourceType = "MANUAL"
-                    )
+                val resolvedCurrency = newCurrency ?: CurrencyFormatter.resolveAccountCurrency(
+                    sourceType = latestBalance?.sourceType,
+                    storedCurrency = latestBalance?.currency ?: "INR",
+                    bankName = newBankName
                 )
+
+                if (!isCreditCard && accountBalanceRepository.isManualAccount(newBankName, accountLast4)) {
+                    // Manual/cash account: balance is derived. Update the currency on its
+                    // anchor rows and back-solve the opening from the typed balance
+                    // (option b) instead of inserting a snapshot the next recompute would
+                    // overwrite.
+                    accountBalanceRepository.updateAccountCurrency(newBankName, accountLast4, resolvedCurrency)
+                    accountBalanceRepository.setManualCurrentBalance(newBankName, accountLast4, newBalance)
+                } else {
+                    // Insert new balance record with updated values
+                    accountBalanceRepository.insertBalance(
+                        AccountBalanceEntity(
+                            bankName = newBankName,
+                            accountLast4 = accountLast4,
+                            balance = newBalance,
+                            creditLimit = newCreditLimit,
+                            timestamp = LocalDateTime.now(),
+                            isCreditCard = isCreditCard,
+                            // Honor an explicit currency edit; otherwise resolve so stamping
+                            // MANUAL doesn't flip an SMS-tracked non-INR account to stored INR.
+                            currency = resolvedCurrency,
+                            accountType = latestBalance?.accountType,
+                            profileId = latestBalance?.profileId ?: ProfileEntity.PERSONAL_ID,
+                            alias = latestBalance?.alias,
+                            sourceType = "MANUAL"
+                        )
+                    )
+                }
 
                 _uiState.update {
                     it.copy(successMessage = "Account updated successfully")

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
@@ -757,12 +757,16 @@ class ManageAccountsViewModel @Inject constructor(
                 )
 
                 if (!isCreditCard && accountBalanceRepository.isManualAccount(newBankName, accountLast4)) {
-                    // Manual/cash account: balance is derived. Update the currency on its
-                    // anchor rows and back-solve the opening from the typed balance
-                    // (option b) instead of inserting a snapshot the next recompute would
-                    // overwrite.
-                    accountBalanceRepository.updateAccountCurrency(newBankName, accountLast4, resolvedCurrency)
-                    accountBalanceRepository.setManualCurrentBalance(newBankName, accountLast4, newBalance)
+                    // Manual/cash account: balance is derived. Atomically update the
+                    // currency on its anchor rows and back-solve the opening from the
+                    // typed balance (option b) instead of inserting a snapshot the next
+                    // recompute would overwrite.
+                    accountBalanceRepository.updateManualBalanceAndCurrency(
+                        bankName = newBankName,
+                        accountLast4 = accountLast4,
+                        currency = resolvedCurrency,
+                        targetBalance = newBalance
+                    )
                 } else {
                     // Insert new balance record with updated values
                     accountBalanceRepository.insertBalance(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
@@ -611,6 +611,19 @@ class TransactionDetailViewModel @Inject constructor(
                     receiptPath = newReceiptPath
                 )
 
+                // Pin opening anchors from the PRE-update snapshot for the affected
+                // manual accounts, so the recompute after the edit reflects the change
+                // (amount/date/account). No-op for SMS accounts.
+                _transaction.value?.let { pre ->
+                    val pb = pre.bankName; val pa = pre.accountNumber
+                    if (pb != null && pa != null) accountBalanceRepository.ensureManualOpening(pb, pa)
+                }
+                normalizedTransaction.bankName?.let { nb ->
+                    normalizedTransaction.accountNumber?.let { na ->
+                        accountBalanceRepository.ensureManualOpening(nb, na)
+                    }
+                }
+
                 transactionRepository.updateTransaction(normalizedTransaction)
 
                 // Update account balance if account was changed or added
@@ -670,6 +683,17 @@ class TransactionDetailViewModel @Inject constructor(
                             )
                         )
                     }
+                }
+
+                // Manual/cash accounts derive their balance from their transactions, so
+                // recompute the affected account(s) — this also covers amount/date edits
+                // that don't change the account (the incremental paths above only fire on
+                // an account change). No-op for SMS accounts.
+                if (newBank != null && newAccount != null) {
+                    accountBalanceRepository.recomputeManualBalance(newBank, newAccount)
+                }
+                if (accountChanged && oldBank != null && oldAccount != null) {
+                    accountBalanceRepository.recomputeManualBalance(oldBank, oldAccount)
                 }
 
                 // Save or remove splits
@@ -790,7 +814,18 @@ class TransactionDetailViewModel @Inject constructor(
 
                 try {
                     txn.receiptPath?.let { receiptManager.deleteReceipt(it) }
+                    // Manual/cash accounts derive their balance from their transactions, so
+                    // deleting one must update the balance. Pin the opening from the
+                    // pre-delete snapshot, then recompute after. No-op for SMS accounts. (#470)
+                    val bank = txn.bankName
+                    val acct = txn.accountNumber
+                    if (bank != null && acct != null) {
+                        accountBalanceRepository.ensureManualOpening(bank, acct)
+                    }
                     transactionRepository.deleteTransaction(txn)
+                    if (bank != null && acct != null) {
+                        accountBalanceRepository.recomputeManualBalance(bank, acct)
+                    }
                     _deleteSuccess.value = true
                 } catch (e: Exception) {
                     _errorMessage.value = "Failed to delete transaction"

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
@@ -663,8 +663,10 @@ class TransactionDetailViewModel @Inject constructor(
                 val shouldRunSingleAccount = !isTransfer && newBank != null && newAccount != null &&
                     (accountChanged || convertedFromTransfer)
 
-                if (shouldRunSingleAccount) {
-                    val currentBalance = accountBalanceRepository.getLatestBalance(newBank!!, newAccount!!)
+                // Skip the incremental snapshot for manual accounts — the recompute
+                // below derives their balance, so this row would be redundant clutter.
+                if (shouldRunSingleAccount && !accountBalanceRepository.isManualAccount(newBank!!, newAccount!!)) {
+                    val currentBalance = accountBalanceRepository.getLatestBalance(newBank, newAccount)
                     if (currentBalance != null) {
                         val balanceChange = when (normalizedTransaction.transactionType) {
                             TransactionType.INCOME -> normalizedTransaction.amount


### PR DESCRIPTION
Fixes the two cash-account balance bugs by changing how manual/cash balances are computed.

## Root cause
A manual/cash account's balance was maintained as an incremental `latest ± amount` snapshot stamped at **the transaction's date**. So anything retroactive broke it:
- **#469** — a back-dated add wrote a row in the past → never became "latest" → balance unchanged.
- **#470** — delete never reversed the delta.
- (latent) amount/date edits drifted.

## Fix — derive instead of nudge
A manual account's balance = **opening + Σ(its transactions)**, recomputed on every add / edit / delete into a single `MANUAL` row refreshed to `now`.

- New repo API: `recomputeManualBalance`, `ensureManualOpening`, `setManualCurrentBalance`, `seedManualAccount` (injects `TransactionDao` for the signed sum — INCOME +, else −, matching the prior convention).
- A stable **OPENING** anchor row (early timestamp, so it never wins "latest") stores the opening. **No schema change / migration** — `OPENING` is just a new `source_type` string value.
- **Upgrade-safe:** for accounts created before this, the opening is derived lazily from a *pre-mutation* snapshot (`opening = currentBalance − Σtxns`), so the displayed balance never jumps on upgrade and the triggering change is still reflected. (The pre-mutation timing is why `ensureManualOpening` is called *before* the insert/delete/update in each write path.)
- **"Update balance"** back-solves the opening (option b): you still type your *current* balance; future transactions adjust from there.
- **SMS accounts and credit cards are excluded** (balance comes from the bank / has inverted semantics) — their paths are untouched.

## Verification (emulator)
1. Created a cash account "Wallet" $1,000.
2. Added a **back-dated** (Jun 5) $200 expense assigned to Wallet → **$800** ✓ (#469 — old behavior left it at $1,000).
3. Deleted that expense → **$1,000** ✓ (#470).

## Follow-up (not in this PR)
- The balance-history **chart** for manual accounts isn't yet derived from opening + running Σ; it still plots stored rows. Cosmetic, can be a separate change.

Closes #469
Closes #470