### PR TITLE
fix(loans): Mark-as-loan sheet scrollable so Confirm is reachable (#489)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailScreen.kt
@@ -2023,6 +2023,11 @@ private fun MarkAsLoanBottomSheet(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                // Scroll so the loan-amount/note fields and the Confirm button stay
+                // reachable when several existing people are listed — otherwise they're
+                // pushed below the sheet and the user can only proceed via "New person".
+                // (#489)
+                .verticalScroll(rememberScrollState())
                 .padding(horizontal = Dimensions.Padding.content)
                 .padding(bottom = Spacing.xl)
                 .navigationBarsPadding(),


### PR DESCRIPTION
## Bug
In the **Mark as loan** sheet, selecting an *existing* person registered the selection but the user couldn't proceed — they were forced to use **New person** instead.

## Root cause
The sheet's content `Column` had **no `verticalScroll`**. With existing people listed, the people list + loan-amount + note + **Confirm** button exceed the sheet height on smaller screens (reporter: Pixel 7 Pro), so Confirm is pushed off‑screen. Switching to *New person* collapses the list, which is why that path appears to be the only one that works.

## Fix
Add `verticalScroll(rememberScrollState())` to the content column so every control — including Confirm — stays reachable.

## Verified (emulator)
- Opened a $100 expense → **Mark as loan** → existing person **John** listed.
- Selected John → **Confirm enabled** → tapped it → transaction became **"Lent to John"** (linked to John's active loan via `addToExistingLoan`).
- So the existing-person logic was always correct; this was purely a reachability/overflow issue.

Closes #489