### PR TITLE
feat(parser): Slice SFB banking SMS (UPI/card/AutoPay) — #497

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SliceParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SliceParser.kt
@@ -1,6 +1,7 @@
 package com.pennywiseai.parser.core.bank
 
 import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
 
 /**
  * Parser for Slice payments bank transactions.
@@ -45,6 +46,25 @@ class SliceParser : BankParser() {
     override fun isTransactionMessage(message: String): Boolean {
         val lowerMessage = message.lowercase()
 
+        // OTP / authorization messages are not completed transactions.
+        // (e.g. "is your OTP for txn of Rs. ... on slice card ending ...")
+        if (lowerMessage.contains("otp")) {
+            return false
+        }
+
+        // UPI AutoPay mandate lifecycle notices ("... is revoked", "is paused",
+        // "is suspended") are not money movements.
+        if (lowerMessage.contains("revoked") ||
+            lowerMessage.contains("is paused") ||
+            lowerMessage.contains("is suspended")) {
+            return false
+        }
+
+        // Slice SFB banking: "received in slice A/c ..." is an inbound credit.
+        if (lowerMessage.contains("received")) {
+            return true
+        }
+
         // Slice uses "sent" for UPI transfers (always success?)
         if (lowerMessage.contains("sent")) {
             return true
@@ -60,6 +80,40 @@ class SliceParser : BankParser() {
 
     override fun extractMerchant(message: String, sender: String): String? {
         val lowerMessage = message.lowercase()
+
+        // --- Slice SFB (banking) formats ---
+
+        // Card transaction: "transaction of Rs. 2.07 at FamAppbyTriO from a/c ... is successful"
+        val atMerchantPattern = Regex(
+            """\bat\s+(.+?)(?:\s+from\b|\s+on\b|\s+is\b|\.\s|$)""",
+            RegexOption.IGNORE_CASE
+        )
+        atMerchantPattern.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(merchant)) {
+                return merchant
+            }
+        }
+
+        // UPI received: "received in slice A/c ... from NASIMUDDIN ... via UPI (Ref ID: ...)"
+        // UPI sent:     "sent from a/c ... to Hussain Shaikh (UPI Ref: ...)"
+        // AutoPay paid: "paid Rs.1 from slice a/c ... to OpenAI LLC on 25-May-26 via UPI AutoPay"
+        // Only applies to the Slice SFB account-to-account flows (they always carry
+        // an a/c reference), so we don't hijack legacy "credited to your slice
+        // account" style messages.
+        if (Regex("""\ba/c\b""", RegexOption.IGNORE_CASE).containsMatchIn(message)) {
+            val payeeKeyword = if (lowerMessage.contains("received")) "from" else "to"
+            val payeePattern = Regex(
+                """\b$payeeKeyword\s+(.+?)(?:\s+on\b|\s+via\b|\s+is\b|\s*\(|\.\s|$)""",
+                RegexOption.IGNORE_CASE
+            )
+            payeePattern.find(message)?.let { match ->
+                val merchant = cleanMerchantName(match.groupValues[1].trim())
+                if (isValidMerchantName(merchant)) {
+                    return merchant
+                }
+            }
+        }
 
         // Look for "sent to NAME" pattern for UPI transfers
         val sentToPattern = Regex("""sent.*to\s+([A-Z][A-Z0-9\s./&-]+?)\s*\(""", RegexOption.IGNORE_CASE)
@@ -98,6 +152,51 @@ class SliceParser : BankParser() {
             lowerMessage.contains("slice") && lowerMessage.contains("credited") -> "Slice Credit"
             else -> super.extractMerchant(message, sender) ?: "Slice"
         }
+    }
+
+    override fun detectIsCard(message: String): Boolean {
+        val lower = message.lowercase()
+        // Slice SFB card-spend format:
+        // "Your transaction of Rs. X at MERCHANT from a/c ... is successful"
+        // carries an a/c reference (which the base detector treats as non-card),
+        // so flag it explicitly. UPI flows use sent/received/paid wording instead.
+        if (lower.contains("transaction of") &&
+            Regex("""\bat\s""", RegexOption.IGNORE_CASE).containsMatchIn(message) &&
+            !lower.contains("sent") &&
+            !lower.contains("received") &&
+            !lower.contains("paid")) {
+            return true
+        }
+        return super.detectIsCard(message)
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        // Slice SFB prints "Avl. Bal. Rs. 2,203.56" (dots after Avl/Bal break the
+        // base [:\s]+ patterns), so handle that shape explicitly first.
+        val sliceBal = Regex(
+            """Avl\.?\s*Bal\.?\s*(?:Rs\.?|INR|₹)?\s*([0-9,]+(?:\.\d{2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        sliceBal.find(message)?.let { match ->
+            return try {
+                BigDecimal(match.groupValues[1].replace(",", ""))
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+
+        return super.extractBalance(message)
+    }
+
+    override fun extractReference(message: String): String? {
+        // Slice SFB UPI formats: "(UPI Ref: 616851070000)" and "(Ref ID: 212756500000)".
+        val upiRef = Regex("""UPI\s+Ref(?:\s+ID)?[:\s]+([0-9]+)""", RegexOption.IGNORE_CASE)
+        upiRef.find(message)?.let { return it.groupValues[1] }
+
+        val refId = Regex("""Ref\s+ID[:\s]+([0-9]+)""", RegexOption.IGNORE_CASE)
+        refId.find(message)?.let { return it.groupValues[1] }
+
+        return super.extractReference(message)
     }
 
     /**

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SliceParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SliceParser.kt
@@ -60,28 +60,12 @@ class SliceParser : BankParser() {
             return false
         }
 
-        // UPI collect / payment requests are not completed money movements,
-        // even though the text can contain "received" (e.g. a "payment request
-        // received" / "is requesting" prompt). Reject before the credit shortcut
-        // below so a collect-request can't be booked as income.
-        if (lowerMessage.contains("request")) {
-            return false
-        }
-
-        // Slice SFB inbound credit: "Rs. X received in slice A/c ... via UPI".
-        // Narrowed to the account-credit shape so a bare "received" elsewhere
-        // doesn't slip a non-transaction through as income.
-        if (lowerMessage.contains("received in") && lowerMessage.contains("a/c")) {
-            return true
-        }
-
-        // Slice SFB outbound UPI: "Rs. X sent from a/c ... to <payee>".
-        if (lowerMessage.contains("sent from") && lowerMessage.contains("a/c")) {
-            return true
-        }
-
-        // Slice SFB UPI AutoPay debit: "Successfully paid Rs.X from slice a/c ...".
-        if (lowerMessage.contains("successfully paid")) {
+        // Slice uses "sent" for UPI transfers, and the base class transaction
+        // keyword list does not include "sent" — so accept it explicitly.
+        // Collect/payment requests do not use "sent" wording and are filtered
+        // by the base class below (it rejects "collect request" / "payment
+        // request" / "has requested" / "have received payment" etc.).
+        if (lowerMessage.contains("sent")) {
             return true
         }
 
@@ -90,6 +74,12 @@ class SliceParser : BankParser() {
             return isSuccessMessage(message) && !isFailureMessage(message)
         }
 
+        // Everything else — including the SFB "received in slice A/c" credit and
+        // the AutoPay "Successfully paid" debit — is handled by the base class,
+        // whose keyword set ("received"/"paid"/...) accepts genuine transactions
+        // while its guards reject collect/payment requests, OTPs and reminders.
+        // A UPI collect-request from the slice sender therefore can no longer be
+        // booked as income.
         return super.isTransactionMessage(message)
     }
 

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SliceParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SliceParser.kt
@@ -60,13 +60,28 @@ class SliceParser : BankParser() {
             return false
         }
 
-        // Slice SFB banking: "received in slice A/c ..." is an inbound credit.
-        if (lowerMessage.contains("received")) {
+        // UPI collect / payment requests are not completed money movements,
+        // even though the text can contain "received" (e.g. a "payment request
+        // received" / "is requesting" prompt). Reject before the credit shortcut
+        // below so a collect-request can't be booked as income.
+        if (lowerMessage.contains("request")) {
+            return false
+        }
+
+        // Slice SFB inbound credit: "Rs. X received in slice A/c ... via UPI".
+        // Narrowed to the account-credit shape so a bare "received" elsewhere
+        // doesn't slip a non-transaction through as income.
+        if (lowerMessage.contains("received in") && lowerMessage.contains("a/c")) {
             return true
         }
 
-        // Slice uses "sent" for UPI transfers (always success?)
-        if (lowerMessage.contains("sent")) {
+        // Slice SFB outbound UPI: "Rs. X sent from a/c ... to <payee>".
+        if (lowerMessage.contains("sent from") && lowerMessage.contains("a/c")) {
+            return true
+        }
+
+        // Slice SFB UPI AutoPay debit: "Successfully paid Rs.X from slice a/c ...".
+        if (lowerMessage.contains("successfully paid")) {
             return true
         }
 

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SliceParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SliceParserTest.kt
@@ -146,6 +146,75 @@ class SliceParserTest {
                     accountLast4 = null,
                     reference = null
                 )
+            ),
+
+            // --- Slice SFB (banking) formats ---
+            ParserTestCase(
+                name = "Slice SFB UPI debit (money sent) is EXPENSE",
+                message = "Rs. 100 sent from a/c xx2743 on 17-Jun-26 to Hussain Shaikh (UPI Ref: 616851070000). Not you? Call 08048329999 - slice",
+                sender = "slice",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("100"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Hussain Shaikh",
+                    accountLast4 = "2743",
+                    reference = "616851070000"
+                )
+            ),
+            ParserTestCase(
+                name = "Slice SFB UPI AutoPay paid is EXPENSE",
+                message = "Successfully paid Rs.1 from slice a/c XX2743 to OpenAI LLC on 25-May-26 via UPI AutoPay. UMN - 019e5exxxa1679b6aee8ae4f0ff88d19@slc - slice",
+                sender = "slice",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "OpenAI LLC",
+                    accountLast4 = "2743",
+                    reference = null
+                )
+            ),
+            ParserTestCase(
+                name = "Slice SFB UPI credit (money received) is INCOME with balance",
+                message = "Rs. 2,000 received in slice A/c xx2743 on 15-Jun-26 from NASIMUDDIN NAJAMUDDIN SHAIKH via UPI (Ref ID: 212756500000). Avl. Bal. Rs. 2,203.56 - slice",
+                sender = "slice",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2000"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    merchant = "NASIMUDDIN NAJAMUDDIN SHAIKH",
+                    accountLast4 = "2743",
+                    balance = BigDecimal("2203.56"),
+                    reference = "212756500000"
+                )
+            ),
+            ParserTestCase(
+                name = "Slice SFB card transaction success is EXPENSE from card",
+                message = "Your transaction of Rs. 2.07 at FamAppbyTriO from a/c xx2743 is successful. If not you, call 080-4832-9999 - slice",
+                sender = "slice",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2.07"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "FamAppbyTriO",
+                    accountLast4 = "2743",
+                    isFromCard = true
+                )
+            ),
+
+            // --- Slice SFB rejections ---
+            ParserTestCase(
+                name = "Slice SFB card OTP must NOT be parsed",
+                message = "5738xx is your OTP for txn of Rs. INR 2.07 at FamApp by TriO on slice card ending with 2887. Do not share OTP for security reasons. - slice",
+                sender = "slice",
+                shouldParse = false
+            ),
+            ParserTestCase(
+                name = "Slice SFB UPI AutoPay revoked must NOT be parsed",
+                message = "UPI AutoPay for OpenAI from slice a/c XX2743 for Rs. 1,999 is revoked. UMN - 019e5ebb3a1679b6aee8a0000ff88d19@slc - slice",
+                sender = "slice",
+                shouldParse = false
             )
         )
 
@@ -155,6 +224,7 @@ class SliceParserTest {
             "JK-SLICEIT" to true,
             "SLICEIT" to true,
             "SLCEIT" to true,
+            "slice" to true,
             "HDFCBK" to false,
             "VK-JTEDGE-S" to false
         )

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SliceParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SliceParserTest.kt
@@ -163,6 +163,19 @@ class SliceParserTest {
                 )
             ),
             ParserTestCase(
+                name = "Payee name containing 'request' still parses (not dropped as a UPI request)",
+                message = "Rs. 250 sent from a/c xx2743 on 17-Jun-26 to Request Foods (UPI Ref: 616851070099). Not you? Call 08048329999 - slice",
+                sender = "slice",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("250"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Request Foods",
+                    accountLast4 = "2743",
+                    reference = "616851070099"
+                )
+            ),
+            ParserTestCase(
                 name = "Slice SFB UPI AutoPay paid is EXPENSE",
                 message = "Successfully paid Rs.1 from slice a/c XX2743 to OpenAI LLC on 25-May-26 via UPI AutoPay. UMN - 019e5exxxa1679b6aee8ae4f0ff88d19@slc - slice",
                 sender = "slice",

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SliceParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SliceParserTest.kt
@@ -215,6 +215,12 @@ class SliceParserTest {
                 message = "UPI AutoPay for OpenAI from slice a/c XX2743 for Rs. 1,999 is revoked. UMN - 019e5ebb3a1679b6aee8a0000ff88d19@slc - slice",
                 sender = "slice",
                 shouldParse = false
+            ),
+            ParserTestCase(
+                name = "Slice SFB UPI collect request must NOT be booked as income",
+                message = "You have received a collect request of Rs. 500 from someone@slc on slice. Approve or decline in the app. - slice",
+                sender = "slice",
+                shouldParse = false
             )
         )
 


### PR DESCRIPTION
Closes #497.

**North East Small Finance Bank (NESFB) → renamed to Slice Small Finance Bank (Slice SFB).** It now sends full banking SMS from the **same `slice` sender** the BNPL "Slice" already uses, so this **extends the existing `SliceParser`** rather than adding a new one (a second parser claiming `slice` would be ambiguous in the factory). `getBankName()` stays `"Slice"` so existing users' accounts don't fragment.

## Now handled (sender `slice`)
| SMS shape | Result |
|---|---|
| `Rs. X sent from a/c xxNNNN ... to <payee> (UPI Ref: …)` | EXPENSE, merchant=payee, ref, last4 |
| `Successfully paid Rs.X from slice a/c … to <payee> … via UPI AutoPay` | EXPENSE, merchant=payee |
| `Rs. X received in slice A/c … from <sender> via UPI (Ref ID: …). Avl. Bal. Rs. Y` | INCOME, merchant=sender, ref, **balance** |
| `Your transaction of Rs. X at <merchant> from a/c … is successful` | EXPENSE, merchant, **isFromCard** |

## Now rejected (return null)
- Card **OTP** (`… is your OTP for txn …`) — authorization, not a completed txn.
- UPI **AutoPay revoked** (`… is revoked. UMN - …`) — mandate lifecycle, not money movement.

## Notes
- `extractBalance` handles the dotted `Avl. Bal. Rs. X` form (base patterns miss it).
- The `to`/`from` payee path is gated on an `a/c` reference so it can't hijack legacy "credited to your slice account" cashback messages.
- Existing BNPL/legacy-card cases still pass.

## Tests
`SliceParserTest` → 19 cases (4 new supported formats + 2 rejections + handle checks). Full `:parser-core:jvmTest`: **1301 tests, 0 failures**. No PII.