### PR TITLE
feat(backup): add daily 2 AM automated folder backup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -235,6 +235,7 @@ dependencies {
     
     // DataStore
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.documentfile)
 
     // Biometric Authentication
     implementation(libs.androidx.biometric)

--- a/app/src/main/java/com/pennywiseai/tracker/PennyWiseApplication.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/PennyWiseApplication.kt
@@ -25,6 +25,12 @@ class PennyWiseApplication : Application(), Configuration.Provider {
     @Inject
     lateinit var purchaseGateway: com.pennywiseai.tracker.billing.PurchaseGateway
 
+    @Inject
+    lateinit var userPreferencesRepository: com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
+
+    @Inject
+    lateinit var scheduledFolderBackupScheduler: com.pennywiseai.tracker.backup.folder.ScheduledFolderBackupScheduler
+
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var activityReferences = 0
     private var isInForeground = false
@@ -55,6 +61,12 @@ class PennyWiseApplication : Application(), Configuration.Provider {
                 purchaseGateway.refresh()
             } catch (e: Exception) {
                 android.util.Log.w("PennyWiseApp", "Initial billing refresh failed: ${e.message}", e)
+            }
+        }
+
+        applicationScope.launch {
+            if (userPreferencesRepository.isScheduledFolderBackupEnabled()) {
+                scheduledFolderBackupScheduler.schedule()
             }
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/backup/folder/FolderBackupWriter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/backup/folder/FolderBackupWriter.kt
@@ -1,0 +1,52 @@
+package com.pennywiseai.tracker.backup.folder
+
+import android.content.Context
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FolderBackupWriter @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    fun canWriteToFolder(treeUri: String): Boolean {
+        val folder = DocumentFile.fromTreeUri(context, Uri.parse(treeUri)) ?: return false
+        if (!folder.isDirectory || !folder.canWrite()) return false
+
+        val existing = folder.findFile(ScheduledFolderBackupConstants.BACKUP_FILE_NAME)
+        return existing == null || existing.canWrite()
+    }
+
+    fun writeBackup(treeUri: String, bytes: ByteArray): Result {
+        val folder = DocumentFile.fromTreeUri(context, Uri.parse(treeUri))
+            ?: return Result.Failure("Backup folder is no longer accessible")
+
+        if (!folder.isDirectory || !folder.canWrite()) {
+            return Result.Failure("Cannot write to the selected backup folder")
+        }
+
+        val backupFile = folder.findFile(ScheduledFolderBackupConstants.BACKUP_FILE_NAME)
+            ?: folder.createFile("application/octet-stream", ScheduledFolderBackupConstants.BACKUP_FILE_NAME)
+            ?: return Result.Failure("Could not create backup file in the selected folder")
+
+        if (!backupFile.canWrite()) {
+            return Result.Failure("Cannot write to the backup file")
+        }
+
+        return try {
+            context.contentResolver.openOutputStream(backupFile.uri, "wt")?.use { stream ->
+                stream.write(bytes)
+            } ?: return Result.Failure("Could not open backup file for writing")
+            Result.Success
+        } catch (e: Exception) {
+            Result.Failure("Failed to write backup: ${e.message ?: "unknown error"}")
+        }
+    }
+
+    sealed class Result {
+        data object Success : Result()
+        data class Failure(val message: String) : Result()
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/backup/folder/ScheduledFolderBackupConstants.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/backup/folder/ScheduledFolderBackupConstants.kt
@@ -1,0 +1,6 @@
+package com.pennywiseai.tracker.backup.folder
+
+object ScheduledFolderBackupConstants {
+    const val BACKUP_FILE_NAME = "PennyWise_Backup.pennywisebackup"
+    const val BACKUP_HOUR_OF_DAY = 2
+}

--- a/app/src/main/java/com/pennywiseai/tracker/backup/folder/ScheduledFolderBackupScheduler.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/backup/folder/ScheduledFolderBackupScheduler.kt
@@ -1,0 +1,68 @@
+package com.pennywiseai.tracker.backup.folder
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import com.pennywiseai.tracker.worker.ScheduledFolderBackupWorker
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ScheduledFolderBackupScheduler @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    fun schedule() {
+        val request = PeriodicWorkRequestBuilder<ScheduledFolderBackupWorker>(
+            24, TimeUnit.HOURS
+        )
+            .setInitialDelay(computeInitialDelayMs(), TimeUnit.MILLISECONDS)
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiresBatteryNotLow(true)
+                    .build()
+            )
+            .build()
+
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            WORK_NAME,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request
+        )
+    }
+
+    fun cancel() {
+        WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+    }
+
+    companion object {
+        const val WORK_NAME = "scheduled_folder_backup"
+
+        /**
+         * Milliseconds until the next [ScheduledFolderBackupConstants.BACKUP_HOUR_OF_DAY]:00
+         * in the device's default timezone.
+         */
+        fun computeInitialDelayMs(
+            now: LocalDateTime = LocalDateTime.now(),
+            zoneId: ZoneId = ZoneId.systemDefault()
+        ): Long {
+            val targetTime = LocalTime.of(
+                ScheduledFolderBackupConstants.BACKUP_HOUR_OF_DAY,
+                0
+            )
+            var nextRun = now.toLocalDate().atTime(targetTime)
+            if (!nextRun.isAfter(now)) {
+                nextRun = nextRun.plusDays(1)
+            }
+            return Duration.between(now.atZone(zoneId).toInstant(), nextRun.atZone(zoneId).toInstant())
+                .toMillis()
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
@@ -32,19 +32,27 @@ class BackupExporter @Inject constructor(
         privacy: ExportPrivacy = ExportPrivacy.FULL
     ): ExportResult {
         return try {
-            // Collect all data
-            val backup = createBackup(privacy)
-
-            // Create backup file
             val file = createBackupFile()
-
-            // Write JSON to file (see BackupSerializers for the format contract)
-            file.writeText(backupJson.encodeToString(backup))
-
+            file.writeText(encodeBackup(privacy))
             ExportResult.Success(file)
         } catch (e: Exception) {
             ExportResult.Error("Export failed: ${e.message}")
         }
+    }
+
+    suspend fun exportBackupBytes(
+        privacy: ExportPrivacy = ExportPrivacy.FULL
+    ): ExportBytesResult {
+        return try {
+            ExportBytesResult.Success(encodeBackup(privacy).toByteArray(Charsets.UTF_8))
+        } catch (e: Exception) {
+            ExportBytesResult.Error("Export failed: ${e.message}")
+        }
+    }
+
+    private suspend fun encodeBackup(privacy: ExportPrivacy): String {
+        val backup = createBackup(privacy)
+        return backupJson.encodeToString(backup)
     }
     
     /**

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
@@ -310,6 +310,14 @@ sealed class ExportResult {
 }
 
 /**
+ * In-memory export result for scheduled and manual folder backups.
+ */
+sealed class ExportBytesResult {
+    data class Success(val bytes: ByteArray) : ExportBytesResult()
+    data class Error(val message: String) : ExportBytesResult()
+}
+
+/**
  * Import strategy options.
  */
 enum class ImportStrategy {

--- a/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
@@ -129,6 +129,11 @@ class UserPreferencesRepository @Inject constructor(
 
         // UPI VPA → contact name lookup (opt-in; gated by READ_CONTACTS).
         val USE_CONTACTS_FOR_VPA = booleanPreferencesKey("use_contacts_for_vpa")
+
+        // Scheduled folder backup (SAF tree URI; shared by standard and F-Droid).
+        val SCHEDULED_FOLDER_BACKUP_ENABLED = booleanPreferencesKey("scheduled_folder_backup_enabled")
+        val SCHEDULED_FOLDER_BACKUP_TREE_URI = stringPreferencesKey("scheduled_folder_backup_tree_uri")
+        val SCHEDULED_FOLDER_BACKUP_LAST_TIMESTAMP = longPreferencesKey("scheduled_folder_backup_last_timestamp")
     }
 
     val userPreferences: Flow<UserPreferences> = context.dataStore.data
@@ -705,6 +710,55 @@ class UserPreferencesRepository @Inject constructor(
             } else {
                 preferences[PreferencesKeys.MAIN_ACCOUNT_KEY] = accountKey
             }
+        }
+    }
+
+    val scheduledFolderBackupEnabled: Flow<Boolean> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.SCHEDULED_FOLDER_BACKUP_ENABLED] ?: false
+        }
+
+    val scheduledFolderBackupTreeUri: Flow<String?> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.SCHEDULED_FOLDER_BACKUP_TREE_URI]
+        }
+
+    val scheduledFolderBackupLastTimestamp: Flow<Long?> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.SCHEDULED_FOLDER_BACKUP_LAST_TIMESTAMP]
+        }
+
+    suspend fun isScheduledFolderBackupEnabled(): Boolean {
+        return scheduledFolderBackupEnabled.first()
+    }
+
+    suspend fun getScheduledFolderBackupTreeUri(): String? {
+        return scheduledFolderBackupTreeUri.first()
+    }
+
+    suspend fun setScheduledFolderBackupEnabled(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.SCHEDULED_FOLDER_BACKUP_ENABLED] = enabled
+        }
+    }
+
+    suspend fun setScheduledFolderBackupTreeUri(treeUri: String) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.SCHEDULED_FOLDER_BACKUP_TREE_URI] = treeUri
+        }
+    }
+
+    suspend fun setScheduledFolderBackupLastTimestamp(timestamp: Long) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.SCHEDULED_FOLDER_BACKUP_LAST_TIMESTAMP] = timestamp
+        }
+    }
+
+    suspend fun clearScheduledFolderBackupState() {
+        context.dataStore.edit { preferences ->
+            preferences.remove(PreferencesKeys.SCHEDULED_FOLDER_BACKUP_ENABLED)
+            preferences.remove(PreferencesKeys.SCHEDULED_FOLDER_BACKUP_TREE_URI)
+            preferences.remove(PreferencesKeys.SCHEDULED_FOLDER_BACKUP_LAST_TIMESTAMP)
         }
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -110,6 +110,9 @@ fun SettingsScreen(
     val mainAccountKey by settingsViewModel.mainAccountKey.collectAsStateWithLifecycle()
     val useContactsForVpa by settingsViewModel.useContactsForVpa.collectAsStateWithLifecycle(initialValue = false)
     val isProEntitled by settingsViewModel.isProEntitled.collectAsStateWithLifecycle()
+    val scheduledFolderBackupEnabled by settingsViewModel.scheduledFolderBackupEnabled.collectAsStateWithLifecycle(initialValue = false)
+    val scheduledFolderBackupLastTimestamp by settingsViewModel.scheduledFolderBackupLastTimestamp.collectAsStateWithLifecycle(initialValue = null)
+    val requestFolderPicker by settingsViewModel.requestFolderPicker.collectAsStateWithLifecycle()
     var showUpgradeSheet by remember { mutableStateOf(false) }
     // Launches the runtime permission request. If granted, we flip the
     // preference on; if denied, leave the switch off so the user can try
@@ -153,6 +156,20 @@ fun SettingsScreen(
             }
         }
     )
+
+    val backupFolderLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocumentTree(),
+        onResult = { uri ->
+            uri?.let { settingsViewModel.onBackupFolderSelected(it) }
+        }
+    )
+
+    LaunchedEffect(requestFolderPicker) {
+        if (requestFolderPicker) {
+            backupFolderLauncher.launch(null)
+            settingsViewModel.onFolderPickerLaunched()
+        }
+    }
 
     // Scroll behaviors for collapsible TopAppBar
     val scrollBehaviorSmall = TopAppBarDefaults.pinnedScrollBehavior()
@@ -465,6 +482,45 @@ fun SettingsScreen(
                     onClick = { settingsViewModel.exportBackup() },
                     position = ItemPosition.MIDDLE
                 )
+                SettingsSwitchRow(
+                    icon = Icons.Default.Backup,
+                    iconBgColor = purple_light,
+                    iconTint = purple_dark,
+                    title = "Automatic Folder Backup",
+                    subtitle = if (scheduledFolderBackupEnabled) {
+                        "Daily backup at 2:00 AM to your chosen folder"
+                    } else {
+                        "Save a backup to a folder every day at 2:00 AM"
+                    },
+                    checked = scheduledFolderBackupEnabled,
+                    onCheckedChange = { settingsViewModel.setScheduledFolderBackupEnabled(it) },
+                    position = ItemPosition.MIDDLE
+                )
+                if (scheduledFolderBackupEnabled) {
+                    SettingsNavItem(
+                        icon = Icons.Default.SaveAlt,
+                        iconBgColor = green_light,
+                        iconTint = green_dark,
+                        title = "Back Up Now",
+                        subtitle = scheduledFolderBackupLastTimestamp?.let { timestamp ->
+                            val formatted = java.time.Instant.ofEpochMilli(timestamp)
+                                .atZone(java.time.ZoneId.systemDefault())
+                                .format(java.time.format.DateTimeFormatter.ofPattern("MMM d, yyyy h:mm a"))
+                            "Last backup: $formatted"
+                        } ?: "Run a backup to your folder now",
+                        onClick = { settingsViewModel.backupToFolderNow() },
+                        position = ItemPosition.MIDDLE
+                    )
+                    SettingsNavItem(
+                        icon = Icons.Default.FolderOpen,
+                        iconBgColor = amber_light,
+                        iconTint = amber_dark,
+                        title = "Change Backup Folder",
+                        subtitle = "Pick a different folder for automatic backups",
+                        onClick = { settingsViewModel.requestChangeBackupFolder() },
+                        position = ItemPosition.MIDDLE
+                    )
+                }
                 SettingsNavItem(
                     icon = Icons.Default.Download,
                     iconBgColor = cyan_light,

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -23,9 +23,12 @@ import com.pennywiseai.tracker.data.repository.UnrecognizedSmsRepository
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.backup.BackupExporter
 import com.pennywiseai.tracker.data.backup.BackupImporter
+import com.pennywiseai.tracker.data.backup.ExportBytesResult
 import com.pennywiseai.tracker.data.backup.ExportResult
 import com.pennywiseai.tracker.data.backup.ImportResult
 import com.pennywiseai.tracker.data.backup.ImportStrategy
+import com.pennywiseai.tracker.backup.folder.FolderBackupWriter
+import com.pennywiseai.tracker.backup.folder.ScheduledFolderBackupScheduler
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
@@ -38,7 +41,6 @@ import com.pennywiseai.tracker.core.Constants
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.first
 import java.net.URLEncoder
 import java.io.File
@@ -54,6 +56,8 @@ class SettingsViewModel @Inject constructor(
     private val accountBalanceRepository: AccountBalanceRepository,
     private val backupExporter: BackupExporter,
     private val backupImporter: BackupImporter,
+    private val folderBackupWriter: FolderBackupWriter,
+    private val scheduledFolderBackupScheduler: ScheduledFolderBackupScheduler,
     private val contactsResolver: com.pennywiseai.tracker.data.contacts.ContactsResolver,
     entitlementGate: EntitlementGate,
 ) : ViewModel() {
@@ -82,7 +86,15 @@ class SettingsViewModel @Inject constructor(
     
     private val _exportedBackupFile = MutableStateFlow<File?>(null)
     val exportedBackupFile: StateFlow<File?> = _exportedBackupFile.asStateFlow()
-    
+
+    val scheduledFolderBackupEnabled = userPreferencesRepository.scheduledFolderBackupEnabled
+    val scheduledFolderBackupLastTimestamp = userPreferencesRepository.scheduledFolderBackupLastTimestamp
+
+    private val _requestFolderPicker = MutableStateFlow(false)
+    val requestFolderPicker: StateFlow<Boolean> = _requestFolderPicker.asStateFlow()
+
+    private var currentFolderPickerAction: FolderPickerAction = FolderPickerAction.ENABLE
+
     private var currentDownloadId: Long? = null
     
     // Developer mode state
@@ -616,6 +628,114 @@ class SettingsViewModel @Inject constructor(
     fun clearImportExportMessage() {
         _importExportMessage.value = null
     }
+
+    fun setScheduledFolderBackupEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            if (enabled) {
+                val treeUri = userPreferencesRepository.getScheduledFolderBackupTreeUri()
+                if (treeUri.isNullOrBlank()) {
+                    currentFolderPickerAction = FolderPickerAction.ENABLE
+                    _requestFolderPicker.value = true
+                    return@launch
+                }
+                enableScheduledFolderBackup(treeUri)
+            } else {
+                userPreferencesRepository.setScheduledFolderBackupEnabled(false)
+                scheduledFolderBackupScheduler.cancel()
+                _importExportMessage.value = "Automatic folder backup disabled"
+            }
+        }
+    }
+
+    fun requestChangeBackupFolder() {
+        currentFolderPickerAction = FolderPickerAction.CHANGE
+        _requestFolderPicker.value = true
+    }
+
+    fun onFolderPickerLaunched() {
+        _requestFolderPicker.value = false
+    }
+
+    fun onBackupFolderSelected(uri: Uri) {
+        viewModelScope.launch {
+            try {
+                val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                    Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                context.contentResolver.takePersistableUriPermission(uri, flags)
+
+                val treeUri = uri.toString()
+                userPreferencesRepository.setScheduledFolderBackupTreeUri(treeUri)
+
+                when (currentFolderPickerAction) {
+                    FolderPickerAction.ENABLE -> enableScheduledFolderBackup(treeUri)
+                    FolderPickerAction.CHANGE -> {
+                        if (userPreferencesRepository.isScheduledFolderBackupEnabled()) {
+                            scheduledFolderBackupScheduler.schedule()
+                        }
+                        backupToFolderNow(showSuccessMessage = true)
+                    }
+                }
+            } catch (e: Exception) {
+                _importExportMessage.value = "Could not access the selected folder: ${e.message}"
+                Log.e("SettingsViewModel", "Failed to persist backup folder", e)
+            }
+        }
+    }
+
+    fun backupToFolderNow(showSuccessMessage: Boolean = true) {
+        viewModelScope.launch {
+            performFolderBackup(showSuccessMessage)
+        }
+    }
+
+    private suspend fun performFolderBackup(showSuccessMessage: Boolean): Boolean {
+        val treeUri = userPreferencesRepository.getScheduledFolderBackupTreeUri()
+        if (treeUri.isNullOrBlank()) {
+            _importExportMessage.value = "Select a backup folder first"
+            return false
+        }
+
+        if (!folderBackupWriter.canWriteToFolder(treeUri)) {
+            _importExportMessage.value = "Cannot write to the selected backup folder"
+            return false
+        }
+
+        return when (val exportResult = backupExporter.exportBackupBytes()) {
+            is ExportBytesResult.Success -> {
+                when (val writeResult = folderBackupWriter.writeBackup(treeUri, exportResult.bytes)) {
+                    is FolderBackupWriter.Result.Success -> {
+                        userPreferencesRepository.setScheduledFolderBackupLastTimestamp(
+                            System.currentTimeMillis()
+                        )
+                        if (showSuccessMessage) {
+                            _importExportMessage.value = "Backup saved to folder"
+                        }
+                        true
+                    }
+                    is FolderBackupWriter.Result.Failure -> {
+                        _importExportMessage.value = writeResult.message
+                        false
+                    }
+                }
+            }
+            is ExportBytesResult.Error -> {
+                _importExportMessage.value = exportResult.message
+                false
+            }
+        }
+    }
+
+    private suspend fun enableScheduledFolderBackup(treeUri: String) {
+        if (!folderBackupWriter.canWriteToFolder(treeUri)) {
+            _importExportMessage.value = "Cannot write to the selected backup folder"
+            return
+        }
+
+        userPreferencesRepository.setScheduledFolderBackupEnabled(true)
+        scheduledFolderBackupScheduler.schedule()
+        performFolderBackup(showSuccessMessage = false)
+        _importExportMessage.value = "Automatic folder backup enabled. Backups run daily at 2:00 AM."
+    }
     
     fun updateBaseCurrency(currency: String) {
         viewModelScope.launch {
@@ -649,4 +769,9 @@ enum class DownloadState {
     COMPLETED,
     FAILED,
     ERROR_INSUFFICIENT_SPACE
+}
+
+private enum class FolderPickerAction {
+    ENABLE,
+    CHANGE
 }

--- a/app/src/main/java/com/pennywiseai/tracker/worker/ScheduledFolderBackupWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/worker/ScheduledFolderBackupWorker.kt
@@ -1,0 +1,66 @@
+package com.pennywiseai.tracker.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.pennywiseai.tracker.backup.folder.FolderBackupWriter
+import com.pennywiseai.tracker.data.backup.BackupExporter
+import com.pennywiseai.tracker.data.backup.ExportBytesResult
+import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class ScheduledFolderBackupWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val backupExporter: BackupExporter,
+    private val folderBackupWriter: FolderBackupWriter,
+    private val userPreferencesRepository: UserPreferencesRepository
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        if (!userPreferencesRepository.isScheduledFolderBackupEnabled()) {
+            return Result.success()
+        }
+
+        val treeUri = userPreferencesRepository.getScheduledFolderBackupTreeUri()
+        if (treeUri.isNullOrBlank()) {
+            Log.w(TAG, "Scheduled folder backup enabled but no folder selected")
+            return Result.failure()
+        }
+
+        if (!folderBackupWriter.canWriteToFolder(treeUri)) {
+            Log.w(TAG, "Cannot write to scheduled backup folder")
+            return Result.retry()
+        }
+
+        return when (val exportResult = backupExporter.exportBackupBytes()) {
+            is ExportBytesResult.Success -> {
+                when (val writeResult = folderBackupWriter.writeBackup(treeUri, exportResult.bytes)) {
+                    is FolderBackupWriter.Result.Success -> {
+                        userPreferencesRepository.setScheduledFolderBackupLastTimestamp(
+                            System.currentTimeMillis()
+                        )
+                        Log.i(TAG, "Scheduled folder backup completed")
+                        Result.success()
+                    }
+                    is FolderBackupWriter.Result.Failure -> {
+                        Log.e(TAG, "Scheduled folder backup write failed: ${writeResult.message}")
+                        Result.retry()
+                    }
+                }
+            }
+            is ExportBytesResult.Error -> {
+                Log.e(TAG, "Scheduled folder backup export failed: ${exportResult.message}")
+                Result.retry()
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "ScheduledFolderBackup"
+    }
+}

--- a/app/src/test/java/com/pennywiseai/tracker/backup/folder/ScheduledFolderBackupSchedulerTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/backup/folder/ScheduledFolderBackupSchedulerTest.kt
@@ -1,0 +1,51 @@
+package com.pennywiseai.tracker.backup.folder
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.concurrent.TimeUnit
+
+class ScheduledFolderBackupSchedulerTest {
+
+    @Test
+    fun computeInitialDelayMs_beforeTwoAm_targetsSameDay() {
+        val now = LocalDateTime.of(2026, 6, 21, 1, 30)
+        val delayMs = ScheduledFolderBackupScheduler.computeInitialDelayMs(
+            now = now,
+            zoneId = ZoneId.of("UTC")
+        )
+        assertEquals(TimeUnit.MINUTES.toMillis(30), delayMs)
+    }
+
+    @Test
+    fun computeInitialDelayMs_afterTwoAm_targetsNextDay() {
+        val now = LocalDateTime.of(2026, 6, 21, 3, 0)
+        val delayMs = ScheduledFolderBackupScheduler.computeInitialDelayMs(
+            now = now,
+            zoneId = ZoneId.of("UTC")
+        )
+        assertEquals(TimeUnit.HOURS.toMillis(23), delayMs)
+    }
+
+    @Test
+    fun computeInitialDelayMs_atTwoAm_targetsNextDay() {
+        val now = LocalDateTime.of(2026, 6, 21, 2, 0)
+        val delayMs = ScheduledFolderBackupScheduler.computeInitialDelayMs(
+            now = now,
+            zoneId = ZoneId.of("UTC")
+        )
+        assertEquals(TimeUnit.HOURS.toMillis(24), delayMs)
+    }
+
+    @Test
+    fun computeInitialDelayMs_isAlwaysPositive() {
+        val now = LocalDateTime.of(2026, 6, 21, 12, 45)
+        val delayMs = ScheduledFolderBackupScheduler.computeInitialDelayMs(
+            now = now,
+            zoneId = ZoneId.of("UTC")
+        )
+        assertTrue(delayMs > 0)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ biometric = "1.1.0"
 colorpickerCompose = "1.1.4"
 coreSplashscreen = "1.2.0"
 datastorePreferences = "1.2.1"
+documentfile = "1.1.0"
 glance = "1.1.1"
 gson = "2.14.0"
 hiltAndroid = "2.59.2"
@@ -49,6 +50,7 @@ androidx-compose-material-icons-extended = { module = "androidx.compose.material
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashscreen" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
+androidx-documentfile = { module = "androidx.documentfile:documentfile", version.ref = "documentfile" }
 androidx-glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glance" }
 androidx-glance-material3 = { module = "androidx.glance:glance-material3", version.ref = "glance" }
 androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hiltCompiler" }


### PR DESCRIPTION
## Summary

Adds scheduled automatic backups to a user-selected folder at 2:00 AM device time every day. Uses WorkManager for scheduling, SAF for folder access, and lives entirely in shared `main` source so both standard and F-Droid builds get the same feature.

Settings gains an **Automatic Folder Backup** toggle with folder picker, **Back Up Now**, and **Change Backup Folder** actions. Backups overwrite a single file (`PennyWise_Backup.pennywisebackup`) in the chosen folder.

## Type of change

- [x] feat: New feature

## How to test

1. Build and install either flavor: `./gradlew :app:installStandardDebug` or `./gradlew :app:installFdroidDebug`
2. Open **Settings** → enable **Automatic Folder Backup** and pick a writable folder via the system folder picker
3. Confirm an immediate backup is written as `PennyWise_Backup.pennywisebackup` in that folder
4. Tap **Back Up Now** and verify the last-backup timestamp updates
5. Tap **Change Backup Folder**, select a different folder, and confirm the backup moves there
6. Disable the toggle and confirm scheduled work is cancelled (no further automatic writes)
7. Run unit tests: `./gradlew :app:testStandardDebugUnitTest --tests "com.pennywiseai.tracker.backup.folder.ScheduledFolderBackupSchedulerTest"`

## Breaking changes

- [x] No breaking changes

## Checklist

- [x] Focused PR (single purpose)
- [x] Tests added/updated
- [x] `./gradlew test` passes locally
- [x] Follows existing code style and patterns

Made with [Cursor](https://cursor.com)