### PR TITLE
feat(parser): Arab Bank (Egypt + Jordan) — EGP/JOD/USD card & transfer SMS

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
@@ -68,7 +68,7 @@ object CurrencyFormatter {
         "NGN" to Locale.Builder().setLanguage("en").setRegion("NG").build(),
         "TZS" to Locale.Builder().setLanguage("en").setRegion("TZ").build(),
         "BRL" to Locale.Builder().setLanguage("pt").setRegion("BR").build(),
-        "EGP" to Locale.Builder().setLanguage("ar").setRegion("EG").build()
+        "EGP" to Locale.Builder().setLanguage("en").setRegion("EG").build()
     )
 
     /**

--- a/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
@@ -38,7 +38,8 @@ object CurrencyFormatter {
         "KRW" to "₩",
         "NGN" to "₦",
         "TZS" to "TSh",
-        "BRL" to "R$"
+        "BRL" to "R$",
+        "EGP" to "E£"
     )
 
     /**
@@ -66,7 +67,8 @@ object CurrencyFormatter {
         "KRW" to Locale.KOREA,
         "NGN" to Locale.Builder().setLanguage("en").setRegion("NG").build(),
         "TZS" to Locale.Builder().setLanguage("en").setRegion("TZ").build(),
-        "BRL" to Locale.Builder().setLanguage("pt").setRegion("BR").build()
+        "BRL" to Locale.Builder().setLanguage("pt").setRegion("BR").build(),
+        "EGP" to Locale.Builder().setLanguage("ar").setRegion("EG").build()
     )
 
     /**

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ArabBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ArabBankParser.kt
@@ -1,0 +1,196 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Arab Bank (Egypt) SMS messages.
+ *
+ * Arab Bank sends both English and Arabic SMS for a multi-currency card account.
+ * Default / base currency is the Egyptian Pound (EGP). The TRANSACTION can be in
+ * EGP or USD, but the account's available balance is always reported in EGP.
+ * The transaction amount/currency reflect the spent currency (EGP or USD) while
+ * the balance currency stays EGP (the parser's base currency). See [parse].
+ *
+ * Supported formats:
+ * - English card spend (EXPENSE):
+ *   "A Trx using Card XXXX2020 from <MERCHANT> for <CCY> <amount> on <date> at <time>.
+ *    Available balance is EGP <balance>."
+ *   - merchant: text between "from " and " for "
+ *   - amount currency: the CCY token after "for " (EGP or USD)
+ * - Arabic credit to the card (INCOME):
+ *   "تم قيد مبلغ <amount> جنيه لبطاقتك الائتمانية رقم #<last4>"
+ *   - amount in EGP ("جنيه"), no merchant, no balance
+ *
+ * Sender: ArabBank (token ARABBANK, case-insensitive).
+ */
+class ArabBankParser : BankParser() {
+
+    override fun getBankName() = "Arab Bank"
+
+    override fun getCurrency() = "EGP"
+
+    override fun canHandle(sender: String): Boolean {
+        val normalized = sender.uppercase()
+        return normalized.contains("ARABBANK")
+    }
+
+    /**
+     * Override parse to surface the per-transaction currency.
+     *
+     * English transactions carry their own currency token after "for " (EGP or USD).
+     * Arabic credits are always EGP. The balance figure stays EGP regardless of the
+     * transaction currency — that is handled by [extractBalance] returning the EGP
+     * "Available balance" amount.
+     */
+    override fun parse(smsBody: String, sender: String, timestamp: Long): ParsedTransaction? {
+        val transaction = super.parse(smsBody, sender, timestamp) ?: return null
+        val currency = extractCurrency(smsBody) ?: getCurrency()
+        return transaction.copy(
+            currency = currency,
+            isFromCard = true
+        )
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+
+        // Reject OTP / verification noise.
+        if (lower.contains("otp") ||
+            lower.contains("one time password") ||
+            lower.contains("verification code") ||
+            lower.contains("passcode") ||
+            message.contains("رمز التحقق") ||      // Arabic: "verification code"
+            message.contains("كلمة المرور")        // Arabic: "password"
+        ) {
+            return false
+        }
+
+        // English card spend marker.
+        if (Regex("""using\s+Card""", RegexOption.IGNORE_CASE).containsMatchIn(message)) {
+            return true
+        }
+
+        // Arabic credit marker: "تم قيد مبلغ" ("an amount has been credited").
+        if (message.contains("تم قيد")) {
+            return true
+        }
+
+        return false
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        // Arabic credit to the card.
+        if (message.contains("تم قيد")) {
+            return TransactionType.INCOME
+        }
+
+        // English card spend.
+        if (Regex("""using\s+Card""", RegexOption.IGNORE_CASE).containsMatchIn(message)) {
+            return TransactionType.EXPENSE
+        }
+
+        return null
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // English: "for <CCY> <amount>" e.g. "for EGP 123.45" / "for USD 9.84".
+        val englishPattern = Regex(
+            """for\s+[A-Z]{3}\s+([0-9,]+(?:\.\d+)?)""",
+            RegexOption.IGNORE_CASE
+        )
+        englishPattern.find(message)?.let { match ->
+            parseAmount(match.groupValues[1])?.let { return it }
+        }
+
+        // Arabic: "<amount> جنيه" e.g. "500.00 جنيه".
+        val arabicPattern = Regex("""([0-9,]+(?:\.\d+)?)\s*جنيه""")
+        arabicPattern.find(message)?.let { match ->
+            parseAmount(match.groupValues[1])?.let { return it }
+        }
+
+        return null
+    }
+
+    override fun extractCurrency(message: String): String? {
+        // English: the CCY token after "for " (EGP or USD).
+        val englishPattern = Regex(
+            """for\s+([A-Z]{3})\s+[0-9,]+(?:\.\d+)?""",
+            RegexOption.IGNORE_CASE
+        )
+        englishPattern.find(message)?.let { match ->
+            return match.groupValues[1].uppercase()
+        }
+
+        // Arabic amount is always in Egyptian pounds ("جنيه").
+        if (message.contains("جنيه")) {
+            return "EGP"
+        }
+
+        return null
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // English only: merchant is the text between "from " and " for ".
+        val merchantPattern = Regex(
+            """from\s+(.+?)\s+for\s+[A-Z]{3}\s""",
+            RegexOption.IGNORE_CASE
+        )
+        merchantPattern.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(merchant)) {
+                return merchant
+            }
+        }
+
+        // Arabic credit SMS has no merchant.
+        return null
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        // English: "Card XXXX2020" -> 2020.
+        val englishCard = Regex(
+            """Card\s+[X*]*(\d{4})""",
+            RegexOption.IGNORE_CASE
+        )
+        englishCard.find(message)?.let { match ->
+            return match.groupValues[1]
+        }
+
+        // Arabic: "رقم #2020" -> 2020.
+        val arabicCard = Regex("""رقم\s*#(\d{4})""")
+        arabicCard.find(message)?.let { match ->
+            return match.groupValues[1]
+        }
+
+        return null
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        // English: "Available balance is EGP <amount>" — always EGP.
+        val balancePattern = Regex(
+            """Available\s+balance\s+is\s+EGP\s+([0-9,]+(?:\.\d+)?)""",
+            RegexOption.IGNORE_CASE
+        )
+        balancePattern.find(message)?.let { match ->
+            parseAmount(match.groupValues[1])?.let { return it }
+        }
+
+        // Arabic credit SMS carries no balance.
+        return null
+    }
+
+    override fun detectIsCard(message: String): Boolean {
+        // This is a card account; every supported message is a card transaction.
+        return true
+    }
+
+    private fun parseAmount(raw: String): BigDecimal? {
+        return try {
+            BigDecimal(raw.replace(",", ""))
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -88,6 +88,7 @@ object BankParserFactory {
         CrdbBankParser(),  // CRDB Bank (Tanzania) — bilingual Swahili/English, multi-currency cards
         TigoPesaParser(),  // Tigo Pesa / Mixx by Yas (Tanzania)
         CIBEgyptParser(),  // CIB - Commercial International Bank (Egypt)
+        ArabBankParser(),  // Arab Bank (Egypt) — multi-currency card, English + Arabic SMS
         DhanlaxmiBankParser(),  // Dhanlaxmi Bank (India)
         DOPBankParser(),  // Department of Post (India)
         HuntingtonBankParser(),  // Huntington Bank (USA)

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/ArabBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/ArabBankParserTest.kt
@@ -1,0 +1,78 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class ArabBankParserTest {
+
+    @TestFactory
+    fun `arab bank parser handles common cases`(): List<DynamicTest> {
+        val parser = ArabBankParser()
+
+        val cases = listOf(
+            ParserTestCase(
+                name = "English card spend, EGP transaction (EXPENSE)",
+                message = "A Trx using Card XXXX2020 from Top Up ETISALAT Egypt for EGP 123.45 " +
+                    "on 18-Jun-2026 at 13:59 GMT+3. Available balance is EGP 9876.54.",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("123.45"),
+                    currency = "EGP",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Top Up ETISALAT Egypt",
+                    accountLast4 = "2020",
+                    balance = BigDecimal("9876.54"),
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "English card spend, USD transaction with EGP balance (EXPENSE)",
+                message = "A Trx using Card XXXX2020 from PORKBUN COM for USD 9.84 " +
+                    "on 05-Oct-2025 at 07:48 GMT+2. Available balance is EGP 5432.10.",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("9.84"),
+                    currency = "USD",
+                    type = TransactionType.EXPENSE,
+                    merchant = "PORKBUN COM",
+                    accountLast4 = "2020",
+                    balance = BigDecimal("5432.10"),
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "Arabic credit to the card (INCOME)",
+                message = "تم قيد مبلغ 500.00 جنيه لبطاقتك الائتمانية رقم #2020",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("500.00"),
+                    currency = "EGP",
+                    type = TransactionType.INCOME,
+                    accountLast4 = "2020",
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "OTP message is rejected",
+                message = "Your OTP for Arab Bank is 123456. Do not share it with anyone.",
+                sender = "ArabBank",
+                shouldParse = false
+            )
+        )
+
+        val handleChecks = listOf(
+            "ArabBank" to true,
+            "ARABBANK" to true,
+            "AD-ARABBANK" to true,
+            "HDFC" to false,
+            "" to false
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases, handleChecks, "Arab Bank Parser")
+    }
+}


### PR DESCRIPTION
## What
Adds a parser for **Arab Bank (Egypt)** (sender `ArabBank`) and registers the **EGP** currency in `CurrencyFormatter`.

Reported with real SMS samples (English card spends + an Arabic credit to the card).

## Formats handled
- **English card spend (EXPENSE)** — `A Trx using Card XXXX2020 from <MERCHANT> for <CCY> <amt> on <date> ... Available balance is EGP <bal>.`
  - Transaction currency follows the `for <CCY>` token (**EGP or USD**); the available balance stays **EGP** even on a USD spend.
- **Arabic credit to the card (INCOME)** — `تم قيد مبلغ <amt> جنيه لبطاقتك الائتمانية رقم #2020` → amount in EGP, no merchant/balance.

## Design
- `ArabBankParser extends BankParser` (not Indian/UAE base). `getCurrency() = "EGP"`.
- Multi-currency `parse()` override sets the per-transaction currency (EGP/USD) while `extractBalance` only reads the `EGP` figure — same pattern as the CIB Egypt / CRDB parsers.
- `isFromCard = true` for all messages; card last4 from `Card XXXX2020` / `رقم #2020`.
- Rejects OTP / verification messages (EN + AR keywords).

## Currency
- Added `EGP` to `CurrencyFormatter` (symbol `E£`, `ar-EG` locale). It was already a parser currency (CIB Egypt) but missing from the formatter maps, so EGP amounts now format correctly app-wide.

## Tests
- `ArabBankParserTest`: 9 tests — all 3 sample types (EGP spend, USD spend with EGP balance, Arabic credit), an OTP rejection, and 5 handle-checks. Asserts amount, **currency (EGP vs USD)**, type, merchant, accountLast4, balance, isFromCard.
- Full `:parser-core:jvmTest`: **1303 tests, 0 failures**.

No PII — all samples are synthetic placeholders.