### PR TITLE
feat(parser): Jaiz Bank + Opay parsers (Nigeria)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -126,7 +126,9 @@ object BankParserFactory {
         SampathBankParser(),  // Sampath Bank (Sri Lanka)
         AccessBankParser(),  // Access Bank (Nigeria)
         ZenithBankParser(),  // Zenith Bank (Nigeria)
-        KeystoneBankParser()  // Keystone Bank (Nigeria)
+        KeystoneBankParser(),  // Keystone Bank (Nigeria)
+        JaizBankParser(),  // Jaiz Bank (Nigeria)
+        OpayBankParser()  // Opay (Nigeria)
         // Add more bank parsers here as we implement them
     )
 

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/JaizBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/JaizBankParser.kt
@@ -1,0 +1,84 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Jaiz Bank (Nigeria) SMS messages.
+ *
+ * Supported format (line-based):
+ * ```
+ * Acct:**737
+ * Amt:N50.00DR                            (DR -> EXPENSE, CR -> INCOME)
+ * Desc:<description>
+ * 04-JAN-26 17:46
+ * Help:07007730000                        (promo/support — ignored)
+ * Bal:N252.28
+ * Buy Airtime, Dial *773*Amount#          (promo — ignored)
+ * ```
+ * Amounts carry an "N" prefix and a trailing DR/CR suffix.
+ *
+ * Sender: Jaiz
+ */
+class JaizBankParser : BankParser() {
+
+    override fun getBankName() = "Jaiz Bank"
+
+    override fun getCurrency() = "NGN"
+
+    override fun canHandle(sender: String): Boolean {
+        return sender.uppercase().contains("JAIZ")
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+        if (lower.contains("otp") || lower.contains("verification code")) {
+            return false
+        }
+        return Regex("""(?i)Amt:\s*N\s*[0-9,]+(?:\.\d{1,2})?\s*(?:DR|CR)""").containsMatchIn(message) &&
+                Regex("""(?i)Acct:""").containsMatchIn(message)
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        return when {
+            Regex("""(?i)Amt:\s*N\s*[0-9,]+(?:\.\d{1,2})?\s*DR""").containsMatchIn(message) -> TransactionType.EXPENSE
+            Regex("""(?i)Amt:\s*N\s*[0-9,]+(?:\.\d{1,2})?\s*CR""").containsMatchIn(message) -> TransactionType.INCOME
+            else -> null
+        }
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        val match = Regex("""(?i)Amt:\s*N\s*([0-9,]+(?:\.\d{1,2})?)\s*(?:DR|CR)""").find(message) ?: return null
+        return try {
+            BigDecimal(match.groupValues[1].replace(",", ""))
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        val match = Regex("""(?i)Bal:\s*N\s*([0-9,]+(?:\.\d{1,2})?)""").find(message) ?: return null
+        return try {
+            BigDecimal(match.groupValues[1].replace(",", ""))
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // Use [ \t]* (not \s*) so an empty "Desc:" line can't let the capture cross the
+        // newline and grab the following date/Bal: line as the merchant.
+        val match = Regex("""(?i)Desc:[ \t]*(.+)""").find(message) ?: return null
+        val desc = match.groupValues[1].trim()
+        return desc.ifBlank { null }
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        val match = Regex("""(?i)Acct:\s*\*+([0-9]+)""").find(message)
+        if (match != null) {
+            return extractLast4Digits(match.groupValues[1])
+        }
+        val plain = Regex("""(?i)Acct:\s*([0-9]+)""").find(message) ?: return null
+        return extractLast4Digits(plain.groupValues[1])
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/OpayBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/OpayBankParser.kt
@@ -1,0 +1,61 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Opay (Nigeria) SMS messages.
+ *
+ * Supported format (sentence-style, NO account number and NO balance — Opay omits both):
+ * ```
+ * Dear OPay user, N2,300.00 has been debited for Card Payment via POS on 14-May-2026 19:28.
+ * Dear OPay user, N150.00 has been credited ... (best-effort credit handling)
+ * ```
+ * Amounts carry an "N" prefix. Merchant/description is the "<purpose> via <channel>"
+ * text captured between "debited/credited for " and " on ".
+ *
+ * Sender: Opay
+ */
+class OpayBankParser : BankParser() {
+
+    override fun getBankName() = "Opay"
+
+    override fun getCurrency() = "NGN"
+
+    override fun canHandle(sender: String): Boolean {
+        return sender.uppercase().contains("OPAY")
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+        if (lower.contains("otp") || lower.contains("verification code")) {
+            return false
+        }
+        return Regex("""(?i)Dear\s+OPay\s+user""").containsMatchIn(message) &&
+                Regex("""(?i)has\s+been\s+(?:debited|credited)""").containsMatchIn(message)
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        return when {
+            Regex("""(?i)has\s+been\s+debited""").containsMatchIn(message) -> TransactionType.EXPENSE
+            Regex("""(?i)has\s+been\s+credited""").containsMatchIn(message) -> TransactionType.INCOME
+            else -> null
+        }
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        val match = Regex("""(?i)N\s*([0-9,]+(?:\.\d{1,2})?)\s+has\s+been""").find(message) ?: return null
+        return try {
+            BigDecimal(match.groupValues[1].replace(",", ""))
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        val match = Regex("""(?i)has\s+been\s+(?:debited|credited)\s+for\s+(.+?)\s+on\s""").find(message)
+            ?: return null
+        val desc = match.groupValues[1].trim()
+        return desc.ifBlank { null }
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/OpayBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/OpayBankParser.kt
@@ -53,8 +53,12 @@ class OpayBankParser : BankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
-        val match = Regex("""(?i)has\s+been\s+(?:debited|credited)\s+for\s+(.+?)\s+on\s""").find(message)
-            ?: return null
+        // Anchor the trailing " on " to the actual date (DD-Mon-YYYY) so a purpose that
+        // itself contains " on " (e.g. "Payment on Account") isn't truncated — the lazy
+        // capture backtracks past any earlier " on " that isn't followed by a date.
+        val match = Regex(
+            """(?i)has\s+been\s+(?:debited|credited)\s+for\s+(.+?)\s+on\s+\d{1,2}-[A-Za-z]{3}-\d{2,4}"""
+        ).find(message) ?: return null
         val desc = match.groupValues[1].trim()
         return desc.ifBlank { null }
     }

--- a/parser-core/src/test/kotlin/TestJaizBankParser.kt
+++ b/parser-core/src/test/kotlin/TestJaizBankParser.kt
@@ -1,0 +1,96 @@
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.bank.JaizBankParser
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.*
+import java.math.BigDecimal
+
+class JaizBankParserTest {
+
+    @TestFactory
+    fun `jaiz bank parser handles common cases`(): List<DynamicTest> {
+        val parser = JaizBankParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "Debit transaction (EXPENSE)",
+                message = """
+                    Acct:**737
+                    Amt:N50.00DR
+                    Desc:IFO NIBSS DIRECT DEBIT Mob Other Bank Trf # 70123
+                    04-JAN-26 17:46
+                    Help:07007730000
+                    Bal:N252.28
+                    Buy Airtime, Dial *773*Amount#
+                """.trimIndent(),
+                sender = "Jaiz",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("50.00"),
+                    currency = "NGN",
+                    type = TransactionType.EXPENSE,
+                    merchant = "IFO NIBSS DIRECT DEBIT Mob Other Bank Trf # 70123",
+                    accountLast4 = "737",
+                    balance = BigDecimal("252.28")
+                )
+            ),
+            ParserTestCase(
+                name = "Credit transaction (INCOME)",
+                message = """
+                    Acct:**737
+                    Amt:N100.00CR
+                    Desc:OPAY DIGITAL SERVICES LIMITED
+                    18-JAN-26 20:11
+                    Help:07007730000
+                    Bal:N352.28
+                    Buy Airtime, Dial *773*Amount#
+                """.trimIndent(),
+                sender = "Jaiz",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("100.00"),
+                    currency = "NGN",
+                    type = TransactionType.INCOME,
+                    merchant = "OPAY DIGITAL SERVICES LIMITED",
+                    accountLast4 = "737",
+                    balance = BigDecimal("352.28")
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            "Jaiz" to true,
+            "JAIZ" to true,
+            "AD-JAIZ-S" to true,
+            "Opay" to false,
+            "KEYSTONE" to false,
+            "HDFC" to false,
+            "" to false
+        )
+
+        return ParserTestUtils.runTestSuite(
+            parser = parser,
+            testCases = testCases,
+            handleCases = handleCases,
+            suiteName = "Jaiz Bank Parser Suite"
+        )
+    }
+
+    @Test
+    fun `empty Desc field yields a null merchant, not the next line`() {
+        val parser = JaizBankParser()
+        val message = """
+            Acct:**737
+            Amt:N50.00DR
+            Desc:
+            04-JAN-26 17:46
+            Bal:N252.28
+        """.trimIndent()
+
+        val parsed = parser.parse(message, "Jaiz", 0L)
+        Assertions.assertNotNull(parsed, "Message should still parse")
+        Assertions.assertNull(
+            parsed!!.merchant,
+            "An empty Desc: must not capture the following date/Bal: line"
+        )
+    }
+}

--- a/parser-core/src/test/kotlin/TestOpayBankParser.kt
+++ b/parser-core/src/test/kotlin/TestOpayBankParser.kt
@@ -67,6 +67,18 @@ class OpayBankParserTest {
     }
 
     @Test
+    fun `merchant containing " on " is not truncated at the first occurrence`() {
+        val parser = OpayBankParser()
+        // The purpose itself contains " on " — the date-anchored regex must capture the
+        // whole purpose, not stop at "Payment".
+        val message = "Dear OPay user, N500.00 has been debited for Payment on Account via POS on 14-May-2026 19:28."
+
+        val parsed = parser.parse(message, "Opay", 0L)
+        Assertions.assertNotNull(parsed)
+        Assertions.assertEquals("Payment on Account via POS", parsed!!.merchant)
+    }
+
+    @Test
     fun `OTP message is rejected`() {
         val parser = OpayBankParser()
         val message = "Dear OPay user, your OTP is 123456. Do not share it with anyone."

--- a/parser-core/src/test/kotlin/TestOpayBankParser.kt
+++ b/parser-core/src/test/kotlin/TestOpayBankParser.kt
@@ -1,0 +1,76 @@
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.bank.OpayBankParser
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.*
+import java.math.BigDecimal
+
+class OpayBankParserTest {
+
+    @TestFactory
+    fun `opay parser handles common cases`(): List<DynamicTest> {
+        val parser = OpayBankParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "Card Payment via POS (EXPENSE)",
+                message = "Dear OPay user, N2,300.00 has been debited for Card Payment via POS on 14-May-2026 19:28.",
+                sender = "Opay",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2300.00"),
+                    currency = "NGN",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Card Payment via POS"
+                )
+            ),
+            ParserTestCase(
+                name = "Transfer via E-Channel (EXPENSE)",
+                message = "Dear OPay user, N150.00 has been debited for Transfer via E-Channel on 12-Jun-2026 16:28.",
+                sender = "Opay",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("150.00"),
+                    currency = "NGN",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Transfer via E-Channel"
+                )
+            )
+        )
+
+        val handleCases = listOf(
+            "Opay" to true,
+            "OPAY" to true,
+            "AD-OPAY-S" to true,
+            "Jaiz" to false,
+            "KEYSTONE" to false,
+            "HDFC" to false,
+            "" to false
+        )
+
+        return ParserTestUtils.runTestSuite(
+            parser = parser,
+            testCases = testCases,
+            handleCases = handleCases,
+            suiteName = "Opay Parser Suite"
+        )
+    }
+
+    @Test
+    fun `credited message is classified as income best-effort`() {
+        val parser = OpayBankParser()
+        val message = "Dear OPay user, N500.00 has been credited for Transfer via E-Channel on 12-Jun-2026 16:28."
+
+        val parsed = parser.parse(message, "Opay", 0L)
+        Assertions.assertNotNull(parsed, "Credit message should parse")
+        Assertions.assertEquals(TransactionType.INCOME, parsed!!.type)
+        Assertions.assertEquals(BigDecimal("500.00"), parsed.amount)
+    }
+
+    @Test
+    fun `OTP message is rejected`() {
+        val parser = OpayBankParser()
+        val message = "Dear OPay user, your OTP is 123456. Do not share it with anyone."
+
+        Assertions.assertNull(parser.parse(message, "Opay", 0L))
+    }
+}


### PR DESCRIPTION
Two more Nigerian (NGN) bank parsers, both extending `BankParser` with `getCurrency()="NGN"`.

| Bank | Sender | Issue | Format |
|------|--------|-------|--------|
| Jaiz Bank | `Jaiz` | #479 | `Acct:**737 / Amt:N50.00DR / Desc:… / Bal:N252.28` — DR/CR, account, balance, merchant |
| Opay | `Opay` | #478 | `Dear OPay user, N… has been debited for <purpose> via <channel> on <date>` — no account/balance (Opay omits both) |

## Tests
- Jaiz: 10 (DR/CR parses + empty-Desc null-merchant + canHandle checks)
- Opay: 11 (2 verified debit parses + best-effort credit + OTP rejection + canHandle checks)
- Full `:parser-core:jvmTest` green, no regressions. `canHandle` confirmed non-colliding (Opay≠Jaiz/Keystone/HDFC).

## Notes for reporter
- **Opay**: only debit samples were provided, so the `credited`→INCOME path is best-effort on the same sentence shape — a real credit sample would confirm the wording. Account/balance are intentionally null (Opay doesn't send them).

Closes #478
Closes #479