### PR TITLE
feat(parser): add Arab Bank Jordan parser (JOD/USD)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,12 +88,13 @@ Bank parsers are now in the `parser-core` module for reusability across platform
 - Use `com.pennywiseai.tracker.data.mapper.toEntity()` to convert ParsedTransaction to TransactionEntity
 - The mapper handles type conversions between modules
 
-## Supported Banks (55 parsers)
+## Supported Banks (56 parsers)
 - Airtel Payments Bank
 - **Al Rajhi Bank (Saudi Arabia)** - Arabic SMS support
 - **Alinma Bank (Saudi Arabia)** - Arabic SMS support
 - **Altana Federal Credit Union (USA)**
 - American Express (AMEX)
+- **Arab Bank (Jordan)** - JOD/USD, card and account transfers
 - Axis Bank
 - Bank of Baroda
 - Bank of India

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Conditions can be combined with **AND** / **OR** logic, and multiple conditions 
 
 ## Supported Banks & Countries
 
-Supporting **90+ banks** across **16 countries** with **multi-currency** capabilities:
+Supporting **90+ banks** across **17 countries** with **multi-currency** capabilities:
 
 ### 🇮🇳 India (44 banks) - INR ₹
 - **HDFC Bank**, **HDFC Mutual Fund**, **State Bank of India (SBI)**, **ICICI Bank**
@@ -166,6 +166,9 @@ Supporting **90+ banks** across **16 countries** with **multi-currency** capabil
 
 ### 🇸🇦 Saudi Arabia (2 banks) - SAR ﷼
 - **Al Rajhi Bank (مصرف الراجحي)**, **Alinma Bank (بنك الإنماء)** - Arabic SMS support
+
+### 🇯🇴 Jordan (1 bank) - JOD د.ا
+- **Arab Bank** - JOD/USD with card and account transfer support
 
 ### 🇷🇺 Russia (1 bank) - RUB ₽
 - **T-Bank (Tinkoff)** - Russian SMS support

--- a/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
@@ -14,6 +14,12 @@ object CurrencyFormatter {
     private val INDIAN_LOCALE = Locale.Builder().setLanguage("en").setRegion("IN").build()
 
     /**
+     * Currencies that use three decimal places (ISO 4217 minor units = 3),
+     * e.g. Jordanian Dinar, Kuwaiti Dinar.
+     */
+    private val THREE_DECIMAL_CURRENCIES = setOf("JOD", "KWD", "BHD", "OMR")
+
+    /**
      * Currency symbol mapping for display
      */
     private val CURRENCY_SYMBOLS = mapOf(
@@ -23,6 +29,7 @@ object CurrencyFormatter {
         "EUR" to "€",
         "GBP" to "£",
         "AED" to "AED",
+        "JOD" to "JD",
         "SGD" to "S$",
         "CAD" to "C$",
         "MXN" to "MX$",
@@ -50,6 +57,7 @@ object CurrencyFormatter {
         "EUR" to Locale.GERMANY,
         "GBP" to Locale.UK,
         "AED" to Locale.Builder().setLanguage("en").setRegion("AE").build(),
+        "JOD" to Locale.Builder().setLanguage("en").setRegion("JO").build(),
         "SGD" to Locale.Builder().setLanguage("en").setRegion("SG").build(),
         "CAD" to Locale.CANADA,
         "MXN" to Locale.Builder().setLanguage("es").setRegion("MX").build(),
@@ -91,7 +99,7 @@ object CurrencyFormatter {
 
             // Show decimals only if they exist
             formatter.minimumFractionDigits = 0
-            formatter.maximumFractionDigits = 2
+            formatter.maximumFractionDigits = if (currencyCode in THREE_DECIMAL_CURRENCIES) 3 else 2
             formatter.format(amount)
         } catch (e: Exception) {
             // Fallback to symbol + amount

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ArabBankJordanParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ArabBankJordanParser.kt
@@ -1,0 +1,210 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Arab Bank (Jordan).
+ *
+ * Handles Jordanian Dinar (JOD) and USD transactions. JOD amounts use three
+ * decimal places (e.g. "JOD 2.750"), so amount/balance extraction accepts 1-3
+ * fractional digits and the currency token can appear either before the amount
+ * ("JOD 50.000") or after it ("37.920JOD").
+ *
+ * Example SMS formats:
+ * - Card purchase:
+ *   "A Trx using Card XXXX9915 from ADANI CORNER for JOD 2.750 on 20-Jun-2026
+ *    at 14:21 GMT+3. Available balance is JOD 1649.832."
+ * - Account debit (transfer):
+ *   "JOD50.000 has been debited from 0156*500 to <name> as CliQ transfer
+ *    Balance 37.920JOD"
+ * - Account credit (transfer):
+ *   "JOD172.000 has been credited to 0156*500from <name> as CliQ transfer
+ *    Balance 959.370JOD"
+ *
+ * Transfer/payee extraction is not tied to any specific scheme (e.g. CliQ): the
+ * counterparty name is read up to the transfer description ("... as ..."), the
+ * balance section, or end of line, so other transfer types parse the same way.
+ */
+class ArabBankJordanParser : BankParser() {
+
+    override fun getBankName() = "Arab Bank Jordan"
+
+    override fun getCurrency() = "JOD"
+
+    override fun canHandle(sender: String): Boolean {
+        val normalizedSender = sender.uppercase().replace(Regex("[\\s\\-_]+"), "")
+        return normalizedSender.contains("ARABBANK") ||
+                // DLT-style senders e.g. "AB-ARABBK-S"
+                normalizedSender.matches(Regex("^[A-Z]{2}ARABBK[A-Z]?$"))
+    }
+
+    override fun parse(smsBody: String, sender: String, timestamp: Long): ParsedTransaction? {
+        val transaction = super.parse(smsBody, sender, timestamp) ?: return null
+        val extractedCurrency = extractCurrency(smsBody)
+        return if (extractedCurrency != null) {
+            transaction.copy(currency = extractedCurrency)
+        } else {
+            transaction
+        }
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lowerMessage = message.lowercase()
+
+        if (lowerMessage.contains("otp") ||
+            lowerMessage.contains("one time password") ||
+            lowerMessage.contains("verification code") ||
+            lowerMessage.contains("do not share") ||
+            lowerMessage.contains("declined") ||
+            lowerMessage.contains("failed")
+        ) {
+            return false
+        }
+
+        val transactionKeywords = listOf(
+            "trx using card",
+            "has been debited",
+            "has been credited"
+        )
+
+        if (transactionKeywords.any { lowerMessage.contains(it) }) {
+            return true
+        }
+
+        return super.isTransactionMessage(message)
+    }
+
+    override fun extractCurrency(message: String): String? {
+        // Pick the currency token next to the transaction amount (the first one
+        // in the message). Both prefix ("JOD 50.000") and suffix ("37.920JOD")
+        // forms are covered by scanning for the first JOD/USD occurrence.
+        CURRENCY_TOKEN.find(message)?.let { return it.groupValues[1].uppercase() }
+        return getCurrency()
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        val patterns = listOf(
+            // Currency before amount: "JOD 2.750", "USD50.000"
+            Regex("""(?:JOD|USD)\s*([0-9,]+(?:\.\d{1,3})?)""", RegexOption.IGNORE_CASE),
+            // Amount before currency: "50.000 JOD"
+            Regex("""([0-9,]+(?:\.\d{1,3})?)\s*(?:JOD|USD)""", RegexOption.IGNORE_CASE)
+        )
+
+        for (pattern in patterns) {
+            pattern.find(message)?.let { match ->
+                val amountStr = match.groupValues[1].replace(",", "")
+                return try {
+                    BigDecimal(amountStr)
+                } catch (e: NumberFormatException) {
+                    null
+                }
+            }
+        }
+
+        return super.extractAmount(message)
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        val patterns = listOf(
+            // "Available balance is JOD 1649.832"
+            Regex("""balance\s+is\s+(?:JOD|USD)\s*([0-9,]+(?:\.\d{1,3})?)""", RegexOption.IGNORE_CASE),
+            // "Balance JOD 1649.832"
+            Regex("""balance\s+(?:JOD|USD)\s*([0-9,]+(?:\.\d{1,3})?)""", RegexOption.IGNORE_CASE),
+            // "Balance 37.920JOD" / "Balance 959.370 JOD"
+            Regex("""balance\s+([0-9,]+(?:\.\d{1,3})?)\s*(?:JOD|USD)""", RegexOption.IGNORE_CASE)
+        )
+
+        for (pattern in patterns) {
+            pattern.find(message)?.let { match ->
+                val balanceStr = match.groupValues[1].replace(",", "")
+                return try {
+                    BigDecimal(balanceStr)
+                } catch (e: NumberFormatException) {
+                    null
+                }
+            }
+        }
+
+        return null
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lowerMessage = message.lowercase()
+
+        return when {
+            // Credit card spend is tracked as CREDIT in this app
+            lowerMessage.contains("trx using card") -> TransactionType.CREDIT
+            lowerMessage.contains("debited") -> TransactionType.EXPENSE
+            lowerMessage.contains("credited") -> TransactionType.INCOME
+            else -> super.extractTransactionType(message)
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        val lowerMessage = message.lowercase()
+
+        // Card purchase: "... from ADANI CORNER for JOD 2.750 ..."
+        if (lowerMessage.contains("trx using card")) {
+            Regex("""from\s+(.+?)\s+for\s+(?:JOD|USD)""", RegexOption.IGNORE_CASE)
+                .find(message)?.let { match ->
+                    val merchant = cleanMerchantName(match.groupValues[1].trim())
+                    if (isValidMerchantName(merchant)) return merchant
+                }
+        }
+
+        // Outgoing transfer: "... debited from <acct> to <name> [as <type> transfer] ..."
+        if (lowerMessage.contains("debited")) {
+            Regex("""to\s+(.+?)$COUNTERPARTY_TERMINATOR""", RegexOption.IGNORE_CASE)
+                .find(message)?.let { match ->
+                    val merchant = cleanMerchantName(match.groupValues[1].trim())
+                    if (isValidMerchantName(merchant)) return merchant
+                }
+        }
+
+        // Incoming transfer: "... credited to <acct> from <name> [as <type> transfer] ..."
+        if (lowerMessage.contains("credited")) {
+            Regex("""from\s+(.+?)$COUNTERPARTY_TERMINATOR""", RegexOption.IGNORE_CASE)
+                .find(message)?.let { match ->
+                    val merchant = cleanMerchantName(match.groupValues[1].trim())
+                    if (isValidMerchantName(merchant)) return merchant
+                }
+        }
+
+        return super.extractMerchant(message, sender)
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        // Card: "Card XXXX9915"
+        Regex("""Card\s+([X*0-9]+)""", RegexOption.IGNORE_CASE).find(message)?.let { match ->
+            extractLast4Digits(match.groupValues[1])?.let { return it }
+        }
+
+        // CliQ account: "from 0156*500 to ..." / "to 0156*500from ..."
+        Regex("""(?:from|to)\s+([0-9][0-9*]{2,})""", RegexOption.IGNORE_CASE)
+            .find(message)?.let { match ->
+                extractLast4Digits(match.groupValues[1])?.let { return it }
+            }
+
+        return super.extractAccountLast4(message)
+    }
+
+    override fun detectIsCard(message: String): Boolean {
+        val lowerMessage = message.lowercase()
+        if (lowerMessage.contains("trx using card")) return true
+        // Account-to-account transfers ("debited from ... to", "credited to ... from")
+        // are never card transactions, regardless of the transfer scheme.
+        if (lowerMessage.contains("debited from") || lowerMessage.contains("credited to")) return false
+        return super.detectIsCard(message)
+    }
+
+    private companion object {
+        val CURRENCY_TOKEN = Regex("""(JOD|USD)""", RegexOption.IGNORE_CASE)
+
+        // Ends a counterparty name at the transfer description ("... as ..."),
+        // the balance section, a line break, or end of message. Kept generic so
+        // the parser is not tied to a particular transfer scheme (e.g. CliQ).
+        const val COUNTERPARTY_TERMINATOR = """(?:\s+as\s+|\s+Balance\b|\n|$)"""
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -119,6 +119,7 @@ object BankParserFactory {
         SNBAlAhliBankParser(),  // Saudi National Bank / Al Ahli Bank (Saudi Arabia)
         STCBankParser(),  // STC Bank (Saudi Arabia)
         SabbBankParser(),  // SABB - Saudi Awwal Bank (Saudi Arabia)
+        ArabBankJordanParser(),  // Arab Bank (Jordan) — JOD/USD, card & account transfers
         MBankCZParser(),  // mBank CZ (Czech Republic)
         SparkasseRheinMaasParser(),  // Sparkasse Rhein-Maas (Germany)
         EnparaBankParser(),  // Enpara (Turkey) — push notifications

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/ArabBankJordanParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/ArabBankJordanParserTest.kt
@@ -1,0 +1,150 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import com.pennywiseai.parser.core.test.SimpleTestCase
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class ArabBankJordanParserTest {
+
+    @TestFactory
+    fun `Arab Bank Jordan parser handles key paths`(): List<DynamicTest> {
+        val parser = ArabBankJordanParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "Credit card purchase (JOD)",
+                message = "A Trx using Card XXXX9915 from ADANI CORNER for JOD 2.750 on 20-Jun-2026 at 14:21 GMT+3. Available balance is JOD 1649.832.",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2.750"),
+                    currency = "JOD",
+                    type = TransactionType.CREDIT,
+                    merchant = "ADANI CORNER",
+                    accountLast4 = "9915",
+                    balance = BigDecimal("1649.832"),
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "Account debit (JOD, CliQ transfer)",
+                message = "JO\nJOD50.000 has been debited from 0156*500 to JOHN MICHAEL SMITH as CliQ transfer Balance 37.920JOD",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("50.000"),
+                    currency = "JOD",
+                    type = TransactionType.EXPENSE,
+                    merchant = "JOHN MICHAEL SMITH",
+                    accountLast4 = "6500",
+                    balance = BigDecimal("37.920"),
+                    isFromCard = false
+                )
+            ),
+            ParserTestCase(
+                name = "Account credit (JOD, CliQ transfer)",
+                message = "JO\nJOD172.000 has been credited to 0156*500from EMILY ROSE CARTER as CliQ transfer Balance 959.370JOD",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("172.000"),
+                    currency = "JOD",
+                    type = TransactionType.INCOME,
+                    merchant = "EMILY ROSE CARTER",
+                    accountLast4 = "6500",
+                    balance = BigDecimal("959.370"),
+                    isFromCard = false
+                )
+            ),
+            ParserTestCase(
+                name = "Account debit - non-CliQ transfer type",
+                message = "JO\nJOD25.500 has been debited from 0156*500 to DAVID ALAN WRIGHT as wire transfer Balance 12.420JOD",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("25.500"),
+                    currency = "JOD",
+                    type = TransactionType.EXPENSE,
+                    merchant = "DAVID ALAN WRIGHT",
+                    accountLast4 = "6500",
+                    balance = BigDecimal("12.420"),
+                    isFromCard = false
+                )
+            ),
+            ParserTestCase(
+                name = "Account credit - no transfer description",
+                message = "JO\nJOD300.000 has been credited to 0156*500from SARAH JANE BENNETT Balance 1200.000JOD",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("300.000"),
+                    currency = "JOD",
+                    type = TransactionType.INCOME,
+                    merchant = "SARAH JANE BENNETT",
+                    accountLast4 = "6500",
+                    balance = BigDecimal("1200.000"),
+                    isFromCard = false
+                )
+            ),
+            ParserTestCase(
+                name = "Credit card purchase (USD)",
+                message = "A Trx using Card XXXX9915 from AMAZON.COM for USD 19.99 on 20-Jun-2026 at 14:21 GMT+3. Available balance is USD 540.18.",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("19.99"),
+                    currency = "USD",
+                    type = TransactionType.CREDIT,
+                    merchant = "AMAZON.COM",
+                    accountLast4 = "9915",
+                    balance = BigDecimal("540.18"),
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "OTP message is ignored",
+                message = "Your Arab Bank OTP is 123456. Do not share it with anyone.",
+                sender = "ArabBank",
+                shouldParse = false
+            ),
+            ParserTestCase(
+                name = "Declined transaction is ignored",
+                message = "A Trx using Card XXXX9915 from ADANI CORNER for JOD 2.750 was declined.",
+                sender = "ArabBank",
+                shouldParse = false
+            )
+        )
+
+        val handleCases = listOf(
+            "ArabBank" to true,
+            "ARABBANK" to true,
+            "Arab Bank" to true,
+            "arabbank" to true,
+            "AB-ARABBK-S" to true,
+            "FAB" to false,
+            "HDFC" to false,
+            "" to false
+        )
+
+        return ParserTestUtils.runTestSuite(parser, testCases, handleCases, "Arab Bank Jordan")
+    }
+
+    @TestFactory
+    fun `factory resolves Arab Bank Jordan`(): List<DynamicTest> {
+        val cases = listOf(
+            SimpleTestCase(
+                bankName = "Arab Bank Jordan",
+                sender = "ArabBank",
+                currency = "JOD",
+                message = "JO\nJOD172.000 has been credited to 0156*500from EMILY ROSE CARTER as CliQ transfer Balance 959.370JOD",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("172.000"),
+                    currency = "JOD",
+                    type = TransactionType.INCOME
+                ),
+                shouldHandle = true
+            )
+        )
+
+        return ParserTestUtils.runFactoryTestSuite(cases, "Arab Bank Jordan Factory Tests")
+    }
+}


### PR DESCRIPTION
## Summary

Adds SMS transaction support for **Arab Bank (Jordan)** — a new country (Jordan) and currency (Jordanian Dinar, JOD), alongside USD.

- New `ArabBankJordanParser` (parser-core) handling:
  - **Card purchases** (e.g. `A Trx using Card XXXX9915 from <merchant> for JOD 2.750 ...`) → typed as `CREDIT` (card spend), `isFromCard = true`.
  - **Account debit/credit transfers** (e.g. `JOD50.000 has been debited from <acct> to <name> ...`).
- Handles JOD **3-decimal** amounts and a currency token that may appear **before** (`JOD 50.000`) or **after** (`37.920JOD`) the amount; supports USD too.
- Counterparty/payee extraction is **scheme-agnostic** (not tied to CliQ): the name is read up to the transfer description (`... as ...`), the balance section, or end of line.
- Registers JOD in `CurrencyFormatter` (symbol `JD`, Jordan locale) with proper 3-decimal display (also covers KWD/BHD/OMR minor-unit-3 currencies).
- Updates supported-bank docs (`README.md`, `CLAUDE.md`).

## Type of change

- [x] feat: New feature

## How to test

1. Run the parser test suite: `./gradlew :parser-core:jvmTest --tests "com.pennywiseai.parser.core.bank.ArabBankJordanParserTest"`
2. Verify card, account-debit, account-credit, USD, non-CliQ transfer, and negative (OTP/declined) cases all pass.
3. Confirm `BankParserFactory` resolves sender `ArabBank` to the new parser with currency `JOD`.

## Breaking changes

- [x] No breaking changes

## Related issues

<!-- none -->

## Checklist

- [x] Focused PR (single purpose)
- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable)
- [x] `./gradlew test` passes locally
- [ ] `./gradlew lint` passes locally
- [x] Follows existing code style and patterns

Made with [Cursor](https://cursor.com)