### PR TITLE
feat(parser): NSDL Payments Bank (India, NSDLPB sender)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -34,6 +34,7 @@ object BankParserFactory {
         BankOfBarodaParser(),
         BankOfIndiaParser(),
         JioPaymentsBankParser(),
+        NSDLPaymentsBankParser(),  // NSDL Payments Bank (India) — legacy NSDLPB sender, rebranded to Jio Payments Bank
         KotakBankParser(),
         IDFCFirstBankParser(),
         UnionBankParser(),

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NSDLPaymentsBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NSDLPaymentsBankParser.kt
@@ -51,14 +51,17 @@ class NSDLPaymentsBankParser : BaseIndianBankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
-        // Debit: "for linked myupihandle@oksbi. UPI Ref ..." — keep the handle before "@".
+        // Debit: "for linked myupihandle@oksbi. UPI Ref ..." — capture the whole VPA up to
+        // the sentence boundary (". " / end), then keep the handle before "@". Capturing
+        // up to the first dot would truncate dotted handles like business.name@oksbi.
         val linkedPattern = Regex(
-            """for\s+linked\s+([^\s.]+)""",
+            """for\s+linked\s+(.+?)(?:\.\s|$)""",
             RegexOption.IGNORE_CASE
         )
         linkedPattern.find(message)?.let { match ->
-            val raw = match.groupValues[1].trim()
-            val name = if (raw.contains("@")) raw.substringBefore("@") else raw
+            var name = match.groupValues[1].trim()
+            if (name.contains("@")) name = name.substringBefore("@")
+            name = name.trimEnd('.', ',', ';')
             val merchant = cleanMerchantName(name)
             if (isValidMerchantName(merchant)) {
                 return merchant

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NSDLPaymentsBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NSDLPaymentsBankParser.kt
@@ -1,0 +1,105 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for NSDL Payments Bank (NSDLPB) SMS messages.
+ *
+ * NSDL Payments Bank was rebranded to Jio Payments Bank, but users still receive
+ * legacy SMS from the NSDLPB sender in a distinct format. This parser handles that
+ * legacy format only; the JIOPBS sender/format is handled by [JioPaymentsBankParser].
+ */
+class NSDLPaymentsBankParser : BaseIndianBankParser() {
+
+    override fun getBankName() = "NSDL Payments Bank"
+
+    override fun canHandle(sender: String): Boolean {
+        // Sender ID is NSDLPB, optionally with a DLT prefix (e.g. AD-NSDLPB, VM-NSDLPB-S).
+        return sender.uppercase().contains("NSDLPB")
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // Handles "Rs 1.00" (space) and "Rs.100.00" (no space).
+        val amountPattern = Regex(
+            """Rs\.?\s*([\d,]+(?:\.\d{2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        amountPattern.find(message)?.let { match ->
+            val amount = match.groupValues[1].replace(",", "")
+            return try {
+                BigDecimal(amount)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+
+        return super.extractAmount(message)
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        // Patterns: "A/c XX1234" (debit) and "A/c no XX1234" (credit).
+        val accountPattern = Regex(
+            """A/c(?:\s+no)?\s+([X\d]+)""",
+            RegexOption.IGNORE_CASE
+        )
+        accountPattern.find(message)?.let { match ->
+            extractLast4Digits(match.groupValues[1])?.let { return it }
+        }
+
+        return super.extractAccountLast4(message)
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // Debit: "for linked myupihandle@oksbi. UPI Ref ..." — keep the handle before "@".
+        val linkedPattern = Regex(
+            """for\s+linked\s+([^\s.]+)""",
+            RegexOption.IGNORE_CASE
+        )
+        linkedPattern.find(message)?.let { match ->
+            val raw = match.groupValues[1].trim()
+            val name = if (raw.contains("@")) raw.substringBefore("@") else raw
+            val merchant = cleanMerchantName(name)
+            if (isValidMerchantName(merchant)) {
+                return merchant
+            }
+        }
+
+        // Credit SMS has no VPA/merchant — leave null.
+        return null
+    }
+
+    override fun extractReference(message: String): String? {
+        // Debit: "UPI Ref 122345526539"
+        // Credit: "(UPI Ref No 617109835321)"
+        val refPattern = Regex(
+            """UPI\s+Ref(?:\s+No)?\s+(\d+)""",
+            RegexOption.IGNORE_CASE
+        )
+        refPattern.find(message)?.let { match ->
+            return match.groupValues[1]
+        }
+
+        return super.extractReference(message)
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lowerMessage = message.lowercase()
+        return when {
+            lowerMessage.contains("debited") -> TransactionType.EXPENSE
+            lowerMessage.contains("credited") -> TransactionType.INCOME
+            else -> super.extractTransactionType(message)
+        }
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lowerMessage = message.lowercase()
+        if (lowerMessage.contains("upi ref") &&
+            (lowerMessage.contains("debited") || lowerMessage.contains("credited"))
+        ) {
+            return true
+        }
+
+        return super.isTransactionMessage(message)
+    }
+}

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/NSDLPaymentsBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/NSDLPaymentsBankParserTest.kt
@@ -1,0 +1,55 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.*
+import java.math.BigDecimal
+
+class NSDLPaymentsBankParserTest {
+
+    @TestFactory
+    fun `nsdl payments bank parser handles common cases`(): List<DynamicTest> {
+        val parser = NSDLPaymentsBankParser()
+
+        val cases = listOf(
+            ParserTestCase(
+                name = "UPI debit",
+                message = "A/c XX1234 debited Rs 1.00 on 20-Jun-26 for linked myupihandle@oksbi. UPI Ref 122345526539 - NSDLPB",
+                sender = "AD-NSDLPB-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "myupihandle",
+                    reference = "122345526539",
+                    accountLast4 = "1234"
+                )
+            ),
+            ParserTestCase(
+                name = "UPI credit",
+                message = "A/c no XX1234 is credited for Rs.100.00 on 20-Jun-26 (UPI Ref No 617109835321) - NSDLPB",
+                sender = "AD-NSDLPB-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("100.00"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    merchant = null,
+                    reference = "617109835321",
+                    accountLast4 = "1234"
+                )
+            )
+        )
+
+        val handleChecks = listOf(
+            "NSDLPB" to true,
+            "AD-NSDLPB-S" to true,
+            "JIOPBS" to false,
+            "HDFC" to false,
+            "UNKNOWN" to false
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases, handleChecks, "NSDL Payments Bank Parser")
+    }
+}

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/NSDLPaymentsBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/NSDLPaymentsBankParserTest.kt
@@ -39,12 +39,26 @@ class NSDLPaymentsBankParserTest {
                     reference = "617109835321",
                     accountLast4 = "1234"
                 )
+            ),
+            ParserTestCase(
+                name = "UPI debit with dotted VPA handle (not truncated at the dot)",
+                message = "A/c XX1234 debited Rs 50.00 on 20-Jun-26 for linked business.name@oksbi. UPI Ref 122345526540 - NSDLPB",
+                sender = "VM-NSDLPB-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("50.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "business.name",
+                    reference = "122345526540",
+                    accountLast4 = "1234"
+                )
             )
         )
 
         val handleChecks = listOf(
             "NSDLPB" to true,
             "AD-NSDLPB-S" to true,
+            "VM-NSDLPB-S" to true,
             "JIOPBS" to false,
             "HDFC" to false,
             "UNKNOWN" to false


### PR DESCRIPTION
User‑reported: NSDL Payments Bank SMS weren't recognized. NSDL Payments Bank was rebranded to **Jio Payments Bank**, but users still receive **NSDLPB**‑sender messages in a legacy UPI format that the existing `JioPaymentsBankParser` (sender `JIOPBS`, different format) doesn't handle.

## New parser
`NSDLPaymentsBankParser` extends `BaseIndianBankParser` (INR). `canHandle`: sender contains `NSDLPB` (covers `AD-NSDLPB`/`VM-NSDLPB-S`) — no collision with Jio.

| Type | Sample | Result |
|------|--------|--------|
| Debit (EXPENSE) | `A/c XX1234 debited Rs 1.00 ... for linked <vpa>. UPI Ref <n> - NSDLPB` | amount, last4, UPI ref, VPA merchant |
| Credit (INCOME) | `A/c no XX1234 is credited for Rs.100.00 ... (UPI Ref No <n>) - NSDLPB` | amount, last4, UPI ref |

Amount handles both `Rs 1.00` (space) and `Rs.100.00` (no space).

## Tests
7 (2 parse cases + 5 canHandle incl. `JIOPBS`→false). Full `:parser-core:jvmTest` green, no regressions.