### PR TITLE
fix(parser): BOB ignores credit-card bill-payment confirmation (#498)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankOfBarodaParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankOfBarodaParser.kt
@@ -339,6 +339,17 @@ class BankOfBarodaParser : BaseIndianBankParser() {
     override fun isTransactionMessage(message: String): Boolean {
         val lowerMessage = message.lowercase()
 
+        // Credit-card bill-payment confirmation, e.g.
+        // "Payment of Rs X received for your BOBCARD ending NNNN ...".
+        // This only acknowledges that a payment landed on the card; it is not a
+        // spend or income. The actual debit is tracked on the funding bank
+        // account, so skip this notice to avoid a spurious transaction. (#498)
+        if (lowerMessage.contains("payment of") &&
+            lowerMessage.contains("received for your bobcard")
+        ) {
+            return false
+        }
+
         // Check for BOB-specific transaction keywords
         if (lowerMessage.contains("dr. from") ||
             lowerMessage.contains("cr. to") ||

--- a/parser-core/src/test/kotlin/TestBankOfBarodaParser.kt
+++ b/parser-core/src/test/kotlin/TestBankOfBarodaParser.kt
@@ -188,6 +188,15 @@ class BankOfBarodaParserTest {
                     balance = BigDecimal("12345.67"),
                     isFromCard = false
                 )
+            ),
+
+            // Credit-card bill-payment confirmation must be ignored, not booked
+            // as a spend/income. (#498)
+            ParserTestCase(
+                name = "BOBCARD payment confirmation is ignored",
+                message = "Payment of Rs 1317.80 received for your BOBCARD ending 2844 on 2026-06-17. Visit bobcard app: bobcard.io/App or online card account at https://www.bobcard.co.in/ for details.",
+                sender = "VM-BOBCRD-S",
+                shouldParse = false
             )
         )
 


### PR DESCRIPTION
Closes #498.

## Problem
Bank of Baroda sends a confirmation when a payment lands on a BOBCARD credit card:

> Payment of Rs 1317.80 received for your BOBCARD ending 2844 on 2026-06-17. Visit bobcard app …

This is just an acknowledgement that a **bill payment** hit the card — not a spend and not income. The parser had no rule for it, so it fell through to the base classifier and was booked as a (wrong) transaction.

## Fix
`isTransactionMessage` now returns `false` for `"Payment of … received for your BOBCARD …"`, so `parse()` skips it. The actual money movement (the bill payment leaving the funding bank account) is still tracked on that account, so nothing is lost.

## Test
Added a `shouldParse = false` case for the exact SMS to `BankOfBarodaParserTest`. Full Bank of Baroda suite green.

No PII — synthetic amount/card.