### PR TITLE
feat(parser): Mixx by Yas (Tanzania) wallet — TZS (#524)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -87,6 +87,7 @@ object BankParserFactory {
         MPESAParser(),  // M-PESA (Kenya)
         SelcomPesaParser(),  // Selcom Pesa (Tanzania)
         CrdbBankParser(),  // CRDB Bank (Tanzania) — bilingual Swahili/English, multi-currency cards
+        MixxByYasParser(),  // Mixx by Yas (Tanzania) — must precede TigoPesaParser (shares MIXXBYYAS sender; claims newer Mixx-specific formats)
         TigoPesaParser(),  // Tigo Pesa / Mixx by Yas (Tanzania)
         DiamondTrustBankParser(),  // Diamond Trust Bank (DTB) Tanzania
         CIBEgyptParser(),  // CIB - Commercial International Bank (Egypt)

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MixxByYasParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MixxByYasParser.kt
@@ -88,7 +88,11 @@ class MixxByYasParser : BankParser() {
             lower.contains("amt tsh") -> TransactionType.EXPENSE          // GePG
             lower.contains("cash out of") -> TransactionType.EXPENSE      // agent cash-out
             lower.contains("bustisha balance by") -> TransactionType.EXPENSE  // loan repayment
-            lower.contains("payment successful") -> TransactionType.EXPENSE   // LUKU token
+            // LUKU electricity token: keyed on the receipt markers, not just the
+            // "Payment Successful" prefix.
+            lower.contains("payment successful") ||
+                lower.contains("kwh") ||
+                lower.contains("ewura") -> TransactionType.EXPENSE
             else -> null
         }
     }
@@ -111,8 +115,10 @@ class MixxByYasParser : BankParser() {
             return "Bustisha"
         }
 
-        // #7 LUKU electricity token.
-        if (lower.contains("payment successful") && lower.contains("kwh")) {
+        // #7 LUKU electricity token. Keyed on the electricity-receipt markers
+        // ("kwh" units or the "EWURA" regulator line) rather than a single
+        // keyword, so a LUKU receipt that omits one still resolves.
+        if (lower.contains("kwh") || lower.contains("ewura")) {
             return "LUKU"
         }
 

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MixxByYasParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MixxByYasParser.kt
@@ -1,0 +1,192 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Mixx by Yas (Tanzania) digital wallet / mobile money SMS.
+ *
+ * Mixx by Yas (sender "MixxByYas") is the rebranded Yas wallet. Its message
+ * formats differ from the legacy Tigo Pesa templates, so this parser claims the
+ * specific Mixx shapes while leaving the legacy Tigo Pesa / TIPS-transfer
+ * formats to [TigoPesaParser] (both share the MIXXBYYAS sender; the factory's
+ * content-aware dispatch picks whichever parses).
+ *
+ * Currency: TSh (Tanzanian Shilling, same as TZS).
+ *
+ * Twin-message dedup: each economic event arrives as a PRIMARY message (carrying
+ * the real amount field) and a SECONDARY confirmation ack that shares the same
+ * TxnID. The secondaries ("You have sent ... Please wait for confirmation" and
+ * the content-less "your transaction is successfull" ack) are rejected so the
+ * same TxnID is not booked twice.
+ *
+ * No PII: recipient phone numbers and agent personal names are never emitted as
+ * the merchant — generic labels ("Mobile Money Transfer", "Agent Cash Out") are
+ * used instead.
+ *
+ * Country: Tanzania
+ */
+class MixxByYasParser : BankParser() {
+
+    override fun getBankName() = "Mixx by Yas"
+
+    override fun getCurrency() = "TZS"  // TSh is the same as TZS (Tanzanian Shilling)
+
+    override fun canHandle(sender: String): Boolean {
+        // Normalize by stripping spaces, dashes and underscores so "MIXX BY YAS",
+        // "MIXX-BY-YAS" and "MixxByYas" all collapse to MIXXBYYAS.
+        val normalized = sender.uppercase().replace(Regex("""[\s\-_]"""), "")
+        return normalized.contains("MIXXBYYAS")
+    }
+
+    // Amount in TSh form: "TSh 52,000", "TSh 0", "TSh 12,366.80".
+    private val tshNumber = """TSh\s*([0-9][0-9,]*(?:\.[0-9]+)?)"""
+
+    // PRIMARY amount anchors, in priority order. Each anchors on the field that
+    // carries the real transaction amount for a given format.
+    private val amountAnchors = listOf(
+        // #1 Outbound P2P: "Money sent successfully ... Amount TSh 52,000"
+        Regex("""Amount\s+$tshNumber""", RegexOption.IGNORE_CASE),
+        // #3 Bill payment: "Txn Amt TSh 150,000 sent to ..."
+        Regex("""Txn\s+Amt\s+$tshNumber""", RegexOption.IGNORE_CASE),
+        // #6 GePG: "Amt TSh 150,000 sent to ..."
+        Regex("""\bAmt\s+$tshNumber""", RegexOption.IGNORE_CASE),
+        // #5 Agent cash-out: "Cash Out of TSh 30,000 from Agent"
+        Regex("""Cash\s*Out\s+of\s+$tshNumber""", RegexOption.IGNORE_CASE),
+        // #4 Bustisha repayment: "paid your Bustisha Balance by TSh 12,366.80"
+        Regex("""Bustisha\s+Balance\s+by\s+$tshNumber""", RegexOption.IGNORE_CASE),
+        // #2/#8 Inbound: "You have received TSh 15,000 from ..."
+        Regex("""received\s+$tshNumber""", RegexOption.IGNORE_CASE),
+        // #7 LUKU token: amount is on the "TOTAL <amt>" line (no TSh prefix)
+        Regex("""TOTAL\s+([0-9][0-9,]*(?:\.[0-9]+)?)""", RegexOption.IGNORE_CASE)
+    )
+
+    override fun extractAmount(message: String): BigDecimal? {
+        for (pattern in amountAnchors) {
+            pattern.find(message)?.let { match ->
+                return parseAmount(match.groupValues[1])
+            }
+        }
+        return null
+    }
+
+    private fun parseAmount(raw: String): BigDecimal? = try {
+        BigDecimal(raw.replace(",", ""))
+    } catch (e: NumberFormatException) {
+        null
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lower = message.lowercase()
+        return when {
+            // Inbound: push transfer, interest reward
+            lower.contains("you have received") -> TransactionType.INCOME
+            // Outbound flows
+            lower.contains("money sent successfully") -> TransactionType.EXPENSE
+            lower.contains("txn amt") -> TransactionType.EXPENSE          // bill payment
+            lower.contains("amt tsh") -> TransactionType.EXPENSE          // GePG
+            lower.contains("cash out of") -> TransactionType.EXPENSE      // agent cash-out
+            lower.contains("bustisha balance by") -> TransactionType.EXPENSE  // loan repayment
+            lower.contains("payment successful") -> TransactionType.EXPENSE   // LUKU token
+            else -> null
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        val lower = message.lowercase()
+
+        // #1 Outbound P2P to a (masked) phone number — never emit the number.
+        if (lower.contains("money sent successfully")) {
+            return "Mobile Money Transfer"
+        }
+
+        // #5 Agent cash-out — never emit the agent's personal name.
+        if (lower.contains("cash out of")) {
+            return "Agent Cash Out"
+        }
+
+        // #4 Bustisha micro-loan repayment.
+        if (lower.contains("bustisha")) {
+            return "Bustisha"
+        }
+
+        // #7 LUKU electricity token.
+        if (lower.contains("payment successful") && lower.contains("kwh")) {
+            return "LUKU"
+        }
+
+        // #8 Mixx interest reward.
+        if (lower.contains("mixx interest")) {
+            return "Mixx Interest"
+        }
+
+        // #2 Inbound push transfer: "received TSh X from CRDB; JOHN DOE ..."
+        // The sending institution is the token before ';'. Never emit the person.
+        Regex("""received\s+TSh\s*[0-9,]+(?:\.[0-9]+)?\s+from\s+([A-Za-z0-9 .&]+?)\s*;""",
+            RegexOption.IGNORE_CASE).find(message)?.let { match ->
+            val institution = match.groupValues[1].trim()
+            if (institution.isNotEmpty()) return institution
+        }
+
+        // #3 Bill payment / #6 government payment: "sent to <Payee> (code)".
+        Regex("""sent\s+to\s+([A-Za-z0-9 ]+?)\s*\(""",
+            RegexOption.IGNORE_CASE).find(message)?.let { match ->
+            val payee = match.groupValues[1].trim()
+            if (payee.isNotEmpty()) return payee
+        }
+
+        return null
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        // "New balance is TSh X" / "New Bal: TSh X" / "New Bal TSh X" / "New balance: TSh X"
+        val balancePatterns = listOf(
+            Regex("""New\s+balance\s+is\s+$tshNumber""", RegexOption.IGNORE_CASE),
+            Regex("""New\s+Bal(?:ance)?:?\s+$tshNumber""", RegexOption.IGNORE_CASE)
+        )
+        for (pattern in balancePatterns) {
+            pattern.find(message)?.let { match ->
+                return parseAmount(match.groupValues[1])
+            }
+        }
+        return null
+    }
+
+    override fun extractReference(message: String): String? {
+        // Prefer "TxnID:/TxnId: <digits>".
+        Regex("""Txn\s*ID:?\s*(\d+)""", RegexOption.IGNORE_CASE)
+            .find(message)?.let { return it.groupValues[1] }
+        return null
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+
+        // Must look like a Mixx wallet message.
+        if (!lower.contains("tsh") && !lower.contains("payment successful")) {
+            return false
+        }
+
+        // ----- Reject the SECONDARY twin messages (dedup) -----
+
+        // Twin of an outbound transfer: "You have sent TSh ... Please wait for confirmation".
+        // (Sample #3, a PRIMARY, says "Wait for confirmation" but does NOT start with
+        // "You have sent", so it is not caught here.)
+        if (lower.contains("you have sent") && lower.contains("please wait for confirmation")) {
+            return false
+        }
+
+        // Content-less success ack: "your transaction is successfull" with no amount field.
+        if (lower.contains("your transaction is successf") && extractAmount(message) == null) {
+            return false
+        }
+
+        // ----- Leave legacy Tigo Pesa / TIPS formats to TigoPesaParser -----
+        if (lower.contains("from tips.")) {
+            return false
+        }
+
+        return true
+    }
+}

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MixxByYasParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MixxByYasParser.kt
@@ -168,6 +168,17 @@ class MixxByYasParser : BankParser() {
             return false
         }
 
+        // Reject OTP / verification noise that the broad "tsh" gate would
+        // otherwise admit (this method accepts Mixx-specific shapes directly,
+        // so the base-class promotional/OTP filter is never reached).
+        if (lower.contains("otp") ||
+            lower.contains("one time password") ||
+            lower.contains("verification code") ||
+            lower.contains("do not share")
+        ) {
+            return false
+        }
+
         // ----- Reject the SECONDARY twin messages (dedup) -----
 
         // Twin of an outbound transfer: "You have sent TSh ... Please wait for confirmation".

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/TigoPesaParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/TigoPesaParser.kt
@@ -254,6 +254,16 @@ class TigoPesaParser : BankParser() {
             return false
         }
 
+        // Reject the SECONDARY twin of a Mixx by Yas outbound transfer:
+        // "You have sent TSh ... Please wait for confirmation". Its PRIMARY
+        // ("Money sent successfully ... Amount TSh ...") is booked by
+        // MixxByYasParser, so parsing this ack would double-count the same TxnID.
+        if (lowerMessage.contains("you have sent") &&
+            lowerMessage.contains("please wait for confirmation")
+        ) {
+            return false
+        }
+
         // Must contain transaction keywords or status indicators
         val transactionKeywords = listOf(
             "cash-in",

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/MixxByYasParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/MixxByYasParserTest.kt
@@ -1,0 +1,189 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class MixxByYasParserTest {
+
+    @TestFactory
+    fun `mixx by yas parser handles common cases`(): List<DynamicTest> {
+        val parser = MixxByYasParser()
+
+        val cases = listOf(
+            // #1 Outbound P2P (PRIMARY of a twin pair)
+            ParserTestCase(
+                name = "Outbound P2P transfer (primary)",
+                message = "Money sent successfully to  -255742311312. Amount TSh 52,000. Total Charges TSh 1,125, VAT TSh 172. New balance is TSh 0. TxnID: 26495371373758. Receipt: 503-DFE9B1DABO. 14/06/26 19:19. Every Transaction is a Winning Goal!",
+                sender = "MixxByYas",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("52000"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Mobile Money Transfer",
+                    balance = BigDecimal("0"),
+                    reference = "26495371373758"
+                )
+            ),
+            // #2 Inbound push transfer
+            ParserTestCase(
+                name = "Inbound push transfer",
+                message = "Transfer Successful. New balance is TSh 15,000. You have received TSh 15,000 from CRDB; JOHN DOE with TxnId: 26452334860211. 003_19ec6e42e888a9a7. 14/06/26 19:08. Every Transaction is a Winning Goal!",
+                sender = "MixxByYas",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("15000"),
+                    currency = "TZS",
+                    type = TransactionType.INCOME,
+                    merchant = "CRDB",
+                    balance = BigDecimal("15000"),
+                    reference = "26452334860211"
+                )
+            ),
+            // #3 Utility/PostPaid bill payment (PRIMARY)
+            ParserTestCase(
+                name = "PostPaid bill payment (primary)",
+                message = "Txn Amt TSh 150,000 sent to Yas PostPaid (100100). Wait for confirmation. Ref: 0676263929. New Bal: TSh 0. Total Charges TSh 0.(Fees TSh 0, Levy TSh 0), VAT TSh 0. TxnID: 26952325632986. 13/06/26 19:41",
+                sender = "MixxByYas",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("150000"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Yas PostPaid",
+                    balance = BigDecimal("0"),
+                    reference = "26952325632986"
+                )
+            ),
+            // #4 Bustisha micro-loan repayment
+            ParserTestCase(
+                name = "Bustisha loan repayment",
+                message = "You have successfully paid your Bustisha Balance by TSh 12,366.80. Your outstanding balance: TSh 0.00. New balance: TSh 137,633. TxnID: 26307515424020. Loan ID: 202606082034582035732170597903. 13/06/26 19:39.",
+                sender = "MixxByYas",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("12366.80"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Bustisha",
+                    balance = BigDecimal("137633"),
+                    reference = "26307515424020"
+                )
+            ),
+            // #5 Agent cash-out
+            ParserTestCase(
+                name = "Agent cash-out",
+                message = "Cash Out of TSh 30,000 from Agent - AGENT NAME HERE is successful. Total Charges TSh 2,201.(Fees TSh 1,850, Levy TSh 351), VAT TSh 282. TxnID: 26106452201270. 08/06/26 17:36. New balance is TSh 5,879. Every Transaction is a Winning Goal!",
+                sender = "MixxByYas",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("30000"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Agent Cash Out",
+                    balance = BigDecimal("5879"),
+                    reference = "26106452201270"
+                )
+            ),
+            // #6 GePG government payment
+            ParserTestCase(
+                name = "GePG government payment",
+                message = "Txn successful, Amt TSh 150,000 sent to Malipo ya Serikali (001001), Control No 994944606117. New Bal TSh 206. Charges TSh 2,000. TxnID: 26592309810022. 29/05/26 21:35.",
+                sender = "MixxByYas",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("150000"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Malipo ya Serikali",
+                    balance = BigDecimal("206"),
+                    reference = "26592309810022"
+                )
+            ),
+            // #7 LUKU electricity token (multi-line; amount on TOTAL line)
+            ParserTestCase(
+                name = "LUKU electricity token",
+                message = "Payment Successful.47300267334\n9001261411323026601\n28.0KWH\n2634 3328 1950 3176 1023\nCost 8,196.73\nVAT 18% 1475.40\nEWURA 1% 81.97\nREA 3% 245.90\nTOTAL 10,000.00 21/05/26 13:23.LKS",
+                sender = "MixxByYas",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("10000.00"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "LUKU"
+                )
+            ),
+            // #8 Mixx interest reward
+            ParserTestCase(
+                name = "Mixx interest reward",
+                message = "Dear Customer, New balance is TSh 414. You have received TSh 414 from MIXX BY YAS as your Mixx interest. TxnId: 26406495404220. 12/06/26 12:11. Ikiingia tu Golii!",
+                sender = "MixxByYas",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("414"),
+                    currency = "TZS",
+                    type = TransactionType.INCOME,
+                    merchant = "Mixx Interest",
+                    balance = BigDecimal("414"),
+                    reference = "26406495404220"
+                )
+            ),
+            // #9 SECONDARY twin of #1 — must NOT parse (would double-count TxnID)
+            ParserTestCase(
+                name = "Secondary outbound twin is rejected",
+                message = "You have sent TSh 52,000 to Vodacom receiver JOHN DOE - 255742311312. Charges TSh 1,125. VAT TSh 172. New balance is TSh 0. TxnID: 26495371373758. 14/06/26 19:19 Please wait for confirmation. Every Transaction is a Winning Goal!",
+                sender = "MixxByYas",
+                shouldParse = false
+            ),
+            // #10 SECONDARY twin of #3 — content-less success ack, must NOT parse
+            ParserTestCase(
+                name = "Content-less success ack is rejected",
+                message = "Payment Successful.Dear Customer your transaction is successfull. PostPaid TxnID TPIL123456789 Mixx by Yas TxnID 26952325632986 13/06/26 19:41.LKS",
+                sender = "MixxByYas",
+                shouldParse = false
+            )
+        )
+
+        val handleChecks = listOf(
+            "MixxByYas" to true,
+            "MIXX BY YAS" to true,
+            "AB-MIXXBYYAS-S" to true,
+            "HDFC" to false,
+            "" to false
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases, handleChecks, "Mixx by Yas Parser")
+    }
+
+    @TestFactory
+    fun `factory routes mixx senders without double counting twins`(): List<DynamicTest> {
+        val ts = System.currentTimeMillis()
+        return listOf(
+            // PRIMARY outbound routes to Mixx by Yas.
+            dynamicTest("Primary outbound routes to Mixx by Yas") {
+                val p = BankParserFactory.parse(
+                    "Money sent successfully to  -255742311312. Amount TSh 52,000. New balance is TSh 0. TxnID: 26495371373758. 14/06/26 19:19.",
+                    "MIXX BY YAS", ts
+                )
+                assertEquals("Mixx by Yas", p?.bankName)
+                assertEquals(BigDecimal("52000"), p?.amount)
+            },
+            // SECONDARY twin must not be booked by ANY parser (no double-count).
+            dynamicTest("Secondary outbound twin is not booked by any parser") {
+                val p = BankParserFactory.parse(
+                    "You have sent TSh 52,000 to Vodacom receiver JOHN DOE - 255742311312. New balance is TSh 0. TxnID: 26495371373758. 14/06/26 19:19 Please wait for confirmation.",
+                    "MIXX BY YAS", ts
+                )
+                assertNull(p, "Twin secondary should not be booked: $p")
+            },
+            // Legacy TIPS transfer stays with Tigo Pesa via content-aware dispatch.
+            dynamicTest("Legacy TIPS transfer stays with Tigo Pesa") {
+                val p = BankParserFactory.parse(
+                    "Transfer Successful. New balance is TSh 97,000. You have received TSh 97,000 from TIPS.Selcom_MFB.2.Tigo, with TxnId: 25693126312543.",
+                    "MIXX BY YAS", ts
+                )
+                assertEquals("Tigo Pesa", p?.bankName)
+            }
+        )
+    }
+}

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/TanzaniaParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/TanzaniaParserTest.kt
@@ -285,6 +285,11 @@ class TanzaniaParserTest {
             // Mixx by Yas (current Yas wallet branding). The MIXXBYYAS sender is
             // shared with the legacy Tigo Pesa parser, but getParser resolves to the
             // dedicated MixxByYasParser, which owns the newer Mixx-specific formats.
+            // NOTE: runFactoryTestSuite uses getParser() (first canHandle match), so a
+            // MIXXBYYAS case here MUST use a Mixx-format message. A legacy TIPS message
+            // would route to TigoPesa only via the content-aware parse() path and would
+            // fail here (MixxByYas returns null for it). TIPS fall-through is covered in
+            // MixxByYasParserTest via BankParserFactory.parse().
             SimpleTestCase(
                 bankName = "Mixx by Yas",
                 sender = "MIXX BY YAS",

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/TanzaniaParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/TanzaniaParserTest.kt
@@ -282,14 +282,16 @@ class TanzaniaParserTest {
                 ),
                 shouldHandle = true
             ),
-            // Mixx by Yas (Tigo Pesa rebranding)
+            // Mixx by Yas (current Yas wallet branding). The MIXXBYYAS sender is
+            // shared with the legacy Tigo Pesa parser, but getParser resolves to the
+            // dedicated MixxByYasParser, which owns the newer Mixx-specific formats.
             SimpleTestCase(
-                bankName = "Tigo Pesa",
+                bankName = "Mixx by Yas",
                 sender = "MIXX BY YAS",
                 currency = "TZS",
-                message = "Transfer Successful. New balance is TSh 97,000. You have received TSh 97,000 from TIPS.Selcom_MFB.2.Tigo, with TxnId: 25693126312543.",
+                message = "Transfer Successful. New balance is TSh 15,000. You have received TSh 15,000 from CRDB; JOHN DOE with TxnId: 26452334860211.",
                 expected = ExpectedTransaction(
-                    amount = BigDecimal("97000"),
+                    amount = BigDecimal("15000"),
                     currency = "TZS",
                     type = TransactionType.INCOME
                 ),


### PR DESCRIPTION
Closes #524. New TZS parser for **Mixx by Yas** (Tanzanian digital wallet; sender `MixxByYas`).

## Handled
| Format | Type | Notes |
|---|---|---|
| Outbound P2P (primary) | EXPENSE | masked phone → label `Mobile Money Transfer` |
| Inbound push transfer | INCOME | merchant = sending institution (e.g. `CRDB`) |
| PostPaid bill | EXPENSE | merchant `Yas PostPaid` |
| Bustisha micro-loan repayment | EXPENSE | amount = the `by TSh X` repaid amount (not outstanding/new bal) |
| Agent cash-out | EXPENSE | label `Agent Cash Out` (no personal name) |
| GePG govt payment | EXPENSE | merchant `Malipo ya Serikali` |
| LUKU electricity token | EXPENSE | amount anchored on `TOTAL` line |
| Mixx interest | INCOME | merchant `Mixx Interest` |

## Twin-message dedup
Mixx sends a primary receipt + a secondary "Please wait for confirmation" ack sharing one `TxnID`. The secondary ack and the content-less "your transaction is successfull" ack **return null** so the same TxnID isn't booked twice.

## Sender collision resolved
`MIXXBYYAS` was already claimed by `TigoPesaParser` (Tigo Tanzania rebranded to **Yas**). Since the SMS pipeline is **content-aware** (`firstNotNullOfOrNull` over all matching parsers), MixxByYas is registered first and parses the new formats; it returns null on legacy `from tips.` transfers, which fall through to Tigo Pesa. A guard in `TigoPesaParser` rejects the Mixx outbound-twin ack so neither parser double-counts it.

## Tests
`MixxByYasParserTest` (18 cases + factory-dispatch no-double-count tests); updated one `TanzaniaParserTest` factory expectation. Full `:parser-core:jvmTest` → **1340 tests, 0 failures**. No PII (phones/agent names replaced with generic labels).