### PR TITLE
fix(parser): CRDB Tanzania — LUKU, transfers, merchant PII, card flag (#520)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CrdbBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CrdbBankParser.kt
@@ -168,6 +168,12 @@ class CrdbBankParser : BankParser() {
         //   - a phone/account number or masked number (digits / "X" runs),
         //   - a structural label ("AC", "Risiti", "REF", "Balance"),
         // so we never leak phone numbers, account numbers or trailing metadata.
+        // The terminator intentionally breaks on the FIRST digit (`\d`, not the
+        // earlier `\d{6,}`): in CRDB transfers the recipient name is always
+        // followed by a phone/account/till number, and CRDB recipient names do
+        // not contain digits — so the single-digit break reliably drops the
+        // trailing number. Do NOT widen this back to a multi-digit run, or the
+        // leading digits of a short till/phone number would leak into the name.
         // "kwenda LIPA <merchant>" is a till/merchant payment — the "LIPA" prefix
         // is dropped and the merchant name kept.
         val kwendaPattern = Regex(

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CrdbBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CrdbBankParser.kt
@@ -77,6 +77,16 @@ class CrdbBankParser : BankParser() {
             parseAmount(match.groupValues[1])?.let { return it }
         }
 
+        // Utility/LUKU token form: anchor on the "TOTAL TZS <amt>" line so the charged
+        // total wins over the intermediate Cost/VAT/EWURA/REA/Debt Collected figures.
+        val totalPattern = Regex(
+            """TOTAL\s+TZS\s*([0-9][0-9,]*(?:\.\d{1,2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        totalPattern.find(message)?.let { match ->
+            parseAmount(match.groupValues[1])?.let { return it }
+        }
+
         // "TZS 50000.00" (with space) or "TZS40000" (no space).
         val tzsPattern = Regex(
             """TZS\s*([0-9][0-9,]*(?:\.\d{1,2})?)""",
@@ -153,30 +163,60 @@ class CrdbBankParser : BankParser() {
             return "ATM Withdrawal"
         }
 
-        // Mobile money send (Swahili): "... kwenda NAME phonenumber".
-        // Recipient is the name after "kwenda" up to a trailing phone number.
+        // Transfer / send (Swahili): "... kwenda <RECIPIENT> ...".
+        // The recipient name follows "kwenda" and ends before any of:
+        //   - a phone/account number or masked number (digits / "X" runs),
+        //   - a structural label ("AC", "Risiti", "REF", "Balance"),
+        // so we never leak phone numbers, account numbers or trailing metadata.
+        // "kwenda LIPA <merchant>" is a till/merchant payment — the "LIPA" prefix
+        // is dropped and the merchant name kept.
         val kwendaPattern = Regex(
-            """kwenda\s+(.+?)(?:\s+\d{6,})?$""",
+            """kwenda\s+(?:LIPA\s+)?(.+?)""" +
+                """(?=\s+(?:\d|[0-9X*]{4,}|AC\b|A/C\b|Risiti\b|REF\b|Balance\b|Bal\b)|[.,]|$)""",
             RegexOption.IGNORE_CASE
         )
         kwendaPattern.find(message)?.let { match ->
-            val merchant = match.groupValues[1].trim()
-            if (merchant.isNotEmpty()) return merchant
+            val merchant = match.groupValues[1].trim().trimEnd('.', ',').trim()
+            // Guard: a bare "akaunti yako" ("your account") is not a recipient name.
+            if (merchant.isNotEmpty() && !merchant.equals("akaunti yako", ignoreCase = true)) {
+                return merchant
+            }
         }
 
-        // Bill payment / utility (Swahili): "Malipo yamekamilika TOTAL TZS 2000".
-        // Merchant is the text between the completion phrase and the amount.
-        val billPattern = Regex(
-            """Malipo yamekamilika\s+(.+?)\s+TZS""",
-            RegexOption.IGNORE_CASE
-        )
-        billPattern.find(message)?.let { match ->
-            val merchant = match.groupValues[1].trim()
-            if (merchant.isNotEmpty()) return merchant
-        }
+        // Utility / token purchase (Swahili): "Malipo yamekamilika ... TOTAL TZS 2000".
+        // The LUKU electricity form has no merchant name in the body, only a TOKEN —
+        // label it generically. The simple bill form keeps the text before the amount.
         if (message.contains("Malipo yamekamilika", ignoreCase = true)) {
+            if (message.contains("TOKEN", ignoreCase = true) ||
+                message.contains("KWH", ignoreCase = true)
+            ) {
+                return "LUKU"
+            }
+            val billPattern = Regex(
+                """Malipo yamekamilika\s+(.+?)\s+TZS""",
+                RegexOption.IGNORE_CASE
+            )
+            billPattern.find(message)?.let { match ->
+                val merchant = match.groupValues[1].trim()
+                if (merchant.isNotEmpty()) return merchant
+            }
             return "Bill Payment"
         }
+
+        return null
+    }
+
+    override fun extractReference(message: String): String? {
+        // SimBanking receipt id: "Risiti:003-19ec660b8a1c1bde".
+        Regex("""Risiti:\s*([A-Za-z0-9-]+)""", RegexOption.IGNORE_CASE)
+            .find(message)?.let { return it.groupValues[1].trim() }
+
+        // Fall back to the generic Ref/REF handling (e.g. "REF: 19ec...").
+        super.extractReference(message)?.let { return it }
+
+        // SimBanking transaction id: "KUMB:19ec6ebe82c12bc7" (used when no receipt id).
+        Regex("""KUMB:\s*([A-Za-z0-9]+)""", RegexOption.IGNORE_CASE)
+            .find(message)?.let { return it.groupValues[1].trim() }
 
         return null
     }
@@ -212,6 +252,15 @@ class CrdbBankParser : BankParser() {
         }
 
         return null
+    }
+
+    override fun detectIsCard(message: String): Boolean {
+        // CRDB card forms use "... using a Card 4232***XXXX" / "Card:4232***0581",
+        // which the generic detector misses. Treat any "Card <masked-number>" as a card.
+        if (Regex("""\bCard:?\s*[0-9*X]{4,}""", RegexOption.IGNORE_CASE).containsMatchIn(message)) {
+            return true
+        }
+        return super.detectIsCard(message)
     }
 
     override fun isTransactionMessage(message: String): Boolean {

--- a/parser-core/src/test/kotlin/CrdbBankParserTest.kt
+++ b/parser-core/src/test/kotlin/CrdbBankParserTest.kt
@@ -88,6 +88,88 @@ class CrdbBankParserTest {
                     type = TransactionType.EXPENSE,
                     balance = BigDecimal("50000.00")
                 )
+            ),
+            ParserTestCase(
+                // LUKU electricity token: amount must anchor on the "TOTAL TZS" line,
+                // never the intermediate Cost/VAT/EWURA/REA/Debt Collected figures.
+                name = "LUKU electricity token (TOTAL anchored)",
+                message = "Malipo yamekamilika.19ec9775f682395e 9007261660708258420 TOKEN 6642 0488 4500 7039 0706 12.2KWH Cost 1229.51 VAT 18% 221.31 EWURA 1% 12.30 REA 3% 36.88 Debt Collected 1500.00 TOTAL TZS 3000.00 2026-06-15 07:08",
+                sender = "CRDB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("3000.00"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "LUKU"
+                )
+            ),
+            ParserTestCase(
+                // SimBanking interbank transfer: recipient name after "kwenda" must stop
+                // before the masked phone number; receipt id captured as reference.
+                name = "SimBanking interbank transfer",
+                message = "KUMB:19ec6ebe82c12bc7 Muamala umefanikiwa TZS35000 SELCOM BANK kwenda JANE DOE 06XXXXXXXX Risiti:003-19ec6ebe82c12bc7 2026-06-14 19:16:49  CRDB SIMBANKING APP",
+                sender = "CRDB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("35000"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "JANE DOE",
+                    reference = "003-19ec6ebe82c12bc7"
+                )
+            ),
+            ParserTestCase(
+                // Account-to-account send ("Umetuma" = you sent): recipient name must stop
+                // before the "AC:"/"REF:" labels.
+                name = "Account-to-account transfer (Umetuma)",
+                message = "Umetuma TZS 39,600.0 kutoka AC:01522***6100 kwenda JOHN DOE AC: 11375680 REF: 19ec69444b7bba7c 2026-06-14 17:41:9. Kwa msaada piga 0755197700",
+                sender = "CRDB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("39600.0"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "JOHN DOE",
+                    reference = "19ec69444b7bba7c"
+                )
+            ),
+            ParserTestCase(
+                // Merchant ("Lipa") payment via SimBanking: "kwenda LIPA <merchant>" drops
+                // the LIPA prefix and keeps the merchant name.
+                name = "Merchant payment via SimBanking (Lipa)",
+                message = "KUMB:19ec660b8a1c1bde Muamala umefanikiwa TZS30000 VODACOM kwenda LIPA MERCHANT NAME 51469658 Risiti:003-19ec660b8a1c1bde 2026-06-14 16:44:48  CRDB SIMBANKING APP",
+                sender = "CRDB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("30000"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "MERCHANT NAME",
+                    reference = "003-19ec660b8a1c1bde"
+                )
+            ),
+            ParserTestCase(
+                // Inbound deposit/credit: "you have received" -> INCOME, REF captured.
+                name = "Inbound deposit / credit",
+                message = "Dear Customer, you have received TZS850,000.00 in your account number: 0152********100 2026-06-13T19:18 REF:FT2616465ZC2 . For queries call 0755197700.",
+                sender = "CRDB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("850000.00"),
+                    currency = "TZS",
+                    type = TransactionType.INCOME,
+                    reference = "FT2616465ZC2"
+                )
+            ),
+            ParserTestCase(
+                // ATM cash withdrawal via card: balance captured, isFromCard true.
+                name = "ATM cash withdrawal (card, masked)",
+                message = "Dear JOHN DOE, TZS150000.00 has been withdrawn using a Card 4232***XXXX On 20.04.26 11:39 Balance is TZS2237.77 Inq. Call: 0755197700",
+                sender = "CRDB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("150000.00"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "ATM Withdrawal",
+                    balance = BigDecimal("2237.77"),
+                    isFromCard = true,
+                    accountLast4 = "4232"
+                )
             )
         )
 

--- a/parser-core/src/test/kotlin/CrdbBankParserTest.kt
+++ b/parser-core/src/test/kotlin/CrdbBankParserTest.kt
@@ -170,6 +170,20 @@ class CrdbBankParserTest {
                     isFromCard = true,
                     accountLast4 = "4232"
                 )
+            ),
+            ParserTestCase(
+                // SimBanking transfer with NO receipt id — reference must fall back
+                // to the leading "KUMB:<id>" transaction id.
+                name = "SimBanking transfer, KUMB-only reference (no Risiti)",
+                message = "KUMB:19ec7af09b2d4ce1 Muamala umefanikiwa TZS12000 AIRTEL kwenda JOHN DOE 07XXXXXXXX 2026-06-15 09:10:21  CRDB SIMBANKING APP",
+                sender = "CRDB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("12000"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "JOHN DOE",
+                    reference = "19ec7af09b2d4ce1"
+                )
             )
         )
 


### PR DESCRIPTION
Closes #520. Verified the existing `CrdbBankParser` against the issue's 6 formats and fixed the gaps (no rewrite of working logic).

| # | Format | Fix |
|---|---|---|
| 1 | LUKU electricity token | amount anchored on `TOTAL TZS` (was matching the first non-balance TZS); merchant `LUKU` |
| 2 | SimBanking transfer | **merchant no longer leaks phone/receipt/date** (PII); added `Risiti:`/`KUMB:` reference |
| 3 | Umetuma A2A | **merchant no longer leaks AC/REF tail** |
| 4 | LIPA merchant | `kwenda LIPA <merchant>` handled |
| 5 | Inbound deposit | already correct |
| 6 | ATM card withdrawal | now flags `isFromCard` |

Samples 2/3/4 previously leaked the trailing phone number / account number into the merchant field — these are corrected (and PII-safe).

## Tests
6 new cases added to `CrdbBankParserTest` (now 12 + handle checks). Full `:parser-core:jvmTest` → **1365 tests, 0 failures**. No PII emitted.