### PR TITLE
feat(parser): Diamond Trust Bank (DTB) Tanzania — TZS (#521)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -88,6 +88,7 @@ object BankParserFactory {
         SelcomPesaParser(),  // Selcom Pesa (Tanzania)
         CrdbBankParser(),  // CRDB Bank (Tanzania) — bilingual Swahili/English, multi-currency cards
         TigoPesaParser(),  // Tigo Pesa / Mixx by Yas (Tanzania)
+        DiamondTrustBankParser(),  // Diamond Trust Bank (DTB) Tanzania
         CIBEgyptParser(),  // CIB - Commercial International Bank (Egypt)
         ArabBankParser(),  // Arab Bank (Egypt) — multi-currency card, English + Arabic SMS
         DhanlaxmiBankParser(),  // Dhanlaxmi Bank (India)

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/DiamondTrustBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/DiamondTrustBankParser.kt
@@ -35,7 +35,7 @@ class DiamondTrustBankParser : BankParser() {
         val normalized = sender.uppercase()
         // Plain "DTB" sender, or DLT-style "AB-DTB-S" where DTB is its own token.
         if (normalized == "DTB") return true
-        return Regex("""(^|[-.])DTB($|[-.])""").containsMatchIn(normalized)
+        return SENDER_PATTERN.containsMatchIn(normalized)
     }
 
     override fun parse(smsBody: String, sender: String, timestamp: Long): ParsedTransaction? {
@@ -165,6 +165,9 @@ class DiamondTrustBankParser : BankParser() {
     }
 
     private companion object {
+        // DLT-style sender where DTB is its own dash/dot-delimited token (e.g. AB-DTB-S).
+        val SENDER_PATTERN = Regex("""(^|[-.])DTB($|[-.])""")
+
         // "has been debited with TZS 49900 for POS TRANSACTION on 22/06/2026"
         // Groups: 1=direction, 2=amount, 3=purpose.
         val ALERT_PATTERN = Regex(

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/DiamondTrustBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/DiamondTrustBankParser.kt
@@ -1,0 +1,193 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Diamond Trust Bank (DTB) Tanzania.
+ *
+ * Sender ID: "DTB" (also DLT-style prefixes like AB-DTB-S).
+ * Default currency: Tanzanian Shilling (TZS). Messages are mostly English.
+ *
+ * Supported formats:
+ * - TIPS outgoing success:
+ *   "Dear NAME, TIPS transaction of TZS <amt> from XXX to 07XXX has been
+ *    successfully processed Ref <ref> Diamond Trust Bank"
+ * - Generic account ALERT (the workhorse pattern):
+ *   "ALERT: Your account no. XXX has been (debited|credited) with TZS <amt>
+ *    for <PURPOSE> on <date>..."
+ * - LUKU electricity token (multi-line); amount anchored on the "TOTAL TZS <amt>" line.
+ *
+ * Rejected (return null):
+ * - TIPS request intake ("...transfer request for... is being processed") — would
+ *   double-count against the success message.
+ * - TANQR / GEPG confirmations that carry no amount.
+ * - OTP / verification messages.
+ */
+class DiamondTrustBankParser : BankParser() {
+
+    override fun getBankName() = "Diamond Trust Bank"
+
+    override fun getCurrency() = "TZS"
+
+    override fun canHandle(sender: String): Boolean {
+        val normalized = sender.uppercase()
+        // Plain "DTB" sender, or DLT-style "AB-DTB-S" where DTB is its own token.
+        if (normalized == "DTB") return true
+        return Regex("""(^|[-.])DTB($|[-.])""").containsMatchIn(normalized)
+    }
+
+    override fun parse(smsBody: String, sender: String, timestamp: Long): ParsedTransaction? {
+        val transaction = super.parse(smsBody, sender, timestamp) ?: return null
+        return transaction.copy(isFromCard = detectCardForDtb(smsBody))
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+
+        // Reject OTP / verification noise.
+        if (lower.contains("otp") ||
+            lower.contains("one time password") ||
+            lower.contains("verification code")
+        ) {
+            return false
+        }
+
+        // Reject TIPS request intake — precedes the success SMS with the same Ref.
+        if (lower.contains("is being processed") ||
+            (lower.contains("transfer request for") && lower.contains("has been received"))
+        ) {
+            return false
+        }
+
+        // Accept the known transaction forms.
+        val isTipsSuccess = lower.contains("has been successfully processed")
+        val isAlert = ALERT_PATTERN.containsMatchIn(message)
+        val isLuku = lower.contains("luku") && TOTAL_PATTERN.containsMatchIn(message)
+
+        return isTipsSuccess || isAlert || isLuku
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // LUKU multi-line: anchor on the TOTAL line, never the COST/VAT/EWURA sub-amounts.
+        if (message.contains("LUKU", ignoreCase = true)) {
+            TOTAL_PATTERN.find(message)?.let { match ->
+                return parseAmount(match.groupValues[1])
+            }
+        }
+
+        // ALERT pattern: amount sits after "with TZS".
+        ALERT_PATTERN.find(message)?.let { match ->
+            return parseAmount(match.groupValues[2])
+        }
+
+        // Generic "TZS <amount>" (TIPS success).
+        TZS_AMOUNT_PATTERN.find(message)?.let { match ->
+            return parseAmount(match.groupValues[1])
+        }
+
+        return null
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        ALERT_PATTERN.find(message)?.let { match ->
+            return when (match.groupValues[1].lowercase()) {
+                "debited" -> TransactionType.EXPENSE
+                "credited" -> TransactionType.INCOME
+                else -> null
+            }
+        }
+
+        val lower = message.lowercase()
+        // TIPS outgoing success and LUKU token purchase are both expenses.
+        if (lower.contains("tips transaction of") ||
+            lower.contains("luku")
+        ) {
+            return TransactionType.EXPENSE
+        }
+
+        return null
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // LUKU electricity token.
+        if (message.contains("LUKU", ignoreCase = true)) {
+            return "LUKU"
+        }
+
+        // ALERT pattern: merchant is the <PURPOSE> text, title-cased.
+        ALERT_PATTERN.find(message)?.let { match ->
+            val purpose = match.groupValues[3].trim()
+            if (purpose.isNotEmpty()) return toTitleCase(purpose)
+        }
+
+        // TIPS outgoing success — recipient is a masked phone (PII), so use a label.
+        if (message.contains("TIPS transaction of", ignoreCase = true)) {
+            return "TIPS Transfer"
+        }
+
+        return null
+    }
+
+    override fun extractReference(message: String): String? {
+        REFERENCE_PATTERNS.forEach { pattern ->
+            pattern.find(message)?.let { match ->
+                return match.groupValues[1].trim()
+            }
+        }
+        return null
+    }
+
+    /**
+     * Card detection is purpose-driven for DTB: POS and ATM cash withdrawals are
+     * card transactions, everything else (mobile/internet banking, transfers,
+     * standing instructions, LUKU, TIPS) is account-based.
+     */
+    private fun detectCardForDtb(message: String): Boolean {
+        val purpose = ALERT_PATTERN.find(message)?.groupValues?.get(3)?.uppercase() ?: return false
+        return purpose.contains("POS") || purpose.contains("ATM")
+    }
+
+    private fun parseAmount(raw: String): BigDecimal? {
+        val cleaned = raw.replace(",", "")
+        return try {
+            BigDecimal(cleaned)
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    private fun toTitleCase(text: String): String {
+        return text.split(Regex("\\s+")).joinToString(" ") { word ->
+            word.lowercase().replaceFirstChar { it.uppercase() }
+        }
+    }
+
+    private companion object {
+        // "has been debited with TZS 49900 for POS TRANSACTION on 22/06/2026"
+        // Groups: 1=direction, 2=amount, 3=purpose.
+        val ALERT_PATTERN = Regex(
+            """has been (debited|credited) with TZS\s*([0-9][0-9,]*(?:\.\d+)?)\s+for\s+(.+?)\s+on\s+\d""",
+            RegexOption.IGNORE_CASE
+        )
+
+        // "TOTAL TZS 20,000" (LUKU multi-line total line).
+        val TOTAL_PATTERN = Regex(
+            """TOTAL\s+TZS\s*([0-9][0-9,]*(?:\.\d+)?)""",
+            RegexOption.IGNORE_CASE
+        )
+
+        // Generic "TZS <amount>" used for TIPS success.
+        val TZS_AMOUNT_PATTERN = Regex(
+            """TZS\s*([0-9][0-9,]*(?:\.\d+)?)""",
+            RegexOption.IGNORE_CASE
+        )
+
+        val REFERENCE_PATTERNS = listOf(
+            Regex("""Ref\s*No\.?\s*:?\s*([0-9]+)""", RegexOption.IGNORE_CASE),
+            Regex("""Reference\s*:?\s*([0-9]+)""", RegexOption.IGNORE_CASE),
+            Regex("""Ref\s*:?\s*([0-9]+)""", RegexOption.IGNORE_CASE)
+        )
+    }
+}

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/DiamondTrustBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/DiamondTrustBankParserTest.kt
@@ -1,0 +1,133 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class DiamondTrustBankParserTest {
+
+    @TestFactory
+    fun `Diamond Trust Bank parser handles common cases`(): List<DynamicTest> {
+        val parser = DiamondTrustBankParser()
+
+        val cases = listOf(
+            ParserTestCase(
+                name = "TIPS outgoing success",
+                message = "Dear JOHN DOE, TIPS transaction of TZS 120000.00 from XXXXXXX to 07XXXXXXXX has been successfully processed Ref 52950397 Diamond Trust Bank",
+                sender = "DTB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("120000.00"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "TIPS Transfer",
+                    reference = "52950397",
+                    isFromCard = false
+                )
+            ),
+            ParserTestCase(
+                name = "ALERT debit - mobile banking charges",
+                message = "ALERT: Your account no. XXXXXXX has been debited with TZS 1000 for MOBILE BANKING TXN CHARGES on 22/06/2026.Thank you. Diamond Trust Bank",
+                sender = "DTB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1000"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Mobile Banking Txn Charges",
+                    isFromCard = false
+                )
+            ),
+            ParserTestCase(
+                name = "ALERT credit - internal funds transfer",
+                message = "ALERT: Your account no. XXXXXXX has been credited with TZS 500000 for ONLINE INTERNAL FUNDS TRANSFER on 22/06/2026.Thank you. Diamond Trust Bank",
+                sender = "DTB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("500000"),
+                    currency = "TZS",
+                    type = TransactionType.INCOME,
+                    merchant = "Online Internal Funds Transfer",
+                    isFromCard = false
+                )
+            ),
+            ParserTestCase(
+                name = "ALERT debit - POS transaction (card)",
+                message = "ALERT: Your account no. XXXXXXX has been debited with TZS 49900 for POS TRANSACTION on 22/06/2026.Thank you. Diamond Trust Bank",
+                sender = "DTB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("49900"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Pos Transaction",
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "ALERT debit - ATM cash withdrawal (card)",
+                message = "ALERT: Your account no. XXXXXXX has been debited with TZS 180000 for ATM CASH WITHDRAWAL on 06/10/2025.Thank you. Diamond Trust Bank",
+                sender = "DTB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("180000"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Atm Cash Withdrawal",
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "ALERT debit - standing instruction",
+                message = "ALERT: Your account no. XXXXXXX has been debited with TZS 100000 for STANDING INSTRUCTION on 10/06/2026.Thank you. Diamond Trust Bank",
+                sender = "DTB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("100000"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Standing Instruction",
+                    isFromCard = false
+                )
+            ),
+            ParserTestCase(
+                name = "LUKU electricity token uses TOTAL line",
+                message = "LUKU\nMETER OWNER NAME\nMeter XXXXXXXXXXX\nReceipt 9006261721549334171\nUnits 56.1kWh\nToken 5376 9223 7930 4023 8001\nCOST TZS 16,393.45\nVAT 18% TZS 2,950.81\nEWURA 1% TZS 163.93\nREA 3% TZS 491.81\nTRANS FEE TZS 0.00\nTOTAL TZS 20,000\nReference 1764992079 Diamond Trust Bank",
+                sender = "DTB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("20000"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "LUKU",
+                    reference = "1764992079",
+                    isFromCard = false
+                )
+            ),
+            ParserTestCase(
+                name = "Reject TIPS request intake (would double-count)",
+                message = "Dear JOHN DOE, your Instant Payment transfer request for TZS 120,000.00 from XXXXXXX to 07XXXXXXXX, has been received successfully and is being processed. Ref No: 52950397.Thank you.Diamond Trust Bank",
+                sender = "DTB",
+                shouldParse = false
+            ),
+            ParserTestCase(
+                name = "Reject TANQR confirmation with no amount",
+                message = "Dear Customer your TANQR transaction is successfully processed on 2026-06-21 10:11:56 Ref: 52942040 Diamond Trust Bank",
+                sender = "DTB",
+                shouldParse = false
+            ),
+            ParserTestCase(
+                name = "Reject GEPG confirmation with no amount",
+                message = "Dear Customer your GEPG transaction is successfully processed on 2026-06-21 05:43:13 Ref: 52938931 Diamond Trust Bank",
+                sender = "DTB",
+                shouldParse = false
+            )
+        )
+
+        val handleChecks = listOf(
+            "DTB" to true,
+            "AB-DTB-S" to true,
+            "HDFC" to false,
+            "" to false
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases, handleChecks, "Diamond Trust Bank Parser")
+    }
+}


### PR DESCRIPTION
Closes #521. New TZS parser for **Diamond Trust Bank (DTB) Tanzania** (sender `DTB`).

## Handled
- **TIPS outgoing success** → EXPENSE + ref (`TIPS transaction of TZS … successfully processed Ref …`).
- **Generic account ALERT** (`ALERT: Your account no. … has been debited/credited with TZS X for <purpose> on <date>`) — debited→EXPENSE, credited→INCOME, merchant = the purpose. `POS TRANSACTION` and `ATM CASH WITHDRAWAL` are flagged `isFromCard`.
- **LUKU electricity token** (multi-line) → EXPENSE, amount anchored on the `TOTAL TZS` line (ignores COST/VAT/EWURA/REA), merchant `LUKU`, reference.

## Rejected (to avoid duplicates / amount-less entries)
- TIPS **request-intake** (`… is being processed`) — precedes the success msg with the same Ref.
- **TANQR** and **GEPG** confirmations — no amount in the SMS.

## Notes
- No PII: the masked recipient phone becomes the label `TIPS Transfer`, never a number; account numbers are fully masked (`XXXXXXX`) so `accountLast4` is null.
- No collision with the existing CRDB / M-Pesa TZ / Selcom / Tigo parsers (each gates on its own token).

## Tests
`DiamondTrustBankParserTest` — TIPS success, 5 ALERT variants (incl. POS/ATM card flags), LUKU, and 3 reject cases (intake, TANQR, GEPG). Full `:parser-core:jvmTest` → **1336 tests, 0 failures**. No PII.