### PR TITLE
feat(currency): add Brazilian Real (BRL)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
@@ -37,7 +37,8 @@ object CurrencyFormatter {
         "KWD" to "KD",
         "KRW" to "₩",
         "NGN" to "₦",
-        "TZS" to "TSh"
+        "TZS" to "TSh",
+        "BRL" to "R$"
     )
 
     /**
@@ -64,7 +65,8 @@ object CurrencyFormatter {
         "KWD" to Locale.Builder().setLanguage("en").setRegion("KW").build(),
         "KRW" to Locale.KOREA,
         "NGN" to Locale.Builder().setLanguage("en").setRegion("NG").build(),
-        "TZS" to Locale.Builder().setLanguage("en").setRegion("TZ").build()
+        "TZS" to Locale.Builder().setLanguage("en").setRegion("TZ").build(),
+        "BRL" to Locale.Builder().setLanguage("pt").setRegion("BR").build()
     )
 
     /**


### PR DESCRIPTION
Adds **Brazilian Real (BRL → R$)** to `CurrencyFormatter`:
- `BRL → "R$"` in the symbol map
- `pt-BR` locale for correct formatting

So it shows up in the account + Settings currency pickers (`getSupportedCurrencies()`) and `formatCurrency` renders it properly via `Currency.getInstance("BRL")`. Same trivial pattern as the recent NGN/TZS additions.

Closes #485