### PR TITLE
feat(settings): add custom SMS scan start date

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/core/Constants.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/core/Constants.kt
@@ -15,6 +15,10 @@ object Constants {
         const val QUERY_LIMIT = 100
         const val INITIAL_SCAN_MONTHS = 3
         const val SCANNING_DELAY_MS = 3000L
+        /** Stored in [last_scan_period] when SMS scan period is set to all time. */
+        const val SCAN_PERIOD_ALL_TIME = -1
+        /** Stored in [last_scan_period] when SMS scan period is a custom start date. */
+        const val SCAN_PERIOD_CUSTOM_DATE = -2
     }
     
     /**

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
@@ -81,6 +81,8 @@ class BackupExporter @Inject constructor(
         val lastReviewPromptTime = userPreferencesRepository.getLastReviewPromptTime().first()
         val lastScanTimestamp = userPreferencesRepository.getLastScanTimestamp().first()
         val lastScanPeriod = userPreferencesRepository.getLastScanPeriod().first()
+        val smsScanUseCustomDate = userPreferencesRepository.getSmsScanUseCustomDate()
+        val smsScanCustomDate = userPreferencesRepository.getSmsScanCustomDate()
         
         // Calculate statistics
         val dateRange = if (transactions.isNotEmpty()) {
@@ -183,7 +185,9 @@ class BackupExporter @Inject constructor(
                     hasSkippedSmsPermission = prefs.hasSkippedSmsPermission,
                     smsScanMonths = prefs.smsScanMonths,
                     lastScanTimestamp = lastScanTimestamp,
-                    lastScanPeriod = lastScanPeriod
+                    lastScanPeriod = lastScanPeriod,
+                    smsScanUseCustomDate = smsScanUseCustomDate,
+                    smsScanCustomDate = smsScanCustomDate
                 ),
                 developer = DeveloperPreferences(
                     isDeveloperModeEnabled = prefs.isDeveloperModeEnabled,

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
@@ -654,6 +654,10 @@ class BackupImporter @Inject constructor(
         // SMS preferences
         userPreferencesRepository.updateHasSkippedSmsPermission(preferences.sms.hasSkippedSmsPermission)
         userPreferencesRepository.updateSmsScanMonths(preferences.sms.smsScanMonths)
+        userPreferencesRepository.updateSmsScanUseCustomDate(preferences.sms.smsScanUseCustomDate)
+        preferences.sms.smsScanCustomDate?.let {
+            userPreferencesRepository.updateSmsScanCustomDate(it)
+        }
         preferences.sms.lastScanTimestamp?.let {
             userPreferencesRepository.updateLastScanTimestamp(it)
         }

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
@@ -258,7 +258,13 @@ data class SmsPreferences(
     val lastScanTimestamp: Long? = null,
 
     @SerialName("last_scan_period")
-    val lastScanPeriod: Int? = null
+    val lastScanPeriod: Int? = null,
+
+    @SerialName("sms_scan_use_custom_date")
+    val smsScanUseCustomDate: Boolean = false,
+
+    @SerialName("sms_scan_custom_date")
+    val smsScanCustomDate: Long? = null
 )
 
 @Serializable

--- a/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsScanParamsCalculator.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsScanParamsCalculator.kt
@@ -1,0 +1,117 @@
+package com.pennywiseai.tracker.data.manager
+
+import com.pennywiseai.tracker.core.Constants
+import com.pennywiseai.tracker.core.TimeConstants
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+data class SmsScanParamsInput(
+    val forceResync: Boolean = false,
+    val lastScanTimestamp: Long? = null,
+    val scanMonths: Int,
+    val scanAllTime: Boolean,
+    val scanUseCustomDate: Boolean,
+    val scanCustomDateMillis: Long? = null,
+    val lastScanPeriod: Int? = null,
+    val nowMillis: Long,
+)
+
+data class SmsScanParams(
+    val scanStartTime: Long,
+    val needsFullScan: Boolean,
+)
+
+object SmsScanParamsCalculator {
+
+    fun compute(input: SmsScanParamsInput, zoneId: ZoneId = ZoneId.systemDefault()): SmsScanParams {
+        val lastScanTimestamp = input.lastScanTimestamp ?: 0L
+        val lastScanPeriod = input.lastScanPeriod ?: 0
+        val now = input.nowMillis
+
+        val scanAllTimeToggled = input.scanAllTime &&
+            lastScanPeriod != Constants.SmsProcessing.SCAN_PERIOD_ALL_TIME
+        val scanAllTimeToggledOff = !input.scanAllTime &&
+            lastScanPeriod == Constants.SmsProcessing.SCAN_PERIOD_ALL_TIME
+        val customDateToggled = input.scanUseCustomDate &&
+            lastScanPeriod != Constants.SmsProcessing.SCAN_PERIOD_CUSTOM_DATE
+        val customDateToggledOff = !input.scanUseCustomDate &&
+            lastScanPeriod == Constants.SmsProcessing.SCAN_PERIOD_CUSTOM_DATE
+        val needsFullScan = input.forceResync || lastScanTimestamp == 0L ||
+            (lastScanPeriod >= 0 && input.scanMonths > lastScanPeriod) ||
+            scanAllTimeToggled || scanAllTimeToggledOff ||
+            customDateToggled || customDateToggledOff
+
+        val periodLimit = scanPeriodStartTime(
+            scanAllTime = input.scanAllTime,
+            scanUseCustomDate = input.scanUseCustomDate,
+            scanCustomDateMillis = input.scanCustomDateMillis,
+            scanMonths = input.scanMonths,
+            nowMillis = now,
+            zoneId = zoneId,
+        )
+
+        val scanStartTime = if (needsFullScan) {
+            periodLimit
+        } else {
+            val threeDaysAgo = now - TimeConstants.MILLIS_PER_3_DAYS
+            maxOf(minOf(lastScanTimestamp, threeDaysAgo), periodLimit)
+        }
+
+        return SmsScanParams(scanStartTime = scanStartTime, needsFullScan = needsFullScan)
+    }
+
+    fun resolveLastScanPeriod(
+        scanAllTime: Boolean,
+        scanUseCustomDate: Boolean,
+        scanMonths: Int,
+    ): Int = when {
+        scanAllTime -> Constants.SmsProcessing.SCAN_PERIOD_ALL_TIME
+        scanUseCustomDate -> Constants.SmsProcessing.SCAN_PERIOD_CUSTOM_DATE
+        else -> scanMonths
+    }
+
+    fun scanPeriodStartTime(
+        scanAllTime: Boolean,
+        scanUseCustomDate: Boolean,
+        scanCustomDateMillis: Long?,
+        scanMonths: Int,
+        nowMillis: Long,
+        zoneId: ZoneId = ZoneId.systemDefault(),
+    ): Long {
+        if (scanAllTime) return 0L
+
+        if (scanUseCustomDate) {
+            return scanCustomDateMillis
+                ?: monthBasedScanStartTime(scanMonths, nowMillis, zoneId)
+        }
+
+        return monthBasedScanStartTime(scanMonths, nowMillis, zoneId)
+    }
+
+    fun monthBasedScanStartTime(
+        scanMonths: Int,
+        nowMillis: Long,
+        zoneId: ZoneId = ZoneId.systemDefault(),
+    ): Long {
+        return Instant.ofEpochMilli(nowMillis)
+            .atZone(zoneId)
+            .toLocalDate()
+            .minusMonths(scanMonths.toLong())
+            .atStartOfDay(zoneId)
+            .toInstant()
+            .toEpochMilli()
+    }
+
+    fun normalizePickerDateToLocalStartOfDay(
+        pickerMillis: Long,
+        zoneId: ZoneId = ZoneId.systemDefault(),
+    ): Long {
+        return Instant.ofEpochMilli(pickerMillis)
+            .atZone(ZoneOffset.UTC)
+            .toLocalDate()
+            .atStartOfDay(zoneId)
+            .toInstant()
+            .toEpochMilli()
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
@@ -62,6 +62,8 @@ class UserPreferencesRepository @Inject constructor(
         val ACTIVE_DOWNLOAD_ID = longPreferencesKey("active_download_id")
         val SMS_SCAN_MONTHS = intPreferencesKey("sms_scan_months")
         val SMS_SCAN_ALL_TIME = booleanPreferencesKey("sms_scan_all_time")
+        val SMS_SCAN_USE_CUSTOM_DATE = booleanPreferencesKey("sms_scan_use_custom_date")
+        val SMS_SCAN_CUSTOM_DATE = longPreferencesKey("sms_scan_custom_date")
         val LAST_SCAN_TIMESTAMP = longPreferencesKey("last_scan_timestamp")
         val LAST_SCAN_PERIOD = intPreferencesKey("last_scan_period")
         val BASE_CURRENCY = stringPreferencesKey("base_currency")
@@ -310,6 +312,38 @@ class UserPreferencesRepository @Inject constructor(
     suspend fun getSmsScanAllTime(): Boolean {
         return context.dataStore.data
             .map { preferences -> preferences[PreferencesKeys.SMS_SCAN_ALL_TIME] ?: true }
+            .first()
+    }
+
+    val smsScanUseCustomDate: Flow<Boolean> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.SMS_SCAN_USE_CUSTOM_DATE] ?: false
+        }
+
+    suspend fun updateSmsScanUseCustomDate(useCustomDate: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.SMS_SCAN_USE_CUSTOM_DATE] = useCustomDate
+        }
+    }
+
+    suspend fun getSmsScanUseCustomDate(): Boolean {
+        return context.dataStore.data
+            .map { preferences -> preferences[PreferencesKeys.SMS_SCAN_USE_CUSTOM_DATE] ?: false }
+            .first()
+    }
+
+    val smsScanCustomDate: Flow<Long?> = context.dataStore.data
+        .map { preferences -> preferences[PreferencesKeys.SMS_SCAN_CUSTOM_DATE] }
+
+    suspend fun updateSmsScanCustomDate(dateMillis: Long) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.SMS_SCAN_CUSTOM_DATE] = dateMillis
+        }
+    }
+
+    suspend fun getSmsScanCustomDate(): Long? {
+        return context.dataStore.data
+            .map { preferences -> preferences[PreferencesKeys.SMS_SCAN_CUSTOM_DATE] }
             .first()
     }
     

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -475,38 +475,60 @@ class TransactionsViewModel @Inject constructor(
             initialValue = false
         )
 
+    private val smsScanUseCustomDate: StateFlow<Boolean> = userPreferencesRepository.smsScanUseCustomDate
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = false
+        )
+
+    private val smsScanCustomDate: StateFlow<Long?> = userPreferencesRepository.smsScanCustomDate
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = null
+        )
+
     fun isShowingLimitedData(): Boolean {
         if (smsScanAllTime.value) return false
 
         val currentPeriod = _selectedPeriod.value
-        val scanMonthsValue = smsScanMonths.value
+        val scanStartDate = getSmsScanStartDate() ?: return false
 
         return when (currentPeriod) {
             TimePeriod.ALL -> true
             TimePeriod.CURRENT_FY -> {
-                // Check if FY start is before scan period
                 val dateRange = getDateRangeForPeriod(TimePeriod.CURRENT_FY)
                 if (dateRange != null) {
                     val (fyStart, _) = dateRange
-                    val scanStart = LocalDate.now().minusMonths(scanMonthsValue.toLong())
-                    fyStart.isBefore(scanStart)
+                    fyStart.isBefore(scanStartDate)
                 } else {
                     false
                 }
             }
             TimePeriod.CUSTOM -> {
-                // Check if custom range start is before scan period
                 val customRange = customDateRange.value
                 if (customRange != null) {
                     val (startDate, _) = customRange
-                    val scanStart = LocalDate.now().minusMonths(scanMonthsValue.toLong())
-                    startDate.isBefore(scanStart)
+                    startDate.isBefore(scanStartDate)
                 } else {
                     false
                 }
             }
             else -> false
         }
+    }
+
+    private fun getSmsScanStartDate(): LocalDate? {
+        if (smsScanUseCustomDate.value) {
+            return smsScanCustomDate.value?.let { millis ->
+                java.time.Instant.ofEpochMilli(millis)
+                    .atZone(java.time.ZoneId.systemDefault())
+                    .toLocalDate()
+            }
+        }
+
+        return LocalDate.now().minusMonths(smsScanMonths.value.toLong())
     }
     
     init {

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
+import androidx.compose.material3.SelectableDates
 import androidx.compose.runtime.*
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -100,6 +101,8 @@ fun SettingsScreen(
     val isDeveloperModeEnabled by settingsViewModel.isDeveloperModeEnabled.collectAsStateWithLifecycle(initialValue = false)
     val smsScanMonths by settingsViewModel.smsScanMonths.collectAsStateWithLifecycle(initialValue = 3)
     val smsScanAllTime by settingsViewModel.smsScanAllTime.collectAsStateWithLifecycle(initialValue = false)
+    val smsScanUseCustomDate by settingsViewModel.smsScanUseCustomDate.collectAsStateWithLifecycle(initialValue = false)
+    val smsScanCustomDate by settingsViewModel.smsScanCustomDate.collectAsStateWithLifecycle(initialValue = null)
     val baseCurrency by settingsViewModel.baseCurrency.collectAsStateWithLifecycle(initialValue = "")
     val importExportMessage by settingsViewModel.importExportMessage.collectAsStateWithLifecycle()
     val exportedBackupFile by settingsViewModel.exportedBackupFile.collectAsStateWithLifecycle()
@@ -120,6 +123,7 @@ fun SettingsScreen(
         if (granted) settingsViewModel.setUseContactsForVpa(true)
     }
     var showSmsScanDialog by remember { mutableStateOf(false) }
+    var showSmsScanDatePicker by remember { mutableStateOf(false) }
     var showExportOptionsDialog by remember { mutableStateOf(false) }
     var showTimeoutDialog by remember { mutableStateOf(false) }
     var showDisplayCurrencyDialog by remember { mutableStateOf(false) }
@@ -497,10 +501,25 @@ fun SettingsScreen(
                     iconBgColor = teal_light,
                     iconTint = teal_dark,
                     title = "SMS Scan Period",
-                    subtitle = if (smsScanAllTime) "Scan all SMS messages" else "Scan last $smsScanMonths months",
+                    subtitle = when {
+                        smsScanAllTime -> "Scan all SMS messages"
+                        smsScanUseCustomDate -> {
+                            val formattedDate = smsScanCustomDate?.let { formatSmsScanCustomDate(it) }
+                            if (formattedDate != null) {
+                                "Scan from $formattedDate to today"
+                            } else {
+                                "Scan from a custom start date to today"
+                            }
+                        }
+                        else -> "Scan last $smsScanMonths months"
+                    },
                     onClick = { showSmsScanDialog = true },
                     position = ItemPosition.BOTTOM,
-                    trailingText = if (smsScanAllTime) "All Time" else "$smsScanMonths mo"
+                    trailingText = when {
+                        smsScanAllTime -> "All Time"
+                        smsScanUseCustomDate -> smsScanCustomDate?.let { formatSmsScanCustomDateShort(it) } ?: "Custom"
+                        else -> "$smsScanMonths mo"
+                    }
                 )
             }
 
@@ -648,45 +667,69 @@ fun SettingsScreen(
                     verticalArrangement = Arrangement.spacedBy(Spacing.sm)
                 ) {
                     Text(
-                        text = "Choose how many months of SMS history to scan for transactions",
+                        text = "Choose how far back to scan SMS messages for transactions",
                         style = MaterialTheme.typography.bodyMedium
                     )
                     Spacer(modifier = Modifier.height(Spacing.md))
 
-                    val options = listOf(-1) + listOf(1, 2, 3, 6, 12, 24)
+                    val options = listOf(-1, -2) + listOf(1, 2, 3, 6, 12, 24)
                     options.forEach { months ->
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clickable {
-                                    if (months == -1) {
-                                        settingsViewModel.updateSmsScanAllTime(true)
-                                    } else {
-                                        settingsViewModel.updateSmsScanMonths(months)
-                                        settingsViewModel.updateSmsScanAllTime(false)
+                                    when (months) {
+                                        -1 -> {
+                                            settingsViewModel.updateSmsScanAllTime(true)
+                                            showSmsScanDialog = false
+                                        }
+                                        -2 -> {
+                                            showSmsScanDialog = false
+                                            showSmsScanDatePicker = true
+                                        }
+                                        else -> {
+                                            settingsViewModel.updateSmsScanMonths(months)
+                                            settingsViewModel.updateSmsScanAllTime(false)
+                                            showSmsScanDialog = false
+                                        }
                                     }
-                                    showSmsScanDialog = false
                                 }
                                 .padding(vertical = Spacing.sm),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            val isSelected = if (months == -1) smsScanAllTime else smsScanMonths == months && !smsScanAllTime
+                            val isSelected = when (months) {
+                                -1 -> smsScanAllTime
+                                -2 -> smsScanUseCustomDate && !smsScanAllTime
+                                else -> smsScanMonths == months && !smsScanAllTime && !smsScanUseCustomDate
+                            }
                             RadioButton(
                                 selected = isSelected,
                                 onClick = {
-                                    if (months == -1) {
-                                        settingsViewModel.updateSmsScanAllTime(true)
-                                    } else {
-                                        settingsViewModel.updateSmsScanMonths(months)
-                                        settingsViewModel.updateSmsScanAllTime(false)
+                                    when (months) {
+                                        -1 -> {
+                                            settingsViewModel.updateSmsScanAllTime(true)
+                                            showSmsScanDialog = false
+                                        }
+                                        -2 -> {
+                                            showSmsScanDialog = false
+                                            showSmsScanDatePicker = true
+                                        }
+                                        else -> {
+                                            settingsViewModel.updateSmsScanMonths(months)
+                                            settingsViewModel.updateSmsScanAllTime(false)
+                                            showSmsScanDialog = false
+                                        }
                                     }
-                                    showSmsScanDialog = false
                                 }
                             )
                             Spacer(modifier = Modifier.width(Spacing.md))
                             Text(
                                 text = when (months) {
                                     -1 -> "All Time"
+                                    -2 -> {
+                                        val formattedDate = smsScanCustomDate?.let { formatSmsScanCustomDate(it) }
+                                        if (formattedDate != null) "Custom date ($formattedDate)" else "Custom date"
+                                    }
                                     1 -> "1 month"
                                     24 -> "2 years"
                                     else -> "$months months"
@@ -703,6 +746,50 @@ fun SettingsScreen(
                 }
             }
         )
+    }
+
+    if (showSmsScanDatePicker) {
+        val todayMillis = java.time.LocalDate.now()
+            .atStartOfDay(java.time.ZoneOffset.UTC)
+            .toInstant()
+            .toEpochMilli()
+        val initialSelectedDateMillis = smsScanCustomDate
+            ?: java.time.LocalDate.now()
+                .minusMonths(3)
+                .atStartOfDay(java.time.ZoneOffset.UTC)
+                .toInstant()
+                .toEpochMilli()
+        val datePickerState = rememberDatePickerState(
+            initialSelectedDateMillis = initialSelectedDateMillis,
+            selectableDates = object : SelectableDates {
+                override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+                    return utcTimeMillis <= todayMillis
+                }
+            }
+        )
+
+        DatePickerDialog(
+            onDismissRequest = { showSmsScanDatePicker = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        datePickerState.selectedDateMillis?.let { millis ->
+                            settingsViewModel.updateSmsScanCustomDate(millis)
+                        }
+                        showSmsScanDatePicker = false
+                    }
+                ) {
+                    Text("OK")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showSmsScanDatePicker = false }) {
+                    Text("Cancel")
+                }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
     }
 
     // Show import/export message
@@ -1268,4 +1355,18 @@ private fun SettingsNavigationContent(onNavigateBack: () -> Unit) {
             )
         }
     }
+}
+
+private fun formatSmsScanCustomDate(dateMillis: Long): String {
+    return java.time.Instant.ofEpochMilli(dateMillis)
+        .atZone(java.time.ZoneId.systemDefault())
+        .toLocalDate()
+        .format(java.time.format.DateTimeFormatter.ofPattern("MMM d, yyyy"))
+}
+
+private fun formatSmsScanCustomDateShort(dateMillis: Long): String {
+    return java.time.Instant.ofEpochMilli(dateMillis)
+        .atZone(java.time.ZoneId.systemDefault())
+        .toLocalDate()
+        .format(java.time.format.DateTimeFormatter.ofPattern("MMM d"))
 }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -21,6 +21,7 @@ import com.pennywiseai.tracker.data.repository.ModelRepository
 import com.pennywiseai.tracker.data.repository.ModelState
 import com.pennywiseai.tracker.data.repository.UnrecognizedSmsRepository
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
+import com.pennywiseai.tracker.data.manager.SmsScanParamsCalculator
 import com.pennywiseai.tracker.data.backup.BackupExporter
 import com.pennywiseai.tracker.data.backup.BackupImporter
 import com.pennywiseai.tracker.data.backup.ExportResult
@@ -91,6 +92,8 @@ class SettingsViewModel @Inject constructor(
     // SMS scan period state
     val smsScanMonths = userPreferencesRepository.smsScanMonths
     val smsScanAllTime = userPreferencesRepository.smsScanAllTime
+    val smsScanUseCustomDate = userPreferencesRepository.smsScanUseCustomDate
+    val smsScanCustomDate = userPreferencesRepository.smsScanCustomDate
 
     // Unified Currency Mode
     val unifiedCurrencyMode = userPreferencesRepository.unifiedCurrencyMode
@@ -477,6 +480,7 @@ class SettingsViewModel @Inject constructor(
                 Log.d("SettingsViewModel", "Scan period increased from $currentMonths to $months months - will perform full scan")
             }
 
+            userPreferencesRepository.updateSmsScanUseCustomDate(false)
             userPreferencesRepository.updateSmsScanMonths(months)
         }
     }
@@ -489,7 +493,25 @@ class SettingsViewModel @Inject constructor(
                 Log.d("SettingsViewModel", "All time scanning enabled - will perform full scan")
             }
 
+            userPreferencesRepository.updateSmsScanUseCustomDate(false)
             userPreferencesRepository.updateSmsScanAllTime(allTime)
+        }
+    }
+
+    fun updateSmsScanCustomDate(selectedDateMillis: Long) {
+        viewModelScope.launch {
+            val normalizedDate = SmsScanParamsCalculator.normalizePickerDateToLocalStartOfDay(selectedDateMillis)
+            val currentDate = userPreferencesRepository.getSmsScanCustomDate()
+            val wasUsingCustomDate = userPreferencesRepository.getSmsScanUseCustomDate()
+
+            if (!wasUsingCustomDate || currentDate == null || normalizedDate < currentDate) {
+                userPreferencesRepository.setLastScanTimestamp(0L)
+                Log.d("SettingsViewModel", "Custom SMS scan date updated - will perform full scan")
+            }
+
+            userPreferencesRepository.updateSmsScanAllTime(false)
+            userPreferencesRepository.updateSmsScanUseCustomDate(true)
+            userPreferencesRepository.updateSmsScanCustomDate(normalizedDate)
         }
     }
     

--- a/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
@@ -19,6 +19,8 @@ import com.pennywiseai.tracker.data.manager.TransactionDeduplication
 import com.pennywiseai.tracker.data.mapper.toEntity
 import com.pennywiseai.tracker.data.mapper.toEntityType
 import com.pennywiseai.tracker.core.TimeConstants
+import com.pennywiseai.tracker.data.manager.SmsScanParamsCalculator
+import com.pennywiseai.tracker.data.manager.SmsScanParamsInput
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.repository.*
 import com.pennywiseai.tracker.domain.model.rule.TransactionRule
@@ -503,7 +505,14 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
         if (needsFullScan) {
             val scanMonths = userPreferencesRepository.getSmsScanMonths()
             val scanAllTime = userPreferencesRepository.getSmsScanAllTime()
-            userPreferencesRepository.setLastScanPeriod(if (scanAllTime) -1 else scanMonths)
+            val scanUseCustomDate = userPreferencesRepository.getSmsScanUseCustomDate()
+            userPreferencesRepository.setLastScanPeriod(
+                SmsScanParamsCalculator.resolveLastScanPeriod(
+                    scanAllTime = scanAllTime,
+                    scanUseCustomDate = scanUseCustomDate,
+                    scanMonths = scanMonths,
+                )
+            )
         }
 
         reportProgress(stats)
@@ -925,33 +934,19 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
 
     /** Computes scan params without reading any message bodies. */
     private suspend fun computeScanParams(forceResync: Boolean): Pair<Long, Boolean> {
-        val lastScanTimestamp = userPreferencesRepository.getLastScanTimestamp().first() ?: 0L
-        val scanMonths        = userPreferencesRepository.getSmsScanMonths()
-        val scanAllTime       = userPreferencesRepository.getSmsScanAllTime()
-        val lastScanPeriod    = userPreferencesRepository.getLastScanPeriod().first() ?: 0
-        val now               = System.currentTimeMillis()
-
-        val scanAllTimeToggled = scanAllTime && lastScanPeriod != -1
-        val scanAllTimeToggledOff = !scanAllTime && lastScanPeriod == -1
-        val needsFullScan = forceResync || lastScanTimestamp == 0L ||
-            (lastScanPeriod >= 0 && scanMonths > lastScanPeriod) ||
-            scanAllTimeToggled || scanAllTimeToggledOff
-
-        val scanStartTime = if (needsFullScan) {
-            if (scanAllTime) 0L
-            else java.util.Calendar.getInstance().apply {
-                add(java.util.Calendar.MONTH, -scanMonths)
-                set(java.util.Calendar.HOUR_OF_DAY, 0); set(java.util.Calendar.MINUTE, 0)
-                set(java.util.Calendar.SECOND, 0);      set(java.util.Calendar.MILLISECOND, 0)
-            }.timeInMillis
-        } else {
-            val threeDaysAgo = now - TimeConstants.MILLIS_PER_3_DAYS
-            val periodLimit  = java.util.Calendar.getInstance().apply {
-                add(java.util.Calendar.MONTH, -scanMonths)
-            }.timeInMillis
-            maxOf(minOf(lastScanTimestamp, threeDaysAgo), periodLimit)
-        }
-        return scanStartTime to needsFullScan
+        val params = SmsScanParamsCalculator.compute(
+            SmsScanParamsInput(
+                forceResync = forceResync,
+                lastScanTimestamp = userPreferencesRepository.getLastScanTimestamp().first(),
+                scanMonths = userPreferencesRepository.getSmsScanMonths(),
+                scanAllTime = userPreferencesRepository.getSmsScanAllTime(),
+                scanUseCustomDate = userPreferencesRepository.getSmsScanUseCustomDate(),
+                scanCustomDateMillis = userPreferencesRepository.getSmsScanCustomDate(),
+                lastScanPeriod = userPreferencesRepository.getLastScanPeriod().first(),
+                nowMillis = System.currentTimeMillis(),
+            )
+        )
+        return params.scanStartTime to params.needsFullScan
     }
 
     /** Fast COUNT-only query — reads zero message bodies. */

--- a/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupModelsTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupModelsTest.kt
@@ -5,6 +5,7 @@ import com.pennywiseai.tracker.data.database.entity.*
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -534,6 +535,8 @@ class BackupModelsTest {
 
         assertEquals(false, backup.preferences.developer.isDeveloperModeEnabled)
         assertEquals(6, backup.preferences.sms.smsScanMonths)
+        assertFalse(backup.preferences.sms.smsScanUseCustomDate)
+        assertNull(backup.preferences.sms.smsScanCustomDate)
         assertNull(backup.preferences.theme.isDarkThemeEnabled)
         assertEquals("", backup.metadata.exportId)
         assertTrue(backup.database.transactions.isEmpty())
@@ -566,5 +569,71 @@ class BackupModelsTest {
             .database.subscriptions.single()
         assertEquals("Monthly", sub.billingCycle)
         assertEquals(SubscriptionDirection.EXPENSE, sub.direction)
+    }
+
+    @Test
+    fun customSmsScanPreferences_roundTrip() {
+        val customDateMillis = 1_705_276_800_000L
+        val backup = PennyWiseBackup(
+            metadata = BackupMetadata(
+                exportId = "custom-sms-scan",
+                appVersion = "test",
+                databaseVersion = SCHEMA_VERSION,
+                device = "Test",
+                androidVersion = 30,
+                statistics = BackupStatistics(
+                    totalTransactions = 0,
+                    totalCategories = 0,
+                    totalCards = 0,
+                    totalSubscriptions = 0,
+                    dateRange = null
+                )
+            ),
+            database = DatabaseSnapshot(),
+            preferences = PreferencesSnapshot(
+                theme = ThemePreferences(isDarkThemeEnabled = null, isDynamicColorEnabled = false),
+                sms = SmsPreferences(
+                    hasSkippedSmsPermission = false,
+                    smsScanMonths = 3,
+                    lastScanTimestamp = null,
+                    lastScanPeriod = -2,
+                    smsScanUseCustomDate = true,
+                    smsScanCustomDate = customDateMillis,
+                ),
+                developer = DeveloperPreferences(isDeveloperModeEnabled = false, systemPrompt = null),
+                app = AppPreferences(
+                    hasShownScanTutorial = false,
+                    firstLaunchTime = null,
+                    hasShownReviewPrompt = false,
+                    lastReviewPromptTime = null
+                )
+            )
+        )
+
+        val deserialized = backupJson.decodeFromString<PennyWiseBackup>(backupJson.encodeToString(backup))
+
+        assertTrue(deserialized.preferences.sms.smsScanUseCustomDate)
+        assertEquals(customDateMillis, deserialized.preferences.sms.smsScanCustomDate)
+        assertEquals(-2, deserialized.preferences.sms.lastScanPeriod)
+    }
+
+    @Test
+    fun oldBackupMissingCustomSmsScanFields_fallsBackToDefaults() {
+        val json = """
+        {
+          "preferences": {
+            "sms": {
+              "sms_scan_months": 6,
+              "last_scan_period": 6
+            }
+          }
+        }
+        """.trimIndent()
+
+        val sms = backupJson.decodeFromString<PennyWiseBackup>(json).preferences.sms
+
+        assertEquals(6, sms.smsScanMonths)
+        assertFalse(sms.smsScanUseCustomDate)
+        assertNull(sms.smsScanCustomDate)
     }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/data/manager/SmsScanParamsCalculatorTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/manager/SmsScanParamsCalculatorTest.kt
@@ -1,0 +1,203 @@
+package com.pennywiseai.tracker.data.manager
+
+import com.pennywiseai.tracker.core.Constants
+import com.pennywiseai.tracker.core.TimeConstants
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+class SmsScanParamsCalculatorTest {
+
+    private val zoneId = ZoneId.of("Asia/Kolkata")
+    private val nowMillis = localStartOfDay(2025, 6, 21, 14, 30)
+
+    @Test
+    fun `custom date scan uses selected start date through today`() {
+        val customStart = localStartOfDay(2025, 1, 15)
+
+        val params = SmsScanParamsCalculator.compute(
+            SmsScanParamsInput(
+                lastScanTimestamp = 0L,
+                scanMonths = 3,
+                scanAllTime = false,
+                scanUseCustomDate = true,
+                scanCustomDateMillis = customStart,
+                lastScanPeriod = 3,
+                nowMillis = nowMillis,
+            ),
+            zoneId = zoneId,
+        )
+
+        assertTrue(params.needsFullScan)
+        assertEquals(customStart, params.scanStartTime)
+    }
+
+    @Test
+    fun `switching to custom date from months triggers full scan`() {
+        val customStart = localStartOfDay(2025, 3, 1)
+
+        val params = SmsScanParamsCalculator.compute(
+            SmsScanParamsInput(
+                lastScanTimestamp = nowMillis - TimeConstants.MILLIS_PER_DAY,
+                scanMonths = 3,
+                scanAllTime = false,
+                scanUseCustomDate = true,
+                scanCustomDateMillis = customStart,
+                lastScanPeriod = 3,
+                nowMillis = nowMillis,
+            ),
+            zoneId = zoneId,
+        )
+
+        assertTrue(params.needsFullScan)
+        assertEquals(customStart, params.scanStartTime)
+    }
+
+    @Test
+    fun `switching from custom date to months triggers full scan`() {
+        val params = SmsScanParamsCalculator.compute(
+            SmsScanParamsInput(
+                lastScanTimestamp = nowMillis - TimeConstants.MILLIS_PER_DAY,
+                scanMonths = 6,
+                scanAllTime = false,
+                scanUseCustomDate = false,
+                lastScanPeriod = Constants.SmsProcessing.SCAN_PERIOD_CUSTOM_DATE,
+                nowMillis = nowMillis,
+            ),
+            zoneId = zoneId,
+        )
+
+        assertTrue(params.needsFullScan)
+        assertEquals(
+            SmsScanParamsCalculator.monthBasedScanStartTime(6, nowMillis, zoneId),
+            params.scanStartTime,
+        )
+    }
+
+    @Test
+    fun `incremental custom date scan respects custom start boundary`() {
+        val customStart = localStartOfDay(2025, 5, 1)
+        val lastScan = nowMillis - TimeConstants.MILLIS_PER_DAY
+
+        val params = SmsScanParamsCalculator.compute(
+            SmsScanParamsInput(
+                lastScanTimestamp = lastScan,
+                scanMonths = 3,
+                scanAllTime = false,
+                scanUseCustomDate = true,
+                scanCustomDateMillis = customStart,
+                lastScanPeriod = Constants.SmsProcessing.SCAN_PERIOD_CUSTOM_DATE,
+                nowMillis = nowMillis,
+            ),
+            zoneId = zoneId,
+        )
+
+        assertFalse(params.needsFullScan)
+        assertEquals(
+            maxOf(
+                minOf(lastScan, nowMillis - TimeConstants.MILLIS_PER_3_DAYS),
+                customStart,
+            ),
+            params.scanStartTime,
+        )
+    }
+
+    @Test
+    fun `custom date without stored value falls back to month based start`() {
+        val expectedStart = SmsScanParamsCalculator.monthBasedScanStartTime(3, nowMillis, zoneId)
+
+        val startTime = SmsScanParamsCalculator.scanPeriodStartTime(
+            scanAllTime = false,
+            scanUseCustomDate = true,
+            scanCustomDateMillis = null,
+            scanMonths = 3,
+            nowMillis = nowMillis,
+            zoneId = zoneId,
+        )
+
+        assertEquals(expectedStart, startTime)
+    }
+
+    @Test
+    fun `resolveLastScanPeriod stores custom date sentinel`() {
+        assertEquals(
+            Constants.SmsProcessing.SCAN_PERIOD_CUSTOM_DATE,
+            SmsScanParamsCalculator.resolveLastScanPeriod(
+                scanAllTime = false,
+                scanUseCustomDate = true,
+                scanMonths = 3,
+            ),
+        )
+    }
+
+    @Test
+    fun `month based scan period still works`() {
+        val expectedStart = SmsScanParamsCalculator.monthBasedScanStartTime(3, nowMillis, zoneId)
+
+        val params = SmsScanParamsCalculator.compute(
+            SmsScanParamsInput(
+                lastScanTimestamp = 0L,
+                scanMonths = 3,
+                scanAllTime = false,
+                scanUseCustomDate = false,
+                lastScanPeriod = 3,
+                nowMillis = nowMillis,
+            ),
+            zoneId = zoneId,
+        )
+
+        assertTrue(params.needsFullScan)
+        assertEquals(expectedStart, params.scanStartTime)
+    }
+
+    @Test
+    fun `all time scan still scans from epoch`() {
+        val params = SmsScanParamsCalculator.compute(
+            SmsScanParamsInput(
+                lastScanTimestamp = 0L,
+                scanMonths = 3,
+                scanAllTime = true,
+                scanUseCustomDate = false,
+                lastScanPeriod = Constants.SmsProcessing.SCAN_PERIOD_ALL_TIME,
+                nowMillis = nowMillis,
+            ),
+            zoneId = zoneId,
+        )
+
+        assertTrue(params.needsFullScan)
+        assertEquals(0L, params.scanStartTime)
+    }
+
+    @Test
+    fun `normalizePickerDateToLocalStartOfDay converts picker date to local midnight`() {
+        val pickerMillis = LocalDate.of(2025, 1, 15)
+            .atStartOfDay(ZoneOffset.UTC)
+            .toInstant()
+            .toEpochMilli()
+
+        val normalized = SmsScanParamsCalculator.normalizePickerDateToLocalStartOfDay(
+            pickerMillis = pickerMillis,
+            zoneId = zoneId,
+        )
+
+        assertEquals(localStartOfDay(2025, 1, 15), normalized)
+    }
+
+    private fun localStartOfDay(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int = 0,
+        minute: Int = 0,
+    ): Long {
+        return LocalDate.of(year, month, day)
+            .atTime(hour, minute)
+            .atZone(zoneId)
+            .toInstant()
+            .toEpochMilli()
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **Custom date** option to Settings → SMS Scan Period so users can scan SMS messages from a chosen start date through today. Scan logic, backup/restore, and the transactions limited-data banner were updated to respect the custom range, with unit tests for the new behavior.

## Type of change

- [x] feat: New feature
- [x] test: Add/update tests

## How to test

1. Open **Settings → SMS Scan Period** and select **Custom date**.
2. Pick a start date in the past and confirm the setting shows “Scan from \<date\> to today”.
3. Trigger an SMS scan and verify transactions are imported from the selected date onward (including today).
4. Export and restore a backup; confirm `sms_scan_use_custom_date` and `sms_scan_custom_date` are preserved.
5. Run `./gradlew :app:testStandardDebugUnitTest --tests "com.pennywiseai.tracker.data.manager.SmsScanParamsCalculatorTest" --tests "com.pennywiseai.tracker.data.backup.BackupModelsTest"`.

## Breaking changes

- [x] No breaking changes

## Checklist

- [x] Focused PR (single purpose)
- [x] Tests added/updated
- [x] Targeted unit tests pass locally
- [x] Follows existing code style and patterns

Made with [Cursor](https://cursor.com)