### PR TITLE
fix(rules): allow Smart Rules to set Transaction Type as Expense

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/RuleRepositoryImpl.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/RuleRepositoryImpl.kt
@@ -39,62 +39,17 @@ class RuleRepositoryImpl @Inject constructor(
         val allActiveRules = ruleDao.getActiveRules()
         return allActiveRules
             .map { entity -> entityToRule(entity) }
-            .filter { rule ->
-                // Check if rule has no TYPE condition (applies to all) or matches the type
-                val hasTypeCondition = rule.conditions.any { it.field == TransactionField.TYPE }
-                if (!hasTypeCondition) {
-                    true // Rule applies to all transaction types
-                } else {
-                    // Check if any TYPE condition matches
-                    rule.conditions.any { condition ->
-                        condition.field == TransactionField.TYPE &&
-                        when (condition.operator) {
-                            ConditionOperator.EQUALS -> condition.value.equals(type.name, ignoreCase = true)
-                            ConditionOperator.IN -> condition.value.split(",")
-                                .map { it.trim() }
-                                .any { it.equals(type.name, ignoreCase = true) }
-                            ConditionOperator.NOT_EQUALS -> !condition.value.equals(type.name, ignoreCase = true)
-                            ConditionOperator.NOT_IN -> !condition.value.split(",")
-                                .map { it.trim() }
-                                .any { it.equals(type.name, ignoreCase = true) }
-                            else -> false
-                        }
-                    }
-                }
-            }
+            .filter { rule -> isRuleApplicableToTransactionType(rule, type) }
     }
 
     override suspend fun getActiveRulesByTypes(types: List<TransactionType>): List<TransactionRule> {
         // Get all active rules and filter in memory based on conditions
         val allActiveRules = ruleDao.getActiveRules()
-        val typeNames = types.map { it.name }
 
         return allActiveRules
             .map { entity -> entityToRule(entity) }
             .filter { rule ->
-                // Check if rule has no TYPE condition (applies to all) or matches any of the types
-                val hasTypeCondition = rule.conditions.any { it.field == TransactionField.TYPE }
-                if (!hasTypeCondition) {
-                    true // Rule applies to all transaction types
-                } else {
-                    // Check if any TYPE condition matches any of the requested types
-                    rule.conditions.any { condition ->
-                        condition.field == TransactionField.TYPE &&
-                        when (condition.operator) {
-                            ConditionOperator.EQUALS -> typeNames.any { it.equals(condition.value, ignoreCase = true) }
-                            ConditionOperator.IN -> {
-                                val conditionTypes = condition.value.split(",").map { it.trim() }
-                                typeNames.any { type -> conditionTypes.any { it.equals(type, ignoreCase = true) } }
-                            }
-                            ConditionOperator.NOT_EQUALS -> typeNames.all { !it.equals(condition.value, ignoreCase = true) }
-                            ConditionOperator.NOT_IN -> {
-                                val conditionTypes = condition.value.split(",").map { it.trim() }
-                                typeNames.any { type -> conditionTypes.none { it.equals(type, ignoreCase = true) } }
-                            }
-                            else -> false
-                        }
-                    }
-                }
+                types.any { type -> isRuleApplicableToTransactionType(rule, type) }
             }
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/domain/model/rule/RuleCondition.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/model/rule/RuleCondition.kt
@@ -1,6 +1,126 @@
 package com.pennywiseai.tracker.domain.model.rule
 
+import com.pennywiseai.tracker.data.database.entity.TransactionType
 import kotlinx.serialization.Serializable
+
+/** User-facing labels for transaction type values stored in rule conditions/actions. */
+val RULE_TRANSACTION_TYPE_OPTIONS: List<Pair<String, String>> = listOf(
+    TransactionType.INCOME.name to "Income",
+    TransactionType.EXPENSE.name to "Expense",
+    TransactionType.CREDIT.name to "Credit",
+    TransactionType.TRANSFER.name to "Transfer",
+    TransactionType.INVESTMENT.name to "Investment"
+)
+
+fun parseRuleTransactionType(value: String): TransactionType? {
+    return runCatching { TransactionType.valueOf(value.trim().uppercase()) }.getOrNull()
+}
+
+private val TYPE_PRE_FILTER_OPERATORS = setOf(
+    ConditionOperator.EQUALS,
+    ConditionOperator.IN,
+    ConditionOperator.NOT_EQUALS,
+    ConditionOperator.NOT_IN
+)
+
+fun matchesTransactionTypeCondition(condition: RuleCondition, typeName: String): Boolean {
+    return when (condition.operator) {
+        ConditionOperator.EQUALS -> condition.value.equals(typeName, ignoreCase = true)
+        ConditionOperator.IN -> condition.value.split(",")
+            .map { it.trim() }
+            .any { it.equals(typeName, ignoreCase = true) }
+        ConditionOperator.NOT_EQUALS -> !condition.value.equals(typeName, ignoreCase = true)
+        ConditionOperator.NOT_IN -> !condition.value.split(",")
+            .map { it.trim() }
+            .any { it.equals(typeName, ignoreCase = true) }
+        else -> false
+    }
+}
+
+/**
+ * Pre-filter helper for rules scoped by transaction type. Rules whose TYPE conditions
+ * use operators we cannot evaluate here are passed through for full evaluation.
+ */
+fun isRuleApplicableToTransactionType(rule: TransactionRule, type: TransactionType): Boolean {
+    val hasTypeCondition = rule.conditions.any { it.field == TransactionField.TYPE }
+    val hasOrLogic = rule.conditions.any { it.logicalOperator == LogicalOperator.OR }
+    if (!hasTypeCondition || hasOrLogic) {
+        return true
+    }
+
+    val typeConditions = rule.conditions.filter { it.field == TransactionField.TYPE }
+    if (typeConditions.any { it.operator !in TYPE_PRE_FILTER_OPERATORS }) {
+        return true
+    }
+
+    return typeConditions.any { matchesTransactionTypeCondition(it, type.name) }
+}
+
+fun TransactionField.defaultConditionOperator(): ConditionOperator = when (this) {
+    TransactionField.AMOUNT -> ConditionOperator.LESS_THAN
+    TransactionField.TRANSACTION_TIME -> ConditionOperator.LESS_THAN
+    TransactionField.TRANSACTION_HOUR -> ConditionOperator.EQUALS
+    TransactionField.TRANSACTION_DAY_OF_WEEK -> ConditionOperator.EQUALS
+    TransactionField.TRANSACTION_DAY_OF_MONTH -> ConditionOperator.EQUALS
+    TransactionField.TRANSACTION_DATE -> ConditionOperator.EQUALS
+    TransactionField.ACCOUNT -> ConditionOperator.EQUALS
+    TransactionField.TYPE -> ConditionOperator.EQUALS
+    else -> ConditionOperator.CONTAINS
+}
+
+fun conditionOperatorsForField(field: TransactionField): List<Pair<ConditionOperator, String>> = when (field) {
+    TransactionField.AMOUNT -> listOf(
+        ConditionOperator.LESS_THAN to "<",
+        ConditionOperator.GREATER_THAN to ">",
+        ConditionOperator.EQUALS to "="
+    )
+    TransactionField.TYPE -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.NOT_EQUALS to "is not"
+    )
+    TransactionField.TRANSACTION_TIME -> listOf(
+        ConditionOperator.LESS_THAN to "before",
+        ConditionOperator.GREATER_THAN to "after",
+        ConditionOperator.GREATER_THAN_OR_EQUAL to "at or after",
+        ConditionOperator.LESS_THAN_OR_EQUAL to "at or before",
+        ConditionOperator.EQUALS to "exactly at"
+    )
+    TransactionField.TRANSACTION_HOUR -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.LESS_THAN to "before",
+        ConditionOperator.GREATER_THAN to "after"
+    )
+    TransactionField.TRANSACTION_DAY_OF_WEEK -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.IN to "is any of",
+        ConditionOperator.NOT_EQUALS to "is not"
+    )
+    TransactionField.TRANSACTION_DAY_OF_MONTH -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.IN to "is any of",
+        ConditionOperator.LESS_THAN to "before",
+        ConditionOperator.GREATER_THAN to "after"
+    )
+    TransactionField.TRANSACTION_DATE -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.LESS_THAN to "before",
+        ConditionOperator.GREATER_THAN to "after"
+    )
+    TransactionField.ACCOUNT -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.NOT_EQUALS to "is not"
+    )
+    else -> listOf(
+        ConditionOperator.CONTAINS to "contains",
+        ConditionOperator.EQUALS to "equals",
+        ConditionOperator.STARTS_WITH to "starts with"
+    )
+}
+
+fun ruleTransactionTypeLabel(value: String): String {
+    return RULE_TRANSACTION_TYPE_OPTIONS.firstOrNull { it.first.equals(value, ignoreCase = true) }?.second
+        ?: value
+}
 
 @Serializable
 data class RuleCondition(
@@ -45,6 +165,7 @@ data class RuleCondition(
                 val parts = value.split("||")
                 parts.size == 2 && parts[0].isNotBlank() && parts[1].isNotBlank()
             }
+            TransactionField.TYPE -> parseRuleTransactionType(value) != null
             else -> true
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/domain/service/RuleEngine.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/service/RuleEngine.kt
@@ -69,26 +69,7 @@ class RuleEngine @Inject constructor() {
         // since a TYPE condition that fails on its own can still let the rule match via
         // an OR'd sibling.
         val applicableRules = rules.filter { rule ->
-            val hasTypeCondition = rule.conditions.any { it.field == TransactionField.TYPE }
-            val hasOrLogic = rule.conditions.any { it.logicalOperator == LogicalOperator.OR }
-            if (!hasTypeCondition || hasOrLogic) {
-                true
-            } else {
-                rule.conditions.any { condition ->
-                    condition.field == TransactionField.TYPE &&
-                    when (condition.operator) {
-                        ConditionOperator.EQUALS -> condition.value.equals(type.name, ignoreCase = true)
-                        ConditionOperator.IN -> condition.value.split(",")
-                            .map { it.trim() }
-                            .any { it.equals(type.name, ignoreCase = true) }
-                        ConditionOperator.NOT_EQUALS -> !condition.value.equals(type.name, ignoreCase = true)
-                        ConditionOperator.NOT_IN -> !condition.value.split(",")
-                            .map { it.trim() }
-                            .any { it.equals(type.name, ignoreCase = true) }
-                        else -> false
-                    }
-                }
-            }
+            isRuleApplicableToTransactionType(rule, type)
         }
 
         return evaluateRules(transaction, smsText, applicableRules)
@@ -285,14 +266,7 @@ class RuleEngine @Inject constructor() {
             }
             TransactionField.TYPE -> {
                 val newType = when (action.actionType) {
-                    ActionType.SET -> {
-                        // Convert string value to TransactionType enum
-                        try {
-                            TransactionType.valueOf(action.value.uppercase())
-                        } catch (e: Exception) {
-                            transaction.transactionType
-                        }
-                    }
+                    ActionType.SET -> parseRuleTransactionType(action.value) ?: transaction.transactionType
                     else -> transaction.transactionType
                 }
                 transaction.copy(transactionType = newType) to newType.name

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
@@ -132,7 +132,7 @@ fun CreateRuleScreen(
             )
             actionType = ActionType.SET
             actionField = TransactionField.TYPE
-            actionValue = "income"
+            actionValue = "INCOME"
         },
         "Daily Investment" to {
             ruleName = "Daily Investment"
@@ -193,7 +193,13 @@ fun CreateRuleScreen(
                                         RuleAction(
                                             field = actionField,
                                             actionType = actionType,
-                                            value = if (actionType == ActionType.BLOCK) "" else actionValue
+                                            value = if (actionType == ActionType.BLOCK) {
+                                                ""
+                                            } else if (actionField == TransactionField.TYPE) {
+                                                actionValue.uppercase()
+                                            } else {
+                                                actionValue
+                                            }
                                         )
                                     ),
                                     isActive = existingRule?.isActive ?: true,
@@ -571,15 +577,9 @@ fun CreateRuleScreen(
                                 verticalArrangement = Arrangement.spacedBy(Spacing.xs),
                                 modifier = Modifier.fillMaxWidth()
                             ) {
-                                listOf(
-                                    "INCOME" to "Incoming",
-                                    "EXPENSE" to "Outgoing",
-                                    "CREDIT" to "Credit Card",
-                                    "TRANSFER" to "Transfer",
-                                    "INVESTMENT" to "Investment"
-                                ).forEach { (type, displayLabel) ->
+                                RULE_TRANSACTION_TYPE_OPTIONS.forEach { (type, displayLabel) ->
                                     FilterChip(
-                                        selected = actionValue == type,
+                                        selected = actionValue.equals(type, ignoreCase = true),
                                         onClick = { actionValue = type },
                                         label = {
                                             Text(
@@ -723,14 +723,7 @@ fun CreateRuleScreen(
                                     )
                                     when {
                                         condition.field == TransactionField.TYPE -> {
-                                            append(when(condition.value) {
-                                                "INCOME" -> "Incoming"
-                                                "EXPENSE" -> "Outgoing"
-                                                "CREDIT" -> "Credit Card"
-                                                "TRANSFER" -> "Transfer"
-                                                "INVESTMENT" -> "Investment"
-                                                else -> condition.value
-                                            })
+                                            append(ruleTransactionTypeLabel(condition.value))
                                         }
                                         condition.field == TransactionField.TRANSACTION_DAY_OF_WEEK -> {
                                             append(condition.value.split(",").joinToString(", ") { dayNames[it.trim()] ?: it })
@@ -759,14 +752,7 @@ fun CreateRuleScreen(
                                     })
                                     // Show user-friendly labels for transaction types in actions too
                                     if (actionField == TransactionField.TYPE) {
-                                        append(when(actionValue) {
-                                            "INCOME" -> "Incoming"
-                                            "EXPENSE" -> "Outgoing"
-                                            "CREDIT" -> "Credit Card"
-                                            "TRANSFER" -> "Transfer"
-                                            "INVESTMENT" -> "Investment"
-                                            else -> actionValue
-                                        })
+                                        append(ruleTransactionTypeLabel(actionValue))
                                     } else {
                                         append(actionValue)
                                     }
@@ -790,6 +776,15 @@ private fun ConditionFieldSelector(
     allAccounts: List<RulesViewModel.AccountInfo> = emptyList()
 ) {
     var fieldDropdownExpanded by remember { mutableStateOf(false) }
+
+    val supportedOperators = remember(condition.field) {
+        conditionOperatorsForField(condition.field).map { it.first }.toSet()
+    }
+    LaunchedEffect(condition.field, condition.operator) {
+        if (condition.field == TransactionField.TYPE && condition.operator !in supportedOperators) {
+            onConditionChange(condition.copy(operator = ConditionOperator.EQUALS))
+        }
+    }
 
     // Field selector
     ExposedDropdownMenuBox(
@@ -826,7 +821,13 @@ private fun ConditionFieldSelector(
                 DropdownMenuItem(
                     text = { Text(label) },
                     onClick = {
-                        onConditionChange(condition.copy(field = field, value = ""))
+                        onConditionChange(
+                            condition.copy(
+                                field = field,
+                                value = "",
+                                operator = field.defaultConditionOperator()
+                            )
+                        )
                         fieldDropdownExpanded = false
                     }
                 )
@@ -837,50 +838,7 @@ private fun ConditionFieldSelector(
     Spacer(modifier = Modifier.height(Spacing.sm))
 
     // Operator selector
-    val operators = when(condition.field) {
-        TransactionField.AMOUNT -> listOf(
-            ConditionOperator.LESS_THAN to "<",
-            ConditionOperator.GREATER_THAN to ">",
-            ConditionOperator.EQUALS to "="
-        )
-        TransactionField.TRANSACTION_TIME -> listOf(
-            ConditionOperator.LESS_THAN to "before",
-            ConditionOperator.GREATER_THAN to "after",
-            ConditionOperator.GREATER_THAN_OR_EQUAL to "at or after",
-            ConditionOperator.LESS_THAN_OR_EQUAL to "at or before",
-            ConditionOperator.EQUALS to "exactly at"
-        )
-        TransactionField.TRANSACTION_HOUR -> listOf(
-            ConditionOperator.EQUALS to "is",
-            ConditionOperator.LESS_THAN to "before",
-            ConditionOperator.GREATER_THAN to "after"
-        )
-        TransactionField.TRANSACTION_DAY_OF_WEEK -> listOf(
-            ConditionOperator.EQUALS to "is",
-            ConditionOperator.IN to "is any of",
-            ConditionOperator.NOT_EQUALS to "is not"
-        )
-        TransactionField.TRANSACTION_DAY_OF_MONTH -> listOf(
-            ConditionOperator.EQUALS to "is",
-            ConditionOperator.IN to "is any of",
-            ConditionOperator.LESS_THAN to "before",
-            ConditionOperator.GREATER_THAN to "after"
-        )
-        TransactionField.TRANSACTION_DATE -> listOf(
-            ConditionOperator.EQUALS to "is",
-            ConditionOperator.LESS_THAN to "before",
-            ConditionOperator.GREATER_THAN to "after"
-        )
-        TransactionField.ACCOUNT -> listOf(
-            ConditionOperator.EQUALS to "is",
-            ConditionOperator.NOT_EQUALS to "is not"
-        )
-        else -> listOf(
-            ConditionOperator.CONTAINS to "contains",
-            ConditionOperator.EQUALS to "equals",
-            ConditionOperator.STARTS_WITH to "starts with"
-        )
-    }
+    val operators = conditionOperatorsForField(condition.field)
 
     FlowRow(
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
@@ -909,16 +867,12 @@ private fun ConditionFieldSelector(
                 verticalArrangement = Arrangement.spacedBy(Spacing.xs),
                 modifier = Modifier.fillMaxWidth()
             ) {
-                listOf(
-                    "INCOME" to "Incoming",
-                    "EXPENSE" to "Outgoing",
-                    "CREDIT" to "Credit Card",
-                    "TRANSFER" to "Transfer",
-                    "INVESTMENT" to "Investment"
-                ).forEach { (type, displayLabel) ->
+                RULE_TRANSACTION_TYPE_OPTIONS.forEach { (type, displayLabel) ->
                     FilterChip(
-                        selected = condition.value == type,
-                        onClick = { onConditionChange(condition.copy(value = type)) },
+                        selected = condition.value.equals(type, ignoreCase = true),
+                        onClick = {
+                            onConditionChange(condition.copy(value = type, operator = ConditionOperator.EQUALS))
+                        },
                         label = {
                             Text(displayLabel, style = MaterialTheme.typography.bodySmall)
                         }

--- a/app/src/test/java/com/pennywiseai/tracker/domain/model/rule/RuleConditionTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/domain/model/rule/RuleConditionTest.kt
@@ -1,5 +1,6 @@
 package com.pennywiseai.tracker.domain.model.rule
 
+import com.pennywiseai.tracker.data.database.entity.TransactionType
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -138,5 +139,49 @@ class RuleConditionTest {
             value = "32"
         )
         assertFalse(condition.validate())
+    }
+
+    @Test
+    fun `TYPE with EXPENSE value returns true`() {
+        val condition = RuleCondition(
+            field = TransactionField.TYPE,
+            operator = ConditionOperator.EQUALS,
+            value = "EXPENSE"
+        )
+        assertTrue(condition.validate())
+    }
+
+    @Test
+    fun `TYPE with invalid value returns false`() {
+        val condition = RuleCondition(
+            field = TransactionField.TYPE,
+            operator = ConditionOperator.EQUALS,
+            value = "Outgoing"
+        )
+        assertFalse(condition.validate())
+    }
+
+    @Test
+    fun `isRuleApplicableToTransactionType matches EXPENSE condition for expense transactions`() {
+        val rule = TransactionRule(
+            name = "Expense rule",
+            conditions = listOf(
+                RuleCondition(
+                    field = TransactionField.TYPE,
+                    operator = ConditionOperator.EQUALS,
+                    value = "EXPENSE"
+                )
+            ),
+            actions = listOf(
+                RuleAction(
+                    field = TransactionField.CATEGORY,
+                    actionType = ActionType.SET,
+                    value = "Food"
+                )
+            )
+        )
+
+        assertTrue(isRuleApplicableToTransactionType(rule, TransactionType.EXPENSE))
+        assertFalse(isRuleApplicableToTransactionType(rule, TransactionType.INCOME))
     }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/domain/service/RuleEngineTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/domain/service/RuleEngineTest.kt
@@ -326,8 +326,71 @@ class RuleEngineTest {
 
         val (_, applications) = engine.evaluateRules(txn, null, listOf(rule))
 
-        assertFalse("Expected combined AND conditions to NOT match when amount is too low",
-            applications.isNotEmpty())
+        assertFalse(
+            "Expected combined AND conditions to NOT match when amount is too low",
+            applications.isNotEmpty()
+        )
+    }
+
+    @Test
+    fun `SET TYPE action can set transaction type to EXPENSE`() {
+        val txn = transaction(
+            merchantName = "Amazon",
+            transactionType = TransactionType.CREDIT
+        )
+        val rule = TransactionRule(
+            name = "Mark card spend as expense",
+            conditions = listOf(
+                RuleCondition(
+                    field = TransactionField.MERCHANT,
+                    operator = ConditionOperator.CONTAINS,
+                    value = "Amazon"
+                )
+            ),
+            actions = listOf(
+                RuleAction(
+                    field = TransactionField.TYPE,
+                    actionType = ActionType.SET,
+                    value = "EXPENSE"
+                )
+            )
+        )
+
+        val (result, applications) = engine.evaluateRules(txn, null, listOf(rule))
+
+        assertEquals(TransactionType.EXPENSE, result.transactionType)
+        assertTrue(applications.isNotEmpty())
+    }
+
+    @Test
+    fun `TYPE EXPENSE condition matches expense transactions`() {
+        val txn = transaction(transactionType = TransactionType.EXPENSE)
+        val rule = TransactionRule(
+            name = "Expense-only rule",
+            conditions = listOf(
+                RuleCondition(
+                    field = TransactionField.TYPE,
+                    operator = ConditionOperator.EQUALS,
+                    value = "EXPENSE"
+                )
+            ),
+            actions = listOf(
+                RuleAction(
+                    field = TransactionField.CATEGORY,
+                    actionType = ActionType.SET,
+                    value = "General"
+                )
+            )
+        )
+
+        val (_, applications) = engine.evaluateRulesForType(
+            txn,
+            smsText = null,
+            rules = listOf(rule),
+            type = TransactionType.EXPENSE
+        )
+
+        assertTrue(applications.isNotEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Summary

Smart Rules could not reliably set or match **Transaction Type → Expense**. The rule editor showed “Outgoing” instead of “Expense”, kept incompatible operators when switching from Amount to Transaction Type (for example `LESS_THAN`), and duplicated fragile TYPE pre-filter logic across the repository and engine.

This change centralizes transaction-type rule helpers, uses proper `is` / `is not` operators for TYPE conditions, resets operators when the condition field changes, validates TYPE values, and adds unit tests for EXPENSE matching and SET TYPE actions.

## Type of change

- [x] fix: Bug fix
- [x] test: Add/update tests

## How to test

1. Open **Settings → Smart Rules → Create Rule**.
2. Under **Then**, choose **Set Field → Set Transaction Type** and select **Expense**; save the rule.
3. Add a condition **Transaction Type → is → Expense** (optionally combined with another condition); confirm Save is enabled and the preview shows “Expense”.
4. Enable the rule and verify it applies on matching transactions.
5. Run:
   ```bash
   ./gradlew :app:testStandardDebugUnitTest --tests "com.pennywiseai.tracker.domain.service.RuleEngineTest" --tests "com.pennywiseai.tracker.domain.model.rule.RuleConditionTest"
   ```

## Breaking changes

No breaking changes.

## Checklist

- [x] Focused PR (single purpose)
- [x] Tests added/updated
- [x] Targeted unit tests pass locally
- [x] Follows existing code style and patterns

Made with [Cursor](https://cursor.com)