### PR TITLE
Fix analytics Top Categories chart custom category colors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,12 +88,13 @@ Bank parsers are now in the `parser-core` module for reusability across platform
 - Use `com.pennywiseai.tracker.data.mapper.toEntity()` to convert ParsedTransaction to TransactionEntity
 - The mapper handles type conversions between modules
 
-## Supported Banks (55 parsers)
+## Supported Banks (56 parsers)
 - Airtel Payments Bank
 - **Al Rajhi Bank (Saudi Arabia)** - Arabic SMS support
 - **Alinma Bank (Saudi Arabia)** - Arabic SMS support
 - **Altana Federal Credit Union (USA)**
 - American Express (AMEX)
+- **Arab Bank (Jordan)** - JOD/USD, card and account transfers
 - Axis Bank
 - Bank of Baroda
 - Bank of India

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Conditions can be combined with **AND** / **OR** logic, and multiple conditions 
 
 ## Supported Banks & Countries
 
-Supporting **90+ banks** across **16 countries** with **multi-currency** capabilities:
+Supporting **90+ banks** across **17 countries** with **multi-currency** capabilities:
 
 ### 🇮🇳 India (44 banks) - INR ₹
 - **HDFC Bank**, **HDFC Mutual Fund**, **State Bank of India (SBI)**, **ICICI Bank**
@@ -166,6 +166,9 @@ Supporting **90+ banks** across **16 countries** with **multi-currency** capabil
 
 ### 🇸🇦 Saudi Arabia (2 banks) - SAR ﷼
 - **Al Rajhi Bank (مصرف الراجحي)**, **Alinma Bank (بنك الإنماء)** - Arabic SMS support
+
+### 🇯🇴 Jordan (1 bank) - JOD د.ا
+- **Arab Bank** - JOD/USD with card and account transfer support
 
 ### 🇷🇺 Russia (1 bank) - RUB ₽
 - **T-Bank (Tinkoff)** - Russian SMS support

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -235,6 +235,7 @@ dependencies {
     
     // DataStore
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.documentfile)
 
     // Biometric Authentication
     implementation(libs.androidx.biometric)

--- a/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/53.json
+++ b/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/53.json
@@ -1,0 +1,1869 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 53,
+    "identityHash": "1659479ea2de624f9fe4097b4671998b",
+    "entities": [
+      {
+        "tableName": "transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` TEXT NOT NULL, `merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `transaction_type` TEXT NOT NULL, `date_time` TEXT NOT NULL, `description` TEXT, `sms_body` TEXT, `bank_name` TEXT, `sms_sender` TEXT, `account_number` TEXT, `balance_after` TEXT, `transaction_hash` TEXT NOT NULL DEFAULT '', `is_recurring` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `excluded_from_analytics` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `from_account` TEXT, `to_account` TEXT, `reference` TEXT, `loan_id` INTEGER DEFAULT NULL, `loan_contribution` TEXT DEFAULT NULL, `receipt_path` TEXT DEFAULT NULL, `budget_category` TEXT DEFAULT NULL, `budget_impact_type` TEXT DEFAULT NULL, `group_id` INTEGER DEFAULT NULL, `profile_id` INTEGER DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionType",
+            "columnName": "transaction_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateTime",
+            "columnName": "date_time",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsSender",
+            "columnName": "sms_sender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountNumber",
+            "columnName": "account_number",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "balanceAfter",
+            "columnName": "balance_after",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "transactionHash",
+            "columnName": "transaction_hash",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isRecurring",
+            "columnName": "is_recurring",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "excludedFromAnalytics",
+            "columnName": "excluded_from_analytics",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "fromAccount",
+            "columnName": "from_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toAccount",
+            "columnName": "to_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "loanId",
+            "columnName": "loan_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "loanContribution",
+            "columnName": "loan_contribution",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "receiptPath",
+            "columnName": "receipt_path",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetCategory",
+            "columnName": "budget_category",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetImpactType",
+            "columnName": "budget_impact_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "group_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transactions_transaction_hash",
+            "unique": true,
+            "columnNames": [
+              "transaction_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_transactions_transaction_hash` ON `${TABLE_NAME}` (`transaction_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `merchant_name` TEXT NOT NULL, `amount` TEXT NOT NULL, `next_payment_date` TEXT, `state` TEXT NOT NULL, `bank_name` TEXT, `umn` TEXT, `category` TEXT, `sms_body` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `direction` TEXT NOT NULL DEFAULT 'EXPENSE', `billing_cycle` TEXT NOT NULL DEFAULT 'Monthly', `last_paid_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextPaymentDate",
+            "columnName": "next_payment_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umn",
+            "columnName": "umn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'EXPENSE'"
+          },
+          {
+            "fieldPath": "billingCycle",
+            "columnName": "billing_cycle",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Monthly'"
+          },
+          {
+            "fieldPath": "lastPaidAt",
+            "columnName": "last_paid_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `message` TEXT NOT NULL, `isUser` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `isSystemPrompt` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUser",
+            "columnName": "isUser",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemPrompt",
+            "columnName": "isSystemPrompt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "merchant_mappings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`merchant_name`))",
+        "fields": [
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "merchant_name"
+          ]
+        }
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `color` TEXT NOT NULL, `is_system` INTEGER NOT NULL, `is_income` INTEGER NOT NULL, `display_order` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIncome",
+            "columnName": "is_income",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_categories_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_categories_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "account_balances",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT NOT NULL, `balance` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `transaction_id` INTEGER, `credit_limit` TEXT, `is_credit_card` INTEGER NOT NULL DEFAULT 0, `sms_source` TEXT, `source_type` TEXT, `account_type` TEXT, `created_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `statement_day` INTEGER DEFAULT NULL, `profile_id` INTEGER NOT NULL DEFAULT 1, `alias` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "creditLimit",
+            "columnName": "credit_limit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isCreditCard",
+            "columnName": "is_credit_card",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "smsSource",
+            "columnName": "sms_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "source_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountType",
+            "columnName": "account_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "statementDay",
+            "columnName": "statement_day",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_account_balances_bank_name_account_last4_timestamp",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "account_last4",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4_timestamp` ON `${TABLE_NAME}` (`bank_name`, `account_last4`, `timestamp`)"
+          },
+          {
+            "name": "index_account_balances_bank_name_account_last4",
+            "unique": false,
+            "columnNames": [
+              "bank_name",
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4` ON `${TABLE_NAME}` (`bank_name`, `account_last4`)"
+          },
+          {
+            "name": "index_account_balances_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "unrecognized_sms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sender` TEXT NOT NULL, `sms_body` TEXT NOT NULL, `received_at` TEXT NOT NULL, `reported` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receivedAt",
+            "columnName": "received_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reported",
+            "columnName": "reported",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_unrecognized_sms_sender_sms_body",
+            "unique": true,
+            "columnNames": [
+              "sender",
+              "sms_body"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_unrecognized_sms_sender_sms_body` ON `${TABLE_NAME}` (`sender`, `sms_body`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `card_last4` TEXT NOT NULL, `card_type` TEXT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT, `nickname` TEXT, `is_active` INTEGER NOT NULL DEFAULT 1, `last_balance` TEXT, `last_balance_source` TEXT, `last_balance_date` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardLast4",
+            "columnName": "card_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardType",
+            "columnName": "card_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastBalance",
+            "columnName": "last_balance",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceSource",
+            "columnName": "last_balance_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceDate",
+            "columnName": "last_balance_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cards_bank_name_card_last4",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cards_bank_name_card_last4` ON `${TABLE_NAME}` (`bank_name`, `card_last4`)"
+          },
+          {
+            "name": "index_cards_card_last4",
+            "unique": false,
+            "columnNames": [
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_card_last4` ON `${TABLE_NAME}` (`card_last4`)"
+          },
+          {
+            "name": "index_cards_account_last4",
+            "unique": false,
+            "columnNames": [
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_account_last4` ON `${TABLE_NAME}` (`account_last4`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `conditions` TEXT NOT NULL, `actions` TEXT NOT NULL, `is_active` INTEGER NOT NULL, `is_system_template` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conditions",
+            "columnName": "conditions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actions",
+            "columnName": "actions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemTemplate",
+            "columnName": "is_system_template",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_rules_priority_is_active",
+            "unique": false,
+            "columnNames": [
+              "priority",
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_priority_is_active` ON `${TABLE_NAME}` (`priority`, `is_active`)"
+          },
+          {
+            "name": "index_transaction_rules_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "rule_applications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `rule_id` TEXT NOT NULL, `rule_name` TEXT NOT NULL, `transaction_id` TEXT NOT NULL, `fields_modified` TEXT NOT NULL, `applied_at` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`rule_id`) REFERENCES `transaction_rules`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "rule_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleName",
+            "columnName": "rule_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fieldsModified",
+            "columnName": "fields_modified",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedAt",
+            "columnName": "applied_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rule_applications_rule_id",
+            "unique": false,
+            "columnNames": [
+              "rule_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_rule_id` ON `${TABLE_NAME}` (`rule_id`)"
+          },
+          {
+            "name": "index_rule_applications_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          },
+          {
+            "name": "index_rule_applications_applied_at",
+            "unique": false,
+            "columnNames": [
+              "applied_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_applied_at` ON `${TABLE_NAME}` (`applied_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transaction_rules",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "rule_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "exchange_rates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `from_currency` TEXT NOT NULL, `to_currency` TEXT NOT NULL, `rate` TEXT NOT NULL, `provider` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `updated_at_unix` INTEGER NOT NULL DEFAULT 0, `expires_at` TEXT NOT NULL, `expires_at_unix` INTEGER NOT NULL DEFAULT 0, `is_custom_rate` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCurrency",
+            "columnName": "from_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCurrency",
+            "columnName": "to_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtUnix",
+            "columnName": "updated_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expires_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAtUnix",
+            "columnName": "expires_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isCustomRate",
+            "columnName": "is_custom_rate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_exchange_rates_from_currency_to_currency",
+            "unique": true,
+            "columnNames": [
+              "from_currency",
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_exchange_rates_from_currency_to_currency` ON `${TABLE_NAME}` (`from_currency`, `to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_from_currency",
+            "unique": false,
+            "columnNames": [
+              "from_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_from_currency` ON `${TABLE_NAME}` (`from_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_to_currency",
+            "unique": false,
+            "columnNames": [
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_to_currency` ON `${TABLE_NAME}` (`to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          },
+          {
+            "name": "index_exchange_rates_expires_at_unix",
+            "unique": false,
+            "columnNames": [
+              "expires_at_unix"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_expires_at_unix` ON `${TABLE_NAME}` (`expires_at_unix`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `period_type` TEXT NOT NULL, `start_date` TEXT NOT NULL, `end_date` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `is_active` INTEGER NOT NULL DEFAULT 1, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "periodType",
+            "columnName": "period_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budgets_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_budgets_is_active",
+            "unique": false,
+            "columnNames": [
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_is_active` ON `${TABLE_NAME}` (`is_active`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budget_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL DEFAULT '0', `match_type` TEXT DEFAULT NULL, FOREIGN KEY(`budget_id`) REFERENCES `budgets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          },
+          {
+            "fieldPath": "matchType",
+            "columnName": "match_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budget_categories_budget_id",
+            "unique": false,
+            "columnNames": [
+              "budget_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budget_categories_budget_id` ON `${TABLE_NAME}` (`budget_id`)"
+          },
+          {
+            "name": "index_budget_categories_budget_id_category_name",
+            "unique": true,
+            "columnNames": [
+              "budget_id",
+              "category_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_budget_categories_budget_id_category_name` ON `${TABLE_NAME}` (`budget_id`, `category_name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "budgets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "budget_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "budget_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `budget_name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetName",
+            "columnName": "budget_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "budget_category_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL, `match_type` TEXT DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchType",
+            "columnName": "match_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "transaction_splits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `transaction_id` INTEGER NOT NULL, `category` TEXT NOT NULL, `amount` TEXT NOT NULL, `created_at` TEXT NOT NULL, FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_splits_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_splits_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bank_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `package_name` TEXT NOT NULL, `sender_alias` TEXT NOT NULL, `message_body` TEXT NOT NULL, `message_hash` TEXT NOT NULL, `posted_at` TEXT NOT NULL, `processed` INTEGER NOT NULL, `transaction_id` INTEGER, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderAlias",
+            "columnName": "sender_alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageBody",
+            "columnName": "message_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageHash",
+            "columnName": "message_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postedAt",
+            "columnName": "posted_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "processed",
+            "columnName": "processed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bank_notifications_package_name_message_hash",
+            "unique": true,
+            "columnNames": [
+              "package_name",
+              "message_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_bank_notifications_package_name_message_hash` ON `${TABLE_NAME}` (`package_name`, `message_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "loans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `person_name` TEXT NOT NULL, `direction` TEXT NOT NULL, `original_amount` TEXT NOT NULL, `remaining_amount` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `status` TEXT NOT NULL DEFAULT 'ACTIVE', `note` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `settled_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personName",
+            "columnName": "person_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalAmount",
+            "columnName": "original_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remainingAmount",
+            "columnName": "remaining_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'ACTIVE'"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settledAt",
+            "columnName": "settled_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_loans_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_loans_person_name",
+            "unique": false,
+            "columnNames": [
+              "person_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_person_name` ON `${TABLE_NAME}` (`person_name`)"
+          },
+          {
+            "name": "index_loans_created_at",
+            "unique": false,
+            "columnNames": [
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_created_at` ON `${TABLE_NAME}` (`created_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `note` TEXT DEFAULT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_groups_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_groups_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `color_hex` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorHex",
+            "columnName": "color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tags_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tags_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_tag_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transaction_id` INTEGER NOT NULL, `tag_id` INTEGER NOT NULL, PRIMARY KEY(`transaction_id`, `tag_id`), FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tag_id`) REFERENCES `tags`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tag_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transaction_id",
+            "tag_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_tag_cross_ref_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_tag_cross_ref_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          },
+          {
+            "name": "index_transaction_tag_cross_ref_tag_id",
+            "unique": false,
+            "columnNames": [
+              "tag_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_tag_cross_ref_tag_id` ON `${TABLE_NAME}` (`tag_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "tags",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tag_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1659479ea2de624f9fe4097b4671998b')"
+    ]
+  }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/PennyWiseApplication.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/PennyWiseApplication.kt
@@ -25,6 +25,12 @@ class PennyWiseApplication : Application(), Configuration.Provider {
     @Inject
     lateinit var purchaseGateway: com.pennywiseai.tracker.billing.PurchaseGateway
 
+    @Inject
+    lateinit var userPreferencesRepository: com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
+
+    @Inject
+    lateinit var scheduledFolderBackupScheduler: com.pennywiseai.tracker.backup.folder.ScheduledFolderBackupScheduler
+
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var activityReferences = 0
     private var isInForeground = false
@@ -55,6 +61,12 @@ class PennyWiseApplication : Application(), Configuration.Provider {
                 purchaseGateway.refresh()
             } catch (e: Exception) {
                 android.util.Log.w("PennyWiseApp", "Initial billing refresh failed: ${e.message}", e)
+            }
+        }
+
+        applicationScope.launch {
+            if (userPreferencesRepository.isScheduledFolderBackupEnabled()) {
+                scheduledFolderBackupScheduler.schedule()
             }
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/backup/folder/FolderBackupWriter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/backup/folder/FolderBackupWriter.kt
@@ -1,0 +1,52 @@
+package com.pennywiseai.tracker.backup.folder
+
+import android.content.Context
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FolderBackupWriter @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    fun canWriteToFolder(treeUri: String): Boolean {
+        val folder = DocumentFile.fromTreeUri(context, Uri.parse(treeUri)) ?: return false
+        if (!folder.isDirectory || !folder.canWrite()) return false
+
+        val existing = folder.findFile(ScheduledFolderBackupConstants.BACKUP_FILE_NAME)
+        return existing == null || existing.canWrite()
+    }
+
+    fun writeBackup(treeUri: String, bytes: ByteArray): Result {
+        val folder = DocumentFile.fromTreeUri(context, Uri.parse(treeUri))
+            ?: return Result.Failure("Backup folder is no longer accessible")
+
+        if (!folder.isDirectory || !folder.canWrite()) {
+            return Result.Failure("Cannot write to the selected backup folder")
+        }
+
+        val backupFile = folder.findFile(ScheduledFolderBackupConstants.BACKUP_FILE_NAME)
+            ?: folder.createFile("application/octet-stream", ScheduledFolderBackupConstants.BACKUP_FILE_NAME)
+            ?: return Result.Failure("Could not create backup file in the selected folder")
+
+        if (!backupFile.canWrite()) {
+            return Result.Failure("Cannot write to the backup file")
+        }
+
+        return try {
+            context.contentResolver.openOutputStream(backupFile.uri, "wt")?.use { stream ->
+                stream.write(bytes)
+            } ?: return Result.Failure("Could not open backup file for writing")
+            Result.Success
+        } catch (e: Exception) {
+            Result.Failure("Failed to write backup: ${e.message ?: "unknown error"}")
+        }
+    }
+
+    sealed class Result {
+        data object Success : Result()
+        data class Failure(val message: String) : Result()
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/backup/folder/ScheduledFolderBackupConstants.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/backup/folder/ScheduledFolderBackupConstants.kt
@@ -1,0 +1,6 @@
+package com.pennywiseai.tracker.backup.folder
+
+object ScheduledFolderBackupConstants {
+    const val BACKUP_FILE_NAME = "PennyWise_Backup.pennywisebackup"
+    const val BACKUP_HOUR_OF_DAY = 2
+}

--- a/app/src/main/java/com/pennywiseai/tracker/backup/folder/ScheduledFolderBackupScheduler.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/backup/folder/ScheduledFolderBackupScheduler.kt
@@ -1,0 +1,68 @@
+package com.pennywiseai.tracker.backup.folder
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import com.pennywiseai.tracker.worker.ScheduledFolderBackupWorker
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ScheduledFolderBackupScheduler @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    fun schedule() {
+        val request = PeriodicWorkRequestBuilder<ScheduledFolderBackupWorker>(
+            24, TimeUnit.HOURS
+        )
+            .setInitialDelay(computeInitialDelayMs(), TimeUnit.MILLISECONDS)
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiresBatteryNotLow(true)
+                    .build()
+            )
+            .build()
+
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            WORK_NAME,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request
+        )
+    }
+
+    fun cancel() {
+        WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+    }
+
+    companion object {
+        const val WORK_NAME = "scheduled_folder_backup"
+
+        /**
+         * Milliseconds until the next [ScheduledFolderBackupConstants.BACKUP_HOUR_OF_DAY]:00
+         * in the device's default timezone.
+         */
+        fun computeInitialDelayMs(
+            now: LocalDateTime = LocalDateTime.now(),
+            zoneId: ZoneId = ZoneId.systemDefault()
+        ): Long {
+            val targetTime = LocalTime.of(
+                ScheduledFolderBackupConstants.BACKUP_HOUR_OF_DAY,
+                0
+            )
+            var nextRun = now.toLocalDate().atTime(targetTime)
+            if (!nextRun.isAfter(now)) {
+                nextRun = nextRun.plusDays(1)
+            }
+            return Duration.between(now.atZone(zoneId).toInstant(), nextRun.atZone(zoneId).toInstant())
+                .toMillis()
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/core/Constants.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/core/Constants.kt
@@ -15,6 +15,10 @@ object Constants {
         const val QUERY_LIMIT = 100
         const val INITIAL_SCAN_MONTHS = 3
         const val SCANNING_DELAY_MS = 3000L
+        /** Stored in [last_scan_period] when SMS scan period is set to all time. */
+        const val SCAN_PERIOD_ALL_TIME = -1
+        /** Stored in [last_scan_period] when SMS scan period is a custom start date. */
+        const val SCAN_PERIOD_CUSTOM_DATE = -2
     }
     
     /**

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
@@ -72,6 +72,8 @@ class BackupExporter @Inject constructor(
         val profiles = database.profileDao().getAllProfiles()
         val budgetMonthSnapshots = database.budgetSnapshotDao().getAllGroupSnapshots()
         val budgetCategoryMonthSnapshots = database.budgetSnapshotDao().getAllCategorySnapshots()
+        val tags = database.tagDao().getAllTagsSync()
+        val transactionTagCrossRefs = database.tagDao().getAllCrossRefs()
         
         // Get preferences from repository
         val prefs = userPreferencesRepository.userPreferences.first()
@@ -124,6 +126,11 @@ class BackupExporter @Inject constructor(
         val exportedProfiles = if (privacy == ExportPrivacy.FULL) profiles else emptyList()
         val exportedBudgetMonthSnapshots = if (privacy == ExportPrivacy.FULL) budgetMonthSnapshots else emptyList()
         val exportedBudgetCategoryMonthSnapshots = if (privacy == ExportPrivacy.FULL) budgetCategoryMonthSnapshots else emptyList()
+        // Tags carry no PII (user-defined labels) but in MASKED/ANONYMOUS the
+        // transaction references are stripped, so the cross-refs are only useful
+        // on a FULL export. Tag names themselves are kept across all modes.
+        val exportedTags = tags
+        val exportedTransactionTagCrossRefs = if (privacy == ExportPrivacy.FULL) transactionTagCrossRefs else emptyList()
         
         return PennyWiseBackup(
             metadata = BackupMetadata(
@@ -172,7 +179,9 @@ class BackupExporter @Inject constructor(
                 transactionGroups = exportedTransactionGroups,
                 profiles = exportedProfiles,
                 budgetMonthSnapshots = exportedBudgetMonthSnapshots,
-                budgetCategoryMonthSnapshots = exportedBudgetCategoryMonthSnapshots
+                budgetCategoryMonthSnapshots = exportedBudgetCategoryMonthSnapshots,
+                tags = exportedTags,
+                transactionTagCrossRefs = exportedTransactionTagCrossRefs
             ),
             preferences = PreferencesSnapshot(
                 theme = ThemePreferences(

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
@@ -81,6 +81,8 @@ class BackupExporter @Inject constructor(
         val lastReviewPromptTime = userPreferencesRepository.getLastReviewPromptTime().first()
         val lastScanTimestamp = userPreferencesRepository.getLastScanTimestamp().first()
         val lastScanPeriod = userPreferencesRepository.getLastScanPeriod().first()
+        val smsScanUseCustomDate = userPreferencesRepository.getSmsScanUseCustomDate()
+        val smsScanCustomDate = userPreferencesRepository.getSmsScanCustomDate()
         
         // Calculate statistics
         val dateRange = if (transactions.isNotEmpty()) {
@@ -183,7 +185,9 @@ class BackupExporter @Inject constructor(
                     hasSkippedSmsPermission = prefs.hasSkippedSmsPermission,
                     smsScanMonths = prefs.smsScanMonths,
                     lastScanTimestamp = lastScanTimestamp,
-                    lastScanPeriod = lastScanPeriod
+                    lastScanPeriod = lastScanPeriod,
+                    smsScanUseCustomDate = smsScanUseCustomDate,
+                    smsScanCustomDate = smsScanCustomDate
                 ),
                 developer = DeveloperPreferences(
                     isDeveloperModeEnabled = prefs.isDeveloperModeEnabled,

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
@@ -32,19 +32,27 @@ class BackupExporter @Inject constructor(
         privacy: ExportPrivacy = ExportPrivacy.FULL
     ): ExportResult {
         return try {
-            // Collect all data
-            val backup = createBackup(privacy)
-
-            // Create backup file
             val file = createBackupFile()
-
-            // Write JSON to file (see BackupSerializers for the format contract)
-            file.writeText(backupJson.encodeToString(backup))
-
+            file.writeText(encodeBackup(privacy))
             ExportResult.Success(file)
         } catch (e: Exception) {
             ExportResult.Error("Export failed: ${e.message}")
         }
+    }
+
+    suspend fun exportBackupBytes(
+        privacy: ExportPrivacy = ExportPrivacy.FULL
+    ): ExportBytesResult {
+        return try {
+            ExportBytesResult.Success(encodeBackup(privacy).toByteArray(Charsets.UTF_8))
+        } catch (e: Exception) {
+            ExportBytesResult.Error("Export failed: ${e.message}")
+        }
+    }
+
+    private suspend fun encodeBackup(privacy: ExportPrivacy): String {
+        val backup = createBackup(privacy)
+        return backupJson.encodeToString(backup)
     }
     
     /**

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
@@ -654,6 +654,10 @@ class BackupImporter @Inject constructor(
         // SMS preferences
         userPreferencesRepository.updateHasSkippedSmsPermission(preferences.sms.hasSkippedSmsPermission)
         userPreferencesRepository.updateSmsScanMonths(preferences.sms.smsScanMonths)
+        userPreferencesRepository.updateSmsScanUseCustomDate(preferences.sms.smsScanUseCustomDate)
+        preferences.sms.smsScanCustomDate?.let {
+            userPreferencesRepository.updateSmsScanCustomDate(it)
+        }
         preferences.sms.lastScanTimestamp?.let {
             userPreferencesRepository.updateLastScanTimestamp(it)
         }

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
@@ -129,6 +129,10 @@ class BackupImporter @Inject constructor(
                 database.transactionGroupDao().deleteAllGroups()
                 database.budgetSnapshotDao().deleteAllGroupSnapshots()
                 database.budgetSnapshotDao().deleteAllCategorySnapshots()
+                // Cross-refs are cascade-deleted when transactions are cleared,
+                // but tags live in their own table — clear both explicitly.
+                database.tagDao().deleteAllCrossRefs()
+                database.tagDao().deleteAllTags()
                 // Note: budget categories and transaction splits are deleted via cascade (budget categories via budget deletion, transaction splits via transaction deletion)
                 // Profiles deliberately preserved — defaults (Personal=1, Business=2)
                 // are seeded on first launch and we don't want to wipe them.
@@ -240,6 +244,16 @@ class BackupImporter @Inject constructor(
                 }
                 backup.database.bankNotifications.insertEachCounting({ skippedRows++ }) { notification ->
                     database.bankNotificationDao().insertOrReplace(notification)
+                }
+
+                // Tags + cross-refs: ids are preserved in REPLACE_ALL (so are
+                // transaction ids), so insert tags first then the links. Insert
+                // tags before cross-refs to satisfy the foreign keys.
+                backup.database.tags.insertEachCounting({ skippedRows++ }) { tag ->
+                    database.tagDao().insertTag(tag)
+                }
+                backup.database.transactionTagCrossRefs.insertEachCounting({ skippedRows++ }) { ref ->
+                    database.tagDao().insertCrossRef(ref)
                 }
 
                 // Profiles were already imported earlier (before transactions /
@@ -440,6 +454,34 @@ class BackupImporter @Inject constructor(
                 }
                 backup.database.bankNotifications.insertEachCounting({ skippedRows++ }) { notification ->
                     database.bankNotificationDao().insertOrReplace(notification)
+                }
+
+                // Tags: dedup by name (case-insensitive) like categories, then
+                // remap the cross-refs' tag_id and transaction_id to their new
+                // local ids. A ref is skipped if its transaction wasn't imported
+                // (missing from the id map). insertCrossRef IGNOREs duplicates,
+                // so a repeat MERGE is idempotent.
+                val existingTagIdByName = database.tagDao().getAllTagsSync()
+                    .associate { it.name.lowercase() to it.id }
+                    .toMutableMap()
+                val oldToNewTagIdMap = mutableMapOf<Long, Long>()
+                backup.database.tags.insertEachCounting({ skippedRows++ }) { tag ->
+                    val key = tag.name.trim().lowercase()
+                    if (key.isNotEmpty()) {
+                        val newId = existingTagIdByName[key]
+                            ?: database.tagDao().insertTag(tag.copy(id = 0))
+                                .also { id -> if (id > 0L) existingTagIdByName[key] = id }
+                        if (newId > 0L && tag.id != 0L) oldToNewTagIdMap[tag.id] = newId
+                    }
+                }
+                backup.database.transactionTagCrossRefs.insertEachCounting({ skippedRows++ }) { ref ->
+                    val mappedTransactionId = oldToNewTransactionIdMap[ref.transactionId]
+                    val mappedTagId = oldToNewTagIdMap[ref.tagId]
+                    if (mappedTransactionId != null && mappedTagId != null) {
+                        database.tagDao().insertCrossRef(
+                            ref.copy(transactionId = mappedTransactionId, tagId = mappedTagId)
+                        )
+                    }
                 }
 
                 // Profiles were already imported earlier (before transactions /

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
@@ -258,7 +258,13 @@ data class SmsPreferences(
     val lastScanTimestamp: Long? = null,
 
     @SerialName("last_scan_period")
-    val lastScanPeriod: Int? = null
+    val lastScanPeriod: Int? = null,
+
+    @SerialName("sms_scan_use_custom_date")
+    val smsScanUseCustomDate: Boolean = false,
+
+    @SerialName("sms_scan_custom_date")
+    val smsScanCustomDate: Long? = null
 )
 
 @Serializable

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
@@ -215,7 +215,13 @@ data class DatabaseSnapshot(
     val budgetMonthSnapshots: List<BudgetMonthSnapshotEntity> = emptyList(),
 
     @SerialName("budget_category_month_snapshots")
-    val budgetCategoryMonthSnapshots: List<BudgetCategoryMonthSnapshotEntity> = emptyList()
+    val budgetCategoryMonthSnapshots: List<BudgetCategoryMonthSnapshotEntity> = emptyList(),
+
+    @SerialName("tags")
+    val tags: List<TagEntity> = emptyList(),
+
+    @SerialName("transaction_tag_cross_refs")
+    val transactionTagCrossRefs: List<TransactionTagCrossRef> = emptyList()
 )
 
 /**

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
@@ -310,6 +310,14 @@ sealed class ExportResult {
 }
 
 /**
+ * In-memory export result for scheduled and manual folder backups.
+ */
+sealed class ExportBytesResult {
+    data class Success(val bytes: ByteArray) : ExportBytesResult()
+    data class Error(val message: String) : ExportBytesResult()
+}
+
+/**
  * Import strategy options.
  */
 enum class ImportStrategy {

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
@@ -12,6 +12,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import com.pennywiseai.tracker.data.database.converter.Converters
 import com.pennywiseai.tracker.data.database.dao.AccountBalanceDao
 import com.pennywiseai.tracker.data.database.dao.ProfileDao
+import com.pennywiseai.tracker.data.database.dao.TagDao
 import com.pennywiseai.tracker.data.database.dao.BankNotificationDao
 import com.pennywiseai.tracker.data.database.dao.BudgetDao
 import com.pennywiseai.tracker.data.database.dao.CardDao
@@ -31,6 +32,8 @@ import com.pennywiseai.tracker.data.database.dao.TransactionSplitDao
 import com.pennywiseai.tracker.data.database.dao.UnrecognizedSmsDao
 import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.data.database.entity.ProfileEntity
+import com.pennywiseai.tracker.data.database.entity.TagEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionTagCrossRef
 import com.pennywiseai.tracker.data.database.entity.BankNotificationEntity
 import com.pennywiseai.tracker.data.database.entity.BudgetCategoryEntity
 import com.pennywiseai.tracker.data.database.entity.BudgetCategoryMonthSnapshotEntity
@@ -57,7 +60,7 @@ import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
  * that needs to record the version it was exported against. Bump this in lock-
  * step with any schema change.
  */
-const val SCHEMA_VERSION = 52
+const val SCHEMA_VERSION = 53
 
 /**
  * The PennyWise Room database.
@@ -70,7 +73,7 @@ const val SCHEMA_VERSION = 52
  * @property autoMigrations List of automatic migrations between versions.
  */
 @Database(
-    entities = [TransactionEntity::class, SubscriptionEntity::class, ChatMessage::class, MerchantMappingEntity::class, CategoryEntity::class, AccountBalanceEntity::class, UnrecognizedSmsEntity::class, CardEntity::class, RuleEntity::class, RuleApplicationEntity::class, ExchangeRateEntity::class, BudgetEntity::class, BudgetCategoryEntity::class, BudgetMonthSnapshotEntity::class, BudgetCategoryMonthSnapshotEntity::class, TransactionSplitEntity::class, BankNotificationEntity::class, LoanEntity::class, TransactionGroupEntity::class, ProfileEntity::class],
+    entities = [TransactionEntity::class, SubscriptionEntity::class, ChatMessage::class, MerchantMappingEntity::class, CategoryEntity::class, AccountBalanceEntity::class, UnrecognizedSmsEntity::class, CardEntity::class, RuleEntity::class, RuleApplicationEntity::class, ExchangeRateEntity::class, BudgetEntity::class, BudgetCategoryEntity::class, BudgetMonthSnapshotEntity::class, BudgetCategoryMonthSnapshotEntity::class, TransactionSplitEntity::class, BankNotificationEntity::class, LoanEntity::class, TransactionGroupEntity::class, ProfileEntity::class, TagEntity::class, TransactionTagCrossRef::class],
     version = SCHEMA_VERSION,
     exportSchema = true,
     autoMigrations = [
@@ -138,6 +141,7 @@ abstract class PennyWiseDatabase : RoomDatabase() {
     abstract fun transactionGroupDao(): TransactionGroupDao
     abstract fun budgetSnapshotDao(): BudgetSnapshotDao
     abstract fun profileDao(): ProfileDao
+    abstract fun tagDao(): TagDao
 
     companion object {
         const val DATABASE_NAME = "pennywise_database"
@@ -512,6 +516,20 @@ abstract class PennyWiseDatabase : RoomDatabase() {
             }
         }
 
+        val MIGRATION_52_53 = object : Migration(52, 53) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // Free-text tags with a many-to-many link to transactions.
+                // SQL mirrors Room's generated schema (schemas/.../53.json) so
+                // the migrated DB matches the compiled identity hash.
+                db.execSQL("CREATE TABLE IF NOT EXISTS `tags` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `created_at` TEXT NOT NULL)")
+                db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_tags_name` ON `tags` (`name`)")
+
+                db.execSQL("CREATE TABLE IF NOT EXISTS `transaction_tag_cross_ref` (`transaction_id` INTEGER NOT NULL, `tag_id` INTEGER NOT NULL, PRIMARY KEY(`transaction_id`, `tag_id`), FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tag_id`) REFERENCES `tags`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_transaction_tag_cross_ref_transaction_id` ON `transaction_tag_cross_ref` (`transaction_id`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_transaction_tag_cross_ref_tag_id` ON `transaction_tag_cross_ref` (`tag_id`)")
+            }
+        }
+
         val MIGRATION_38_39 = object : Migration(38, 39) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 // Add receipt_path to transactions if missing
@@ -564,6 +582,7 @@ abstract class PennyWiseDatabase : RoomDatabase() {
             MIGRATION_49_50,
             MIGRATION_50_51,
             MIGRATION_51_52,
+            MIGRATION_52_53,
         )
     }
     

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TagDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TagDao.kt
@@ -1,0 +1,83 @@
+package com.pennywiseai.tracker.data.database.dao
+
+import androidx.room.*
+import com.pennywiseai.tracker.data.database.entity.TagEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionTagCrossRef
+import com.pennywiseai.tracker.data.database.entity.TransactionTagName
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface TagDao {
+
+    // ── Tags ──────────────────────────────────────────────────────────────
+
+    @Query("SELECT * FROM tags ORDER BY name COLLATE NOCASE ASC")
+    fun getAllTags(): Flow<List<TagEntity>>
+
+    @Query("SELECT * FROM tags ORDER BY name COLLATE NOCASE ASC")
+    suspend fun getAllTagsSync(): List<TagEntity>
+
+    @Query("SELECT * FROM tags WHERE name = :name COLLATE NOCASE LIMIT 1")
+    suspend fun getTagByName(name: String): TagEntity?
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertTag(tag: TagEntity): Long
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertTags(tags: List<TagEntity>)
+
+    @Query("DELETE FROM tags")
+    suspend fun deleteAllTags()
+
+    /** Removes tags that are no longer referenced by any transaction. */
+    @Query("DELETE FROM tags WHERE id NOT IN (SELECT DISTINCT tag_id FROM transaction_tag_cross_ref)")
+    suspend fun deleteOrphanTags()
+
+    // ── Cross references ─────────────────────────────────────────────────
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertCrossRef(ref: TransactionTagCrossRef)
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertCrossRefs(refs: List<TransactionTagCrossRef>)
+
+    @Query("DELETE FROM transaction_tag_cross_ref WHERE transaction_id = :transactionId")
+    suspend fun deleteCrossRefsForTransaction(transactionId: Long)
+
+    @Query("DELETE FROM transaction_tag_cross_ref")
+    suspend fun deleteAllCrossRefs()
+
+    @Query("SELECT * FROM transaction_tag_cross_ref")
+    suspend fun getAllCrossRefs(): List<TransactionTagCrossRef>
+
+    // ── Joins ─────────────────────────────────────────────────────────────
+
+    @Query(
+        """
+        SELECT t.* FROM tags t
+        INNER JOIN transaction_tag_cross_ref cr ON t.id = cr.tag_id
+        WHERE cr.transaction_id = :transactionId
+        ORDER BY t.name COLLATE NOCASE ASC
+        """
+    )
+    fun getTagsForTransaction(transactionId: Long): Flow<List<TagEntity>>
+
+    @Query(
+        """
+        SELECT t.* FROM tags t
+        INNER JOIN transaction_tag_cross_ref cr ON t.id = cr.tag_id
+        WHERE cr.transaction_id = :transactionId
+        ORDER BY t.name COLLATE NOCASE ASC
+        """
+    )
+    suspend fun getTagsForTransactionSync(transactionId: Long): List<TagEntity>
+
+    @Query(
+        """
+        SELECT cr.transaction_id AS transactionId, t.name AS name
+        FROM transaction_tag_cross_ref cr
+        INNER JOIN tags t ON cr.tag_id = t.id
+        """
+    )
+    fun getAllTransactionTagPairs(): Flow<List<TransactionTagName>>
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/TagEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/TagEntity.kt
@@ -1,0 +1,85 @@
+package com.pennywiseai.tracker.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.time.LocalDateTime
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+/**
+ * A user-defined, free-text tag that can be attached to any number of
+ * transactions (and a transaction can have any number of tags). Tags are
+ * created on demand from the transaction add/edit screens — typing a new name
+ * creates a row here, while an existing name is reused.
+ *
+ * Backup contract: every field has a Kotlin default so an older backup that
+ * omits a column still restores (see docs/backup-format.md).
+ */
+@Entity(
+    tableName = "tags",
+    indices = [Index(value = ["name"], unique = true)]
+)
+@Serializable
+data class TagEntity(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "id")
+    val id: Long = 0,
+
+    @ColumnInfo(name = "name")
+    val name: String = "",
+
+    @ColumnInfo(name = "created_at")
+    @Contextual
+    val createdAt: LocalDateTime = LocalDateTime.now()
+)
+
+/**
+ * Junction table implementing the many-to-many relationship between
+ * transactions and tags. Rows are removed automatically (CASCADE) when either
+ * the transaction or the tag is deleted.
+ */
+@Entity(
+    tableName = "transaction_tag_cross_ref",
+    primaryKeys = ["transaction_id", "tag_id"],
+    indices = [
+        Index(value = ["transaction_id"]),
+        Index(value = ["tag_id"])
+    ],
+    foreignKeys = [
+        ForeignKey(
+            entity = TransactionEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["transaction_id"],
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = TagEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["tag_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ]
+)
+@Serializable
+data class TransactionTagCrossRef(
+    @ColumnInfo(name = "transaction_id")
+    val transactionId: Long = 0,
+
+    @ColumnInfo(name = "tag_id")
+    val tagId: Long = 0
+)
+
+/**
+ * Lightweight projection used to load all (transaction, tagName) pairs in a
+ * single query, for in-memory tag search and tag analytics aggregation.
+ */
+data class TransactionTagName(
+    @ColumnInfo(name = "transactionId")
+    val transactionId: Long,
+
+    @ColumnInfo(name = "name")
+    val name: String
+)

--- a/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsScanParamsCalculator.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsScanParamsCalculator.kt
@@ -1,0 +1,117 @@
+package com.pennywiseai.tracker.data.manager
+
+import com.pennywiseai.tracker.core.Constants
+import com.pennywiseai.tracker.core.TimeConstants
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+data class SmsScanParamsInput(
+    val forceResync: Boolean = false,
+    val lastScanTimestamp: Long? = null,
+    val scanMonths: Int,
+    val scanAllTime: Boolean,
+    val scanUseCustomDate: Boolean,
+    val scanCustomDateMillis: Long? = null,
+    val lastScanPeriod: Int? = null,
+    val nowMillis: Long,
+)
+
+data class SmsScanParams(
+    val scanStartTime: Long,
+    val needsFullScan: Boolean,
+)
+
+object SmsScanParamsCalculator {
+
+    fun compute(input: SmsScanParamsInput, zoneId: ZoneId = ZoneId.systemDefault()): SmsScanParams {
+        val lastScanTimestamp = input.lastScanTimestamp ?: 0L
+        val lastScanPeriod = input.lastScanPeriod ?: 0
+        val now = input.nowMillis
+
+        val scanAllTimeToggled = input.scanAllTime &&
+            lastScanPeriod != Constants.SmsProcessing.SCAN_PERIOD_ALL_TIME
+        val scanAllTimeToggledOff = !input.scanAllTime &&
+            lastScanPeriod == Constants.SmsProcessing.SCAN_PERIOD_ALL_TIME
+        val customDateToggled = input.scanUseCustomDate &&
+            lastScanPeriod != Constants.SmsProcessing.SCAN_PERIOD_CUSTOM_DATE
+        val customDateToggledOff = !input.scanUseCustomDate &&
+            lastScanPeriod == Constants.SmsProcessing.SCAN_PERIOD_CUSTOM_DATE
+        val needsFullScan = input.forceResync || lastScanTimestamp == 0L ||
+            (lastScanPeriod >= 0 && input.scanMonths > lastScanPeriod) ||
+            scanAllTimeToggled || scanAllTimeToggledOff ||
+            customDateToggled || customDateToggledOff
+
+        val periodLimit = scanPeriodStartTime(
+            scanAllTime = input.scanAllTime,
+            scanUseCustomDate = input.scanUseCustomDate,
+            scanCustomDateMillis = input.scanCustomDateMillis,
+            scanMonths = input.scanMonths,
+            nowMillis = now,
+            zoneId = zoneId,
+        )
+
+        val scanStartTime = if (needsFullScan) {
+            periodLimit
+        } else {
+            val threeDaysAgo = now - TimeConstants.MILLIS_PER_3_DAYS
+            maxOf(minOf(lastScanTimestamp, threeDaysAgo), periodLimit)
+        }
+
+        return SmsScanParams(scanStartTime = scanStartTime, needsFullScan = needsFullScan)
+    }
+
+    fun resolveLastScanPeriod(
+        scanAllTime: Boolean,
+        scanUseCustomDate: Boolean,
+        scanMonths: Int,
+    ): Int = when {
+        scanAllTime -> Constants.SmsProcessing.SCAN_PERIOD_ALL_TIME
+        scanUseCustomDate -> Constants.SmsProcessing.SCAN_PERIOD_CUSTOM_DATE
+        else -> scanMonths
+    }
+
+    fun scanPeriodStartTime(
+        scanAllTime: Boolean,
+        scanUseCustomDate: Boolean,
+        scanCustomDateMillis: Long?,
+        scanMonths: Int,
+        nowMillis: Long,
+        zoneId: ZoneId = ZoneId.systemDefault(),
+    ): Long {
+        if (scanAllTime) return 0L
+
+        if (scanUseCustomDate) {
+            return scanCustomDateMillis
+                ?: monthBasedScanStartTime(scanMonths, nowMillis, zoneId)
+        }
+
+        return monthBasedScanStartTime(scanMonths, nowMillis, zoneId)
+    }
+
+    fun monthBasedScanStartTime(
+        scanMonths: Int,
+        nowMillis: Long,
+        zoneId: ZoneId = ZoneId.systemDefault(),
+    ): Long {
+        return Instant.ofEpochMilli(nowMillis)
+            .atZone(zoneId)
+            .toLocalDate()
+            .minusMonths(scanMonths.toLong())
+            .atStartOfDay(zoneId)
+            .toInstant()
+            .toEpochMilli()
+    }
+
+    fun normalizePickerDateToLocalStartOfDay(
+        pickerMillis: Long,
+        zoneId: ZoneId = ZoneId.systemDefault(),
+    ): Long {
+        return Instant.ofEpochMilli(pickerMillis)
+            .atZone(ZoneOffset.UTC)
+            .toLocalDate()
+            .atStartOfDay(zoneId)
+            .toInstant()
+            .toEpochMilli()
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
@@ -129,6 +129,11 @@ class UserPreferencesRepository @Inject constructor(
 
         // UPI VPA → contact name lookup (opt-in; gated by READ_CONTACTS).
         val USE_CONTACTS_FOR_VPA = booleanPreferencesKey("use_contacts_for_vpa")
+
+        // Scheduled folder backup (SAF tree URI; shared by standard and F-Droid).
+        val SCHEDULED_FOLDER_BACKUP_ENABLED = booleanPreferencesKey("scheduled_folder_backup_enabled")
+        val SCHEDULED_FOLDER_BACKUP_TREE_URI = stringPreferencesKey("scheduled_folder_backup_tree_uri")
+        val SCHEDULED_FOLDER_BACKUP_LAST_TIMESTAMP = longPreferencesKey("scheduled_folder_backup_last_timestamp")
     }
 
     val userPreferences: Flow<UserPreferences> = context.dataStore.data
@@ -705,6 +710,55 @@ class UserPreferencesRepository @Inject constructor(
             } else {
                 preferences[PreferencesKeys.MAIN_ACCOUNT_KEY] = accountKey
             }
+        }
+    }
+
+    val scheduledFolderBackupEnabled: Flow<Boolean> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.SCHEDULED_FOLDER_BACKUP_ENABLED] ?: false
+        }
+
+    val scheduledFolderBackupTreeUri: Flow<String?> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.SCHEDULED_FOLDER_BACKUP_TREE_URI]
+        }
+
+    val scheduledFolderBackupLastTimestamp: Flow<Long?> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.SCHEDULED_FOLDER_BACKUP_LAST_TIMESTAMP]
+        }
+
+    suspend fun isScheduledFolderBackupEnabled(): Boolean {
+        return scheduledFolderBackupEnabled.first()
+    }
+
+    suspend fun getScheduledFolderBackupTreeUri(): String? {
+        return scheduledFolderBackupTreeUri.first()
+    }
+
+    suspend fun setScheduledFolderBackupEnabled(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.SCHEDULED_FOLDER_BACKUP_ENABLED] = enabled
+        }
+    }
+
+    suspend fun setScheduledFolderBackupTreeUri(treeUri: String) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.SCHEDULED_FOLDER_BACKUP_TREE_URI] = treeUri
+        }
+    }
+
+    suspend fun setScheduledFolderBackupLastTimestamp(timestamp: Long) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.SCHEDULED_FOLDER_BACKUP_LAST_TIMESTAMP] = timestamp
+        }
+    }
+
+    suspend fun clearScheduledFolderBackupState() {
+        context.dataStore.edit { preferences ->
+            preferences.remove(PreferencesKeys.SCHEDULED_FOLDER_BACKUP_ENABLED)
+            preferences.remove(PreferencesKeys.SCHEDULED_FOLDER_BACKUP_TREE_URI)
+            preferences.remove(PreferencesKeys.SCHEDULED_FOLDER_BACKUP_LAST_TIMESTAMP)
         }
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
@@ -62,6 +62,8 @@ class UserPreferencesRepository @Inject constructor(
         val ACTIVE_DOWNLOAD_ID = longPreferencesKey("active_download_id")
         val SMS_SCAN_MONTHS = intPreferencesKey("sms_scan_months")
         val SMS_SCAN_ALL_TIME = booleanPreferencesKey("sms_scan_all_time")
+        val SMS_SCAN_USE_CUSTOM_DATE = booleanPreferencesKey("sms_scan_use_custom_date")
+        val SMS_SCAN_CUSTOM_DATE = longPreferencesKey("sms_scan_custom_date")
         val LAST_SCAN_TIMESTAMP = longPreferencesKey("last_scan_timestamp")
         val LAST_SCAN_PERIOD = intPreferencesKey("last_scan_period")
         val BASE_CURRENCY = stringPreferencesKey("base_currency")
@@ -310,6 +312,38 @@ class UserPreferencesRepository @Inject constructor(
     suspend fun getSmsScanAllTime(): Boolean {
         return context.dataStore.data
             .map { preferences -> preferences[PreferencesKeys.SMS_SCAN_ALL_TIME] ?: true }
+            .first()
+    }
+
+    val smsScanUseCustomDate: Flow<Boolean> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.SMS_SCAN_USE_CUSTOM_DATE] ?: false
+        }
+
+    suspend fun updateSmsScanUseCustomDate(useCustomDate: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.SMS_SCAN_USE_CUSTOM_DATE] = useCustomDate
+        }
+    }
+
+    suspend fun getSmsScanUseCustomDate(): Boolean {
+        return context.dataStore.data
+            .map { preferences -> preferences[PreferencesKeys.SMS_SCAN_USE_CUSTOM_DATE] ?: false }
+            .first()
+    }
+
+    val smsScanCustomDate: Flow<Long?> = context.dataStore.data
+        .map { preferences -> preferences[PreferencesKeys.SMS_SCAN_CUSTOM_DATE] }
+
+    suspend fun updateSmsScanCustomDate(dateMillis: Long) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.SMS_SCAN_CUSTOM_DATE] = dateMillis
+        }
+    }
+
+    suspend fun getSmsScanCustomDate(): Long? {
+        return context.dataStore.data
+            .map { preferences -> preferences[PreferencesKeys.SMS_SCAN_CUSTOM_DATE] }
             .first()
     }
     

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/RuleRepositoryImpl.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/RuleRepositoryImpl.kt
@@ -39,62 +39,17 @@ class RuleRepositoryImpl @Inject constructor(
         val allActiveRules = ruleDao.getActiveRules()
         return allActiveRules
             .map { entity -> entityToRule(entity) }
-            .filter { rule ->
-                // Check if rule has no TYPE condition (applies to all) or matches the type
-                val hasTypeCondition = rule.conditions.any { it.field == TransactionField.TYPE }
-                if (!hasTypeCondition) {
-                    true // Rule applies to all transaction types
-                } else {
-                    // Check if any TYPE condition matches
-                    rule.conditions.any { condition ->
-                        condition.field == TransactionField.TYPE &&
-                        when (condition.operator) {
-                            ConditionOperator.EQUALS -> condition.value.equals(type.name, ignoreCase = true)
-                            ConditionOperator.IN -> condition.value.split(",")
-                                .map { it.trim() }
-                                .any { it.equals(type.name, ignoreCase = true) }
-                            ConditionOperator.NOT_EQUALS -> !condition.value.equals(type.name, ignoreCase = true)
-                            ConditionOperator.NOT_IN -> !condition.value.split(",")
-                                .map { it.trim() }
-                                .any { it.equals(type.name, ignoreCase = true) }
-                            else -> false
-                        }
-                    }
-                }
-            }
+            .filter { rule -> isRuleApplicableToTransactionType(rule, type) }
     }
 
     override suspend fun getActiveRulesByTypes(types: List<TransactionType>): List<TransactionRule> {
         // Get all active rules and filter in memory based on conditions
         val allActiveRules = ruleDao.getActiveRules()
-        val typeNames = types.map { it.name }
 
         return allActiveRules
             .map { entity -> entityToRule(entity) }
             .filter { rule ->
-                // Check if rule has no TYPE condition (applies to all) or matches any of the types
-                val hasTypeCondition = rule.conditions.any { it.field == TransactionField.TYPE }
-                if (!hasTypeCondition) {
-                    true // Rule applies to all transaction types
-                } else {
-                    // Check if any TYPE condition matches any of the requested types
-                    rule.conditions.any { condition ->
-                        condition.field == TransactionField.TYPE &&
-                        when (condition.operator) {
-                            ConditionOperator.EQUALS -> typeNames.any { it.equals(condition.value, ignoreCase = true) }
-                            ConditionOperator.IN -> {
-                                val conditionTypes = condition.value.split(",").map { it.trim() }
-                                typeNames.any { type -> conditionTypes.any { it.equals(type, ignoreCase = true) } }
-                            }
-                            ConditionOperator.NOT_EQUALS -> typeNames.all { !it.equals(condition.value, ignoreCase = true) }
-                            ConditionOperator.NOT_IN -> {
-                                val conditionTypes = condition.value.split(",").map { it.trim() }
-                                typeNames.any { type -> conditionTypes.none { it.equals(type, ignoreCase = true) } }
-                            }
-                            else -> false
-                        }
-                    }
-                }
+                types.any { type -> isRuleApplicableToTransactionType(rule, type) }
             }
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TagRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TagRepository.kt
@@ -1,0 +1,79 @@
+package com.pennywiseai.tracker.data.repository
+
+import com.pennywiseai.tracker.data.database.dao.TagDao
+import com.pennywiseai.tracker.data.database.entity.TagEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionTagCrossRef
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Manages the many-to-many relationship between transactions and free-text
+ * [TagEntity]s. Tags are created on demand: setting a tag name that doesn't
+ * exist yet inserts a new row, otherwise the existing tag is reused.
+ */
+@Singleton
+class TagRepository @Inject constructor(
+    private val tagDao: TagDao
+) {
+
+    fun observeAllTags(): Flow<List<TagEntity>> = tagDao.getAllTags()
+
+    /** All tag names currently in use, for autocomplete suggestions. */
+    fun observeAllTagNames(): Flow<List<String>> =
+        tagDao.getAllTags().map { tags -> tags.map { it.name } }
+
+    fun observeTagsForTransaction(transactionId: Long): Flow<List<TagEntity>> =
+        tagDao.getTagsForTransaction(transactionId)
+
+    fun observeTagNamesForTransaction(transactionId: Long): Flow<List<String>> =
+        tagDao.getTagsForTransaction(transactionId).map { tags -> tags.map { it.name } }
+
+    /**
+     * Emits a map of transactionId -> list of tag names, used by search and
+     * analytics which need every transaction's tags in one pass.
+     */
+    fun observeTransactionTagNames(): Flow<Map<Long, List<String>>> =
+        tagDao.getAllTransactionTagPairs().map { pairs ->
+            pairs.groupBy({ it.transactionId }, { it.name })
+        }
+
+    suspend fun getTagNamesForTransaction(transactionId: Long): List<String> =
+        tagDao.getTagsForTransactionSync(transactionId).map { it.name }
+
+    /**
+     * Returns the id of the tag with [name], creating it if necessary. Returns
+     * -1 for a blank name (which is never persisted).
+     */
+    suspend fun getOrCreateTag(name: String): Long {
+        val normalized = name.trim()
+        if (normalized.isEmpty()) return -1L
+        tagDao.getTagByName(normalized)?.let { return it.id }
+        val inserted = tagDao.insertTag(TagEntity(name = normalized))
+        // IGNORE conflict returns -1 on a race; re-read the existing row.
+        return if (inserted != -1L) inserted else tagDao.getTagByName(normalized)?.id ?: -1L
+    }
+
+    /**
+     * Replaces the full set of tags on a transaction with [tagNames]
+     * (deduplicated, case-insensitively). Creates any missing tags and prunes
+     * tags that no longer reference any transaction.
+     */
+    suspend fun setTagsForTransaction(transactionId: Long, tagNames: List<String>) {
+        tagDao.deleteCrossRefsForTransaction(transactionId)
+
+        val tagIds = tagNames
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .distinctBy { it.lowercase() }
+            .map { getOrCreateTag(it) }
+            .filter { it > 0L }
+            .distinct()
+
+        if (tagIds.isNotEmpty()) {
+            tagDao.insertCrossRefs(tagIds.map { TransactionTagCrossRef(transactionId, it) })
+        }
+        tagDao.deleteOrphanTags()
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/di/DatabaseModule.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/di/DatabaseModule.kt
@@ -21,6 +21,7 @@ import com.pennywiseai.tracker.data.database.dao.MerchantMappingDao
 import com.pennywiseai.tracker.data.database.dao.RuleApplicationDao
 import com.pennywiseai.tracker.data.database.dao.RuleDao
 import com.pennywiseai.tracker.data.database.dao.SubscriptionDao
+import com.pennywiseai.tracker.data.database.dao.TagDao
 import com.pennywiseai.tracker.data.database.dao.TransactionDao
 import com.pennywiseai.tracker.data.database.dao.TransactionSplitDao
 import com.pennywiseai.tracker.data.database.dao.UnrecognizedSmsDao
@@ -259,6 +260,12 @@ object DatabaseModule {
     @Singleton
     fun provideProfileDao(database: PennyWiseDatabase): ProfileDao {
         return database.profileDao()
+    }
+
+    @Provides
+    @Singleton
+    fun provideTagDao(database: PennyWiseDatabase): TagDao {
+        return database.tagDao()
     }
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/domain/model/rule/RuleCondition.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/model/rule/RuleCondition.kt
@@ -1,6 +1,126 @@
 package com.pennywiseai.tracker.domain.model.rule
 
+import com.pennywiseai.tracker.data.database.entity.TransactionType
 import kotlinx.serialization.Serializable
+
+/** User-facing labels for transaction type values stored in rule conditions/actions. */
+val RULE_TRANSACTION_TYPE_OPTIONS: List<Pair<String, String>> = listOf(
+    TransactionType.INCOME.name to "Income",
+    TransactionType.EXPENSE.name to "Expense",
+    TransactionType.CREDIT.name to "Credit",
+    TransactionType.TRANSFER.name to "Transfer",
+    TransactionType.INVESTMENT.name to "Investment"
+)
+
+fun parseRuleTransactionType(value: String): TransactionType? {
+    return runCatching { TransactionType.valueOf(value.trim().uppercase()) }.getOrNull()
+}
+
+private val TYPE_PRE_FILTER_OPERATORS = setOf(
+    ConditionOperator.EQUALS,
+    ConditionOperator.IN,
+    ConditionOperator.NOT_EQUALS,
+    ConditionOperator.NOT_IN
+)
+
+fun matchesTransactionTypeCondition(condition: RuleCondition, typeName: String): Boolean {
+    return when (condition.operator) {
+        ConditionOperator.EQUALS -> condition.value.equals(typeName, ignoreCase = true)
+        ConditionOperator.IN -> condition.value.split(",")
+            .map { it.trim() }
+            .any { it.equals(typeName, ignoreCase = true) }
+        ConditionOperator.NOT_EQUALS -> !condition.value.equals(typeName, ignoreCase = true)
+        ConditionOperator.NOT_IN -> !condition.value.split(",")
+            .map { it.trim() }
+            .any { it.equals(typeName, ignoreCase = true) }
+        else -> false
+    }
+}
+
+/**
+ * Pre-filter helper for rules scoped by transaction type. Rules whose TYPE conditions
+ * use operators we cannot evaluate here are passed through for full evaluation.
+ */
+fun isRuleApplicableToTransactionType(rule: TransactionRule, type: TransactionType): Boolean {
+    val hasTypeCondition = rule.conditions.any { it.field == TransactionField.TYPE }
+    val hasOrLogic = rule.conditions.any { it.logicalOperator == LogicalOperator.OR }
+    if (!hasTypeCondition || hasOrLogic) {
+        return true
+    }
+
+    val typeConditions = rule.conditions.filter { it.field == TransactionField.TYPE }
+    if (typeConditions.any { it.operator !in TYPE_PRE_FILTER_OPERATORS }) {
+        return true
+    }
+
+    return typeConditions.any { matchesTransactionTypeCondition(it, type.name) }
+}
+
+fun TransactionField.defaultConditionOperator(): ConditionOperator = when (this) {
+    TransactionField.AMOUNT -> ConditionOperator.LESS_THAN
+    TransactionField.TRANSACTION_TIME -> ConditionOperator.LESS_THAN
+    TransactionField.TRANSACTION_HOUR -> ConditionOperator.EQUALS
+    TransactionField.TRANSACTION_DAY_OF_WEEK -> ConditionOperator.EQUALS
+    TransactionField.TRANSACTION_DAY_OF_MONTH -> ConditionOperator.EQUALS
+    TransactionField.TRANSACTION_DATE -> ConditionOperator.EQUALS
+    TransactionField.ACCOUNT -> ConditionOperator.EQUALS
+    TransactionField.TYPE -> ConditionOperator.EQUALS
+    else -> ConditionOperator.CONTAINS
+}
+
+fun conditionOperatorsForField(field: TransactionField): List<Pair<ConditionOperator, String>> = when (field) {
+    TransactionField.AMOUNT -> listOf(
+        ConditionOperator.LESS_THAN to "<",
+        ConditionOperator.GREATER_THAN to ">",
+        ConditionOperator.EQUALS to "="
+    )
+    TransactionField.TYPE -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.NOT_EQUALS to "is not"
+    )
+    TransactionField.TRANSACTION_TIME -> listOf(
+        ConditionOperator.LESS_THAN to "before",
+        ConditionOperator.GREATER_THAN to "after",
+        ConditionOperator.GREATER_THAN_OR_EQUAL to "at or after",
+        ConditionOperator.LESS_THAN_OR_EQUAL to "at or before",
+        ConditionOperator.EQUALS to "exactly at"
+    )
+    TransactionField.TRANSACTION_HOUR -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.LESS_THAN to "before",
+        ConditionOperator.GREATER_THAN to "after"
+    )
+    TransactionField.TRANSACTION_DAY_OF_WEEK -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.IN to "is any of",
+        ConditionOperator.NOT_EQUALS to "is not"
+    )
+    TransactionField.TRANSACTION_DAY_OF_MONTH -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.IN to "is any of",
+        ConditionOperator.LESS_THAN to "before",
+        ConditionOperator.GREATER_THAN to "after"
+    )
+    TransactionField.TRANSACTION_DATE -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.LESS_THAN to "before",
+        ConditionOperator.GREATER_THAN to "after"
+    )
+    TransactionField.ACCOUNT -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.NOT_EQUALS to "is not"
+    )
+    else -> listOf(
+        ConditionOperator.CONTAINS to "contains",
+        ConditionOperator.EQUALS to "equals",
+        ConditionOperator.STARTS_WITH to "starts with"
+    )
+}
+
+fun ruleTransactionTypeLabel(value: String): String {
+    return RULE_TRANSACTION_TYPE_OPTIONS.firstOrNull { it.first.equals(value, ignoreCase = true) }?.second
+        ?: value
+}
 
 @Serializable
 data class RuleCondition(
@@ -45,6 +165,7 @@ data class RuleCondition(
                 val parts = value.split("||")
                 parts.size == 2 && parts[0].isNotBlank() && parts[1].isNotBlank()
             }
+            TransactionField.TYPE -> parseRuleTransactionType(value) != null
             else -> true
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/domain/service/RuleEngine.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/service/RuleEngine.kt
@@ -69,26 +69,7 @@ class RuleEngine @Inject constructor() {
         // since a TYPE condition that fails on its own can still let the rule match via
         // an OR'd sibling.
         val applicableRules = rules.filter { rule ->
-            val hasTypeCondition = rule.conditions.any { it.field == TransactionField.TYPE }
-            val hasOrLogic = rule.conditions.any { it.logicalOperator == LogicalOperator.OR }
-            if (!hasTypeCondition || hasOrLogic) {
-                true
-            } else {
-                rule.conditions.any { condition ->
-                    condition.field == TransactionField.TYPE &&
-                    when (condition.operator) {
-                        ConditionOperator.EQUALS -> condition.value.equals(type.name, ignoreCase = true)
-                        ConditionOperator.IN -> condition.value.split(",")
-                            .map { it.trim() }
-                            .any { it.equals(type.name, ignoreCase = true) }
-                        ConditionOperator.NOT_EQUALS -> !condition.value.equals(type.name, ignoreCase = true)
-                        ConditionOperator.NOT_IN -> !condition.value.split(",")
-                            .map { it.trim() }
-                            .any { it.equals(type.name, ignoreCase = true) }
-                        else -> false
-                    }
-                }
-            }
+            isRuleApplicableToTransactionType(rule, type)
         }
 
         return evaluateRules(transaction, smsText, applicableRules)
@@ -285,14 +266,7 @@ class RuleEngine @Inject constructor() {
             }
             TransactionField.TYPE -> {
                 val newType = when (action.actionType) {
-                    ActionType.SET -> {
-                        // Convert string value to TransactionType enum
-                        try {
-                            TransactionType.valueOf(action.value.uppercase())
-                        } catch (e: Exception) {
-                            transaction.transactionType
-                        }
-                    }
+                    ActionType.SET -> parseRuleTransactionType(action.value) ?: transaction.transactionType
                     else -> transaction.transactionType
                 }
                 transaction.copy(transactionType = newType) to newType.name

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
@@ -8,6 +8,7 @@ import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.SubscriptionRepository
+import com.pennywiseai.tracker.data.repository.TagRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import java.math.BigDecimal
 import java.security.MessageDigest
@@ -17,7 +18,8 @@ import javax.inject.Inject
 class AddTransactionUseCase @Inject constructor(
     private val transactionRepository: TransactionRepository,
     private val subscriptionRepository: SubscriptionRepository,
-    private val accountBalanceRepository: AccountBalanceRepository
+    private val accountBalanceRepository: AccountBalanceRepository,
+    private val tagRepository: TagRepository
 ) {
     suspend fun execute(
         amount: BigDecimal,
@@ -26,6 +28,7 @@ class AddTransactionUseCase @Inject constructor(
         type: TransactionType,
         date: LocalDateTime,
         notes: String? = null,
+        tags: List<String> = emptyList(),
         isRecurring: Boolean = false,
         bankName: String? = null,
         accountLast4: String? = null,
@@ -74,6 +77,11 @@ class AddTransactionUseCase @Inject constructor(
 
         // Insert the transaction
         val transactionId = transactionRepository.insertTransaction(transaction)
+
+        // Link tags (create-or-select handled in the repository)
+        if (transactionId != -1L && tags.isNotEmpty()) {
+            tagRepository.setTagsForTransaction(transactionId, tags)
+        }
 
         // Update account balance if account was selected
         if (transactionId != -1L && bankName != null && accountLast4 != null) {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
@@ -13,6 +13,7 @@ import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.receipt.ReceiptManager
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository
+import com.pennywiseai.tracker.data.repository.TagRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import com.pennywiseai.tracker.domain.usecase.AddTransactionUseCase
 import com.pennywiseai.tracker.domain.usecase.AddSubscriptionUseCase
@@ -39,9 +40,14 @@ class AddViewModel @Inject constructor(
     private val budgetGroupRepository: BudgetGroupRepository,
     private val userPreferencesRepository: UserPreferencesRepository,
     private val transactionRepository: TransactionRepository,
+    private val tagRepository: TagRepository,
     private val receiptManager: ReceiptManager,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+
+    /** All known tag names for autocomplete in the add form. */
+    val allTagNames: StateFlow<List<String>> = tagRepository.observeAllTagNames()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     // When launched via "Duplicate", this holds the id of the source transaction
     // whose values should pre-fill the form. Null for a fresh add.
@@ -94,6 +100,7 @@ class AddViewModel @Inject constructor(
                 categoryError = null,
                 date = LocalDateTime.now(),
                 notes = source.description ?: "",
+                tags = tagRepository.getTagNamesForTransaction(source.id),
                 isRecurring = source.isRecurring,
                 currency = source.currency,
                 budgetImpactType = source.budgetImpactType,
@@ -226,6 +233,21 @@ class AddViewModel @Inject constructor(
             currentState.copy(notes = notes)
         }
     }
+
+    fun addTransactionTag(tag: String) {
+        val trimmed = tag.trim()
+        if (trimmed.isEmpty()) return
+        _transactionUiState.update { currentState ->
+            if (currentState.tags.any { it.equals(trimmed, ignoreCase = true) }) currentState
+            else currentState.copy(tags = currentState.tags + trimmed)
+        }
+    }
+
+    fun removeTransactionTag(tag: String) {
+        _transactionUiState.update { currentState ->
+            currentState.copy(tags = currentState.tags.filterNot { it.equals(tag, ignoreCase = true) })
+        }
+    }
     
     fun updateTransactionRecurring(isRecurring: Boolean) {
         _transactionUiState.update { currentState ->
@@ -287,6 +309,7 @@ class AddViewModel @Inject constructor(
                     type = state.transactionType,
                     date = state.date,
                     notes = state.notes.takeIf { it.isNotBlank() },
+                    tags = state.tags,
                     isRecurring = state.isRecurring,
                     bankName = selectedAccount?.bankName,
                     accountLast4 = selectedAccount?.accountLast4,
@@ -486,6 +509,7 @@ data class TransactionUiState(
     val categoryError: String? = null,
     val date: LocalDateTime = LocalDateTime.now(),
     val notes: String = "",
+    val tags: List<String> = emptyList(),
     val isRecurring: Boolean = false,
     val isLoading: Boolean = false,
     val error: String? = null,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/TransactionTabContent.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/TransactionTabContent.kt
@@ -35,6 +35,7 @@ import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.domain.model.displayName
 import com.pennywiseai.tracker.domain.model.getAccountType
 import com.pennywiseai.tracker.presentation.accounts.AccountType
+import com.pennywiseai.tracker.ui.components.TagInputField
 import com.pennywiseai.tracker.ui.theme.*
 import com.pennywiseai.tracker.utils.CurrencyFormatter
 import java.time.format.DateTimeFormatter
@@ -167,6 +168,15 @@ fun TransactionTabContent(
                     colors = filledFieldColors()
                 )
             }
+
+            // ── Tags (create or select existing) ──
+            val allTagNames by viewModel.allTagNames.collectAsState()
+            TagInputField(
+                selectedTags = uiState.tags,
+                allTags = allTagNames,
+                onAddTag = viewModel::addTransactionTag,
+                onRemoveTag = viewModel::removeTransactionTag
+            )
 
             // ── Transaction Type chips ──
             FlowRow(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailScreen.kt
@@ -74,6 +74,7 @@ import com.pennywiseai.tracker.ui.components.cards.SectionHeaderV2
 import com.pennywiseai.tracker.ui.components.SplitBreakdownCard
 import com.pennywiseai.tracker.ui.components.SplitEditor
 import com.pennywiseai.tracker.ui.components.SplitItem
+import com.pennywiseai.tracker.ui.components.TagInputField
 import com.pennywiseai.tracker.ui.theme.*
 import com.pennywiseai.tracker.utils.CurrencyFormatter
 import dev.chrisbanes.haze.HazeState
@@ -836,6 +837,17 @@ private fun TransactionReceipt(
                 )
             }
 
+            // Tags
+            val detailTags by viewModel.transactionTags.collectAsStateWithLifecycle()
+            if (detailTags.isNotEmpty()) {
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                DetailInfoRow(
+                    icon = Icons.Default.Sell,
+                    label = if (detailTags.size == 1) "Tag" else "Tags",
+                    value = detailTags.joinToString(", ")
+                )
+            }
+
             // Recurring
             if (transaction.isRecurring) {
                 HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
@@ -1214,6 +1226,16 @@ private fun EditableTransactionHeader(
                 colors = editFilledColors()
             )
         }
+
+        // Tags (optional) — create or select existing
+        val editTags by viewModel.editableTags.collectAsStateWithLifecycle()
+        val allTagNames by viewModel.allTagNames.collectAsStateWithLifecycle()
+        TagInputField(
+            selectedTags = editTags,
+            allTags = allTagNames,
+            onAddTag = { viewModel.addTag(it) },
+            onRemoveTag = { viewModel.removeTag(it) }
+        )
 
         // Transaction Type
         FlowRow(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
@@ -20,6 +20,7 @@ import com.pennywiseai.tracker.data.repository.BudgetGroupRepository
 import com.pennywiseai.tracker.data.repository.CategoryRepository
 import com.pennywiseai.tracker.data.repository.LoanRepository
 import com.pennywiseai.tracker.data.repository.MerchantMappingRepository
+import com.pennywiseai.tracker.data.repository.TagRepository
 import com.pennywiseai.tracker.data.repository.TransactionGroupRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import com.pennywiseai.tracker.data.database.entity.TransactionGroupEntity
@@ -43,6 +44,7 @@ class TransactionDetailViewModel @Inject constructor(
     private val loanRepository: LoanRepository,
     private val budgetGroupRepository: BudgetGroupRepository,
     private val transactionGroupRepository: TransactionGroupRepository,
+    private val tagRepository: TagRepository,
     private val currencyConversionService: CurrencyConversionService,
     private val userPreferencesRepository: UserPreferencesRepository,
     private val receiptManager: ReceiptManager,
@@ -66,6 +68,23 @@ class TransactionDetailViewModel @Inject constructor(
     
     private val _editableTransaction = MutableStateFlow<TransactionEntity?>(null)
     val editableTransaction: StateFlow<TransactionEntity?> = _editableTransaction.asStateFlow()
+
+    // Tags ----------------------------------------------------------------
+    // Read-only set of tag names on the currently loaded transaction.
+    val transactionTags: StateFlow<List<String>> = _transaction
+        .flatMapLatest { tx ->
+            if (tx == null) flowOf(emptyList())
+            else tagRepository.observeTagNamesForTransaction(tx.id)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    // All known tag names, for autocomplete in the editor.
+    val allTagNames: StateFlow<List<String>> = tagRepository.observeAllTagNames()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    // Working copy of tags while in edit mode (persisted on save).
+    private val _editableTags = MutableStateFlow<List<String>>(emptyList())
+    val editableTags: StateFlow<List<String>> = _editableTags.asStateFlow()
     
     private val _isSaving = MutableStateFlow(false)
     val isSaving: StateFlow<Boolean> = _isSaving.asStateFlow()
@@ -324,6 +343,13 @@ class TransactionDetailViewModel @Inject constructor(
         _pendingReceiptUri.value = null
         _receiptRemoved.value = false
 
+        // Seed the editable tag list from the persisted tags.
+        _transaction.value?.let { txn ->
+            viewModelScope.launch {
+                _editableTags.value = tagRepository.getTagNamesForTransaction(txn.id)
+            }
+        }
+
         // Restore split state from original splits
         if (_hasSplits.value) {
             _splits.value = _originalSplits.value
@@ -345,6 +371,7 @@ class TransactionDetailViewModel @Inject constructor(
     fun exitEditMode() {
         _editableTransaction.value = null
         _isEditMode.value = false
+        _editableTags.value = emptyList()
         _errorMessage.value = null
         _applyToAllFromMerchant.value = false
         _updateExistingTransactions.value = false
@@ -413,6 +440,21 @@ class TransactionDetailViewModel @Inject constructor(
     fun updateDescription(description: String?) {
         _editableTransaction.update { current ->
             current?.copy(description = if (description.isNullOrEmpty()) null else description)
+        }
+    }
+
+    fun addTag(name: String) {
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) return
+        _editableTags.update { current ->
+            if (current.any { it.equals(trimmed, ignoreCase = true) }) current
+            else current + trimmed
+        }
+    }
+
+    fun removeTag(name: String) {
+        _editableTags.update { current ->
+            current.filterNot { it.equals(name, ignoreCase = true) }
         }
     }
     
@@ -625,6 +667,9 @@ class TransactionDetailViewModel @Inject constructor(
                 }
 
                 transactionRepository.updateTransaction(normalizedTransaction)
+
+                // Persist the edited tag set (create-or-select handled in repo).
+                tagRepository.setTagsForTransaction(normalizedTransaction.id, _editableTags.value)
 
                 // Update account balance if account was changed or added
                 val originalTxn = _transaction.value

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
@@ -111,6 +111,8 @@ fun TransactionsScreen(
     val profileAccountKeys by viewModel.profileAccountKeys.collectAsState()
     val accountFilter by viewModel.accountFilter.collectAsState()
     val accountOptions by viewModel.accountOptions.collectAsState()
+    val tagFilter by viewModel.tagFilter.collectAsState()
+    val availableTags by viewModel.availableTags.collectAsState()
 
     // Bulk-edit selection (#369)
     val selectedIds by viewModel.selectedIds.collectAsState()
@@ -135,6 +137,7 @@ fun TransactionsScreen(
     var showTypeMenu by remember { mutableStateOf(false) }
     var showMoreFiltersMenu by remember { mutableStateOf(false) }
     var showAccountMenu by remember { mutableStateOf(false) }
+    var showTagMenu by remember { mutableStateOf(false) }
 
     // Focus management for search field
     val searchFocusRequester = remember { FocusRequester() }
@@ -155,6 +158,7 @@ fun TransactionsScreen(
         transactionTypeFilter != TransactionTypeFilter.ALL ||
         selectedProfileId != null ||
         accountFilter != null ||
+        tagFilter != null ||
         hasCurrencyFilter ||
         customDateRange != null
 
@@ -366,7 +370,8 @@ fun TransactionsScreen(
             showTypeMenu = showTypeMenu,
             showMoreFiltersMenu = showMoreFiltersMenu,
             showAccountMenu = showAccountMenu,
-            collapsed = collapseTransactionHeader && !showPeriodMenu && !showTypeMenu && !showMoreFiltersMenu && !showAccountMenu,
+            showTagMenu = showTagMenu,
+            collapsed = collapseTransactionHeader && !showPeriodMenu && !showTypeMenu && !showMoreFiltersMenu && !showAccountMenu && !showTagMenu,
             sortOption = sortOption,
             timePeriods = timePeriods,
             availableCategories = availableCategories,
@@ -374,6 +379,8 @@ fun TransactionsScreen(
             selectedProfileId = selectedProfileId,
             accountOptions = accountOptions,
             accountFilter = accountFilter,
+            availableTags = availableTags,
+            tagFilter = tagFilter,
             onSearchQueryChange = viewModel::updateSearchQuery,
             onSortClick = { showSortMenu = true },
             onSortDismiss = { showSortMenu = false },
@@ -419,6 +426,13 @@ fun TransactionsScreen(
                 view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
                 viewModel.setAccountFilter(accountKey)
                 showAccountMenu = false
+            },
+            onTagClick = { showTagMenu = true },
+            onTagDismiss = { showTagMenu = false },
+            onTagSelected = { tag ->
+                view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+                viewModel.setTagFilter(tag)
+                showTagMenu = false
             },
             onResetFilters = viewModel::resetFilters,
             focusRequester = searchFocusRequester,
@@ -822,6 +836,7 @@ private fun TransactionFilterHeader(
     showTypeMenu: Boolean,
     showMoreFiltersMenu: Boolean,
     showAccountMenu: Boolean,
+    showTagMenu: Boolean,
     collapsed: Boolean,
     sortOption: SortOption,
     timePeriods: List<TimePeriod>,
@@ -830,6 +845,8 @@ private fun TransactionFilterHeader(
     selectedProfileId: Long?,
     accountOptions: List<com.pennywiseai.tracker.presentation.common.AccountOption>,
     accountFilter: String?,
+    availableTags: List<String>,
+    tagFilter: String?,
     onSearchQueryChange: (String) -> Unit,
     onSortClick: () -> Unit,
     onSortDismiss: () -> Unit,
@@ -847,6 +864,9 @@ private fun TransactionFilterHeader(
     onAccountClick: () -> Unit,
     onAccountDismiss: () -> Unit,
     onAccountSelected: (String?) -> Unit,
+    onTagClick: () -> Unit,
+    onTagDismiss: () -> Unit,
+    onTagSelected: (String?) -> Unit,
     onResetFilters: () -> Unit,
     focusRequester: FocusRequester,
     modifier: Modifier = Modifier
@@ -1080,6 +1100,49 @@ private fun TransactionFilterHeader(
                                     },
                                     onClick = { onProfileSelected(profile.id) }
                                 )
+                            }
+                        }
+                    }
+                }
+
+                if (availableTags.isNotEmpty() || tagFilter != null) {
+                    item {
+                        Box {
+                            ExpressiveFilterChip(
+                                selected = tagFilter != null,
+                                text = tagFilter ?: "Tag",
+                                icon = Icons.Default.Sell,
+                                onClick = onTagClick
+                            )
+
+                            DropdownMenu(
+                                expanded = showTagMenu,
+                                onDismissRequest = onTagDismiss
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text("All tags") },
+                                    leadingIcon = {
+                                        if (tagFilter == null) {
+                                            Icon(Icons.Default.Check, contentDescription = null)
+                                        } else {
+                                            Icon(Icons.Default.Sell, contentDescription = null)
+                                        }
+                                    },
+                                    onClick = { onTagSelected(null) }
+                                )
+                                availableTags.forEach { tag ->
+                                    DropdownMenuItem(
+                                        text = { Text(tag, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                                        leadingIcon = {
+                                            if (tagFilter?.equals(tag, ignoreCase = true) == true) {
+                                                Icon(Icons.Default.Check, contentDescription = null)
+                                            } else {
+                                                Icon(Icons.Default.Sell, contentDescription = null)
+                                            }
+                                        },
+                                        onClick = { onTagSelected(tag) }
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -8,6 +8,7 @@ import com.pennywiseai.tracker.data.database.entity.CategoryEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.repository.CategoryRepository
+import com.pennywiseai.tracker.data.repository.TagRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import com.pennywiseai.tracker.presentation.common.TimePeriod
 import com.pennywiseai.tracker.presentation.common.TransactionTypeFilter
@@ -42,6 +43,7 @@ import javax.inject.Inject
 class TransactionsViewModel @Inject constructor(
     private val transactionRepository: TransactionRepository,
     private val categoryRepository: CategoryRepository,
+    private val tagRepository: TagRepository,
     private val transactionSplitDao: TransactionSplitDao,
     private val userPreferencesRepository: com.pennywiseai.tracker.data.preferences.UserPreferencesRepository,
     private val currencyConversionService: CurrencyConversionService,
@@ -53,6 +55,11 @@ class TransactionsViewModel @Inject constructor(
     
     private val _searchQuery = MutableStateFlow("")
     val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    // transactionId -> tag names, kept in sync for in-memory tag search.
+    private val transactionTagsMap: StateFlow<Map<Long, List<String>>> =
+        tagRepository.observeTransactionTagNames()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyMap())
     
     private val _selectedPeriod = MutableStateFlow(TimePeriod.THIS_MONTH)
     val selectedPeriod: StateFlow<TimePeriod> = _selectedPeriod.asStateFlow()
@@ -76,6 +83,13 @@ class TransactionsViewModel @Inject constructor(
     // Account filter — null means "All accounts". Key is "bankName_accountLast4".
     private val _accountFilter = MutableStateFlow<String?>(null)
     val accountFilter: StateFlow<String?> = _accountFilter.asStateFlow()
+
+    // Tag filter — null means "All tags". Matches any transaction that carries the tag.
+    private val _tagFilter = MutableStateFlow<String?>(null)
+    val tagFilter: StateFlow<String?> = _tagFilter.asStateFlow()
+
+    val availableTags: StateFlow<List<String>> = tagRepository.observeAllTagNames()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     // Pickable account options for the account filter dropdown (alias-preferred labels).
     val accountOptions: StateFlow<List<AccountOption>> =
@@ -521,6 +535,14 @@ class TransactionsViewModel @Inject constructor(
                 _profileAccountKeys.value = buildProfileAccountKeys(balances)
             }
         }
+        viewModelScope.launch {
+            availableTags.collect { tags ->
+                val current = _tagFilter.value
+                if (current != null && tags.none { it.equals(current, ignoreCase = true) }) {
+                    _tagFilter.value = null
+                }
+            }
+        }
 
         // Load unified mode preferences
         viewModelScope.launch {
@@ -576,10 +598,12 @@ class TransactionsViewModel @Inject constructor(
             _selectedProfileId.map { "profileFilter" },
             _profileAccountKeys.map { "profileAccountKeys" },
             _accountFilter.map { "accountFilter" },
+            tagFilter.map { "tagFilter" },
             selectedCurrency.map { "currency" },
             _isUnifiedMode.map { "unifiedMode" },
             sortOption.map { "sort" },
-            customDateRange.map { "customDate" }
+            customDateRange.map { "customDate" },
+            transactionTagsMap.map { "tags" }
         )
             .transformLatest { trigger ->
                 // Get current values from all StateFlows
@@ -593,15 +617,24 @@ class TransactionsViewModel @Inject constructor(
 
                 val profileId = _selectedProfileId.value
                 val accountKey = _accountFilter.value
+                val tag = _tagFilter.value
 
                 // Get filtered transactions (without currency filter first)
                 getFilteredTransactions(query, period, category, categories, typeFilter)
                     .collect { allTransactions ->
-                        // Apply profile filter, then account filter
-                        val transactions = filterTransactionsByAccount(
+                        // Apply profile, account, then tag filters
+                        val profileAndAccountFiltered = filterTransactionsByAccount(
                             filterByProfile(allTransactions, profileId),
                             accountKey
                         )
+                        val transactions = if (tag != null) {
+                            profileAndAccountFiltered.filter { tx ->
+                                transactionTagsMap.value[tx.id]
+                                    ?.any { it.equals(tag, ignoreCase = true) } == true
+                            }
+                        } else {
+                            profileAndAccountFiltered
+                        }
                         if (isUnified) {
                             // Show all transactions regardless of currency
                             emit(sortTransactions(transactions, sort))
@@ -707,6 +740,15 @@ class TransactionsViewModel @Inject constructor(
     fun setAccountFilter(accountKey: String?) {
         _accountFilter.value = accountKey
     }
+
+    /** Sets the tag filter; null clears it ("All tags"). */
+    fun setTagFilter(tag: String?) {
+        _tagFilter.value = tag?.takeIf { it.isNotBlank() }
+    }
+
+    fun clearTagFilter() {
+        _tagFilter.value = null
+    }
     
     fun setSelectedProfile(profileId: Long?) {
         _selectedProfileId.value = profileId
@@ -789,6 +831,7 @@ class TransactionsViewModel @Inject constructor(
         selectPeriod(TimePeriod.THIS_MONTH)
         setTransactionTypeFilter(TransactionTypeFilter.ALL)
         setAccountFilter(null)
+        clearTagFilter()
         _selectedProfileId.value = null  // reset local state only; does not update the shared DataStore preference
         setSortOption(SortOption.DATE_NEWEST)
         if (!_isUnifiedMode.value) {
@@ -1089,7 +1132,11 @@ class TransactionsViewModel @Inject constructor(
                     // Check merchant name and description
                     val matchesMerchant = transaction.merchantName.contains(searchQuery, ignoreCase = true)
                     val matchesDescription = transaction.description?.contains(searchQuery, ignoreCase = true) == true
-                    
+
+                    // Check user-set tags
+                    val matchesTag = transactionTagsMap.value[transaction.id]
+                        ?.any { it.contains(searchQuery, ignoreCase = true) } == true
+
                     // Check SMS body (full text search)
                     val matchesSmsBody = transaction.smsBody?.contains(searchQuery, ignoreCase = true) == true
                     
@@ -1112,7 +1159,7 @@ class TransactionsViewModel @Inject constructor(
                         false
                     }
                     
-                    matchesMerchant || matchesDescription || matchesSmsBody || matchesAmount
+                    matchesMerchant || matchesDescription || matchesTag || matchesSmsBody || matchesAmount
                 }
             }
         }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -475,38 +475,60 @@ class TransactionsViewModel @Inject constructor(
             initialValue = false
         )
 
+    private val smsScanUseCustomDate: StateFlow<Boolean> = userPreferencesRepository.smsScanUseCustomDate
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = false
+        )
+
+    private val smsScanCustomDate: StateFlow<Long?> = userPreferencesRepository.smsScanCustomDate
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = null
+        )
+
     fun isShowingLimitedData(): Boolean {
         if (smsScanAllTime.value) return false
 
         val currentPeriod = _selectedPeriod.value
-        val scanMonthsValue = smsScanMonths.value
+        val scanStartDate = getSmsScanStartDate() ?: return false
 
         return when (currentPeriod) {
             TimePeriod.ALL -> true
             TimePeriod.CURRENT_FY -> {
-                // Check if FY start is before scan period
                 val dateRange = getDateRangeForPeriod(TimePeriod.CURRENT_FY)
                 if (dateRange != null) {
                     val (fyStart, _) = dateRange
-                    val scanStart = LocalDate.now().minusMonths(scanMonthsValue.toLong())
-                    fyStart.isBefore(scanStart)
+                    fyStart.isBefore(scanStartDate)
                 } else {
                     false
                 }
             }
             TimePeriod.CUSTOM -> {
-                // Check if custom range start is before scan period
                 val customRange = customDateRange.value
                 if (customRange != null) {
                     val (startDate, _) = customRange
-                    val scanStart = LocalDate.now().minusMonths(scanMonthsValue.toLong())
-                    startDate.isBefore(scanStart)
+                    startDate.isBefore(scanStartDate)
                 } else {
                     false
                 }
             }
             else -> false
         }
+    }
+
+    private fun getSmsScanStartDate(): LocalDate? {
+        if (smsScanUseCustomDate.value) {
+            return smsScanCustomDate.value?.let { millis ->
+                java.time.Instant.ofEpochMilli(millis)
+                    .atZone(java.time.ZoneId.systemDefault())
+                    .toLocalDate()
+            }
+        }
+
+        return LocalDate.now().minusMonths(smsScanMonths.value.toLong())
     }
     
     init {

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/CategoryBreakdownCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/CategoryBreakdownCard.kt
@@ -15,8 +15,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.pennywiseai.tracker.data.database.entity.CategoryEntity
 import com.pennywiseai.tracker.ui.components.cards.PennyWiseCardV2
-import com.pennywiseai.tracker.ui.icons.CategoryMapping
+import com.pennywiseai.tracker.ui.icons.categoryColorFor
 import com.pennywiseai.tracker.ui.screens.analytics.CategoryData
 import com.pennywiseai.tracker.ui.theme.Spacing
 import com.pennywiseai.tracker.utils.CurrencyFormatter
@@ -26,6 +27,7 @@ fun CategoryBreakdownCard(
     categories: List<CategoryData>,
     currency: String,
     modifier: Modifier = Modifier,
+    categoriesByName: Map<String, CategoryEntity> = emptyMap(),
     onCategoryClick: (CategoryData) -> Unit = {}
 ) {
     val maxAmount = categories.map { it.amount }.maxOrNull() ?: java.math.BigDecimal.ZERO
@@ -50,6 +52,7 @@ fun CategoryBreakdownCard(
                     category = category,
                     maxAmount = maxAmount,
                     currency = currency,
+                    categoriesByName = categoriesByName,
                     onClick = { onCategoryClick(category) }
                 )
             }
@@ -62,6 +65,7 @@ private fun CategoryBar(
     category: CategoryData,
     maxAmount: java.math.BigDecimal,
     currency: String,
+    categoriesByName: Map<String, CategoryEntity>,
     onClick: () -> Unit = {}
 ) {
     val targetFraction = if (maxAmount > java.math.BigDecimal.ZERO) {
@@ -78,10 +82,7 @@ private fun CategoryBar(
         label = "category_bar_${category.name}"
     )
 
-    // Get category-specific color
-    val categoryInfo = CategoryMapping.categories[category.name]
-        ?: CategoryMapping.categories["Others"]!!
-    val categoryColor = categoryInfo.color
+    val categoryColor = categoryColorFor(category.name, categoriesByName)
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/TagBreakdownCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/TagBreakdownCard.kt
@@ -1,0 +1,174 @@
+package com.pennywiseai.tracker.ui.components
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.pennywiseai.tracker.ui.components.cards.PennyWiseCardV2
+import com.pennywiseai.tracker.ui.screens.analytics.TagData
+import com.pennywiseai.tracker.ui.theme.Spacing
+import com.pennywiseai.tracker.utils.CurrencyFormatter
+import java.math.BigDecimal
+import kotlin.math.absoluteValue
+
+/**
+ * Stable palette for tag visualisations. Tags are free-text and have no
+ * predefined colors (unlike categories), so we deterministically pick a color
+ * from this palette based on the tag name. The same tag therefore always gets
+ * the same color across the chart and list.
+ */
+private val TagPalette = listOf(
+    Color(0xFF4285F4),
+    Color(0xFFEA4335),
+    Color(0xFFFBBC05),
+    Color(0xFF34A853),
+    Color(0xFFAB47BC),
+    Color(0xFF00ACC1),
+    Color(0xFFFF7043),
+    Color(0xFF9E9D24),
+    Color(0xFF5C6BC0),
+    Color(0xFFEC407A)
+)
+
+fun tagColor(name: String): Color {
+    if (TagPalette.isEmpty()) return Color.Gray
+    val index = name.hashCode().absoluteValue % TagPalette.size
+    return TagPalette[index]
+}
+
+@Composable
+fun TagBreakdownCard(
+    tags: List<TagData>,
+    currency: String,
+    modifier: Modifier = Modifier,
+    onTagClick: (TagData) -> Unit = {}
+) {
+    val maxAmount = tags.map { it.amount }.maxOrNull() ?: BigDecimal.ZERO
+
+    PennyWiseCardV2(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(Spacing.md)
+        ) {
+            Text(
+                text = "Spending by Tag",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium
+            )
+
+            ExpandableList(
+                items = tags,
+                visibleItemCount = 5
+            ) { tag ->
+                TagBar(
+                    tag = tag,
+                    maxAmount = maxAmount,
+                    currency = currency,
+                    onClick = { onTagClick(tag) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TagBar(
+    tag: TagData,
+    maxAmount: BigDecimal,
+    currency: String,
+    onClick: () -> Unit = {}
+) {
+    val targetFraction = if (maxAmount > BigDecimal.ZERO) {
+        (tag.amount.toFloat() / maxAmount.toFloat()).coerceIn(0f, 1f)
+    } else 0f
+
+    var visible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { visible = true }
+
+    val animatedFraction by animateFloatAsState(
+        targetValue = if (visible) targetFraction else 0f,
+        animationSpec = tween(800),
+        label = "tag_bar_${tag.name}"
+    )
+
+    val barColor = tagColor(tag.name)
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .clickable { onClick() }
+            .padding(vertical = Spacing.xs),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(
+                modifier = Modifier.weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(10.dp)
+                        .clip(CircleShape)
+                        .background(barColor)
+                )
+                Text(
+                    text = tag.name,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "${tag.percentage.toInt()}%",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = CurrencyFormatter.formatCurrency(tag.amount, currency),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(8.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(animatedFraction)
+                    .fillMaxHeight()
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(barColor)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/TagInputField.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/TagInputField.kt
@@ -1,0 +1,169 @@
+package com.pennywiseai.tracker.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Sell
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.InputChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
+import com.pennywiseai.tracker.ui.theme.Dimensions
+import com.pennywiseai.tracker.ui.theme.Spacing
+
+/**
+ * Free-text tag picker. Shows the currently selected tags as removable chips,
+ * a text field for typing, and live suggestions drawn from existing tags. The
+ * typed value can either match an existing tag (select) or be committed as a
+ * brand-new tag (create) via the IME action, the add icon, or the "Create"
+ * suggestion chip.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun TagInputField(
+    selectedTags: List<String>,
+    allTags: List<String>,
+    onAddTag: (String) -> Unit,
+    onRemoveTag: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    label: String = "Tags (Optional)"
+) {
+    var input by remember { mutableStateOf("") }
+
+    fun commit(raw: String) {
+        val name = raw.trim()
+        if (name.isEmpty()) return
+        if (selectedTags.none { it.equals(name, ignoreCase = true) }) {
+            onAddTag(name)
+        }
+        input = ""
+    }
+
+    val trimmed = input.trim()
+    val suggestions = remember(input, allTags, selectedTags) {
+        if (trimmed.isEmpty()) {
+            emptyList()
+        } else {
+            allTags.filter { tag ->
+                tag.contains(trimmed, ignoreCase = true) &&
+                    selectedTags.none { it.equals(tag, ignoreCase = true) }
+            }.take(5)
+        }
+    }
+    val showCreateOption = trimmed.isNotEmpty() &&
+        allTags.none { it.equals(trimmed, ignoreCase = true) } &&
+        selectedTags.none { it.equals(trimmed, ignoreCase = true) }
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(Spacing.sm)
+    ) {
+        if (selectedTags.isNotEmpty()) {
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                selectedTags.forEach { tag ->
+                    InputChip(
+                        selected = true,
+                        onClick = { onRemoveTag(tag) },
+                        label = {
+                            Text(
+                                tag,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        },
+                        trailingIcon = {
+                            Icon(
+                                Icons.Default.Close,
+                                contentDescription = "Remove $tag",
+                                modifier = Modifier.size(Dimensions.Icon.small)
+                            )
+                        }
+                    )
+                }
+            }
+        }
+
+        TextField(
+            value = input,
+            onValueChange = { input = it },
+            label = { Text(label) },
+            singleLine = true,
+            leadingIcon = {
+                Icon(
+                    Icons.Default.Sell,
+                    contentDescription = null,
+                    modifier = Modifier.size(Dimensions.Icon.medium)
+                )
+            },
+            trailingIcon = {
+                if (trimmed.isNotEmpty()) {
+                    IconButton(onClick = { commit(input) }) {
+                        Icon(
+                            Icons.Default.Add,
+                            contentDescription = "Add tag",
+                            modifier = Modifier.size(Dimensions.Icon.medium)
+                        )
+                    }
+                }
+            },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { commit(input) }),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        if (suggestions.isNotEmpty() || showCreateOption) {
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                suggestions.forEach { suggestion ->
+                    AssistChip(
+                        onClick = { commit(suggestion) },
+                        label = {
+                            Text(
+                                suggestion,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    )
+                }
+                if (showCreateOption) {
+                    AssistChip(
+                        onClick = { commit(trimmed) },
+                        leadingIcon = {
+                            Icon(
+                                Icons.Default.Add,
+                                contentDescription = null,
+                                modifier = Modifier.size(Dimensions.Icon.small)
+                            )
+                        },
+                        label = {
+                            Text(
+                                "Create \"$trimmed\"",
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/ui/icons/CategoryColors.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/icons/CategoryColors.kt
@@ -1,0 +1,35 @@
+package com.pennywiseai.tracker.ui.icons
+
+import androidx.compose.ui.graphics.Color
+import com.pennywiseai.tracker.data.database.entity.CategoryEntity
+
+private val defaultCategoryColor: Color
+    get() = CategoryMapping.categories["Others"]!!.color
+
+/**
+ * Resolves the display color for a category name.
+ * Prefers persisted category colors (system + custom), then falls back to [CategoryMapping].
+ */
+fun categoryColorFor(
+    categoryName: String,
+    categoriesByName: Map<String, CategoryEntity> = emptyMap(),
+): Color {
+    categoriesByName[categoryName]?.let { entity ->
+        return parseHexColor(entity.color, defaultCategoryColor)
+    }
+    return CategoryMapping.categories[categoryName]?.color ?: defaultCategoryColor
+}
+
+internal fun parseHexColor(colorString: String, fallback: Color): Color {
+    return try {
+        val hex = colorString.removePrefix("#")
+        val colorLong = when (hex.length) {
+            6 -> 0xFF000000L or hex.toLong(16)
+            8 -> hex.toLong(16)
+            else -> throw IllegalArgumentException("Invalid hex color: $colorString")
+        }
+        Color(colorLong)
+    } catch (_: Exception) {
+        fallback
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsScreen.kt
@@ -80,6 +80,7 @@ fun AnalyticsScreen(
     val profiles by viewModel.profiles.collectAsStateWithLifecycle()
     val accountFilter by viewModel.accountFilter.collectAsStateWithLifecycle()
     val accountOptions by viewModel.accountOptions.collectAsStateWithLifecycle()
+    val categoriesByName by viewModel.categoriesByName.collectAsStateWithLifecycle()
     var showDateRangePicker by rememberSaveable { mutableStateOf(false) }
     var categoryViewType by rememberSaveable { mutableStateOf(CategoryViewType.CHART) }
     var tagViewType by rememberSaveable { mutableStateOf(CategoryViewType.CHART) }
@@ -415,6 +416,7 @@ fun AnalyticsScreen(
                             CategoryViewType.CHART -> CategoryPieChart(
                                 categories = uiState.categoryBreakdown,
                                 currency = selectedCurrency,
+                                categoriesByName = categoriesByName,
                                 onCategoryClick = { category ->
                                     onNavigateToTransactions(category.name, null, selectedPeriod.name, selectedCurrency)
                                 }
@@ -422,6 +424,7 @@ fun AnalyticsScreen(
                             CategoryViewType.LIST -> CategoryBreakdownCard(
                                 categories = uiState.categoryBreakdown,
                                 currency = selectedCurrency,
+                                categoriesByName = categoriesByName,
                                 onCategoryClick = { category ->
                                     onNavigateToTransactions(category.name, null, selectedPeriod.name, selectedCurrency)
                                 }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsScreen.kt
@@ -82,6 +82,7 @@ fun AnalyticsScreen(
     val accountOptions by viewModel.accountOptions.collectAsStateWithLifecycle()
     var showDateRangePicker by rememberSaveable { mutableStateOf(false) }
     var categoryViewType by rememberSaveable { mutableStateOf(CategoryViewType.CHART) }
+    var tagViewType by rememberSaveable { mutableStateOf(CategoryViewType.CHART) }
     var showChartTypeSelector by remember { mutableStateOf(false) }
     var showPeriodMenu by remember { mutableStateOf(false) }
     var showTypeMenu by remember { mutableStateOf(false) }
@@ -423,6 +424,67 @@ fun AnalyticsScreen(
                                 currency = selectedCurrency,
                                 onCategoryClick = { category ->
                                     onNavigateToTransactions(category.name, null, selectedPeriod.name, selectedCurrency)
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // Tag Breakdown Section with Pie/List toggle
+        if (uiState.tagBreakdown.isNotEmpty()) {
+            item {
+                Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                    SectionHeaderV2(
+                        title = "Top Tags",
+                        action = {
+                            IconButton(onClick = {
+                                tagViewType = if (tagViewType == CategoryViewType.CHART) {
+                                    CategoryViewType.LIST
+                                } else {
+                                    CategoryViewType.CHART
+                                }
+                            }) {
+                                Icon(
+                                    imageVector = if (tagViewType == CategoryViewType.CHART)
+                                        Icons.AutoMirrored.Filled.List
+                                    else Icons.Default.PieChart,
+                                    contentDescription = "Toggle View",
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+                    )
+
+                    AnimatedContent(
+                        targetState = tagViewType,
+                        transitionSpec = {
+                            if (targetState == CategoryViewType.CHART) {
+                                (slideInHorizontally { -it } + fadeIn()) togetherWith
+                                    (slideOutHorizontally { it } + fadeOut()) using
+                                    SizeTransform(clip = false)
+                            } else {
+                                (slideInHorizontally { it } + fadeIn()) togetherWith
+                                    (slideOutHorizontally { -it } + fadeOut()) using
+                                    SizeTransform(clip = false)
+                            }
+                        },
+                        label = "tag_view_transition"
+                    ) { viewType ->
+                        when (viewType) {
+                            CategoryViewType.CHART -> TagPieChart(
+                                tags = uiState.tagBreakdown,
+                                currency = selectedCurrency,
+                                onTagClick = { tag ->
+                                    onNavigateToTransactions(null, tag.name, selectedPeriod.name, selectedCurrency)
+                                }
+                            )
+                            CategoryViewType.LIST -> TagBreakdownCard(
+                                tags = uiState.tagBreakdown,
+                                currency = selectedCurrency,
+                                onTagClick = { tag ->
+                                    onNavigateToTransactions(null, tag.name, selectedPeriod.name, selectedCurrency)
                                 }
                             )
                         }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -7,7 +7,9 @@ import com.pennywiseai.tracker.data.currency.CurrencyConversionService
 import com.pennywiseai.tracker.data.database.entity.ProfileEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionWithSplits
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
+import com.pennywiseai.tracker.data.database.entity.CategoryEntity
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
+import com.pennywiseai.tracker.data.repository.CategoryRepository
 import com.pennywiseai.tracker.data.repository.ProfileRepository
 import com.pennywiseai.tracker.data.repository.TagRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
@@ -42,8 +44,17 @@ class AnalyticsViewModel @Inject constructor(
     private val accountBalanceRepository: AccountBalanceRepository,
     private val profileRepository: ProfileRepository,
     private val tagRepository: TagRepository,
+    private val categoryRepository: CategoryRepository,
     private val savedStateHandle: androidx.lifecycle.SavedStateHandle
 ) : ViewModel() {
+
+    val categoriesByName: StateFlow<Map<String, CategoryEntity>> = categoryRepository.getAllCategories()
+        .map { categories -> categories.associateBy { it.name } }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyMap()
+        )
 
     // Profile filter — reuses the global Home profile selection so the two stay in sync.
     val selectedProfileId: StateFlow<Long?> = userPreferencesRepository.selectedProfileId

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -9,6 +9,7 @@ import com.pennywiseai.tracker.data.database.entity.TransactionWithSplits
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.ProfileRepository
+import com.pennywiseai.tracker.data.repository.TagRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import com.pennywiseai.tracker.presentation.common.TimePeriod
@@ -40,6 +41,7 @@ class AnalyticsViewModel @Inject constructor(
     private val currencyConversionService: CurrencyConversionService,
     private val accountBalanceRepository: AccountBalanceRepository,
     private val profileRepository: ProfileRepository,
+    private val tagRepository: TagRepository,
     private val savedStateHandle: androidx.lifecycle.SavedStateHandle
 ) : ViewModel() {
 
@@ -154,7 +156,9 @@ class AnalyticsViewModel @Inject constructor(
         )
     }.combine(accountBalanceRepository.getAllLatestBalances()) { fs, balances ->
         fs to balances
-    }.flatMapLatest { (filterState, balances) ->
+    }.combine(tagRepository.observeTransactionTagNames()) { (fs, balances), tagMap ->
+        Triple(fs, balances, tagMap)
+    }.flatMapLatest { (filterState, balances, tagMap) ->
         // Determine date range based on selected period
         val dateRange = if (filterState.period == TimePeriod.CUSTOM) {
             val customRange = filterState.customRange
@@ -315,6 +319,38 @@ class AnalyticsViewModel @Inject constructor(
                     )
                 }.sortedByDescending { it.amount }
 
+                // Build tag breakdown from the many-to-many tag map. A
+                // transaction can carry several tags, and its full amount
+                // counts toward each of them (tags overlap, unlike categories),
+                // so tag percentages can sum to more than 100%. Untagged
+                // transactions are skipped.
+                val tagAmounts = mutableMapOf<String, BigDecimal>()
+                val tagTransactionCounts = mutableMapOf<String, Int>()
+
+                for (tx in filteredTransactions) {
+                    val tagNames = tagMap[tx.id]?.takeIf { it.isNotEmpty() } ?: continue
+                    val converted = if (isUnified) {
+                        currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                    } else {
+                        tx.amount
+                    }
+                    for (tagName in tagNames) {
+                        tagAmounts[tagName] = (tagAmounts[tagName] ?: BigDecimal.ZERO) + converted
+                        tagTransactionCounts[tagName] = (tagTransactionCounts[tagName] ?: 0) + 1
+                    }
+                }
+
+                val tagBreakdown = tagAmounts.map { (tagName, tagTotal) ->
+                    TagData(
+                        name = tagName,
+                        amount = tagTotal,
+                        percentage = if (totalSpending > BigDecimal.ZERO) {
+                            (tagTotal.divide(totalSpending, 4, java.math.RoundingMode.HALF_UP) * BigDecimal(100)).toFloat()
+                        } else 0f,
+                        transactionCount = tagTransactionCounts[tagName] ?: 0
+                    )
+                }.sortedByDescending { it.amount }
+
                 // Group by merchant — convert if unified
                 val merchantBreakdown = filteredTransactions
                     .groupBy { it.merchantName }
@@ -392,7 +428,8 @@ class AnalyticsViewModel @Inject constructor(
                     isLoading = false,
                     spendingTrend = calculateSpendingTrend(filteredTransactions, dateRange.first, dateRange.second),
                     availableCategories = allCategoryNames,
-                    accountBreakdown = accountBreakdown
+                    accountBreakdown = accountBreakdown,
+                    tagBreakdown = tagBreakdown
                 )
             }
         }
@@ -560,7 +597,8 @@ data class AnalyticsUiState(
     val isLoading: Boolean = true,
     val spendingTrend: List<BalancePoint> = emptyList(),
     val availableCategories: List<String> = emptyList(),
-    val accountBreakdown: List<AccountBreakdownData> = emptyList()
+    val accountBreakdown: List<AccountBreakdownData> = emptyList(),
+    val tagBreakdown: List<TagData> = emptyList()
 )
 
 data class AccountBreakdownData(
@@ -572,6 +610,13 @@ data class AccountBreakdownData(
 )
 
 data class CategoryData(
+    val name: String,
+    val amount: BigDecimal,
+    val percentage: Float,
+    val transactionCount: Int
+)
+
+data class TagData(
     val name: String,
     val amount: BigDecimal,
     val percentage: Float,

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/CategoryPieChart.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/CategoryPieChart.kt
@@ -23,9 +23,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.pennywiseai.tracker.data.database.entity.CategoryEntity
 import com.pennywiseai.tracker.ui.components.CategoryIcon
 import com.pennywiseai.tracker.ui.effects.BlurredAnimatedVisibility
-import com.pennywiseai.tracker.ui.icons.CategoryMapping
+import com.pennywiseai.tracker.ui.icons.categoryColorFor
 import com.pennywiseai.tracker.ui.theme.Spacing
 import com.pennywiseai.tracker.utils.CurrencyFormatter
 import ir.ehsannarmani.compose_charts.PieChart
@@ -36,6 +37,7 @@ fun CategoryPieChart(
     categories: List<CategoryData>,
     currency: String,
     modifier: Modifier = Modifier,
+    categoriesByName: Map<String, CategoryEntity> = emptyMap(),
     onCategoryClick: (CategoryData) -> Unit = {}
 ) {
     if (categories.isEmpty()) return
@@ -43,14 +45,14 @@ fun CategoryPieChart(
     val total = categories.fold(BigDecimal.ZERO) { acc, cat -> acc + cat.amount }.toDouble()
     if (total == 0.0) return
 
-    val pieData = remember(categories) {
+    val pieData = remember(categories, categoriesByName) {
         categories.map { category ->
+            val color = categoryColorFor(category.name, categoriesByName)
             Pie(
                 label = category.name,
                 data = category.amount.toDouble(),
-                color = CategoryMapping.categories[category.name]?.color ?: Color.Gray,
-                selectedColor = (CategoryMapping.categories[category.name]?.color
-                    ?: Color.Gray).copy(alpha = 0.8f),
+                color = color,
+                selectedColor = color.copy(alpha = 0.8f),
                 selected = false,
                 scaleAnimEnterSpec = tween(400),
                 colorAnimEnterSpec = tween(500)
@@ -102,6 +104,7 @@ fun CategoryPieChart(
                     CategoryIcon(
                         category = selectedPie.label!!,
                         size = 32.dp,
+                        tint = selectedPie.color,
                         modifier = Modifier
                             .size(56.dp)
                             .clip(CircleShape)

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/TagPieChart.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/TagPieChart.kt
@@ -1,0 +1,170 @@
+package com.pennywiseai.tracker.ui.screens.analytics
+
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.pennywiseai.tracker.ui.components.tagColor
+import com.pennywiseai.tracker.ui.theme.Spacing
+import com.pennywiseai.tracker.utils.CurrencyFormatter
+import ir.ehsannarmani.compose_charts.PieChart
+import ir.ehsannarmani.compose_charts.models.Pie
+import java.math.BigDecimal
+
+@Composable
+fun TagPieChart(
+    tags: List<TagData>,
+    currency: String,
+    modifier: Modifier = Modifier,
+    onTagClick: (TagData) -> Unit = {}
+) {
+    if (tags.isEmpty()) return
+
+    val total = tags.fold(BigDecimal.ZERO) { acc, tag -> acc + tag.amount }.toDouble()
+    if (total == 0.0) return
+
+    val pieData = remember(tags) {
+        tags.map { tag ->
+            Pie(
+                label = tag.name,
+                data = tag.amount.toDouble(),
+                color = tagColor(tag.name),
+                selectedColor = tagColor(tag.name).copy(alpha = 0.8f),
+                selected = false,
+                scaleAnimEnterSpec = tween(400),
+                colorAnimEnterSpec = tween(500)
+            )
+        }
+    }
+
+    var chartData by remember(pieData) { mutableStateOf(pieData) }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(200.dp)
+            .padding(Spacing.sm),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .weight(1.2f)
+                .fillMaxHeight(),
+            contentAlignment = Alignment.Center
+        ) {
+            PieChart(
+                modifier = Modifier.size(160.dp),
+                data = chartData,
+                onPieClick = { clickedPie ->
+                    val pieIndex = chartData.indexOf(clickedPie)
+                    chartData = chartData.mapIndexed { index, pie ->
+                        pie.copy(selected = index == pieIndex)
+                    }
+                    val tagName = clickedPie.label ?: return@PieChart
+                    tags.find { it.name == tagName }?.let(onTagClick)
+                },
+                selectedScale = 1.1f,
+                scaleAnimEnterSpec = tween(400),
+                colorAnimEnterSpec = tween(500),
+                style = Pie.Style.Stroke(width = 12.dp)
+            )
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight()
+                .padding(start = Spacing.md)
+        ) {
+            items(chartData.sortedByDescending { it.data }) { pie ->
+                TagLegendItem(
+                    label = pie.label ?: "Unknown",
+                    value = pie.data,
+                    color = pie.color,
+                    isSelected = pie.selected,
+                    currency = currency,
+                    totalAmount = total,
+                    onClick = {
+                        val pieIndex = chartData.indexOf(pie)
+                        chartData = chartData.mapIndexed { index, p ->
+                            p.copy(selected = index == pieIndex)
+                        }
+                        val tagName = pie.label ?: return@TagLegendItem
+                        tags.find { it.name == tagName }?.let(onTagClick)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TagLegendItem(
+    label: String,
+    value: Double,
+    color: androidx.compose.ui.graphics.Color,
+    currency: String,
+    isSelected: Boolean,
+    totalAmount: Double,
+    onClick: () -> Unit
+) {
+    val percentage = (value / totalAmount * 100).toInt()
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .sizeIn(minHeight = 48.dp)
+            .padding(vertical = 4.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(
+                if (isSelected) MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                else androidx.compose.ui.graphics.Color.Transparent
+            )
+            .padding(6.dp)
+            .clickable(onClick = onClick),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(10.dp)
+                .clip(CircleShape)
+                .background(color)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = CurrencyFormatter.formatAbbreviated(value, currency),
+                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = "($percentage%)",
+                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
@@ -132,7 +132,7 @@ fun CreateRuleScreen(
             )
             actionType = ActionType.SET
             actionField = TransactionField.TYPE
-            actionValue = "income"
+            actionValue = "INCOME"
         },
         "Daily Investment" to {
             ruleName = "Daily Investment"
@@ -193,7 +193,13 @@ fun CreateRuleScreen(
                                         RuleAction(
                                             field = actionField,
                                             actionType = actionType,
-                                            value = if (actionType == ActionType.BLOCK) "" else actionValue
+                                            value = if (actionType == ActionType.BLOCK) {
+                                                ""
+                                            } else if (actionField == TransactionField.TYPE) {
+                                                actionValue.uppercase()
+                                            } else {
+                                                actionValue
+                                            }
                                         )
                                     ),
                                     isActive = existingRule?.isActive ?: true,
@@ -571,15 +577,9 @@ fun CreateRuleScreen(
                                 verticalArrangement = Arrangement.spacedBy(Spacing.xs),
                                 modifier = Modifier.fillMaxWidth()
                             ) {
-                                listOf(
-                                    "INCOME" to "Incoming",
-                                    "EXPENSE" to "Outgoing",
-                                    "CREDIT" to "Credit Card",
-                                    "TRANSFER" to "Transfer",
-                                    "INVESTMENT" to "Investment"
-                                ).forEach { (type, displayLabel) ->
+                                RULE_TRANSACTION_TYPE_OPTIONS.forEach { (type, displayLabel) ->
                                     FilterChip(
-                                        selected = actionValue == type,
+                                        selected = actionValue.equals(type, ignoreCase = true),
                                         onClick = { actionValue = type },
                                         label = {
                                             Text(
@@ -723,14 +723,7 @@ fun CreateRuleScreen(
                                     )
                                     when {
                                         condition.field == TransactionField.TYPE -> {
-                                            append(when(condition.value) {
-                                                "INCOME" -> "Incoming"
-                                                "EXPENSE" -> "Outgoing"
-                                                "CREDIT" -> "Credit Card"
-                                                "TRANSFER" -> "Transfer"
-                                                "INVESTMENT" -> "Investment"
-                                                else -> condition.value
-                                            })
+                                            append(ruleTransactionTypeLabel(condition.value))
                                         }
                                         condition.field == TransactionField.TRANSACTION_DAY_OF_WEEK -> {
                                             append(condition.value.split(",").joinToString(", ") { dayNames[it.trim()] ?: it })
@@ -759,14 +752,7 @@ fun CreateRuleScreen(
                                     })
                                     // Show user-friendly labels for transaction types in actions too
                                     if (actionField == TransactionField.TYPE) {
-                                        append(when(actionValue) {
-                                            "INCOME" -> "Incoming"
-                                            "EXPENSE" -> "Outgoing"
-                                            "CREDIT" -> "Credit Card"
-                                            "TRANSFER" -> "Transfer"
-                                            "INVESTMENT" -> "Investment"
-                                            else -> actionValue
-                                        })
+                                        append(ruleTransactionTypeLabel(actionValue))
                                     } else {
                                         append(actionValue)
                                     }
@@ -790,6 +776,15 @@ private fun ConditionFieldSelector(
     allAccounts: List<RulesViewModel.AccountInfo> = emptyList()
 ) {
     var fieldDropdownExpanded by remember { mutableStateOf(false) }
+
+    val supportedOperators = remember(condition.field) {
+        conditionOperatorsForField(condition.field).map { it.first }.toSet()
+    }
+    LaunchedEffect(condition.field, condition.operator) {
+        if (condition.field == TransactionField.TYPE && condition.operator !in supportedOperators) {
+            onConditionChange(condition.copy(operator = ConditionOperator.EQUALS))
+        }
+    }
 
     // Field selector
     ExposedDropdownMenuBox(
@@ -826,7 +821,13 @@ private fun ConditionFieldSelector(
                 DropdownMenuItem(
                     text = { Text(label) },
                     onClick = {
-                        onConditionChange(condition.copy(field = field, value = ""))
+                        onConditionChange(
+                            condition.copy(
+                                field = field,
+                                value = "",
+                                operator = field.defaultConditionOperator()
+                            )
+                        )
                         fieldDropdownExpanded = false
                     }
                 )
@@ -837,50 +838,7 @@ private fun ConditionFieldSelector(
     Spacer(modifier = Modifier.height(Spacing.sm))
 
     // Operator selector
-    val operators = when(condition.field) {
-        TransactionField.AMOUNT -> listOf(
-            ConditionOperator.LESS_THAN to "<",
-            ConditionOperator.GREATER_THAN to ">",
-            ConditionOperator.EQUALS to "="
-        )
-        TransactionField.TRANSACTION_TIME -> listOf(
-            ConditionOperator.LESS_THAN to "before",
-            ConditionOperator.GREATER_THAN to "after",
-            ConditionOperator.GREATER_THAN_OR_EQUAL to "at or after",
-            ConditionOperator.LESS_THAN_OR_EQUAL to "at or before",
-            ConditionOperator.EQUALS to "exactly at"
-        )
-        TransactionField.TRANSACTION_HOUR -> listOf(
-            ConditionOperator.EQUALS to "is",
-            ConditionOperator.LESS_THAN to "before",
-            ConditionOperator.GREATER_THAN to "after"
-        )
-        TransactionField.TRANSACTION_DAY_OF_WEEK -> listOf(
-            ConditionOperator.EQUALS to "is",
-            ConditionOperator.IN to "is any of",
-            ConditionOperator.NOT_EQUALS to "is not"
-        )
-        TransactionField.TRANSACTION_DAY_OF_MONTH -> listOf(
-            ConditionOperator.EQUALS to "is",
-            ConditionOperator.IN to "is any of",
-            ConditionOperator.LESS_THAN to "before",
-            ConditionOperator.GREATER_THAN to "after"
-        )
-        TransactionField.TRANSACTION_DATE -> listOf(
-            ConditionOperator.EQUALS to "is",
-            ConditionOperator.LESS_THAN to "before",
-            ConditionOperator.GREATER_THAN to "after"
-        )
-        TransactionField.ACCOUNT -> listOf(
-            ConditionOperator.EQUALS to "is",
-            ConditionOperator.NOT_EQUALS to "is not"
-        )
-        else -> listOf(
-            ConditionOperator.CONTAINS to "contains",
-            ConditionOperator.EQUALS to "equals",
-            ConditionOperator.STARTS_WITH to "starts with"
-        )
-    }
+    val operators = conditionOperatorsForField(condition.field)
 
     FlowRow(
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
@@ -909,16 +867,12 @@ private fun ConditionFieldSelector(
                 verticalArrangement = Arrangement.spacedBy(Spacing.xs),
                 modifier = Modifier.fillMaxWidth()
             ) {
-                listOf(
-                    "INCOME" to "Incoming",
-                    "EXPENSE" to "Outgoing",
-                    "CREDIT" to "Credit Card",
-                    "TRANSFER" to "Transfer",
-                    "INVESTMENT" to "Investment"
-                ).forEach { (type, displayLabel) ->
+                RULE_TRANSACTION_TYPE_OPTIONS.forEach { (type, displayLabel) ->
                     FilterChip(
-                        selected = condition.value == type,
-                        onClick = { onConditionChange(condition.copy(value = type)) },
+                        selected = condition.value.equals(type, ignoreCase = true),
+                        onClick = {
+                            onConditionChange(condition.copy(value = type, operator = ConditionOperator.EQUALS))
+                        },
                         label = {
                             Text(displayLabel, style = MaterialTheme.typography.bodySmall)
                         }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -110,6 +110,9 @@ fun SettingsScreen(
     val mainAccountKey by settingsViewModel.mainAccountKey.collectAsStateWithLifecycle()
     val useContactsForVpa by settingsViewModel.useContactsForVpa.collectAsStateWithLifecycle(initialValue = false)
     val isProEntitled by settingsViewModel.isProEntitled.collectAsStateWithLifecycle()
+    val scheduledFolderBackupEnabled by settingsViewModel.scheduledFolderBackupEnabled.collectAsStateWithLifecycle(initialValue = false)
+    val scheduledFolderBackupLastTimestamp by settingsViewModel.scheduledFolderBackupLastTimestamp.collectAsStateWithLifecycle(initialValue = null)
+    val requestFolderPicker by settingsViewModel.requestFolderPicker.collectAsStateWithLifecycle()
     var showUpgradeSheet by remember { mutableStateOf(false) }
     // Launches the runtime permission request. If granted, we flip the
     // preference on; if denied, leave the switch off so the user can try
@@ -153,6 +156,20 @@ fun SettingsScreen(
             }
         }
     )
+
+    val backupFolderLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocumentTree(),
+        onResult = { uri ->
+            uri?.let { settingsViewModel.onBackupFolderSelected(it) }
+        }
+    )
+
+    LaunchedEffect(requestFolderPicker) {
+        if (requestFolderPicker) {
+            backupFolderLauncher.launch(null)
+            settingsViewModel.onFolderPickerLaunched()
+        }
+    }
 
     // Scroll behaviors for collapsible TopAppBar
     val scrollBehaviorSmall = TopAppBarDefaults.pinnedScrollBehavior()
@@ -465,6 +482,45 @@ fun SettingsScreen(
                     onClick = { settingsViewModel.exportBackup() },
                     position = ItemPosition.MIDDLE
                 )
+                SettingsSwitchRow(
+                    icon = Icons.Default.Backup,
+                    iconBgColor = purple_light,
+                    iconTint = purple_dark,
+                    title = "Automatic Folder Backup",
+                    subtitle = if (scheduledFolderBackupEnabled) {
+                        "Daily backup at 2:00 AM to your chosen folder"
+                    } else {
+                        "Save a backup to a folder every day at 2:00 AM"
+                    },
+                    checked = scheduledFolderBackupEnabled,
+                    onCheckedChange = { settingsViewModel.setScheduledFolderBackupEnabled(it) },
+                    position = ItemPosition.MIDDLE
+                )
+                if (scheduledFolderBackupEnabled) {
+                    SettingsNavItem(
+                        icon = Icons.Default.SaveAlt,
+                        iconBgColor = green_light,
+                        iconTint = green_dark,
+                        title = "Back Up Now",
+                        subtitle = scheduledFolderBackupLastTimestamp?.let { timestamp ->
+                            val formatted = java.time.Instant.ofEpochMilli(timestamp)
+                                .atZone(java.time.ZoneId.systemDefault())
+                                .format(java.time.format.DateTimeFormatter.ofPattern("MMM d, yyyy h:mm a"))
+                            "Last backup: $formatted"
+                        } ?: "Run a backup to your folder now",
+                        onClick = { settingsViewModel.backupToFolderNow() },
+                        position = ItemPosition.MIDDLE
+                    )
+                    SettingsNavItem(
+                        icon = Icons.Default.FolderOpen,
+                        iconBgColor = amber_light,
+                        iconTint = amber_dark,
+                        title = "Change Backup Folder",
+                        subtitle = "Pick a different folder for automatic backups",
+                        onClick = { settingsViewModel.requestChangeBackupFolder() },
+                        position = ItemPosition.MIDDLE
+                    )
+                }
                 SettingsNavItem(
                     icon = Icons.Default.Download,
                     iconBgColor = cyan_light,

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
+import androidx.compose.material3.SelectableDates
 import androidx.compose.runtime.*
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -100,6 +101,8 @@ fun SettingsScreen(
     val isDeveloperModeEnabled by settingsViewModel.isDeveloperModeEnabled.collectAsStateWithLifecycle(initialValue = false)
     val smsScanMonths by settingsViewModel.smsScanMonths.collectAsStateWithLifecycle(initialValue = 3)
     val smsScanAllTime by settingsViewModel.smsScanAllTime.collectAsStateWithLifecycle(initialValue = false)
+    val smsScanUseCustomDate by settingsViewModel.smsScanUseCustomDate.collectAsStateWithLifecycle(initialValue = false)
+    val smsScanCustomDate by settingsViewModel.smsScanCustomDate.collectAsStateWithLifecycle(initialValue = null)
     val baseCurrency by settingsViewModel.baseCurrency.collectAsStateWithLifecycle(initialValue = "")
     val importExportMessage by settingsViewModel.importExportMessage.collectAsStateWithLifecycle()
     val exportedBackupFile by settingsViewModel.exportedBackupFile.collectAsStateWithLifecycle()
@@ -120,6 +123,7 @@ fun SettingsScreen(
         if (granted) settingsViewModel.setUseContactsForVpa(true)
     }
     var showSmsScanDialog by remember { mutableStateOf(false) }
+    var showSmsScanDatePicker by remember { mutableStateOf(false) }
     var showExportOptionsDialog by remember { mutableStateOf(false) }
     var showTimeoutDialog by remember { mutableStateOf(false) }
     var showDisplayCurrencyDialog by remember { mutableStateOf(false) }
@@ -497,10 +501,25 @@ fun SettingsScreen(
                     iconBgColor = teal_light,
                     iconTint = teal_dark,
                     title = "SMS Scan Period",
-                    subtitle = if (smsScanAllTime) "Scan all SMS messages" else "Scan last $smsScanMonths months",
+                    subtitle = when {
+                        smsScanAllTime -> "Scan all SMS messages"
+                        smsScanUseCustomDate -> {
+                            val formattedDate = smsScanCustomDate?.let { formatSmsScanCustomDate(it) }
+                            if (formattedDate != null) {
+                                "Scan from $formattedDate to today"
+                            } else {
+                                "Scan from a custom start date to today"
+                            }
+                        }
+                        else -> "Scan last $smsScanMonths months"
+                    },
                     onClick = { showSmsScanDialog = true },
                     position = ItemPosition.BOTTOM,
-                    trailingText = if (smsScanAllTime) "All Time" else "$smsScanMonths mo"
+                    trailingText = when {
+                        smsScanAllTime -> "All Time"
+                        smsScanUseCustomDate -> smsScanCustomDate?.let { formatSmsScanCustomDateShort(it) } ?: "Custom"
+                        else -> "$smsScanMonths mo"
+                    }
                 )
             }
 
@@ -648,45 +667,69 @@ fun SettingsScreen(
                     verticalArrangement = Arrangement.spacedBy(Spacing.sm)
                 ) {
                     Text(
-                        text = "Choose how many months of SMS history to scan for transactions",
+                        text = "Choose how far back to scan SMS messages for transactions",
                         style = MaterialTheme.typography.bodyMedium
                     )
                     Spacer(modifier = Modifier.height(Spacing.md))
 
-                    val options = listOf(-1) + listOf(1, 2, 3, 6, 12, 24)
+                    val options = listOf(-1, -2) + listOf(1, 2, 3, 6, 12, 24)
                     options.forEach { months ->
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clickable {
-                                    if (months == -1) {
-                                        settingsViewModel.updateSmsScanAllTime(true)
-                                    } else {
-                                        settingsViewModel.updateSmsScanMonths(months)
-                                        settingsViewModel.updateSmsScanAllTime(false)
+                                    when (months) {
+                                        -1 -> {
+                                            settingsViewModel.updateSmsScanAllTime(true)
+                                            showSmsScanDialog = false
+                                        }
+                                        -2 -> {
+                                            showSmsScanDialog = false
+                                            showSmsScanDatePicker = true
+                                        }
+                                        else -> {
+                                            settingsViewModel.updateSmsScanMonths(months)
+                                            settingsViewModel.updateSmsScanAllTime(false)
+                                            showSmsScanDialog = false
+                                        }
                                     }
-                                    showSmsScanDialog = false
                                 }
                                 .padding(vertical = Spacing.sm),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            val isSelected = if (months == -1) smsScanAllTime else smsScanMonths == months && !smsScanAllTime
+                            val isSelected = when (months) {
+                                -1 -> smsScanAllTime
+                                -2 -> smsScanUseCustomDate && !smsScanAllTime
+                                else -> smsScanMonths == months && !smsScanAllTime && !smsScanUseCustomDate
+                            }
                             RadioButton(
                                 selected = isSelected,
                                 onClick = {
-                                    if (months == -1) {
-                                        settingsViewModel.updateSmsScanAllTime(true)
-                                    } else {
-                                        settingsViewModel.updateSmsScanMonths(months)
-                                        settingsViewModel.updateSmsScanAllTime(false)
+                                    when (months) {
+                                        -1 -> {
+                                            settingsViewModel.updateSmsScanAllTime(true)
+                                            showSmsScanDialog = false
+                                        }
+                                        -2 -> {
+                                            showSmsScanDialog = false
+                                            showSmsScanDatePicker = true
+                                        }
+                                        else -> {
+                                            settingsViewModel.updateSmsScanMonths(months)
+                                            settingsViewModel.updateSmsScanAllTime(false)
+                                            showSmsScanDialog = false
+                                        }
                                     }
-                                    showSmsScanDialog = false
                                 }
                             )
                             Spacer(modifier = Modifier.width(Spacing.md))
                             Text(
                                 text = when (months) {
                                     -1 -> "All Time"
+                                    -2 -> {
+                                        val formattedDate = smsScanCustomDate?.let { formatSmsScanCustomDate(it) }
+                                        if (formattedDate != null) "Custom date ($formattedDate)" else "Custom date"
+                                    }
                                     1 -> "1 month"
                                     24 -> "2 years"
                                     else -> "$months months"
@@ -703,6 +746,50 @@ fun SettingsScreen(
                 }
             }
         )
+    }
+
+    if (showSmsScanDatePicker) {
+        val todayMillis = java.time.LocalDate.now()
+            .atStartOfDay(java.time.ZoneOffset.UTC)
+            .toInstant()
+            .toEpochMilli()
+        val initialSelectedDateMillis = smsScanCustomDate
+            ?: java.time.LocalDate.now()
+                .minusMonths(3)
+                .atStartOfDay(java.time.ZoneOffset.UTC)
+                .toInstant()
+                .toEpochMilli()
+        val datePickerState = rememberDatePickerState(
+            initialSelectedDateMillis = initialSelectedDateMillis,
+            selectableDates = object : SelectableDates {
+                override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+                    return utcTimeMillis <= todayMillis
+                }
+            }
+        )
+
+        DatePickerDialog(
+            onDismissRequest = { showSmsScanDatePicker = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        datePickerState.selectedDateMillis?.let { millis ->
+                            settingsViewModel.updateSmsScanCustomDate(millis)
+                        }
+                        showSmsScanDatePicker = false
+                    }
+                ) {
+                    Text("OK")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showSmsScanDatePicker = false }) {
+                    Text("Cancel")
+                }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
     }
 
     // Show import/export message
@@ -1268,4 +1355,18 @@ private fun SettingsNavigationContent(onNavigateBack: () -> Unit) {
             )
         }
     }
+}
+
+private fun formatSmsScanCustomDate(dateMillis: Long): String {
+    return java.time.Instant.ofEpochMilli(dateMillis)
+        .atZone(java.time.ZoneId.systemDefault())
+        .toLocalDate()
+        .format(java.time.format.DateTimeFormatter.ofPattern("MMM d, yyyy"))
+}
+
+private fun formatSmsScanCustomDateShort(dateMillis: Long): String {
+    return java.time.Instant.ofEpochMilli(dateMillis)
+        .atZone(java.time.ZoneId.systemDefault())
+        .toLocalDate()
+        .format(java.time.format.DateTimeFormatter.ofPattern("MMM d"))
 }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -21,6 +21,7 @@ import com.pennywiseai.tracker.data.repository.ModelRepository
 import com.pennywiseai.tracker.data.repository.ModelState
 import com.pennywiseai.tracker.data.repository.UnrecognizedSmsRepository
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
+import com.pennywiseai.tracker.data.manager.SmsScanParamsCalculator
 import com.pennywiseai.tracker.data.backup.BackupExporter
 import com.pennywiseai.tracker.data.backup.BackupImporter
 import com.pennywiseai.tracker.data.backup.ExportResult
@@ -91,6 +92,8 @@ class SettingsViewModel @Inject constructor(
     // SMS scan period state
     val smsScanMonths = userPreferencesRepository.smsScanMonths
     val smsScanAllTime = userPreferencesRepository.smsScanAllTime
+    val smsScanUseCustomDate = userPreferencesRepository.smsScanUseCustomDate
+    val smsScanCustomDate = userPreferencesRepository.smsScanCustomDate
 
     // Unified Currency Mode
     val unifiedCurrencyMode = userPreferencesRepository.unifiedCurrencyMode
@@ -477,6 +480,7 @@ class SettingsViewModel @Inject constructor(
                 Log.d("SettingsViewModel", "Scan period increased from $currentMonths to $months months - will perform full scan")
             }
 
+            userPreferencesRepository.updateSmsScanUseCustomDate(false)
             userPreferencesRepository.updateSmsScanMonths(months)
         }
     }
@@ -489,7 +493,25 @@ class SettingsViewModel @Inject constructor(
                 Log.d("SettingsViewModel", "All time scanning enabled - will perform full scan")
             }
 
+            userPreferencesRepository.updateSmsScanUseCustomDate(false)
             userPreferencesRepository.updateSmsScanAllTime(allTime)
+        }
+    }
+
+    fun updateSmsScanCustomDate(selectedDateMillis: Long) {
+        viewModelScope.launch {
+            val normalizedDate = SmsScanParamsCalculator.normalizePickerDateToLocalStartOfDay(selectedDateMillis)
+            val currentDate = userPreferencesRepository.getSmsScanCustomDate()
+            val wasUsingCustomDate = userPreferencesRepository.getSmsScanUseCustomDate()
+
+            if (!wasUsingCustomDate || currentDate == null || normalizedDate < currentDate) {
+                userPreferencesRepository.setLastScanTimestamp(0L)
+                Log.d("SettingsViewModel", "Custom SMS scan date updated - will perform full scan")
+            }
+
+            userPreferencesRepository.updateSmsScanAllTime(false)
+            userPreferencesRepository.updateSmsScanUseCustomDate(true)
+            userPreferencesRepository.updateSmsScanCustomDate(normalizedDate)
         }
     }
     

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -23,9 +23,12 @@ import com.pennywiseai.tracker.data.repository.UnrecognizedSmsRepository
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.backup.BackupExporter
 import com.pennywiseai.tracker.data.backup.BackupImporter
+import com.pennywiseai.tracker.data.backup.ExportBytesResult
 import com.pennywiseai.tracker.data.backup.ExportResult
 import com.pennywiseai.tracker.data.backup.ImportResult
 import com.pennywiseai.tracker.data.backup.ImportStrategy
+import com.pennywiseai.tracker.backup.folder.FolderBackupWriter
+import com.pennywiseai.tracker.backup.folder.ScheduledFolderBackupScheduler
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
@@ -38,7 +41,6 @@ import com.pennywiseai.tracker.core.Constants
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.first
 import java.net.URLEncoder
 import java.io.File
@@ -54,6 +56,8 @@ class SettingsViewModel @Inject constructor(
     private val accountBalanceRepository: AccountBalanceRepository,
     private val backupExporter: BackupExporter,
     private val backupImporter: BackupImporter,
+    private val folderBackupWriter: FolderBackupWriter,
+    private val scheduledFolderBackupScheduler: ScheduledFolderBackupScheduler,
     private val contactsResolver: com.pennywiseai.tracker.data.contacts.ContactsResolver,
     entitlementGate: EntitlementGate,
 ) : ViewModel() {
@@ -82,7 +86,15 @@ class SettingsViewModel @Inject constructor(
     
     private val _exportedBackupFile = MutableStateFlow<File?>(null)
     val exportedBackupFile: StateFlow<File?> = _exportedBackupFile.asStateFlow()
-    
+
+    val scheduledFolderBackupEnabled = userPreferencesRepository.scheduledFolderBackupEnabled
+    val scheduledFolderBackupLastTimestamp = userPreferencesRepository.scheduledFolderBackupLastTimestamp
+
+    private val _requestFolderPicker = MutableStateFlow(false)
+    val requestFolderPicker: StateFlow<Boolean> = _requestFolderPicker.asStateFlow()
+
+    private var currentFolderPickerAction: FolderPickerAction = FolderPickerAction.ENABLE
+
     private var currentDownloadId: Long? = null
     
     // Developer mode state
@@ -616,6 +628,114 @@ class SettingsViewModel @Inject constructor(
     fun clearImportExportMessage() {
         _importExportMessage.value = null
     }
+
+    fun setScheduledFolderBackupEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            if (enabled) {
+                val treeUri = userPreferencesRepository.getScheduledFolderBackupTreeUri()
+                if (treeUri.isNullOrBlank()) {
+                    currentFolderPickerAction = FolderPickerAction.ENABLE
+                    _requestFolderPicker.value = true
+                    return@launch
+                }
+                enableScheduledFolderBackup(treeUri)
+            } else {
+                userPreferencesRepository.setScheduledFolderBackupEnabled(false)
+                scheduledFolderBackupScheduler.cancel()
+                _importExportMessage.value = "Automatic folder backup disabled"
+            }
+        }
+    }
+
+    fun requestChangeBackupFolder() {
+        currentFolderPickerAction = FolderPickerAction.CHANGE
+        _requestFolderPicker.value = true
+    }
+
+    fun onFolderPickerLaunched() {
+        _requestFolderPicker.value = false
+    }
+
+    fun onBackupFolderSelected(uri: Uri) {
+        viewModelScope.launch {
+            try {
+                val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                    Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                context.contentResolver.takePersistableUriPermission(uri, flags)
+
+                val treeUri = uri.toString()
+                userPreferencesRepository.setScheduledFolderBackupTreeUri(treeUri)
+
+                when (currentFolderPickerAction) {
+                    FolderPickerAction.ENABLE -> enableScheduledFolderBackup(treeUri)
+                    FolderPickerAction.CHANGE -> {
+                        if (userPreferencesRepository.isScheduledFolderBackupEnabled()) {
+                            scheduledFolderBackupScheduler.schedule()
+                        }
+                        backupToFolderNow(showSuccessMessage = true)
+                    }
+                }
+            } catch (e: Exception) {
+                _importExportMessage.value = "Could not access the selected folder: ${e.message}"
+                Log.e("SettingsViewModel", "Failed to persist backup folder", e)
+            }
+        }
+    }
+
+    fun backupToFolderNow(showSuccessMessage: Boolean = true) {
+        viewModelScope.launch {
+            performFolderBackup(showSuccessMessage)
+        }
+    }
+
+    private suspend fun performFolderBackup(showSuccessMessage: Boolean): Boolean {
+        val treeUri = userPreferencesRepository.getScheduledFolderBackupTreeUri()
+        if (treeUri.isNullOrBlank()) {
+            _importExportMessage.value = "Select a backup folder first"
+            return false
+        }
+
+        if (!folderBackupWriter.canWriteToFolder(treeUri)) {
+            _importExportMessage.value = "Cannot write to the selected backup folder"
+            return false
+        }
+
+        return when (val exportResult = backupExporter.exportBackupBytes()) {
+            is ExportBytesResult.Success -> {
+                when (val writeResult = folderBackupWriter.writeBackup(treeUri, exportResult.bytes)) {
+                    is FolderBackupWriter.Result.Success -> {
+                        userPreferencesRepository.setScheduledFolderBackupLastTimestamp(
+                            System.currentTimeMillis()
+                        )
+                        if (showSuccessMessage) {
+                            _importExportMessage.value = "Backup saved to folder"
+                        }
+                        true
+                    }
+                    is FolderBackupWriter.Result.Failure -> {
+                        _importExportMessage.value = writeResult.message
+                        false
+                    }
+                }
+            }
+            is ExportBytesResult.Error -> {
+                _importExportMessage.value = exportResult.message
+                false
+            }
+        }
+    }
+
+    private suspend fun enableScheduledFolderBackup(treeUri: String) {
+        if (!folderBackupWriter.canWriteToFolder(treeUri)) {
+            _importExportMessage.value = "Cannot write to the selected backup folder"
+            return
+        }
+
+        userPreferencesRepository.setScheduledFolderBackupEnabled(true)
+        scheduledFolderBackupScheduler.schedule()
+        performFolderBackup(showSuccessMessage = false)
+        _importExportMessage.value = "Automatic folder backup enabled. Backups run daily at 2:00 AM."
+    }
     
     fun updateBaseCurrency(currency: String) {
         viewModelScope.launch {
@@ -649,4 +769,9 @@ enum class DownloadState {
     COMPLETED,
     FAILED,
     ERROR_INSUFFICIENT_SPACE
+}
+
+private enum class FolderPickerAction {
+    ENABLE,
+    CHANGE
 }

--- a/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
@@ -14,6 +14,12 @@ object CurrencyFormatter {
     private val INDIAN_LOCALE = Locale.Builder().setLanguage("en").setRegion("IN").build()
 
     /**
+     * Currencies that use three decimal places (ISO 4217 minor units = 3),
+     * e.g. Jordanian Dinar, Kuwaiti Dinar.
+     */
+    private val THREE_DECIMAL_CURRENCIES = setOf("JOD", "KWD", "BHD", "OMR")
+
+    /**
      * Currency symbol mapping for display
      */
     private val CURRENCY_SYMBOLS = mapOf(
@@ -23,6 +29,7 @@ object CurrencyFormatter {
         "EUR" to "€",
         "GBP" to "£",
         "AED" to "AED",
+        "JOD" to "JD",
         "SGD" to "S$",
         "CAD" to "C$",
         "MXN" to "MX$",
@@ -50,6 +57,7 @@ object CurrencyFormatter {
         "EUR" to Locale.GERMANY,
         "GBP" to Locale.UK,
         "AED" to Locale.Builder().setLanguage("en").setRegion("AE").build(),
+        "JOD" to Locale.Builder().setLanguage("en").setRegion("JO").build(),
         "SGD" to Locale.Builder().setLanguage("en").setRegion("SG").build(),
         "CAD" to Locale.CANADA,
         "MXN" to Locale.Builder().setLanguage("es").setRegion("MX").build(),
@@ -91,7 +99,7 @@ object CurrencyFormatter {
 
             // Show decimals only if they exist
             formatter.minimumFractionDigits = 0
-            formatter.maximumFractionDigits = 2
+            formatter.maximumFractionDigits = if (currencyCode in THREE_DECIMAL_CURRENCIES) 3 else 2
             formatter.format(amount)
         } catch (e: Exception) {
             // Fallback to symbol + amount

--- a/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
@@ -19,6 +19,8 @@ import com.pennywiseai.tracker.data.manager.TransactionDeduplication
 import com.pennywiseai.tracker.data.mapper.toEntity
 import com.pennywiseai.tracker.data.mapper.toEntityType
 import com.pennywiseai.tracker.core.TimeConstants
+import com.pennywiseai.tracker.data.manager.SmsScanParamsCalculator
+import com.pennywiseai.tracker.data.manager.SmsScanParamsInput
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.repository.*
 import com.pennywiseai.tracker.domain.model.rule.TransactionRule
@@ -503,7 +505,14 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
         if (needsFullScan) {
             val scanMonths = userPreferencesRepository.getSmsScanMonths()
             val scanAllTime = userPreferencesRepository.getSmsScanAllTime()
-            userPreferencesRepository.setLastScanPeriod(if (scanAllTime) -1 else scanMonths)
+            val scanUseCustomDate = userPreferencesRepository.getSmsScanUseCustomDate()
+            userPreferencesRepository.setLastScanPeriod(
+                SmsScanParamsCalculator.resolveLastScanPeriod(
+                    scanAllTime = scanAllTime,
+                    scanUseCustomDate = scanUseCustomDate,
+                    scanMonths = scanMonths,
+                )
+            )
         }
 
         reportProgress(stats)
@@ -925,33 +934,19 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
 
     /** Computes scan params without reading any message bodies. */
     private suspend fun computeScanParams(forceResync: Boolean): Pair<Long, Boolean> {
-        val lastScanTimestamp = userPreferencesRepository.getLastScanTimestamp().first() ?: 0L
-        val scanMonths        = userPreferencesRepository.getSmsScanMonths()
-        val scanAllTime       = userPreferencesRepository.getSmsScanAllTime()
-        val lastScanPeriod    = userPreferencesRepository.getLastScanPeriod().first() ?: 0
-        val now               = System.currentTimeMillis()
-
-        val scanAllTimeToggled = scanAllTime && lastScanPeriod != -1
-        val scanAllTimeToggledOff = !scanAllTime && lastScanPeriod == -1
-        val needsFullScan = forceResync || lastScanTimestamp == 0L ||
-            (lastScanPeriod >= 0 && scanMonths > lastScanPeriod) ||
-            scanAllTimeToggled || scanAllTimeToggledOff
-
-        val scanStartTime = if (needsFullScan) {
-            if (scanAllTime) 0L
-            else java.util.Calendar.getInstance().apply {
-                add(java.util.Calendar.MONTH, -scanMonths)
-                set(java.util.Calendar.HOUR_OF_DAY, 0); set(java.util.Calendar.MINUTE, 0)
-                set(java.util.Calendar.SECOND, 0);      set(java.util.Calendar.MILLISECOND, 0)
-            }.timeInMillis
-        } else {
-            val threeDaysAgo = now - TimeConstants.MILLIS_PER_3_DAYS
-            val periodLimit  = java.util.Calendar.getInstance().apply {
-                add(java.util.Calendar.MONTH, -scanMonths)
-            }.timeInMillis
-            maxOf(minOf(lastScanTimestamp, threeDaysAgo), periodLimit)
-        }
-        return scanStartTime to needsFullScan
+        val params = SmsScanParamsCalculator.compute(
+            SmsScanParamsInput(
+                forceResync = forceResync,
+                lastScanTimestamp = userPreferencesRepository.getLastScanTimestamp().first(),
+                scanMonths = userPreferencesRepository.getSmsScanMonths(),
+                scanAllTime = userPreferencesRepository.getSmsScanAllTime(),
+                scanUseCustomDate = userPreferencesRepository.getSmsScanUseCustomDate(),
+                scanCustomDateMillis = userPreferencesRepository.getSmsScanCustomDate(),
+                lastScanPeriod = userPreferencesRepository.getLastScanPeriod().first(),
+                nowMillis = System.currentTimeMillis(),
+            )
+        )
+        return params.scanStartTime to params.needsFullScan
     }
 
     /** Fast COUNT-only query — reads zero message bodies. */

--- a/app/src/main/java/com/pennywiseai/tracker/worker/ScheduledFolderBackupWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/worker/ScheduledFolderBackupWorker.kt
@@ -1,0 +1,66 @@
+package com.pennywiseai.tracker.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.pennywiseai.tracker.backup.folder.FolderBackupWriter
+import com.pennywiseai.tracker.data.backup.BackupExporter
+import com.pennywiseai.tracker.data.backup.ExportBytesResult
+import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class ScheduledFolderBackupWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val backupExporter: BackupExporter,
+    private val folderBackupWriter: FolderBackupWriter,
+    private val userPreferencesRepository: UserPreferencesRepository
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        if (!userPreferencesRepository.isScheduledFolderBackupEnabled()) {
+            return Result.success()
+        }
+
+        val treeUri = userPreferencesRepository.getScheduledFolderBackupTreeUri()
+        if (treeUri.isNullOrBlank()) {
+            Log.w(TAG, "Scheduled folder backup enabled but no folder selected")
+            return Result.failure()
+        }
+
+        if (!folderBackupWriter.canWriteToFolder(treeUri)) {
+            Log.w(TAG, "Cannot write to scheduled backup folder")
+            return Result.retry()
+        }
+
+        return when (val exportResult = backupExporter.exportBackupBytes()) {
+            is ExportBytesResult.Success -> {
+                when (val writeResult = folderBackupWriter.writeBackup(treeUri, exportResult.bytes)) {
+                    is FolderBackupWriter.Result.Success -> {
+                        userPreferencesRepository.setScheduledFolderBackupLastTimestamp(
+                            System.currentTimeMillis()
+                        )
+                        Log.i(TAG, "Scheduled folder backup completed")
+                        Result.success()
+                    }
+                    is FolderBackupWriter.Result.Failure -> {
+                        Log.e(TAG, "Scheduled folder backup write failed: ${writeResult.message}")
+                        Result.retry()
+                    }
+                }
+            }
+            is ExportBytesResult.Error -> {
+                Log.e(TAG, "Scheduled folder backup export failed: ${exportResult.message}")
+                Result.retry()
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "ScheduledFolderBackup"
+    }
+}

--- a/app/src/test/java/com/pennywiseai/tracker/backup/folder/ScheduledFolderBackupSchedulerTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/backup/folder/ScheduledFolderBackupSchedulerTest.kt
@@ -1,0 +1,51 @@
+package com.pennywiseai.tracker.backup.folder
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.concurrent.TimeUnit
+
+class ScheduledFolderBackupSchedulerTest {
+
+    @Test
+    fun computeInitialDelayMs_beforeTwoAm_targetsSameDay() {
+        val now = LocalDateTime.of(2026, 6, 21, 1, 30)
+        val delayMs = ScheduledFolderBackupScheduler.computeInitialDelayMs(
+            now = now,
+            zoneId = ZoneId.of("UTC")
+        )
+        assertEquals(TimeUnit.MINUTES.toMillis(30), delayMs)
+    }
+
+    @Test
+    fun computeInitialDelayMs_afterTwoAm_targetsNextDay() {
+        val now = LocalDateTime.of(2026, 6, 21, 3, 0)
+        val delayMs = ScheduledFolderBackupScheduler.computeInitialDelayMs(
+            now = now,
+            zoneId = ZoneId.of("UTC")
+        )
+        assertEquals(TimeUnit.HOURS.toMillis(23), delayMs)
+    }
+
+    @Test
+    fun computeInitialDelayMs_atTwoAm_targetsNextDay() {
+        val now = LocalDateTime.of(2026, 6, 21, 2, 0)
+        val delayMs = ScheduledFolderBackupScheduler.computeInitialDelayMs(
+            now = now,
+            zoneId = ZoneId.of("UTC")
+        )
+        assertEquals(TimeUnit.HOURS.toMillis(24), delayMs)
+    }
+
+    @Test
+    fun computeInitialDelayMs_isAlwaysPositive() {
+        val now = LocalDateTime.of(2026, 6, 21, 12, 45)
+        val delayMs = ScheduledFolderBackupScheduler.computeInitialDelayMs(
+            now = now,
+            zoneId = ZoneId.of("UTC")
+        )
+        assertTrue(delayMs > 0)
+    }
+}

--- a/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupModelsTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupModelsTest.kt
@@ -5,6 +5,7 @@ import com.pennywiseai.tracker.data.database.entity.*
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -534,6 +535,8 @@ class BackupModelsTest {
 
         assertEquals(false, backup.preferences.developer.isDeveloperModeEnabled)
         assertEquals(6, backup.preferences.sms.smsScanMonths)
+        assertFalse(backup.preferences.sms.smsScanUseCustomDate)
+        assertNull(backup.preferences.sms.smsScanCustomDate)
         assertNull(backup.preferences.theme.isDarkThemeEnabled)
         assertEquals("", backup.metadata.exportId)
         assertTrue(backup.database.transactions.isEmpty())
@@ -566,5 +569,71 @@ class BackupModelsTest {
             .database.subscriptions.single()
         assertEquals("Monthly", sub.billingCycle)
         assertEquals(SubscriptionDirection.EXPENSE, sub.direction)
+    }
+
+    @Test
+    fun customSmsScanPreferences_roundTrip() {
+        val customDateMillis = 1_705_276_800_000L
+        val backup = PennyWiseBackup(
+            metadata = BackupMetadata(
+                exportId = "custom-sms-scan",
+                appVersion = "test",
+                databaseVersion = SCHEMA_VERSION,
+                device = "Test",
+                androidVersion = 30,
+                statistics = BackupStatistics(
+                    totalTransactions = 0,
+                    totalCategories = 0,
+                    totalCards = 0,
+                    totalSubscriptions = 0,
+                    dateRange = null
+                )
+            ),
+            database = DatabaseSnapshot(),
+            preferences = PreferencesSnapshot(
+                theme = ThemePreferences(isDarkThemeEnabled = null, isDynamicColorEnabled = false),
+                sms = SmsPreferences(
+                    hasSkippedSmsPermission = false,
+                    smsScanMonths = 3,
+                    lastScanTimestamp = null,
+                    lastScanPeriod = -2,
+                    smsScanUseCustomDate = true,
+                    smsScanCustomDate = customDateMillis,
+                ),
+                developer = DeveloperPreferences(isDeveloperModeEnabled = false, systemPrompt = null),
+                app = AppPreferences(
+                    hasShownScanTutorial = false,
+                    firstLaunchTime = null,
+                    hasShownReviewPrompt = false,
+                    lastReviewPromptTime = null
+                )
+            )
+        )
+
+        val deserialized = backupJson.decodeFromString<PennyWiseBackup>(backupJson.encodeToString(backup))
+
+        assertTrue(deserialized.preferences.sms.smsScanUseCustomDate)
+        assertEquals(customDateMillis, deserialized.preferences.sms.smsScanCustomDate)
+        assertEquals(-2, deserialized.preferences.sms.lastScanPeriod)
+    }
+
+    @Test
+    fun oldBackupMissingCustomSmsScanFields_fallsBackToDefaults() {
+        val json = """
+        {
+          "preferences": {
+            "sms": {
+              "sms_scan_months": 6,
+              "last_scan_period": 6
+            }
+          }
+        }
+        """.trimIndent()
+
+        val sms = backupJson.decodeFromString<PennyWiseBackup>(json).preferences.sms
+
+        assertEquals(6, sms.smsScanMonths)
+        assertFalse(sms.smsScanUseCustomDate)
+        assertNull(sms.smsScanCustomDate)
     }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupSchemaGuardTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupSchemaGuardTest.kt
@@ -68,6 +68,8 @@ class BackupSchemaGuardTest {
         serializer<ProfileEntity>().descriptor,
         serializer<BudgetMonthSnapshotEntity>().descriptor,
         serializer<BudgetCategoryMonthSnapshotEntity>().descriptor,
+        serializer<TagEntity>().descriptor,
+        serializer<TransactionTagCrossRef>().descriptor,
     )
 
     private fun SerialDescriptor.requiredFields(): List<String> =

--- a/app/src/test/java/com/pennywiseai/tracker/data/manager/SmsScanParamsCalculatorTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/manager/SmsScanParamsCalculatorTest.kt
@@ -1,0 +1,203 @@
+package com.pennywiseai.tracker.data.manager
+
+import com.pennywiseai.tracker.core.Constants
+import com.pennywiseai.tracker.core.TimeConstants
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+class SmsScanParamsCalculatorTest {
+
+    private val zoneId = ZoneId.of("Asia/Kolkata")
+    private val nowMillis = localStartOfDay(2025, 6, 21, 14, 30)
+
+    @Test
+    fun `custom date scan uses selected start date through today`() {
+        val customStart = localStartOfDay(2025, 1, 15)
+
+        val params = SmsScanParamsCalculator.compute(
+            SmsScanParamsInput(
+                lastScanTimestamp = 0L,
+                scanMonths = 3,
+                scanAllTime = false,
+                scanUseCustomDate = true,
+                scanCustomDateMillis = customStart,
+                lastScanPeriod = 3,
+                nowMillis = nowMillis,
+            ),
+            zoneId = zoneId,
+        )
+
+        assertTrue(params.needsFullScan)
+        assertEquals(customStart, params.scanStartTime)
+    }
+
+    @Test
+    fun `switching to custom date from months triggers full scan`() {
+        val customStart = localStartOfDay(2025, 3, 1)
+
+        val params = SmsScanParamsCalculator.compute(
+            SmsScanParamsInput(
+                lastScanTimestamp = nowMillis - TimeConstants.MILLIS_PER_DAY,
+                scanMonths = 3,
+                scanAllTime = false,
+                scanUseCustomDate = true,
+                scanCustomDateMillis = customStart,
+                lastScanPeriod = 3,
+                nowMillis = nowMillis,
+            ),
+            zoneId = zoneId,
+        )
+
+        assertTrue(params.needsFullScan)
+        assertEquals(customStart, params.scanStartTime)
+    }
+
+    @Test
+    fun `switching from custom date to months triggers full scan`() {
+        val params = SmsScanParamsCalculator.compute(
+            SmsScanParamsInput(
+                lastScanTimestamp = nowMillis - TimeConstants.MILLIS_PER_DAY,
+                scanMonths = 6,
+                scanAllTime = false,
+                scanUseCustomDate = false,
+                lastScanPeriod = Constants.SmsProcessing.SCAN_PERIOD_CUSTOM_DATE,
+                nowMillis = nowMillis,
+            ),
+            zoneId = zoneId,
+        )
+
+        assertTrue(params.needsFullScan)
+        assertEquals(
+            SmsScanParamsCalculator.monthBasedScanStartTime(6, nowMillis, zoneId),
+            params.scanStartTime,
+        )
+    }
+
+    @Test
+    fun `incremental custom date scan respects custom start boundary`() {
+        val customStart = localStartOfDay(2025, 5, 1)
+        val lastScan = nowMillis - TimeConstants.MILLIS_PER_DAY
+
+        val params = SmsScanParamsCalculator.compute(
+            SmsScanParamsInput(
+                lastScanTimestamp = lastScan,
+                scanMonths = 3,
+                scanAllTime = false,
+                scanUseCustomDate = true,
+                scanCustomDateMillis = customStart,
+                lastScanPeriod = Constants.SmsProcessing.SCAN_PERIOD_CUSTOM_DATE,
+                nowMillis = nowMillis,
+            ),
+            zoneId = zoneId,
+        )
+
+        assertFalse(params.needsFullScan)
+        assertEquals(
+            maxOf(
+                minOf(lastScan, nowMillis - TimeConstants.MILLIS_PER_3_DAYS),
+                customStart,
+            ),
+            params.scanStartTime,
+        )
+    }
+
+    @Test
+    fun `custom date without stored value falls back to month based start`() {
+        val expectedStart = SmsScanParamsCalculator.monthBasedScanStartTime(3, nowMillis, zoneId)
+
+        val startTime = SmsScanParamsCalculator.scanPeriodStartTime(
+            scanAllTime = false,
+            scanUseCustomDate = true,
+            scanCustomDateMillis = null,
+            scanMonths = 3,
+            nowMillis = nowMillis,
+            zoneId = zoneId,
+        )
+
+        assertEquals(expectedStart, startTime)
+    }
+
+    @Test
+    fun `resolveLastScanPeriod stores custom date sentinel`() {
+        assertEquals(
+            Constants.SmsProcessing.SCAN_PERIOD_CUSTOM_DATE,
+            SmsScanParamsCalculator.resolveLastScanPeriod(
+                scanAllTime = false,
+                scanUseCustomDate = true,
+                scanMonths = 3,
+            ),
+        )
+    }
+
+    @Test
+    fun `month based scan period still works`() {
+        val expectedStart = SmsScanParamsCalculator.monthBasedScanStartTime(3, nowMillis, zoneId)
+
+        val params = SmsScanParamsCalculator.compute(
+            SmsScanParamsInput(
+                lastScanTimestamp = 0L,
+                scanMonths = 3,
+                scanAllTime = false,
+                scanUseCustomDate = false,
+                lastScanPeriod = 3,
+                nowMillis = nowMillis,
+            ),
+            zoneId = zoneId,
+        )
+
+        assertTrue(params.needsFullScan)
+        assertEquals(expectedStart, params.scanStartTime)
+    }
+
+    @Test
+    fun `all time scan still scans from epoch`() {
+        val params = SmsScanParamsCalculator.compute(
+            SmsScanParamsInput(
+                lastScanTimestamp = 0L,
+                scanMonths = 3,
+                scanAllTime = true,
+                scanUseCustomDate = false,
+                lastScanPeriod = Constants.SmsProcessing.SCAN_PERIOD_ALL_TIME,
+                nowMillis = nowMillis,
+            ),
+            zoneId = zoneId,
+        )
+
+        assertTrue(params.needsFullScan)
+        assertEquals(0L, params.scanStartTime)
+    }
+
+    @Test
+    fun `normalizePickerDateToLocalStartOfDay converts picker date to local midnight`() {
+        val pickerMillis = LocalDate.of(2025, 1, 15)
+            .atStartOfDay(ZoneOffset.UTC)
+            .toInstant()
+            .toEpochMilli()
+
+        val normalized = SmsScanParamsCalculator.normalizePickerDateToLocalStartOfDay(
+            pickerMillis = pickerMillis,
+            zoneId = zoneId,
+        )
+
+        assertEquals(localStartOfDay(2025, 1, 15), normalized)
+    }
+
+    private fun localStartOfDay(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int = 0,
+        minute: Int = 0,
+    ): Long {
+        return LocalDate.of(year, month, day)
+            .atTime(hour, minute)
+            .atZone(zoneId)
+            .toInstant()
+            .toEpochMilli()
+    }
+}

--- a/app/src/test/java/com/pennywiseai/tracker/domain/model/rule/RuleConditionTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/domain/model/rule/RuleConditionTest.kt
@@ -1,5 +1,6 @@
 package com.pennywiseai.tracker.domain.model.rule
 
+import com.pennywiseai.tracker.data.database.entity.TransactionType
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -138,5 +139,49 @@ class RuleConditionTest {
             value = "32"
         )
         assertFalse(condition.validate())
+    }
+
+    @Test
+    fun `TYPE with EXPENSE value returns true`() {
+        val condition = RuleCondition(
+            field = TransactionField.TYPE,
+            operator = ConditionOperator.EQUALS,
+            value = "EXPENSE"
+        )
+        assertTrue(condition.validate())
+    }
+
+    @Test
+    fun `TYPE with invalid value returns false`() {
+        val condition = RuleCondition(
+            field = TransactionField.TYPE,
+            operator = ConditionOperator.EQUALS,
+            value = "Outgoing"
+        )
+        assertFalse(condition.validate())
+    }
+
+    @Test
+    fun `isRuleApplicableToTransactionType matches EXPENSE condition for expense transactions`() {
+        val rule = TransactionRule(
+            name = "Expense rule",
+            conditions = listOf(
+                RuleCondition(
+                    field = TransactionField.TYPE,
+                    operator = ConditionOperator.EQUALS,
+                    value = "EXPENSE"
+                )
+            ),
+            actions = listOf(
+                RuleAction(
+                    field = TransactionField.CATEGORY,
+                    actionType = ActionType.SET,
+                    value = "Food"
+                )
+            )
+        )
+
+        assertTrue(isRuleApplicableToTransactionType(rule, TransactionType.EXPENSE))
+        assertFalse(isRuleApplicableToTransactionType(rule, TransactionType.INCOME))
     }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/domain/service/RuleEngineTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/domain/service/RuleEngineTest.kt
@@ -326,8 +326,71 @@ class RuleEngineTest {
 
         val (_, applications) = engine.evaluateRules(txn, null, listOf(rule))
 
-        assertFalse("Expected combined AND conditions to NOT match when amount is too low",
-            applications.isNotEmpty())
+        assertFalse(
+            "Expected combined AND conditions to NOT match when amount is too low",
+            applications.isNotEmpty()
+        )
+    }
+
+    @Test
+    fun `SET TYPE action can set transaction type to EXPENSE`() {
+        val txn = transaction(
+            merchantName = "Amazon",
+            transactionType = TransactionType.CREDIT
+        )
+        val rule = TransactionRule(
+            name = "Mark card spend as expense",
+            conditions = listOf(
+                RuleCondition(
+                    field = TransactionField.MERCHANT,
+                    operator = ConditionOperator.CONTAINS,
+                    value = "Amazon"
+                )
+            ),
+            actions = listOf(
+                RuleAction(
+                    field = TransactionField.TYPE,
+                    actionType = ActionType.SET,
+                    value = "EXPENSE"
+                )
+            )
+        )
+
+        val (result, applications) = engine.evaluateRules(txn, null, listOf(rule))
+
+        assertEquals(TransactionType.EXPENSE, result.transactionType)
+        assertTrue(applications.isNotEmpty())
+    }
+
+    @Test
+    fun `TYPE EXPENSE condition matches expense transactions`() {
+        val txn = transaction(transactionType = TransactionType.EXPENSE)
+        val rule = TransactionRule(
+            name = "Expense-only rule",
+            conditions = listOf(
+                RuleCondition(
+                    field = TransactionField.TYPE,
+                    operator = ConditionOperator.EQUALS,
+                    value = "EXPENSE"
+                )
+            ),
+            actions = listOf(
+                RuleAction(
+                    field = TransactionField.CATEGORY,
+                    actionType = ActionType.SET,
+                    value = "General"
+                )
+            )
+        )
+
+        val (_, applications) = engine.evaluateRulesForType(
+            txn,
+            smsText = null,
+            rules = listOf(rule),
+            type = TransactionType.EXPENSE
+        )
+
+        assertTrue(applications.isNotEmpty())
     }
 
     @Test

--- a/app/src/test/java/com/pennywiseai/tracker/ui/icons/CategoryColorsTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/ui/icons/CategoryColorsTest.kt
@@ -1,0 +1,47 @@
+package com.pennywiseai.tracker.ui.icons
+
+import androidx.compose.ui.graphics.Color
+import com.pennywiseai.tracker.data.database.entity.CategoryEntity
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CategoryColorsTest {
+
+    @Test
+    fun `uses persisted color for custom category`() {
+        val categoriesByName = mapOf(
+            "My Custom" to CategoryEntity(
+                name = "My Custom",
+                color = "#FF5722"
+            )
+        )
+
+        assertEquals(Color(0xFFFF5722), categoryColorFor("My Custom", categoriesByName))
+    }
+
+    @Test
+    fun `falls back to CategoryMapping for known system category`() {
+        val expected = CategoryMapping.categories["Food & Dining"]!!.color
+
+        assertEquals(expected, categoryColorFor("Food & Dining"))
+    }
+
+    @Test
+    fun `falls back to Others for unknown category`() {
+        val expected = CategoryMapping.categories["Others"]!!.color
+
+        assertEquals(expected, categoryColorFor("Unknown Category"))
+    }
+
+    @Test
+    fun `prefers persisted color over CategoryMapping for system category`() {
+        val categoriesByName = mapOf(
+            "Food & Dining" to CategoryEntity(
+                name = "Food & Dining",
+                color = "#123456"
+            )
+        )
+
+        assertEquals(Color(0xFF123456), categoryColorFor("Food & Dining", categoriesByName))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ biometric = "1.1.0"
 colorpickerCompose = "1.1.4"
 coreSplashscreen = "1.2.0"
 datastorePreferences = "1.2.1"
+documentfile = "1.1.0"
 glance = "1.1.1"
 gson = "2.14.0"
 hiltAndroid = "2.59.2"
@@ -49,6 +50,7 @@ androidx-compose-material-icons-extended = { module = "androidx.compose.material
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashscreen" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
+androidx-documentfile = { module = "androidx.documentfile:documentfile", version.ref = "documentfile" }
 androidx-glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glance" }
 androidx-glance-material3 = { module = "androidx.glance:glance-material3", version.ref = "glance" }
 androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hiltCompiler" }

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ArabBankJordanParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ArabBankJordanParser.kt
@@ -1,0 +1,210 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Arab Bank (Jordan).
+ *
+ * Handles Jordanian Dinar (JOD) and USD transactions. JOD amounts use three
+ * decimal places (e.g. "JOD 2.750"), so amount/balance extraction accepts 1-3
+ * fractional digits and the currency token can appear either before the amount
+ * ("JOD 50.000") or after it ("37.920JOD").
+ *
+ * Example SMS formats:
+ * - Card purchase:
+ *   "A Trx using Card XXXX9915 from ADANI CORNER for JOD 2.750 on 20-Jun-2026
+ *    at 14:21 GMT+3. Available balance is JOD 1649.832."
+ * - Account debit (transfer):
+ *   "JOD50.000 has been debited from 0156*500 to <name> as CliQ transfer
+ *    Balance 37.920JOD"
+ * - Account credit (transfer):
+ *   "JOD172.000 has been credited to 0156*500from <name> as CliQ transfer
+ *    Balance 959.370JOD"
+ *
+ * Transfer/payee extraction is not tied to any specific scheme (e.g. CliQ): the
+ * counterparty name is read up to the transfer description ("... as ..."), the
+ * balance section, or end of line, so other transfer types parse the same way.
+ */
+class ArabBankJordanParser : BankParser() {
+
+    override fun getBankName() = "Arab Bank Jordan"
+
+    override fun getCurrency() = "JOD"
+
+    override fun canHandle(sender: String): Boolean {
+        val normalizedSender = sender.uppercase().replace(Regex("[\\s\\-_]+"), "")
+        return normalizedSender.contains("ARABBANK") ||
+                // DLT-style senders e.g. "AB-ARABBK-S"
+                normalizedSender.matches(Regex("^[A-Z]{2}ARABBK[A-Z]?$"))
+    }
+
+    override fun parse(smsBody: String, sender: String, timestamp: Long): ParsedTransaction? {
+        val transaction = super.parse(smsBody, sender, timestamp) ?: return null
+        val extractedCurrency = extractCurrency(smsBody)
+        return if (extractedCurrency != null) {
+            transaction.copy(currency = extractedCurrency)
+        } else {
+            transaction
+        }
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lowerMessage = message.lowercase()
+
+        if (lowerMessage.contains("otp") ||
+            lowerMessage.contains("one time password") ||
+            lowerMessage.contains("verification code") ||
+            lowerMessage.contains("do not share") ||
+            lowerMessage.contains("declined") ||
+            lowerMessage.contains("failed")
+        ) {
+            return false
+        }
+
+        val transactionKeywords = listOf(
+            "trx using card",
+            "has been debited",
+            "has been credited"
+        )
+
+        if (transactionKeywords.any { lowerMessage.contains(it) }) {
+            return true
+        }
+
+        return super.isTransactionMessage(message)
+    }
+
+    override fun extractCurrency(message: String): String? {
+        // Pick the currency token next to the transaction amount (the first one
+        // in the message). Both prefix ("JOD 50.000") and suffix ("37.920JOD")
+        // forms are covered by scanning for the first JOD/USD occurrence.
+        CURRENCY_TOKEN.find(message)?.let { return it.groupValues[1].uppercase() }
+        return getCurrency()
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        val patterns = listOf(
+            // Currency before amount: "JOD 2.750", "USD50.000"
+            Regex("""(?:JOD|USD)\s*([0-9,]+(?:\.\d{1,3})?)""", RegexOption.IGNORE_CASE),
+            // Amount before currency: "50.000 JOD"
+            Regex("""([0-9,]+(?:\.\d{1,3})?)\s*(?:JOD|USD)""", RegexOption.IGNORE_CASE)
+        )
+
+        for (pattern in patterns) {
+            pattern.find(message)?.let { match ->
+                val amountStr = match.groupValues[1].replace(",", "")
+                return try {
+                    BigDecimal(amountStr)
+                } catch (e: NumberFormatException) {
+                    null
+                }
+            }
+        }
+
+        return super.extractAmount(message)
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        val patterns = listOf(
+            // "Available balance is JOD 1649.832"
+            Regex("""balance\s+is\s+(?:JOD|USD)\s*([0-9,]+(?:\.\d{1,3})?)""", RegexOption.IGNORE_CASE),
+            // "Balance JOD 1649.832"
+            Regex("""balance\s+(?:JOD|USD)\s*([0-9,]+(?:\.\d{1,3})?)""", RegexOption.IGNORE_CASE),
+            // "Balance 37.920JOD" / "Balance 959.370 JOD"
+            Regex("""balance\s+([0-9,]+(?:\.\d{1,3})?)\s*(?:JOD|USD)""", RegexOption.IGNORE_CASE)
+        )
+
+        for (pattern in patterns) {
+            pattern.find(message)?.let { match ->
+                val balanceStr = match.groupValues[1].replace(",", "")
+                return try {
+                    BigDecimal(balanceStr)
+                } catch (e: NumberFormatException) {
+                    null
+                }
+            }
+        }
+
+        return null
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lowerMessage = message.lowercase()
+
+        return when {
+            // Credit card spend is tracked as CREDIT in this app
+            lowerMessage.contains("trx using card") -> TransactionType.CREDIT
+            lowerMessage.contains("debited") -> TransactionType.EXPENSE
+            lowerMessage.contains("credited") -> TransactionType.INCOME
+            else -> super.extractTransactionType(message)
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        val lowerMessage = message.lowercase()
+
+        // Card purchase: "... from ADANI CORNER for JOD 2.750 ..."
+        if (lowerMessage.contains("trx using card")) {
+            Regex("""from\s+(.+?)\s+for\s+(?:JOD|USD)""", RegexOption.IGNORE_CASE)
+                .find(message)?.let { match ->
+                    val merchant = cleanMerchantName(match.groupValues[1].trim())
+                    if (isValidMerchantName(merchant)) return merchant
+                }
+        }
+
+        // Outgoing transfer: "... debited from <acct> to <name> [as <type> transfer] ..."
+        if (lowerMessage.contains("debited")) {
+            Regex("""to\s+(.+?)$COUNTERPARTY_TERMINATOR""", RegexOption.IGNORE_CASE)
+                .find(message)?.let { match ->
+                    val merchant = cleanMerchantName(match.groupValues[1].trim())
+                    if (isValidMerchantName(merchant)) return merchant
+                }
+        }
+
+        // Incoming transfer: "... credited to <acct> from <name> [as <type> transfer] ..."
+        if (lowerMessage.contains("credited")) {
+            Regex("""from\s+(.+?)$COUNTERPARTY_TERMINATOR""", RegexOption.IGNORE_CASE)
+                .find(message)?.let { match ->
+                    val merchant = cleanMerchantName(match.groupValues[1].trim())
+                    if (isValidMerchantName(merchant)) return merchant
+                }
+        }
+
+        return super.extractMerchant(message, sender)
+    }
+
+    override fun extractAccountLast4(message: String): String? {
+        // Card: "Card XXXX9915"
+        Regex("""Card\s+([X*0-9]+)""", RegexOption.IGNORE_CASE).find(message)?.let { match ->
+            extractLast4Digits(match.groupValues[1])?.let { return it }
+        }
+
+        // CliQ account: "from 0156*500 to ..." / "to 0156*500from ..."
+        Regex("""(?:from|to)\s+([0-9][0-9*]{2,})""", RegexOption.IGNORE_CASE)
+            .find(message)?.let { match ->
+                extractLast4Digits(match.groupValues[1])?.let { return it }
+            }
+
+        return super.extractAccountLast4(message)
+    }
+
+    override fun detectIsCard(message: String): Boolean {
+        val lowerMessage = message.lowercase()
+        if (lowerMessage.contains("trx using card")) return true
+        // Account-to-account transfers ("debited from ... to", "credited to ... from")
+        // are never card transactions, regardless of the transfer scheme.
+        if (lowerMessage.contains("debited from") || lowerMessage.contains("credited to")) return false
+        return super.detectIsCard(message)
+    }
+
+    private companion object {
+        val CURRENCY_TOKEN = Regex("""(JOD|USD)""", RegexOption.IGNORE_CASE)
+
+        // Ends a counterparty name at the transfer description ("... as ..."),
+        // the balance section, a line break, or end of message. Kept generic so
+        // the parser is not tied to a particular transfer scheme (e.g. CliQ).
+        const val COUNTERPARTY_TERMINATOR = """(?:\s+as\s+|\s+Balance\b|\n|$)"""
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -119,6 +119,7 @@ object BankParserFactory {
         SNBAlAhliBankParser(),  // Saudi National Bank / Al Ahli Bank (Saudi Arabia)
         STCBankParser(),  // STC Bank (Saudi Arabia)
         SabbBankParser(),  // SABB - Saudi Awwal Bank (Saudi Arabia)
+        ArabBankJordanParser(),  // Arab Bank (Jordan) — JOD/USD, card & account transfers
         MBankCZParser(),  // mBank CZ (Czech Republic)
         SparkasseRheinMaasParser(),  // Sparkasse Rhein-Maas (Germany)
         EnparaBankParser(),  // Enpara (Turkey) — push notifications

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/ArabBankJordanParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/ArabBankJordanParserTest.kt
@@ -1,0 +1,150 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import com.pennywiseai.parser.core.test.SimpleTestCase
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class ArabBankJordanParserTest {
+
+    @TestFactory
+    fun `Arab Bank Jordan parser handles key paths`(): List<DynamicTest> {
+        val parser = ArabBankJordanParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "Credit card purchase (JOD)",
+                message = "A Trx using Card XXXX9915 from ADANI CORNER for JOD 2.750 on 20-Jun-2026 at 14:21 GMT+3. Available balance is JOD 1649.832.",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2.750"),
+                    currency = "JOD",
+                    type = TransactionType.CREDIT,
+                    merchant = "ADANI CORNER",
+                    accountLast4 = "9915",
+                    balance = BigDecimal("1649.832"),
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "Account debit (JOD, CliQ transfer)",
+                message = "JO\nJOD50.000 has been debited from 0156*500 to JOHN MICHAEL SMITH as CliQ transfer Balance 37.920JOD",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("50.000"),
+                    currency = "JOD",
+                    type = TransactionType.EXPENSE,
+                    merchant = "JOHN MICHAEL SMITH",
+                    accountLast4 = "6500",
+                    balance = BigDecimal("37.920"),
+                    isFromCard = false
+                )
+            ),
+            ParserTestCase(
+                name = "Account credit (JOD, CliQ transfer)",
+                message = "JO\nJOD172.000 has been credited to 0156*500from EMILY ROSE CARTER as CliQ transfer Balance 959.370JOD",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("172.000"),
+                    currency = "JOD",
+                    type = TransactionType.INCOME,
+                    merchant = "EMILY ROSE CARTER",
+                    accountLast4 = "6500",
+                    balance = BigDecimal("959.370"),
+                    isFromCard = false
+                )
+            ),
+            ParserTestCase(
+                name = "Account debit - non-CliQ transfer type",
+                message = "JO\nJOD25.500 has been debited from 0156*500 to DAVID ALAN WRIGHT as wire transfer Balance 12.420JOD",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("25.500"),
+                    currency = "JOD",
+                    type = TransactionType.EXPENSE,
+                    merchant = "DAVID ALAN WRIGHT",
+                    accountLast4 = "6500",
+                    balance = BigDecimal("12.420"),
+                    isFromCard = false
+                )
+            ),
+            ParserTestCase(
+                name = "Account credit - no transfer description",
+                message = "JO\nJOD300.000 has been credited to 0156*500from SARAH JANE BENNETT Balance 1200.000JOD",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("300.000"),
+                    currency = "JOD",
+                    type = TransactionType.INCOME,
+                    merchant = "SARAH JANE BENNETT",
+                    accountLast4 = "6500",
+                    balance = BigDecimal("1200.000"),
+                    isFromCard = false
+                )
+            ),
+            ParserTestCase(
+                name = "Credit card purchase (USD)",
+                message = "A Trx using Card XXXX9915 from AMAZON.COM for USD 19.99 on 20-Jun-2026 at 14:21 GMT+3. Available balance is USD 540.18.",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("19.99"),
+                    currency = "USD",
+                    type = TransactionType.CREDIT,
+                    merchant = "AMAZON.COM",
+                    accountLast4 = "9915",
+                    balance = BigDecimal("540.18"),
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "OTP message is ignored",
+                message = "Your Arab Bank OTP is 123456. Do not share it with anyone.",
+                sender = "ArabBank",
+                shouldParse = false
+            ),
+            ParserTestCase(
+                name = "Declined transaction is ignored",
+                message = "A Trx using Card XXXX9915 from ADANI CORNER for JOD 2.750 was declined.",
+                sender = "ArabBank",
+                shouldParse = false
+            )
+        )
+
+        val handleCases = listOf(
+            "ArabBank" to true,
+            "ARABBANK" to true,
+            "Arab Bank" to true,
+            "arabbank" to true,
+            "AB-ARABBK-S" to true,
+            "FAB" to false,
+            "HDFC" to false,
+            "" to false
+        )
+
+        return ParserTestUtils.runTestSuite(parser, testCases, handleCases, "Arab Bank Jordan")
+    }
+
+    @TestFactory
+    fun `factory resolves Arab Bank Jordan`(): List<DynamicTest> {
+        val cases = listOf(
+            SimpleTestCase(
+                bankName = "Arab Bank Jordan",
+                sender = "ArabBank",
+                currency = "JOD",
+                message = "JO\nJOD172.000 has been credited to 0156*500from EMILY ROSE CARTER as CliQ transfer Balance 959.370JOD",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("172.000"),
+                    currency = "JOD",
+                    type = TransactionType.INCOME
+                ),
+                shouldHandle = true
+            )
+        )
+
+        return ParserTestUtils.runFactoryTestSuite(cases, "Arab Bank Jordan Factory Tests")
+    }
+}


### PR DESCRIPTION
## Summary

The Top Categories chart and list breakdown on the Analytics page only looked up colors from hardcoded `CategoryMapping` entries, so custom categories always appeared with the default gray/Others color. This change loads persisted category colors from the database and uses them in both chart and list views.

## Type of change

- [x] fix: Bug fix
- [x] test: Add/update tests

## How to test

1. Create a custom category with a distinct color in Settings → Categories.
2. Assign transactions to that category (or use existing ones).
3. Open Analytics → Top Categories and confirm the pie chart slice and list bar use the custom color.
4. Run `./gradlew :app:testStandardDebugUnitTest --tests "com.pennywiseai.tracker.ui.icons.CategoryColorsTest"`.

## Breaking changes

No breaking changes.


Made with [Cursor](https://cursor.com)