### PR TITLE
feat(cards): IndusInd credit-card typing + available-limit tracking (#486)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsTransactionProcessor.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsTransactionProcessor.kt
@@ -292,13 +292,23 @@ class SmsTransactionProcessor @Inject constructor(
                 }
             }
 
+            // Credit-card SMS report the AVAILABLE limit, not the total. The UI derives
+            // available = creditLimit − balance, so store total = available + outstanding
+            // (the post-transaction balance) to keep that math correct. Falls back to the
+            // existing stored limit when the SMS carries no limit. (#486)
+            val resolvedCreditLimit = if (isCreditCard && parsedTransaction.creditLimit != null) {
+                parsedTransaction.creditLimit!! + newBalance
+            } else {
+                existingAccount?.creditLimit
+            }
+
             val balanceEntity = AccountBalanceEntity(
                 bankName = parsedTransaction.bankName,
                 accountLast4 = targetAccountLast4,
                 balance = newBalance,
                 timestamp = entity.dateTime,
                 transactionId = if (rowId != -1L) rowId else null,
-                creditLimit = existingAccount?.creditLimit,
+                creditLimit = resolvedCreditLimit,
                 isCreditCard = isCreditCard || (existingAccount?.isCreditCard ?: false),
                 smsSource = parsedTransaction.smsBody.take(500),
                 sourceType = "TRANSACTION",

--- a/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
@@ -808,13 +808,23 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
             }
         }
 
+        // Credit-card SMS report the AVAILABLE limit, not the total. The UI derives
+        // available = creditLimit − balance, so store total = available + outstanding
+        // (the post-transaction balance). Falls back to the existing stored limit when
+        // the SMS carries no limit. (#486)
+        val resolvedCreditLimit = if (isCreditCard && parsed.creditLimit != null) {
+            parsed.creditLimit!! + newBalance
+        } else {
+            existing?.creditLimit
+        }
+
         val balanceEntity = AccountBalanceEntity(
             bankName      = parsed.bankName,
             accountLast4  = targetAccount,
             balance       = newBalance,
             timestamp     = entity.dateTime,
             transactionId = if (rowId != -1L) rowId else null,
-            creditLimit   = existing?.creditLimit,
+            creditLimit   = resolvedCreditLimit,
             isCreditCard  = isCreditCard || (existing?.isCreditCard ?: false),
             smsSource     = parsed.smsBody.take(500),
             sourceType    = "TRANSACTION",

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParser.kt
@@ -385,26 +385,23 @@ abstract class BankParser {
      */
     protected open fun extractAvailableLimit(message: String): BigDecimal? {
 
-        // Common patterns for credit limit across banks
+        // Currency token: most banks print "Rs"/"₹", but some (e.g. IndusInd) use
+        // "Avl Lmt: INR ..." — accept all three. Only ever evaluated for CREDIT
+        // messages (extractAvailableLimit is gated on type == CREDIT in parse()).
+        val cur = """(?:Rs\.?|INR|₹)"""
         val creditLimitPatterns = listOf(
-            // "Available limit Rs.111,111.89" - Federal Bank format (no space after Rs.)
-            Regex("""Available\s+limit\s+Rs\.([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE),
-            // "Available limit Rs. 111,111.89" or "Available limit: Rs 111,111.89"
-            Regex(
-                """Available\s+limit:?\s*Rs\.?\s*([0-9,]+(?:\.\d{2})?)""",
-                RegexOption.IGNORE_CASE
-            ),
-            // "Avl Lmt Rs.111,111.89" or "Avl Lmt: Rs 111,111.89" (ICICI and others)
-            Regex("""Avl\s+Lmt:?\s*Rs\.?\s*([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE),
+            // "Available limit Rs.111,111.89" / "Available limit INR 111,111.89"
+            Regex("""Available\s+limit\s+$cur\s*([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE),
+            // "Available limit: Rs 111,111.89"
+            Regex("""Available\s+limit:?\s*$cur\s*([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE),
+            // "Avl Lmt: Rs 111,111.89" / "Avl Lmt: INR 111,111.89" (ICICI, IndusInd, others)
+            Regex("""Avl\s+Lmt:?\s*$cur\s*([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE),
             // "Avail Limit Rs.111,111.89"
-            Regex("""Avail\s+Limit:?\s*Rs\.?\s*([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE),
+            Regex("""Avail\s+Limit:?\s*$cur\s*([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE),
             // "Available Credit Limit: Rs.111,111.89"
-            Regex(
-                """Available\s+Credit\s+Limit:?\s*Rs\.?\s*([0-9,]+(?:\.\d{2})?)""",
-                RegexOption.IGNORE_CASE
-            ),
+            Regex("""Available\s+Credit\s+Limit:?\s*$cur\s*([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE),
             // "Limit: Rs.111,111.89" (generic, but only for credit card messages)
-            Regex("""(?:^|\s)Limit:?\s*Rs\.?\s*([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE)
+            Regex("""(?:^|\s)Limit:?\s*$cur\s*([0-9,]+(?:\.\d{2})?)""", RegexOption.IGNORE_CASE)
         )
 
         for ((index, pattern) in creditLimitPatterns.withIndex()) {

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/IndusIndBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/IndusIndBankParser.kt
@@ -38,6 +38,12 @@ class IndusIndBankParser : BaseIndianBankParser() {
         // IndusInd typically uses standard verbs; fall back to base for most, but
         // explicitly treat "spent" and "purchase" as expenses to avoid ambiguity.
         return when {
+            // A credit-card purchase ("spent on IndusInd Card ... Avl Lmt: INR ...") must
+            // type as CREDIT — not EXPENSE — so it counts as card spend and the base
+            // parser's available-limit extraction (gated on CREDIT) runs. Refund SMS say
+            // "credited to your ... Card" but carry no "Avl Lmt", so they fall through to
+            // INCOME via super. (#486)
+            lower.contains("card") && lower.contains("avl lmt") -> TransactionType.CREDIT
             lower.contains("spent") -> TransactionType.EXPENSE
             lower.contains("debited") -> TransactionType.EXPENSE
             lower.contains("purchase") -> TransactionType.EXPENSE

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/IndusIndBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/IndusIndBankParser.kt
@@ -199,8 +199,9 @@ class IndusIndBankParser : BaseIndianBankParser() {
             }
         }
 
-        // Card/POS: at <merchant>
-        val atPattern = Regex("""at\s+([^\n]+?)(?:\s+Ref|\s+on|$)""", RegexOption.IGNORE_CASE)
+        // Card/POS: at <merchant>. Stop at " Ref", " on", a sentence-boundary period
+        // (e.g. "at INSTAMART. Avl Lmt: ..." on credit-card spends), or end of line.
+        val atPattern = Regex("""at\s+([^\n]+?)(?:\s+Ref|\s+on|\.\s|$)""", RegexOption.IGNORE_CASE)
         atPattern.find(message)?.let { match ->
             val merchant = match.groupValues[1].trim()
             if (merchant.isNotEmpty()) return cleanMerchantName(merchant)

--- a/parser-core/src/test/kotlin/TestIndusIndBankParser.kt
+++ b/parser-core/src/test/kotlin/TestIndusIndBankParser.kt
@@ -184,6 +184,26 @@ class IndusIndBankParserTest {
                     accountLast4 = "1234",
                     reference = "123456789"
                 )
+            ),
+            ParserTestCase(
+                name = "Credit-card spend types as CREDIT (Avl Lmt present)",
+                message = "INR 1,250.00 spent on IndusInd Card XX1234 on 14-06-2026 04:21:45 pm at INSTAMART. Avl Lmt: INR 48,750.00. To dispute, call 18602677777/SMS BLOCK 1234 to 5676757",
+                sender = "AD-INDUSIND-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1250.00"),
+                    currency = "INR",
+                    type = TransactionType.CREDIT
+                )
+            ),
+            ParserTestCase(
+                name = "Credit-card refund types as INCOME (no Avl Lmt)",
+                message = "Dear Customer, refund of INR 250 from Swiggy Limited Banga has been credited to your IndusInd Bank Credit Card XX1234 on 11-Jun-26 and the refund amount has been adjusted against the outstanding on your card account - IndusInd Bank",
+                sender = "AD-INDUSIND-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("250"),
+                    currency = "INR",
+                    type = TransactionType.INCOME
+                )
             )
         )
 

--- a/parser-core/src/test/kotlin/TestIndusIndBankParser.kt
+++ b/parser-core/src/test/kotlin/TestIndusIndBankParser.kt
@@ -193,6 +193,9 @@ class IndusIndBankParserTest {
                     amount = BigDecimal("1250.00"),
                     currency = "INR",
                     type = TransactionType.CREDIT,
+                    merchant = "INSTAMART",
+                    accountLast4 = "1234",
+                    isFromCard = true,
                     // Parser returns the SMS *available* limit; the app back-calcs total.
                     creditLimit = BigDecimal("48750.00")
                 )

--- a/parser-core/src/test/kotlin/TestIndusIndBankParser.kt
+++ b/parser-core/src/test/kotlin/TestIndusIndBankParser.kt
@@ -186,13 +186,15 @@ class IndusIndBankParserTest {
                 )
             ),
             ParserTestCase(
-                name = "Credit-card spend types as CREDIT (Avl Lmt present)",
+                name = "Credit-card spend types as CREDIT and extracts INR Avl Lmt",
                 message = "INR 1,250.00 spent on IndusInd Card XX1234 on 14-06-2026 04:21:45 pm at INSTAMART. Avl Lmt: INR 48,750.00. To dispute, call 18602677777/SMS BLOCK 1234 to 5676757",
                 sender = "AD-INDUSIND-S",
                 expected = ExpectedTransaction(
                     amount = BigDecimal("1250.00"),
                     currency = "INR",
-                    type = TransactionType.CREDIT
+                    type = TransactionType.CREDIT,
+                    // Parser returns the SMS *available* limit; the app back-calcs total.
+                    creditLimit = BigDecimal("48750.00")
                 )
             ),
             ParserTestCase(


### PR DESCRIPTION
Implements issues **1 & 2** from the detailed analysis in #486.

## Issue 1 — CC spends were typed EXPENSE → now CREDIT
`IndusIndBankParser` mapped `spent`/`purchase` → EXPENSE, so a credit-card purchase was counted as a bank expense and never typed CREDIT (which also gated available-limit extraction). Now detect the card-spend signal **before** the generic branch:
```kotlin
lower.contains("card") && lower.contains("avl lmt") -> TransactionType.CREDIT
```
Refunds (`credited to your … Card`, no `Avl Lmt`) still fall through to INCOME. Scoped to IndusInd CC spends only — regular account txns (`Avl Bal`) and other banks are untouched.

## Issue 2 — Available-limit tracking
- **Parser:** broadened `extractAvailableLimit`'s currency token `Rs` → `(Rs|INR|₹)` so `Avl Lmt: INR …` matches. Only ever evaluated for CREDIT messages.
- **App (the design call):** the SMS reports the *available* limit, but the card UI derives `available = creditLimit − balance` (`ManageAccountsScreen.kt:588`). Storing it raw would double-subtract. So at both balance-write sites (`SmsTransactionProcessor`, `OptimizedSmsReaderWorker`) we store **`creditLimit = parsedAvailable + outstanding`** — the existing UI math then yields the SMS available figure, no UI changes, no double-count.

## Tests
- CC spend → **CREDIT** + extracts **Avl Lmt INR 48,750** ✓
- Refund → **INCOME** ✓
- Existing IndusInd debit/UPI cases unaffected.
- Full `:parser-core:jvmTest`: **1254 tests, 0 failures**. App compiles.

## Follow-up (not in this PR)
**Issue 3** — netting credit-card refunds against the monthly "credit card spent" figure (`HomeViewModel.currentMonthCreditCard`). Deferred: there's no reliable signal yet to distinguish a credit-card refund from other income, which would need an auto-tagging mechanism. (The refund already correctly reduces the card's outstanding → restores the available limit; only the monthly stat doesn't net it.)

Addresses #486 (issues 1 & 2).