### PR TITLE
feat(parser): Arab Bank Jordan (JOD/USD) — extends merged Egypt parser

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
@@ -47,7 +47,9 @@ object CurrencyFormatter {
         "TZS" to "TSh",
         "BRL" to "R$",
         "EGP" to "E£",
-        "JOD" to "JD"
+        "JOD" to "JD",
+        "BHD" to "BD",
+        "OMR" to "RO"
     )
 
     /**
@@ -77,7 +79,9 @@ object CurrencyFormatter {
         "TZS" to Locale.Builder().setLanguage("en").setRegion("TZ").build(),
         "BRL" to Locale.Builder().setLanguage("pt").setRegion("BR").build(),
         "EGP" to Locale.Builder().setLanguage("en").setRegion("EG").build(),
-        "JOD" to Locale.Builder().setLanguage("en").setRegion("JO").build()
+        "JOD" to Locale.Builder().setLanguage("en").setRegion("JO").build(),
+        "BHD" to Locale.Builder().setLanguage("en").setRegion("BH").build(),
+        "OMR" to Locale.Builder().setLanguage("en").setRegion("OM").build()
     )
 
     /**

--- a/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
@@ -14,6 +14,13 @@ object CurrencyFormatter {
     private val INDIAN_LOCALE = Locale.Builder().setLanguage("en").setRegion("IN").build()
 
     /**
+     * Currencies whose ISO 4217 minor unit is 3 (three decimal places),
+     * e.g. Jordanian Dinar, Kuwaiti Dinar. Used so amounts aren't truncated
+     * to 2 decimals on the symbol/fallback display paths.
+     */
+    private val THREE_DECIMAL_CURRENCIES = setOf("JOD", "KWD", "BHD", "OMR")
+
+    /**
      * Currency symbol mapping for display
      */
     private val CURRENCY_SYMBOLS = mapOf(
@@ -39,7 +46,8 @@ object CurrencyFormatter {
         "NGN" to "₦",
         "TZS" to "TSh",
         "BRL" to "R$",
-        "EGP" to "E£"
+        "EGP" to "E£",
+        "JOD" to "JD"
     )
 
     /**
@@ -68,7 +76,8 @@ object CurrencyFormatter {
         "NGN" to Locale.Builder().setLanguage("en").setRegion("NG").build(),
         "TZS" to Locale.Builder().setLanguage("en").setRegion("TZ").build(),
         "BRL" to Locale.Builder().setLanguage("pt").setRegion("BR").build(),
-        "EGP" to Locale.Builder().setLanguage("en").setRegion("EG").build()
+        "EGP" to Locale.Builder().setLanguage("en").setRegion("EG").build(),
+        "JOD" to Locale.Builder().setLanguage("en").setRegion("JO").build()
     )
 
     /**
@@ -88,17 +97,17 @@ object CurrencyFormatter {
             } catch (e: Exception) {
                 // If currency not supported, use symbol mapping
                 val symbol = CURRENCY_SYMBOLS[currencyCode] ?: currencyCode
-                return "$symbol${formatAmount(amount)}"
+                return "$symbol${formatAmount(amount, currencyCode)}"
             }
 
             // Show decimals only if they exist
             formatter.minimumFractionDigits = 0
-            formatter.maximumFractionDigits = 2
+            formatter.maximumFractionDigits = if (currencyCode in THREE_DECIMAL_CURRENCIES) 3 else 2
             formatter.format(amount)
         } catch (e: Exception) {
             // Fallback to symbol + amount
             val symbol = CURRENCY_SYMBOLS[currencyCode] ?: currencyCode
-            "$symbol${formatAmount(amount)}"
+            "$symbol${formatAmount(amount, currencyCode)}"
         }
     }
 
@@ -126,10 +135,10 @@ object CurrencyFormatter {
     /**
      * Formats just the numeric amount without currency symbol
      */
-    private fun formatAmount(amount: BigDecimal): String {
+    private fun formatAmount(amount: BigDecimal, currencyCode: String? = null): String {
         val formatter = NumberFormat.getNumberInstance(INDIAN_LOCALE)
         formatter.minimumFractionDigits = 0
-        formatter.maximumFractionDigits = 2
+        formatter.maximumFractionDigits = if (currencyCode != null && currencyCode in THREE_DECIMAL_CURRENCIES) 3 else 2
         return formatter.format(amount)
     }
 

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ArabBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ArabBankParser.kt
@@ -46,11 +46,10 @@ class ArabBankParser : BankParser() {
      */
     override fun parse(smsBody: String, sender: String, timestamp: Long): ParsedTransaction? {
         val transaction = super.parse(smsBody, sender, timestamp) ?: return null
+        // super.parse already sets isFromCard via detectIsCard (always true here);
+        // only the per-transaction currency (EGP or USD) needs overriding.
         val currency = extractCurrency(smsBody) ?: getCurrency()
-        return transaction.copy(
-            currency = currency,
-            isFromCard = true
-        )
+        return transaction.copy(currency = currency)
     }
 
     override fun isTransactionMessage(message: String): Boolean {

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ArabBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ArabBankParser.kt
@@ -5,25 +5,31 @@ import com.pennywiseai.parser.core.TransactionType
 import java.math.BigDecimal
 
 /**
- * Parser for Arab Bank (Egypt) SMS messages.
+ * Parser for Arab Bank SMS messages.
  *
- * Arab Bank sends both English and Arabic SMS for a multi-currency card account.
- * Default / base currency is the Egyptian Pound (EGP). The TRANSACTION can be in
- * EGP or USD, but the account's available balance is always reported in EGP.
- * The transaction amount/currency reflect the spent currency (EGP or USD) while
- * the balance currency stays EGP (the parser's base currency). See [parse].
+ * Arab Bank is a single bank operating in multiple countries. The SMS currency
+ * token (EGP / JOD / USD) is the differentiator between markets — there is ONE
+ * parser for all of them. The base/default currency stays EGP (Egypt), while
+ * per-message currency detection picks EGP, JOD or USD.
  *
  * Supported formats:
- * - English card spend (EXPENSE):
+ * - English card spend (EXPENSE), Egypt + Jordan (isFromCard = true):
  *   "A Trx using Card XXXX2020 from <MERCHANT> for <CCY> <amount> on <date> at <time>.
- *    Available balance is EGP <balance>."
- *   - merchant: text between "from " and " for "
- *   - amount currency: the CCY token after "for " (EGP or USD)
- * - Arabic credit to the card (INCOME):
+ *    Available balance is <CCY> <balance>."
+ *   - merchant: text between "from " and " for <CCY>"
+ *   - amount currency: the CCY token after "for " (EGP, USD or JOD)
+ *   - JOD uses 3 fractional digits.
+ * - Arabic credit to the card (INCOME), Egypt (isFromCard = true):
  *   "تم قيد مبلغ <amount> جنيه لبطاقتك الائتمانية رقم #<last4>"
  *   - amount in EGP ("جنيه"), no merchant, no balance
+ * - Jordan account transfer (CliQ), NOT a card (isFromCard = false):
+ *   - DEBIT (EXPENSE):
+ *     "<CCY><amount> has been debited from <acct> to <name> as CliQ transfer Balance <bal><CCY>"
+ *   - CREDIT (INCOME):
+ *     "<CCY><amount> has been credited to <acct>from <name> as CliQ transfer Balance <bal><CCY>"
+ *   - currency token may be a PREFIX ("JOD50.000") or SUFFIX on balance ("37.920JOD").
  *
- * Sender: ArabBank (token ARABBANK, case-insensitive).
+ * Sender: ArabBank (token ARABBANK) or DLT-style "AB-ARABBK-S".
  */
 class ArabBankParser : BankParser() {
 
@@ -33,21 +39,20 @@ class ArabBankParser : BankParser() {
 
     override fun canHandle(sender: String): Boolean {
         val normalized = sender.uppercase()
-        return normalized.contains("ARABBANK")
+        if (normalized.contains("ARABBANK")) return true
+        // DLT-style "AB-ARABBK-S": strip spaces/dashes/underscores then match.
+        val stripped = normalized.replace(Regex("""[\s\-_]"""), "")
+        return stripped.contains("ARABBANK") ||
+            stripped.matches(Regex("""^[A-Z]{2}ARABBK[A-Z]?$"""))
     }
 
     /**
-     * Override parse to surface the per-transaction currency.
-     *
-     * English transactions carry their own currency token after "for " (EGP or USD).
-     * Arabic credits are always EGP. The balance figure stays EGP regardless of the
-     * transaction currency — that is handled by [extractBalance] returning the EGP
-     * "Available balance" amount.
+     * Override parse to surface the per-transaction currency (EGP, JOD or USD).
+     * isFromCard is decided by detectIsCard (card spends + Arabic credit = true,
+     * account transfers = false).
      */
     override fun parse(smsBody: String, sender: String, timestamp: Long): ParsedTransaction? {
         val transaction = super.parse(smsBody, sender, timestamp) ?: return null
-        // super.parse already sets isFromCard via detectIsCard (always true here);
-        // only the per-transaction currency (EGP or USD) needs overriding.
         val currency = extractCurrency(smsBody) ?: getCurrency()
         return transaction.copy(currency = currency)
     }
@@ -55,11 +60,13 @@ class ArabBankParser : BankParser() {
     override fun isTransactionMessage(message: String): Boolean {
         val lower = message.lowercase()
 
-        // Reject OTP / verification noise.
+        // Reject OTP / verification / declined / failed noise.
         if (lower.contains("otp") ||
             lower.contains("one time password") ||
             lower.contains("verification code") ||
             lower.contains("passcode") ||
+            lower.contains("declined") ||
+            lower.contains("failed") ||
             message.contains("رمز التحقق") ||      // Arabic: "verification code"
             message.contains("كلمة المرور")        // Arabic: "password"
         ) {
@@ -68,6 +75,11 @@ class ArabBankParser : BankParser() {
 
         // English card spend marker.
         if (Regex("""using\s+Card""", RegexOption.IGNORE_CASE).containsMatchIn(message)) {
+            return true
+        }
+
+        // Jordan account transfer markers.
+        if (lower.contains("has been debited") || lower.contains("has been credited")) {
             return true
         }
 
@@ -80,6 +92,8 @@ class ArabBankParser : BankParser() {
     }
 
     override fun extractTransactionType(message: String): TransactionType? {
+        val lower = message.lowercase()
+
         // Arabic credit to the card.
         if (message.contains("تم قيد")) {
             return TransactionType.INCOME
@@ -90,16 +104,33 @@ class ArabBankParser : BankParser() {
             return TransactionType.EXPENSE
         }
 
+        // Jordan account transfers.
+        if (lower.contains("has been debited")) {
+            return TransactionType.EXPENSE
+        }
+        if (lower.contains("has been credited")) {
+            return TransactionType.INCOME
+        }
+
         return null
     }
 
     override fun extractAmount(message: String): BigDecimal? {
-        // English: "for <CCY> <amount>" e.g. "for EGP 123.45" / "for USD 9.84".
-        val englishPattern = Regex(
+        // English card spend: "for <CCY> <amount>" e.g. "for EGP 123.45" / "for JOD 2.750".
+        val cardPattern = Regex(
             """for\s+[A-Z]{3}\s+([0-9,]+(?:\.\d+)?)""",
             RegexOption.IGNORE_CASE
         )
-        englishPattern.find(message)?.let { match ->
+        cardPattern.find(message)?.let { match ->
+            parseAmount(match.groupValues[1])?.let { return it }
+        }
+
+        // Jordan transfer: leading "<CCY><amount>" e.g. "JOD50.000" / "USD 50.000".
+        val transferPattern = Regex(
+            """^(?:JOD|USD|EGP)\s*([0-9,]+(?:\.\d+)?)""",
+            RegexOption.IGNORE_CASE
+        )
+        transferPattern.find(message.trim())?.let { match ->
             parseAmount(match.groupValues[1])?.let { return it }
         }
 
@@ -113,12 +144,21 @@ class ArabBankParser : BankParser() {
     }
 
     override fun extractCurrency(message: String): String? {
-        // English: the CCY token after "for " (EGP or USD).
-        val englishPattern = Regex(
+        // English card spend: the CCY token after "for " (EGP, USD or JOD).
+        val cardPattern = Regex(
             """for\s+([A-Z]{3})\s+[0-9,]+(?:\.\d+)?""",
             RegexOption.IGNORE_CASE
         )
-        englishPattern.find(message)?.let { match ->
+        cardPattern.find(message)?.let { match ->
+            return match.groupValues[1].uppercase()
+        }
+
+        // Jordan transfer: leading "<CCY><amount>".
+        val transferPattern = Regex(
+            """^(JOD|USD|EGP)\s*[0-9,]+(?:\.\d+)?""",
+            RegexOption.IGNORE_CASE
+        )
+        transferPattern.find(message.trim())?.let { match ->
             return match.groupValues[1].uppercase()
         }
 
@@ -131,15 +171,46 @@ class ArabBankParser : BankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
-        // English only: merchant is the text between "from " and " for ".
-        val merchantPattern = Regex(
+        // English card spend: merchant is the text between "from " and " for <CCY>".
+        val cardPattern = Regex(
             """from\s+(.+?)\s+for\s+[A-Z]{3}\s""",
             RegexOption.IGNORE_CASE
         )
-        merchantPattern.find(message)?.let { match ->
+        cardPattern.find(message)?.let { match ->
             val merchant = cleanMerchantName(match.groupValues[1].trim())
             if (isValidMerchantName(merchant)) {
                 return merchant
+            }
+        }
+
+        val lower = message.lowercase()
+
+        // Jordan transfer DEBIT: name after "to " up to " as " / " Balance" / end.
+        if (lower.contains("has been debited")) {
+            val debitPattern = Regex(
+                """\bto\s+(.+?)(?:\s+as\b|\s+Balance\b|$)""",
+                RegexOption.IGNORE_CASE
+            )
+            debitPattern.find(message)?.let { match ->
+                val merchant = cleanMerchantName(match.groupValues[1].trim())
+                if (isValidMerchantName(merchant)) {
+                    return merchant
+                }
+            }
+        }
+
+        // Jordan transfer CREDIT: name after "from " up to " as " / " Balance" / end.
+        // Handle the no-space "0156*500from Jane Doe" case.
+        if (lower.contains("has been credited")) {
+            val creditPattern = Regex(
+                """from\s*(.+?)(?:\s+as\b|\s+Balance\b|$)""",
+                RegexOption.IGNORE_CASE
+            )
+            creditPattern.find(message)?.let { match ->
+                val merchant = cleanMerchantName(match.groupValues[1].trim())
+                if (isValidMerchantName(merchant)) {
+                    return merchant
+                }
             }
         }
 
@@ -148,7 +219,7 @@ class ArabBankParser : BankParser() {
     }
 
     override fun extractAccountLast4(message: String): String? {
-        // English: "Card XXXX2020" -> 2020.
+        // English card spend: "Card XXXX2020" -> 2020.
         val englishCard = Regex(
             """Card\s+[X*]*(\d{4})""",
             RegexOption.IGNORE_CASE
@@ -163,16 +234,58 @@ class ArabBankParser : BankParser() {
             return match.groupValues[1]
         }
 
+        val lower = message.lowercase()
+
+        // Jordan transfer DEBIT: "debited from <acct>" e.g. "from 0156*500".
+        if (lower.contains("has been debited")) {
+            val debitAcct = Regex(
+                """debited\s+from\s+([0-9*]+)""",
+                RegexOption.IGNORE_CASE
+            )
+            debitAcct.find(message)?.let { match ->
+                extractLast4Digits(match.groupValues[1])?.let { return it }
+            }
+        }
+
+        // Jordan transfer CREDIT: "credited to <acct>" e.g. "to 0156*500from".
+        if (lower.contains("has been credited")) {
+            val creditAcct = Regex(
+                """credited\s+to\s+([0-9*]+)""",
+                RegexOption.IGNORE_CASE
+            )
+            creditAcct.find(message)?.let { match ->
+                extractLast4Digits(match.groupValues[1])?.let { return it }
+            }
+        }
+
         return null
     }
 
     override fun extractBalance(message: String): BigDecimal? {
-        // English: "Available balance is EGP <amount>" — always EGP.
-        val balancePattern = Regex(
-            """Available\s+balance\s+is\s+EGP\s+([0-9,]+(?:\.\d+)?)""",
+        // Card spend (Egypt + Jordan): "Available balance is <CCY> <amount>".
+        val cardBalance = Regex(
+            """Available\s+balance\s+is\s+[A-Z]{3}\s+([0-9,]+(?:\.\d+)?)""",
             RegexOption.IGNORE_CASE
         )
-        balancePattern.find(message)?.let { match ->
+        cardBalance.find(message)?.let { match ->
+            parseAmount(match.groupValues[1])?.let { return it }
+        }
+
+        // Jordan transfer suffix form: "Balance <amount><CCY>" e.g. "Balance 37.920JOD".
+        val suffixBalance = Regex(
+            """Balance\s+([0-9,]+(?:\.\d+)?)\s*(?:JOD|USD|EGP)""",
+            RegexOption.IGNORE_CASE
+        )
+        suffixBalance.find(message)?.let { match ->
+            parseAmount(match.groupValues[1])?.let { return it }
+        }
+
+        // Jordan transfer prefix form: "Balance <CCY> <amount>".
+        val prefixBalance = Regex(
+            """Balance\s+(?:JOD|USD|EGP)\s+([0-9,]+(?:\.\d+)?)""",
+            RegexOption.IGNORE_CASE
+        )
+        prefixBalance.find(message)?.let { match ->
             parseAmount(match.groupValues[1])?.let { return it }
         }
 
@@ -181,8 +294,28 @@ class ArabBankParser : BankParser() {
     }
 
     override fun detectIsCard(message: String): Boolean {
-        // This is a card account; every supported message is a card transaction.
-        return true
+        val lower = message.lowercase()
+
+        // Account transfers are NOT card transactions.
+        if (lower.contains("has been debited") ||
+            lower.contains("has been credited") ||
+            lower.contains("debited from") ||
+            lower.contains("credited to")
+        ) {
+            return false
+        }
+
+        // English card spend.
+        if (lower.contains("trx using card")) {
+            return true
+        }
+
+        // Arabic card credit ("لبطاقتك" = "to your card").
+        if (message.contains("تم قيد") || message.contains("لبطاقتك")) {
+            return true
+        }
+
+        return false
     }
 
     private fun parseAmount(raw: String): BigDecimal? {

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ArabBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ArabBankParser.kt
@@ -60,13 +60,20 @@ class ArabBankParser : BankParser() {
     override fun isTransactionMessage(message: String): Boolean {
         val lower = message.lowercase()
 
-        // Reject OTP / verification / declined / failed noise.
+        // Reject OTP / verification / failed-transaction noise.
+        // The failure check uses specific status phrases rather than a bare
+        // "failed", so a successful SMS that merely references a prior failed
+        // attempt is not dropped.
         if (lower.contains("otp") ||
             lower.contains("one time password") ||
             lower.contains("verification code") ||
             lower.contains("passcode") ||
             lower.contains("declined") ||
-            lower.contains("failed") ||
+            lower.contains("transaction failed") ||
+            lower.contains("trx failed") ||
+            lower.contains("has failed") ||
+            lower.contains("was unsuccessful") ||
+            lower.contains("not successful") ||
             message.contains("رمز التحقق") ||      // Arabic: "verification code"
             message.contains("كلمة المرور")        // Arabic: "password"
         ) {

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/ArabBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/ArabBankParserTest.kt
@@ -58,6 +58,51 @@ class ArabBankParserTest {
                 )
             ),
             ParserTestCase(
+                name = "Jordan card spend, JOD transaction (EXPENSE, 3 decimals)",
+                message = "A Trx using Card XXXX9915 from ADANI CORNER for JOD 2.750 " +
+                    "on 20-Jun-2026 at 14:21 GMT+3. Available balance is JOD 1649.832.",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2.750"),
+                    currency = "JOD",
+                    type = TransactionType.EXPENSE,
+                    merchant = "ADANI CORNER",
+                    accountLast4 = "9915",
+                    balance = BigDecimal("1649.832"),
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "Jordan CliQ transfer debit (EXPENSE, suffix balance, not a card)",
+                message = "JOD50.000 has been debited from 0156*500 to John Smith " +
+                    "as CliQ transfer Balance 37.920JOD",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("50.000"),
+                    currency = "JOD",
+                    type = TransactionType.EXPENSE,
+                    merchant = "John Smith",
+                    accountLast4 = "6500",
+                    balance = BigDecimal("37.920"),
+                    isFromCard = false
+                )
+            ),
+            ParserTestCase(
+                name = "Jordan CliQ transfer credit (INCOME, no-space to/from, not a card)",
+                message = "JOD172.000 has been credited to 0156*500from Jane Doe " +
+                    "as CliQ transfer Balance 959.370JOD",
+                sender = "ArabBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("172.000"),
+                    currency = "JOD",
+                    type = TransactionType.INCOME,
+                    merchant = "Jane Doe",
+                    accountLast4 = "6500",
+                    balance = BigDecimal("959.370"),
+                    isFromCard = false
+                )
+            ),
+            ParserTestCase(
                 name = "OTP message is rejected",
                 message = "Your OTP for Arab Bank is 123456. Do not share it with anyone.",
                 sender = "ArabBank",
@@ -76,6 +121,7 @@ class ArabBankParserTest {
             "ArabBank" to true,
             "ARABBANK" to true,
             "AD-ARABBANK" to true,
+            "AB-ARABBK-S" to true,
             "HDFC" to false,
             "" to false
         )

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/ArabBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/ArabBankParserTest.kt
@@ -62,6 +62,13 @@ class ArabBankParserTest {
                 message = "Your OTP for Arab Bank is 123456. Do not share it with anyone.",
                 sender = "ArabBank",
                 shouldParse = false
+            ),
+            ParserTestCase(
+                name = "Arabic OTP message is rejected",
+                // "Your verification code for Arab Bank is 123456" — رمز التحقق = verification code.
+                message = "رمز التحقق الخاص بك في Arab Bank هو 123456",
+                sender = "ArabBank",
+                shouldParse = false
             )
         )
 


### PR DESCRIPTION
Adds **Arab Bank Jordan (JOD/USD)** support to the existing `ArabBankParser` (Egypt/EGP landed in #508). Folds in the work from #513 (by @saadaltabari) — closed in favour of a single parser, since two parsers claiming the same `ArabBank` sender are ambiguous in the factory.

> Note: this was originally pushed onto the #508 branch, but #508 had already merged — so these commits were orphaned and never reached main. This PR brings them in cleanly on top of current main.

## What's added (on top of merged Egypt support)
- **JOD/USD card spends** — same `A Trx using Card … for <CCY> <amt>` format; JOD uses **3 decimal places** (`JOD 2.750`).
- **CliQ-style account transfers** — `JOD50.000 has been debited from <acct> to <name> … Balance 37.920JOD` (EXPENSE) and the `credited to <acct>from <name>` credit (INCOME). Suffix-form balance supported.
- **`detectIsCard` fixed** — now `false` for account transfers (only card spends are `isFromCard`); previously always true.
- **DLT senders** like `AB-ARABBK-S`.
- Card spend stays **EXPENSE** (the SMS shows *"Available balance"* — a debit/prepaid balance, not an *available credit limit*), consistent with Egypt.
- **`CurrencyFormatter`**: JOD (`JD`, `en-JO`) + 3-decimal handling for JOD/KWD/BHD/OMR across the currency **and** symbol-fallback paths (fixes the `formatAmount` truncation Greptile flagged on #513).

Also carries the two #508 cosmetic items Greptile noted: drop a redundant `isFromCard` copy + add an Arabic-OTP rejection test.

## Tests
`ArabBankParserTest` extended with JOD card spend, JOD CliQ debit/credit, and a DLT handle-check. Full `:parser-core:jvmTest` → **1327 tests, 0 failures**; app compiles.

Supersedes #513.

Co-authored-by: saadaltabari <saadaltabari@users.noreply.github.com>