### PR TITLE
feat(parser): Bankino + blu Bank parsers (Iran, Persian SMS)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -100,6 +100,8 @@ object BankParserFactory {
         MelliBankParser(),  // Melli Bank (Iran)
         MellatBankParser(), // Mellat Bank (Iran)
         ParsianBankParser(),  // Parsian Bank (Iran)
+        BankinoBankParser(),  // Bankino / Middle East Bank (Iran)
+        BluBankParser(),  // blu Bank (Iran)
         BangkokBankParser(),  // Bangkok Bank (Thailand)
         KasikornBankParser(),  // Kasikorn Bank (Thailand)
         SiamCommercialBankParser(),  // Siam Commercial Bank (Thailand)

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankinoBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankinoBankParser.kt
@@ -22,11 +22,9 @@ import java.math.BigDecimal
  *   "-" => EXPENSE, "+" => INCOME.
  * - Currency is Iranian Rial (IRR).
  */
-class BankinoBankParser : BankParser() {
+class BankinoBankParser : BaseIranianBankParser() {
 
     override fun getBankName() = "Bankino"
-
-    override fun getCurrency() = "IRR"
 
     // "بانک خاورمیانه" = Middle East Bank (Bankino).
     private val bankNameMarker = "بانک خاورمیانه"

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankinoBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankinoBankParser.kt
@@ -1,0 +1,100 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Bankino (digital arm of Middle East Bank / بانک خاورمیانه), Iran.
+ *
+ * Handles line-based Persian SMS such as:
+ *   بانک خاورمیانه
+ *   خرید با کارت 7284
+ *   -3,300,000
+ *   XXX/XXXXXXXX
+ *   مانده 14,412,600
+ *   03/22
+ *   12:49
+ *
+ * Notes:
+ * - Amounts use Western digits with comma grouping; only date/time use Persian
+ *   digits, which we do not parse (timestamp comes from SMS metadata).
+ * - The leading sign on the amount is the reliable type signal:
+ *   "-" => EXPENSE, "+" => INCOME.
+ * - Currency is Iranian Rial (IRR).
+ */
+class BankinoBankParser : BankParser() {
+
+    override fun getBankName() = "Bankino"
+
+    override fun getCurrency() = "IRR"
+
+    // "بانک خاورمیانه" = Middle East Bank (Bankino).
+    private val bankNameMarker = "بانک خاورمیانه"
+
+    // "کارت" = card; followed by the masked last 4 digits.
+    private val cardPattern = Regex("""کارت\s+(\d{3,})""")
+
+    // Signed amount on its own line: leading +/- then a comma-grouped number.
+    private val signedAmountPattern = Regex("""([+-])\s*([0-9][0-9,]*)""")
+
+    // "مانده" = balance, followed by a comma-grouped number.
+    private val balancePattern = Regex("""مانده\s+([0-9][0-9,]*)""")
+
+    override fun canHandle(sender: String): Boolean {
+        val digits = sender.filter { it.isDigit() }
+        return digits.contains("20004861")
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        // Must look like a Bankino SMS and carry a signed amount.
+        return message.contains(bankNameMarker) &&
+                signedAmountPattern.containsMatchIn(message)
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        signedAmountPattern.find(message)?.let { match ->
+            val amountStr = match.groupValues[2].replace(",", "")
+            return try {
+                BigDecimal(amountStr)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+        return null
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        signedAmountPattern.find(message)?.let { match ->
+            return if (match.groupValues[1] == "-") {
+                TransactionType.EXPENSE
+            } else {
+                TransactionType.INCOME
+            }
+        }
+        return null
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        balancePattern.find(message)?.let { match ->
+            val balanceStr = match.groupValues[1].replace(",", "")
+            return try {
+                BigDecimal(balanceStr)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+        return null
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        cardPattern.find(message)?.let { match ->
+            return extractLast4Digits(match.groupValues[1])
+        }
+        return null
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // Bankino SMS carries no merchant/payee field.
+        return null
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BluBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BluBankParser.kt
@@ -1,0 +1,102 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for blu Bank (بلو), Iran.
+ *
+ * Handles line-based Persian SMS such as:
+ *   بلو
+ *   برداشت پول
+ *   <NAME> عزیز، 2,500,000 ریال از حساب شما پرید.
+ *   موجودی: 488,152 ریال
+ *   ۷:۲۸
+ *   ۱۴۰۵.۰۳.۲۲
+ *
+ * Notes:
+ * - Amounts use Western digits with comma grouping; only date/time use Persian
+ *   digits, which we do not parse (timestamp comes from SMS metadata).
+ * - Type signals: "برداشت پول" / "پرید" => EXPENSE (money left the account);
+ *   "واریز پول" / "نشست" => INCOME (money landed in the account).
+ * - blu samples carry no card/account number, so accountLast4 is always null.
+ * - Currency is Iranian Rial (IRR).
+ *
+ * NOTE: blu sender IDs vary widely with no reliable shared prefix (e.g.
+ * "0999 998 7641", "+989999987641", "98300087641"). The only stable core
+ * across observed samples is the "87641" suffix, plus the "9999987641" core.
+ * canHandle matches those; additional sender IDs may need to be added as more
+ * samples surface (known limitation).
+ */
+class BluBankParser : BankParser() {
+
+    override fun getBankName() = "blu Bank"
+
+    override fun getCurrency() = "IRR"
+
+    // "بلو" = blu (bank-name line; strongest in-body signal).
+    private val bankNameMarker = "بلو"
+
+    // "ریال" = Rial. Main sentence amount: a comma-grouped number before "ریال".
+    private val amountPattern = Regex("""([0-9][0-9,]*)\s*ریال""")
+
+    // "موجودی:" = balance, followed by a comma-grouped number before "ریال".
+    private val balancePattern = Regex("""موجودی:\s*([0-9][0-9,]*)\s*ریال""")
+
+    override fun canHandle(sender: String): Boolean {
+        val digits = sender.filter { it.isDigit() }
+        return digits.endsWith("87641") || digits.contains("9999987641")
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        if (!message.contains(bankNameMarker)) return false
+        // Must carry one of the action signals.
+        return message.contains("برداشت پول") || message.contains("پرید") ||
+                message.contains("واریز پول") || message.contains("نشست")
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // First "<number> ریال" is the transaction amount (balance line comes later).
+        amountPattern.find(message)?.let { match ->
+            val amountStr = match.groupValues[1].replace(",", "")
+            return try {
+                BigDecimal(amountStr)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+        return null
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        if (message.contains("برداشت پول") || message.contains("پرید")) {
+            return TransactionType.EXPENSE
+        }
+        if (message.contains("واریز پول") || message.contains("نشست")) {
+            return TransactionType.INCOME
+        }
+        return null
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        balancePattern.find(message)?.let { match ->
+            val balanceStr = match.groupValues[1].replace(",", "")
+            return try {
+                BigDecimal(balanceStr)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+        return null
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        // blu samples carry no card/account number.
+        return null
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // blu SMS carries no merchant/payee field.
+        return null
+    }
+}

--- a/parser-core/src/test/kotlin/TestBankinoBankParser.kt
+++ b/parser-core/src/test/kotlin/TestBankinoBankParser.kt
@@ -1,0 +1,66 @@
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.bank.BankinoBankParser
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class BankinoBankParserTest {
+
+    @TestFactory
+    fun `bankino parser handles common cases`(): List<DynamicTest> {
+        val parser = BankinoBankParser()
+
+        val cases = listOf(
+            ParserTestCase(
+                name = "Purchase / debit (EXPENSE)",
+                message = "بانک خاورمیانه\nخرید با کارت 7284\n-3,300,000\nXXX/XXXXXXXX\nمانده 14,412,600\n03/22\n12:49",
+                sender = "20004861",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("3300000"),
+                    currency = "IRR",
+                    type = TransactionType.EXPENSE,
+                    balance = BigDecimal("14412600"),
+                    accountLast4 = "7284"
+                )
+            ),
+            ParserTestCase(
+                name = "Second purchase / debit (EXPENSE)",
+                message = "بانک خاورمیانه\nخرید با کارت 7284\n-1,100,000\nXXX/XXXXXXXXX\nمانده 17,712,600\n03/22\n12:42",
+                sender = "+98 20 0048 61",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1100000"),
+                    currency = "IRR",
+                    type = TransactionType.EXPENSE,
+                    balance = BigDecimal("17712600"),
+                    accountLast4 = "7284"
+                )
+            ),
+            ParserTestCase(
+                name = "Internet-bank transfer / credit (INCOME)",
+                message = "بانک خاورمیانه\nانتقال از اینترنت بانک از کارت 9286\n+2,500,000\nXXX/XXXXXXXXX\nمانده 19,021,600\n03/22\n07:28",
+                sender = "98200048610",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2500000"),
+                    currency = "IRR",
+                    type = TransactionType.INCOME,
+                    balance = BigDecimal("19021600"),
+                    accountLast4 = "9286"
+                )
+            )
+        )
+
+        val handleChecks = listOf(
+            "20004861" to true,
+            "+98 20 0048 61" to true,
+            "98200048610" to true,
+            "AD-ICICIB" to false,
+            "HDFC" to false,
+            "UNKNOWN" to false
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases, handleChecks, "Bankino Bank Parser")
+    }
+}

--- a/parser-core/src/test/kotlin/TestBankinoBankParser.kt
+++ b/parser-core/src/test/kotlin/TestBankinoBankParser.kt
@@ -23,7 +23,8 @@ class BankinoBankParserTest {
                     currency = "IRR",
                     type = TransactionType.EXPENSE,
                     balance = BigDecimal("14412600"),
-                    accountLast4 = "7284"
+                    accountLast4 = "7284",
+                    isFromCard = true
                 )
             ),
             ParserTestCase(
@@ -35,7 +36,8 @@ class BankinoBankParserTest {
                     currency = "IRR",
                     type = TransactionType.EXPENSE,
                     balance = BigDecimal("17712600"),
-                    accountLast4 = "7284"
+                    accountLast4 = "7284",
+                    isFromCard = true
                 )
             ),
             ParserTestCase(
@@ -47,7 +49,8 @@ class BankinoBankParserTest {
                     currency = "IRR",
                     type = TransactionType.INCOME,
                     balance = BigDecimal("19021600"),
-                    accountLast4 = "9286"
+                    accountLast4 = "9286",
+                    isFromCard = true
                 )
             )
         )

--- a/parser-core/src/test/kotlin/TestBluBankParser.kt
+++ b/parser-core/src/test/kotlin/TestBluBankParser.kt
@@ -1,0 +1,63 @@
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.bank.BluBankParser
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class BluBankParserTest {
+
+    @TestFactory
+    fun `blu parser handles common cases`(): List<DynamicTest> {
+        val parser = BluBankParser()
+
+        val cases = listOf(
+            ParserTestCase(
+                name = "Withdrawal / debit (EXPENSE)",
+                message = "بلو\nبرداشت پول\n<NAME> عزیز، 2,500,000 ریال از حساب شما پرید.\nموجودی: 488,152 ریال\n۷:۲۸\n۱۴۰۵.۰۳.۲۲",
+                sender = "0999 998 7641",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2500000"),
+                    currency = "IRR",
+                    type = TransactionType.EXPENSE,
+                    balance = BigDecimal("488152")
+                )
+            ),
+            ParserTestCase(
+                name = "Second withdrawal / debit (EXPENSE)",
+                message = "بلو\nبرداشت پول\n<NAME> عزیز، 3,000,000 ریال از حساب شما پرید.\nموجودی: 8,151,152 ریال\n۲۲:۱۴\n۱۴۰۵.۰۳.۲۰",
+                sender = "+989999987641",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("3000000"),
+                    currency = "IRR",
+                    type = TransactionType.EXPENSE,
+                    balance = BigDecimal("8151152")
+                )
+            ),
+            ParserTestCase(
+                name = "Deposit / credit (INCOME)",
+                message = "بلو\nواریز پول\n<NAME> عزیز، 70,000,000 ریال به حساب شما نشست.\nموجودی: 71,087,723 ریال\n۱۱:۴۹\n۱۴۰۵.۰۳.۱۸",
+                sender = "98300087641",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("70000000"),
+                    currency = "IRR",
+                    type = TransactionType.INCOME,
+                    balance = BigDecimal("71087723")
+                )
+            )
+        )
+
+        val handleChecks = listOf(
+            "0999 998 7641" to true,
+            "+989999987641" to true,
+            "98300087641" to true,
+            "AD-ICICIB" to false,
+            "HDFC" to false,
+            "UNKNOWN" to false
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases, handleChecks, "blu Bank Parser")
+    }
+}


### PR DESCRIPTION
Two more Iranian (IRR) bank SMS parsers for Persian/Farsi messages — adding to the existing Iranian support (Melli/Mellat/Parsian).

| Bank | Issue | Extends | Sender | Type signal |
|------|-------|---------|--------|-------------|
| Bankino | #480 | `BaseIranianBankParser` | digits contain `20004861` | signed amount (`-`=EXPENSE, `+`=INCOME); balance after `مانده`, card last4 after `کارت` |
| blu Bank | #481 | `BankParser` | heuristic (see below) | `برداشت پول`/`پرید`=EXPENSE, `واریز پول`/`نشست`=INCOME; amount before `ریال`, balance after `موجودی`, no account no. |

## Tests
9 each (3 sample parses incl. debit+credit + canHandle checks). Full `:parser-core:jvmTest` green, no regressions. Amounts use Western digits; dates/times (Persian digits) are ignored.

## ⚠️ blu sender limitation
blu's sender IDs vary with no stable prefix across the 3 samples (`0999 998 7641`, `+989999987641`, `98300087641`). `canHandle` is a best-effort heuristic (`endsWith 87641` / `contains 9999987641`); the `بلو` body marker in `isTransactionMessage` guards against mis-parsing non-blu messages. **More blu sender IDs may be needed** — flagged for the reporter. blu could also be moved onto `BaseIranianBankParser` for consistency later.

Closes #480
Closes #481