### PR TITLE
fix(rules): Smart Rules info card unreadable in dark mode

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/RulesScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/RulesScreen.kt
@@ -154,8 +154,12 @@ fun RulesScreen(
             ) {
                 // Info Card
                 item {
+                    // Use a primaryContainer background so the onPrimaryContainer icon/text
+                    // are legible. On the default surface card they're near-invisible in
+                    // dark mode (low-contrast primary tone on a dark surface).
                     PennyWiseCardV2(
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier.fillMaxWidth(),
+                        containerColor = MaterialTheme.colorScheme.primaryContainer
                     ) {
                         Row(
                             modifier = Modifier


### PR DESCRIPTION
## Bug
On the **Smart Rules** screen, the top "Automatic Categorization" info card is near-invisible in dark mode (reported via screenshot).

## Cause
The card colors its icon + both text lines with `onPrimaryContainer`, but `PennyWiseCardV2` defaults to a **`surfaceContainerLow`** background. `onPrimaryContainer` is meant for a `primaryContainer` background; on a dark surface it's a low-contrast primary tone → unreadable in dark mode. (The dev clearly intended a primaryContainer banner but never set the background.)

## Fix
Pass `containerColor = primaryContainer` to the card, so the `onPrimaryContainer` icon/text are legible and it renders as the intended highlighted info banner — correct in both light and dark.

## Verified (emulator, dark mode)
Card now shows a primary-tinted banner with a clear sparkle icon + readable "Automatic Categorization" / description text.