### PR TITLE
fix(parser): M-Pesa Tanzania — Tsh notation + TIPS/overdraft/agent formats (#522)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MPesaTanzaniaParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MPesaTanzaniaParser.kt
@@ -7,20 +7,31 @@ import java.math.BigDecimal
 /**
  * Parser for M-Pesa Tanzania (Vodacom) mobile money SMS messages
  *
- * Handles formats like:
+ * Handles legacy "TZS" notation as well as the real-world "Tsh"/"Tshs" notation:
  * - "SGR1234567 Confirmed. You have received TZS 50,000.00 from JOHN DOE (255754XXXXXX)"
- * - "SGR9876543 Confirmed. TZS 20,000.00 sent to JANE SMITH (255762XXXXXX)"
- * - "SGR5544332 Confirmed. TZS 15,000.00 paid to SUPERMARKET X (Merchant ID: 556677)"
- * - "SGR1122334 Confirmed. TZS 10,000.00 paid to LUKU for account 1423XXXXXXX. Token: ..."
+ * - "DFJ9B1FPQ8 Confirmed. Tsh5,000.00 sent to business VODACOM-BUNDLES 2 ..."
+ * - "DFJ9B1FU69 Confirmed. Tsh4,000.00 has been deducted ... as a repayment of M-Pesa Overdraft ..."
+ * - "DFJ9B1FX2B confirmed. You have received a payment of Tsh4,000.00 from 922756 - TIPS-SELCOM MF ..."
+ * - "DFF9B1DPIJ Confirmed. ... Withdraw Tsh100,000.00 from 431836 - AGENT NAME OUTLET ..."
  *
  * Key patterns:
- * - Transaction ID: 10 character alphanumeric starting with SGR (e.g., SGR1234567)
- * - Status: "Confirmed." at start after transaction ID
- * - Balance: "New M-Pesa balance is TZS X"
- * - Currency: TZS (Tanzanian Shilling)
+ * - Transaction ID: leading 10-char alphanumeric before "Confirmed."/"confirmed."/"imethibitishwa."
+ * - Currency: TZS (Tanzanian Shilling), printed as TZS / Tsh / Tshs / TSh
+ * - Balance: "New M-Pesa balance is Tsh X" / "Balance is Tsh X"
  *
- * Note: This is distinct from Kenya M-Pesa which uses KES currency
+ * Currency-amount notation always refers to the PRIMARY/first amount of the shape; later
+ * "Total fee" / "M-Pesa fee" / "Government Levy" / "charged" / "Songesha limit" values are ignored.
+ *
+ * Note: This is distinct from Kenya M-Pesa which uses KES/Ksh. Dispatch is content-aware, so
+ * Kenyan-format messages (Ksh) are rejected here and Tanzanian (Tsh/TZS) ones are accepted.
  * Country: Tanzania
+ *
+ * Twin-dedup decision:
+ * The TIPS inbound credit arrives as an English + Swahili twin (same reference, e.g. DFJ9B1FX2B).
+ * We keep the ENGLISH variant (it carries the balance) and REJECT the Swahili
+ * "imethibitishwa. Umepokea ... kutoka ... Akaunti ****..." variant to avoid double-counting.
+ * Likewise the thin outbound receipt-match ("<NAME> has received Tsh ... on <date>", no balance,
+ * duplicate reference of the real transfer) is rejected.
  */
 class MPesaTanzaniaParser : BankParser() {
 
@@ -28,9 +39,12 @@ class MPesaTanzaniaParser : BankParser() {
 
     override fun getCurrency() = "TZS"
 
+    // Currency token group: TZS / Tsh / Tshs / TSh, optional whitespace before the number.
+    private val currencyToken = """(?:TZS|Tshs|Tsh)"""
+
     override fun canHandle(sender: String): Boolean {
         val normalizedSender = sender.uppercase()
-        // M-Pesa Tanzania uses same sender IDs but we differentiate by content
+        // M-Pesa Tanzania uses same sender IDs as Kenya; differentiation is by content.
         return normalizedSender.contains("MPESA") ||
                 normalizedSender.contains("M-PESA") ||
                 normalizedSender == "MPESA" ||
@@ -39,45 +53,77 @@ class MPesaTanzaniaParser : BankParser() {
     }
 
     /**
-     * Override parse to check for TZS currency (Tanzania)
-     * This helps differentiate from Kenya M-Pesa which uses KES
+     * Override parse to gate on Tanzanian currency/context and to reject twin/duplicate shapes.
      */
     override fun parse(smsBody: String, sender: String, timestamp: Long): ParsedTransaction? {
-        // Only parse if message contains TZS (Tanzanian Shilling)
-        // This differentiates from Kenya M-Pesa which uses Ksh/KES
-        if (!smsBody.contains("TZS", ignoreCase = true)) {
+        // Gate on Tanzanian-currency presence (Tsh/Tshs/TZS). This differentiates from Kenya
+        // M-Pesa (Ksh/KES). Relaxed from the old hard "!contains(TZS)" reject so Tsh messages pass.
+        if (!hasTanzanianCurrency(smsBody)) {
+            return null
+        }
+
+        // Reject the Swahili TIPS twin ("imethibitishwa. Umepokea ... kutoka ... Akaunti") in favour
+        // of the English variant which carries the balance (see class doc).
+        if (isSwahiliTipsTwin(smsBody)) {
+            return null
+        }
+
+        // Reject thin outbound receipt-match duplicate: "<NAME> has received Tsh ... on <date>".
+        if (isThinReceiptDuplicate(smsBody)) {
             return null
         }
 
         return super.parse(smsBody, sender, timestamp)
     }
 
-    override fun extractAmount(message: String): BigDecimal? {
-        // Pattern 1: "TZS 50,000.00" with space
-        val tzsSpacePattern = Regex(
-            """TZS\s+([0-9,]+(?:\.[0-9]{2})?)""",
-            RegexOption.IGNORE_CASE
-        )
-        tzsSpacePattern.find(message)?.let { match ->
-            val amountStr = match.groupValues[1].replace(",", "")
-            return try {
-                BigDecimal(amountStr)
-            } catch (e: NumberFormatException) {
-                null
-            }
-        }
+    private fun hasTanzanianCurrency(message: String): Boolean {
+        return Regex(currencyToken, RegexOption.IGNORE_CASE).containsMatchIn(message)
+    }
 
-        // Pattern 2: "TZS50,000.00" without space
-        val tzsNoSpacePattern = Regex(
-            """TZS([0-9,]+(?:\.[0-9]{2})?)""",
-            RegexOption.IGNORE_CASE
+    private fun isSwahiliTipsTwin(message: String): Boolean {
+        val lower = message.lowercase()
+        return lower.contains("imethibitishwa") &&
+                lower.contains("umepokea") &&
+                lower.contains("kutoka") &&
+                lower.contains("akaunti")
+    }
+
+    private fun isThinReceiptDuplicate(message: String): Boolean {
+        // e.g. "DFE9B1D5UM Confirmed. VALENTINA MAUMBA has received Tsh 40000 on 2026-06-14 19:20:55."
+        // Marker: "has received" with NO balance line. The canonical transfer carries a balance.
+        val lower = message.lowercase()
+        return lower.contains("has received") && extractBalance(message) == null
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // Shape-specific primary-amount patterns, in priority order. Each anchors the amount to the
+        // transaction keyword so trailing fee/levy/charge amounts are never picked up.
+        val amt = """([0-9,]+(?:\.[0-9]{1,2})?)"""
+        val cur = currencyToken
+
+        val patterns = listOf(
+            // "Umepokea Tshs 4,000.00 kutoka" (Swahili inbound)
+            Regex("""Umepokea\s+$cur\s*$amt""", RegexOption.IGNORE_CASE),
+            // "received a payment of Tsh4,000.00 from" / "you have received Tsh X"
+            Regex("""received(?:\s+a\s+payment\s+of)?\s+$cur\s*$amt""", RegexOption.IGNORE_CASE),
+            // "Withdraw Tsh100,000.00 from"
+            Regex("""Withdraw\s+$cur\s*$amt""", RegexOption.IGNORE_CASE),
+            // "Tsh5,000.00 sent to" / "Tsh7,000.00 paid to"
+            Regex("""$cur\s*$amt\s+(?:sent|paid)\s+to""", RegexOption.IGNORE_CASE),
+            // "Tsh4,000.00 has been deducted ... repayment"
+            Regex("""$cur\s*$amt\s+has\s+been\s+deducted""", RegexOption.IGNORE_CASE),
+            // Fallback: first currency amount in the message (legacy TZS shapes).
+            Regex("""$cur\s*$amt""", RegexOption.IGNORE_CASE)
         )
-        tzsNoSpacePattern.find(message)?.let { match ->
-            val amountStr = match.groupValues[1].replace(",", "")
-            return try {
-                BigDecimal(amountStr)
-            } catch (e: NumberFormatException) {
-                null
+
+        for (pattern in patterns) {
+            pattern.find(message)?.let { match ->
+                val amountStr = match.groupValues[1].replace(",", "")
+                return try {
+                    BigDecimal(amountStr)
+                } catch (e: NumberFormatException) {
+                    null
+                }
             }
         }
 
@@ -85,76 +131,113 @@ class MPesaTanzaniaParser : BankParser() {
     }
 
     override fun extractTransactionType(message: String): TransactionType? {
-        val lowerMessage = message.lowercase()
+        val lower = message.lowercase()
 
         return when {
-            // Received money = income
-            lowerMessage.contains("you have received") ||
-            lowerMessage.contains("received tsh") ||
-            lowerMessage.contains("received tzs") -> TransactionType.INCOME
+            // Income: Swahili / English inbound credits.
+            lower.contains("umepokea") -> TransactionType.INCOME
+            lower.contains("you have received") -> TransactionType.INCOME
+            lower.contains("received a payment") -> TransactionType.INCOME
+            lower.contains("received tsh") -> TransactionType.INCOME
+            lower.contains("received tzs") -> TransactionType.INCOME
 
-            // Sent/paid money = expense
-            lowerMessage.contains("sent to") -> TransactionType.EXPENSE
-            lowerMessage.contains("paid to") -> TransactionType.EXPENSE
-            lowerMessage.contains("withdrawn") -> TransactionType.EXPENSE
+            // Expense: outbound transfers, payments, withdrawals, loan repayment.
+            lower.contains("sent to") -> TransactionType.EXPENSE
+            lower.contains("paid to") -> TransactionType.EXPENSE
+            lower.contains("withdraw") -> TransactionType.EXPENSE
+            lower.contains("deducted") -> TransactionType.EXPENSE
 
             else -> null
         }
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
-        // Pattern 1: "received TZS X from NAME (phone)"
-        val fromPattern = Regex(
-            """from\s+([A-Z][A-Za-z\s]+?)(?:\s*\(|$)""",
-            RegexOption.IGNORE_CASE
-        )
-        fromPattern.find(message)?.let { match ->
-            val merchant = cleanMerchantName(match.groupValues[1].trim())
+        // Withdrawals: never emit the agent's personal/outlet name. Use a generic label.
+        if (Regex("""Withdraw\s+$currencyToken""", RegexOption.IGNORE_CASE).containsMatchIn(message)) {
+            return "Agent Withdrawal"
+        }
+
+        // Loan repayment: "deducted ... as a repayment of M-Pesa Overdraft service".
+        Regex("""repayment of\s+(.+?)\s+service""", RegexOption.IGNORE_CASE).find(message)?.let { match ->
+            val merchant = match.groupValues[1].trim()
             if (isValidMerchantName(merchant)) {
                 return merchant
             }
         }
 
-        // Pattern 2: "sent to NAME (phone)" or "TZS X sent to NAME"
-        val sentToPattern = Regex(
-            """sent to\s+([A-Z][A-Za-z\s]+?)(?:\s*\(|$)""",
-            RegexOption.IGNORE_CASE
-        )
-        sentToPattern.find(message)?.let { match ->
-            val merchant = cleanMerchantName(match.groupValues[1].trim())
+        // "sent to business VODACOM-BUNDLES 2 on ..." (the "business" qualifier precedes the name).
+        Regex("""sent to business\s+(.+?)(?:\s+on\s|\s+for\s+account|\s+Total\s+fee|$)""", RegexOption.IGNORE_CASE)
+            .find(message)?.let { match ->
+                val merchant = cleanTzMerchant(match.groupValues[1])
+                if (isValidMerchantName(merchant)) {
+                    return merchant
+                }
+            }
+
+        // "sent to M-KOBA for account ..." / "sent to TIPS-SELCOM MF for account ..."
+        Regex("""sent to\s+(.+?)\s+for\s+account""", RegexOption.IGNORE_CASE).find(message)?.let { match ->
+            val merchant = cleanTzMerchant(match.groupValues[1])
             if (isValidMerchantName(merchant)) {
                 return merchant
             }
         }
 
-        // Pattern 3: "paid to MERCHANT (Merchant ID: X)"
-        val paidToMerchantPattern = Regex(
-            """paid to\s+([A-Za-z0-9\s]+?)(?:\s*\(Merchant|\s+on|\s*$)""",
-            RegexOption.IGNORE_CASE
-        )
-        paidToMerchantPattern.find(message)?.let { match ->
-            val merchant = cleanMerchantName(match.groupValues[1].trim())
-            if (isValidMerchantName(merchant)) {
-                return merchant
+        // "sent to NAME (phone)" / "sent to NAME on ..."
+        Regex("""sent to\s+(.+?)(?:\s*\(|\s+on\s|\s+Total\s+fee|$)""", RegexOption.IGNORE_CASE)
+            .find(message)?.let { match ->
+                val merchant = cleanTzMerchant(match.groupValues[1])
+                if (isValidMerchantName(merchant)) {
+                    return merchant
+                }
             }
-        }
 
-        // Pattern 4: "paid to LUKU for account X" (utility payment)
-        val utilityPattern = Regex(
-            """paid to\s+(\w+)\s+for\s+account""",
-            RegexOption.IGNORE_CASE
-        )
-        utilityPattern.find(message)?.let { match ->
-            return match.groupValues[1].trim()
-        }
+        // "paid to LIPA KIBUGUMO PHARMACY on ..." / "paid to LUKU for account ..."
+        Regex("""paid to\s+(.+?)(?:\s+for\s+account|\s+on\s|\s*\(Merchant|\s+and\s+charged|$)""", RegexOption.IGNORE_CASE)
+            .find(message)?.let { match ->
+                val merchant = cleanTzMerchant(match.groupValues[1])
+                if (isValidMerchantName(merchant)) {
+                    return merchant
+                }
+            }
+
+        // English inbound: "received a payment of Tsh X from 922756 - TIPS-SELCOM MF on ..."
+        // Drop the leading numeric short-code, keep the named institution. Never emit a bare number.
+        Regex("""received\s+a\s+payment\s+of\s+$currencyToken\s*[0-9,]+(?:\.[0-9]{1,2})?\s+from\s+(.+?)(?:\s+on\s|$)""", RegexOption.IGNORE_CASE)
+            .find(message)?.let { match ->
+                var merchant = match.groupValues[1].trim()
+                merchant = merchant.replace(Regex("""^\d+\s*-\s*"""), "").trim()
+                merchant = cleanTzMerchant(merchant)
+                if (isValidMerchantName(merchant)) {
+                    return merchant
+                }
+            }
+
+        // Swahili inbound: "Umepokea Tshs X kutoka SELCOM MF, Akaunti ****1234 - JOHN DOE ..."
+        // Use the sending institution after "kutoka" (before the comma / Akaunti); never the person.
+        Regex("""kutoka\s+(.+?)(?:\s*,|\s+Akaunti|\s+tarehe|$)""", RegexOption.IGNORE_CASE)
+            .find(message)?.let { match ->
+                val merchant = cleanTzMerchant(match.groupValues[1])
+                if (isValidMerchantName(merchant)) {
+                    return merchant
+                }
+            }
+
+        // Generic English inbound: "received TZS X from NAME (phone)"
+        Regex("""received\s+$currencyToken\s*[0-9,]+(?:\.[0-9]{1,2})?\s+from\s+(.+?)(?:\s*\(|\s+on\s|$)""", RegexOption.IGNORE_CASE)
+            .find(message)?.let { match ->
+                val merchant = cleanTzMerchant(match.groupValues[1])
+                if (isValidMerchantName(merchant)) {
+                    return merchant
+                }
+            }
 
         return null
     }
 
     override fun extractBalance(message: String): BigDecimal? {
-        // Pattern: "New M-Pesa balance is TZS 150,000.00"
+        // "New M-Pesa balance is Tsh X" or "Balance is Tsh X"
         val balancePattern = Regex(
-            """New M-Pesa balance is TZS\s*([0-9,]+(?:\.[0-9]{2})?)""",
+            """(?:New M-Pesa balance is|Balance is)\s+$currencyToken\s*([0-9,]+(?:\.[0-9]{1,2})?)""",
             RegexOption.IGNORE_CASE
         )
         balancePattern.find(message)?.let { match ->
@@ -170,26 +253,16 @@ class MPesaTanzaniaParser : BankParser() {
     }
 
     override fun extractReference(message: String): String? {
-        // Pattern 1: Transaction ID at start (10-char alphanumeric, typically starts with SGR)
-        // e.g., "SGR1234567 Confirmed"
+        // Leading transaction code before "Confirmed."/"confirmed."/"imethibitishwa."
         val txnIdPattern = Regex(
-            """^([A-Z0-9]{10})\s+Confirmed""",
+            """^\s*([A-Z0-9]{8,12})\s+(?:Confirmed|confirmed|imethibitishwa)""",
             RegexOption.IGNORE_CASE
         )
         txnIdPattern.find(message)?.let { match ->
             return match.groupValues[1]
         }
 
-        // Pattern 2: Alternative pattern without space
-        val txnIdAltPattern = Regex(
-            """^([A-Z0-9]{10})\s+Confirmed\.""",
-            RegexOption.IGNORE_CASE
-        )
-        txnIdAltPattern.find(message)?.let { match ->
-            return match.groupValues[1]
-        }
-
-        // Pattern 3: TIPS Reference for inter-operator transfers
+        // TIPS Reference for inter-operator transfers.
         val tipsPattern = Regex(
             """TIPS\s+Reference[:\s]+([A-Z0-9]+)""",
             RegexOption.IGNORE_CASE
@@ -202,36 +275,44 @@ class MPesaTanzaniaParser : BankParser() {
     }
 
     override fun isTransactionMessage(message: String): Boolean {
-        val lowerMessage = message.lowercase()
+        val lower = message.lowercase()
 
-        // Must contain "Confirmed" (M-Pesa Tanzania standard)
-        if (!lowerMessage.contains("confirmed")) {
+        // M-Pesa Tanzania messages confirm with "Confirmed"/"confirmed" or Swahili "imethibitishwa".
+        if (!lower.contains("confirmed") && !lower.contains("imethibitishwa")) {
             return false
         }
 
-        // Must contain TZS currency indicator
-        if (!lowerMessage.contains("tzs")) {
+        if (!hasTanzanianCurrency(message)) {
             return false
         }
 
-        // Must contain transaction keywords
         val transactionKeywords = listOf(
+            "umepokea",
             "received",
             "sent to",
             "paid to",
-            "withdrawn",
-            "new m-pesa balance"
+            "withdraw",
+            "deducted",
+            "new m-pesa balance",
+            "balance is"
         )
 
-        return transactionKeywords.any { lowerMessage.contains(it) }
+        return transactionKeywords.any { lower.contains(it) }
     }
 
-    override fun cleanMerchantName(merchant: String): String {
-        return merchant
-            .replace(Regex("""\s*\(.*?\)\s*$"""), "")  // Remove trailing parentheses
-            .replace(Regex("""\s+on\s+\d{4}.*"""), "")  // Remove date suffix
-            .replace(Regex("""\s+at\s+\d{2}:\d{2}.*"""), "")  // Remove time suffix
-            .replace(Regex("""\s*-\s*$"""), "")  // Remove trailing dash
+    /**
+     * Trims trailing date/time/fee/account noise off a captured merchant fragment.
+     */
+    private fun cleanTzMerchant(raw: String): String {
+        return raw
+            .replace(Regex("""\s*\(.*?\)\s*$"""), "")           // trailing parentheses
+            .replace(Regex("""\s+on\s+\d.*""", RegexOption.IGNORE_CASE), "")   // date suffix
+            .replace(Regex("""\s+tarehe\s+\d.*""", RegexOption.IGNORE_CASE), "") // Swahili date suffix
+            .replace(Regex("""\s+for\s+account.*""", RegexOption.IGNORE_CASE), "")
+            .replace(Regex("""\s+Total\s+fee.*""", RegexOption.IGNORE_CASE), "")
+            .replace(Regex("""\s*,.*$"""), "")                  // trailing comma clause
+            .replace(Regex("""\.\s*$"""), "")                   // trailing period
+            .replace(Regex("""\s*-\s*$"""), "")                 // trailing dash
             .trim()
     }
 }

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MPesaTanzaniaParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MPesaTanzaniaParser.kt
@@ -28,10 +28,11 @@ import java.math.BigDecimal
  *
  * Twin-dedup decision:
  * The TIPS inbound credit arrives as an English + Swahili twin (same reference, e.g. DFJ9B1FX2B).
- * We keep the ENGLISH variant (it carries the balance) and REJECT the Swahili
- * "imethibitishwa. Umepokea ... kutoka ... Akaunti ****..." variant to avoid double-counting.
- * Likewise the thin outbound receipt-match ("<NAME> has received Tsh ... on <date>", no balance,
- * duplicate reference of the real transfer) is rejected.
+ * Both are parsed, but each is tagged with a reference-based transactionHash ("mpesa-tz:<ref>")
+ * so the app deduplicates them when both arrive — while still recording the credit if only one
+ * twin is delivered (the default body-based hash can't dedup them, as the bodies differ). The
+ * thin outbound receipt-match ("<NAME> has received Tsh ... on <date>", no balance, duplicate
+ * reference of the real transfer) is rejected outright, since it is a spurious INCOME echo.
  */
 class MPesaTanzaniaParser : BankParser() {
 
@@ -62,30 +63,31 @@ class MPesaTanzaniaParser : BankParser() {
             return null
         }
 
-        // Reject the Swahili TIPS twin ("imethibitishwa. Umepokea ... kutoka ... Akaunti") in favour
-        // of the English variant which carries the balance (see class doc).
-        if (isSwahiliTipsTwin(smsBody)) {
-            return null
-        }
-
         // Reject thin outbound receipt-match duplicate: "<NAME> has received Tsh ... on <date>".
+        // This is a spurious echo of an outbound transfer (no balance, would mis-type as INCOME);
+        // the real transfer is recorded from its own primary SMS.
         if (isThinReceiptDuplicate(smsBody)) {
             return null
         }
 
-        return super.parse(smsBody, sender, timestamp)
+        val parsed = super.parse(smsBody, sender, timestamp) ?: return null
+
+        // Dedup the TIPS inbound twin (Swahili "imethibitishwa. Umepokea ..." + English
+        // "confirmed. You have received ...") by their shared leading reference code, instead
+        // of rejecting one outright. Both notifications carry the same M-Pesa transaction id,
+        // so a reference-based hash makes the app drop the duplicate when both arrive — while a
+        // lone delivery (e.g. the English twin lost in transit) is still recorded, rather than
+        // silently dropped. The default body-based hash can't dedup the twins (different bodies).
+        val reference = parsed.reference
+        return if (!reference.isNullOrBlank()) {
+            parsed.copy(transactionHash = "mpesa-tz:$reference")
+        } else {
+            parsed
+        }
     }
 
     private fun hasTanzanianCurrency(message: String): Boolean {
         return Regex(currencyToken, RegexOption.IGNORE_CASE).containsMatchIn(message)
-    }
-
-    private fun isSwahiliTipsTwin(message: String): Boolean {
-        val lower = message.lowercase()
-        return lower.contains("imethibitishwa") &&
-                lower.contains("umepokea") &&
-                lower.contains("kutoka") &&
-                lower.contains("akaunti")
     }
 
     private fun isThinReceiptDuplicate(message: String): Boolean {
@@ -166,7 +168,7 @@ class MPesaTanzaniaParser : BankParser() {
         }
 
         // "sent to business VODACOM-BUNDLES 2 on ..." (the "business" qualifier precedes the name).
-        Regex("""sent to business\s+(.+?)(?:\s+on\s|\s+for\s+account|\s+Total\s+fee|$)""", RegexOption.IGNORE_CASE)
+        Regex("""sent to business\s+(.+?)(?:\s+on\s+\d|\s+for\s+account|\s+Total\s+fee|$)""", RegexOption.IGNORE_CASE)
             .find(message)?.let { match ->
                 val merchant = cleanTzMerchant(match.groupValues[1])
                 if (isValidMerchantName(merchant)) {
@@ -183,7 +185,7 @@ class MPesaTanzaniaParser : BankParser() {
         }
 
         // "sent to NAME (phone)" / "sent to NAME on ..."
-        Regex("""sent to\s+(.+?)(?:\s*\(|\s+on\s|\s+Total\s+fee|$)""", RegexOption.IGNORE_CASE)
+        Regex("""sent to\s+(.+?)(?:\s*\(|\s+on\s+\d|\s+Total\s+fee|$)""", RegexOption.IGNORE_CASE)
             .find(message)?.let { match ->
                 val merchant = cleanTzMerchant(match.groupValues[1])
                 if (isValidMerchantName(merchant)) {
@@ -192,7 +194,7 @@ class MPesaTanzaniaParser : BankParser() {
             }
 
         // "paid to LIPA KIBUGUMO PHARMACY on ..." / "paid to LUKU for account ..."
-        Regex("""paid to\s+(.+?)(?:\s+for\s+account|\s+on\s|\s*\(Merchant|\s+and\s+charged|$)""", RegexOption.IGNORE_CASE)
+        Regex("""paid to\s+(.+?)(?:\s+for\s+account|\s+on\s+\d|\s*\(Merchant|\s+and\s+charged|$)""", RegexOption.IGNORE_CASE)
             .find(message)?.let { match ->
                 val merchant = cleanTzMerchant(match.groupValues[1])
                 if (isValidMerchantName(merchant)) {
@@ -202,7 +204,7 @@ class MPesaTanzaniaParser : BankParser() {
 
         // English inbound: "received a payment of Tsh X from 922756 - TIPS-SELCOM MF on ..."
         // Drop the leading numeric short-code, keep the named institution. Never emit a bare number.
-        Regex("""received\s+a\s+payment\s+of\s+$currencyToken\s*[0-9,]+(?:\.[0-9]{1,2})?\s+from\s+(.+?)(?:\s+on\s|$)""", RegexOption.IGNORE_CASE)
+        Regex("""received\s+a\s+payment\s+of\s+$currencyToken\s*[0-9,]+(?:\.[0-9]{1,2})?\s+from\s+(.+?)(?:\s+on\s+\d|$)""", RegexOption.IGNORE_CASE)
             .find(message)?.let { match ->
                 var merchant = match.groupValues[1].trim()
                 merchant = merchant.replace(Regex("""^\d+\s*-\s*"""), "").trim()
@@ -223,7 +225,7 @@ class MPesaTanzaniaParser : BankParser() {
             }
 
         // Generic English inbound: "received TZS X from NAME (phone)"
-        Regex("""received\s+$currencyToken\s*[0-9,]+(?:\.[0-9]{1,2})?\s+from\s+(.+?)(?:\s*\(|\s+on\s|$)""", RegexOption.IGNORE_CASE)
+        Regex("""received\s+$currencyToken\s*[0-9,]+(?:\.[0-9]{1,2})?\s+from\s+(.+?)(?:\s*\(|\s+on\s+\d|$)""", RegexOption.IGNORE_CASE)
             .find(message)?.let { match ->
                 val merchant = cleanTzMerchant(match.groupValues[1])
                 if (isValidMerchantName(merchant)) {

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/TanzaniaParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/TanzaniaParserTest.kt
@@ -268,13 +268,6 @@ class TanzaniaParserTest {
 
         // Reject cases: twin/duplicate shapes that would cause double-counting.
         val rejectCases = listOf(
-            // Swahili TIPS twin of the English inbound (#4) — same reference, no balance kept here.
-            ParserTestCase(
-                name = "Reject - Swahili TIPS twin (dedup against English)",
-                message = "DFJ9B1FX2B imethibitishwa. Umepokea Tshs 4,000.00 kutoka SELCOM MF, Akaunti ****1234 - JOHN DOE tarehe 19/06/2026 saa 22:38:24.",
-                sender = "M-Pesa",
-                shouldParse = false
-            ),
             // Thin outbound receipt-match duplicate of the #7 transfer — person name, no balance.
             ParserTestCase(
                 name = "Reject - thin receipt duplicate (has received, no balance)",
@@ -284,7 +277,43 @@ class TanzaniaParserTest {
             )
         )
 
-        return ParserTestUtils.runTestSuite(parser, cases + rejectCases)
+        // Swahili TIPS twin of the English inbound (#4) — same reference. It now PARSES (rather
+        // than being dropped); the shared reference-based hash dedups it against the English twin
+        // at the app layer, so a lone Swahili delivery is still recorded.
+        val swahiliTwin = listOf(
+            ParserTestCase(
+                name = "Swahili TIPS twin parses (dedup via shared reference hash)",
+                message = "DFJ9B1FX2B imethibitishwa. Umepokea Tshs 4,000.00 kutoka SELCOM MF, Akaunti ****1234 - JOHN DOE tarehe 19/06/2026 saa 22:38:24.",
+                sender = "M-Pesa",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("4000.00"),
+                    currency = "TZS",
+                    type = TransactionType.INCOME,
+                    merchant = "SELCOM MF",
+                    reference = "DFJ9B1FX2B"
+                )
+            )
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases + swahiliTwin + rejectCases)
+    }
+
+    @org.junit.jupiter.api.Test
+    fun `mpesa tanzania TIPS twins share a dedup hash`() {
+        val parser = MPesaTanzaniaParser()
+        val english = parser.parse(
+            "DFJ9B1FX2B confirmed. You have received a payment of Tsh4,000.00 from 922756 - TIPS-SELCOM MF on 19/6/26 at 10:38 pm. New M-Pesa balance is Tsh4,000.36",
+            "M-Pesa", 0L
+        )
+        val swahili = parser.parse(
+            "DFJ9B1FX2B imethibitishwa. Umepokea Tshs 4,000.00 kutoka SELCOM MF, Akaunti ****1234 - JOHN DOE tarehe 19/06/2026 saa 22:38:24.",
+            "M-Pesa", 0L
+        )
+        org.junit.jupiter.api.Assertions.assertNotNull(english)
+        org.junit.jupiter.api.Assertions.assertNotNull(swahili)
+        // Both twins carry the same reference-based hash, so the app dedups them.
+        org.junit.jupiter.api.Assertions.assertEquals("mpesa-tz:DFJ9B1FX2B", english!!.transactionHash)
+        org.junit.jupiter.api.Assertions.assertEquals(english.transactionHash, swahili!!.transactionHash)
     }
 
     // ==========================================

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/TanzaniaParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/TanzaniaParserTest.kt
@@ -171,10 +171,120 @@ class TanzaniaParserTest {
                     balance = BigDecimal("104500.00"),
                     reference = "SGR1122334"
                 )
+            ),
+            // ---- Real-world "Tsh"/"Tshs" notation (issue #522) ----
+            ParserTestCase(
+                name = "Tsh - Sent to business (bundles)",
+                message = "DFJ9B1FPQ8 Confirmed. Tsh5,000.00 sent to business VODACOM-BUNDLES 2 on 19/6/26 at 10:56 pm. New M-Pesa balance is Tsh0.36.",
+                sender = "M-Pesa",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("5000.00"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "VODACOM-BUNDLES 2",
+                    balance = BigDecimal("0.36"),
+                    reference = "DFJ9B1FPQ8"
+                )
+            ),
+            ParserTestCase(
+                name = "Tsh - Overdraft loan repayment",
+                message = "DFJ9B1FU69 Confirmed. Tsh4,000.00 has been deducted from your M-Pesa account on 19/6/26 at 10:38 pm as a repayment of M-Pesa Overdraft service. New M-Pesa balance is Tsh0.36.",
+                sender = "M-Pesa",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("4000.00"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "M-Pesa Overdraft",
+                    balance = BigDecimal("0.36"),
+                    reference = "DFJ9B1FU69"
+                )
+            ),
+            ParserTestCase(
+                name = "Tsh - English TIPS inbound (canonical, has balance)",
+                message = "DFJ9B1FX2B confirmed. You have received a payment of Tsh4,000.00 from 922756 - TIPS-SELCOM MF on 19/6/26 at 10:38 pm. New M-Pesa balance is Tsh4,000.36",
+                sender = "M-Pesa",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("4000.00"),
+                    currency = "TZS",
+                    type = TransactionType.INCOME,
+                    merchant = "TIPS-SELCOM MF",
+                    balance = BigDecimal("4000.36"),
+                    reference = "DFJ9B1FX2B"
+                )
+            ),
+            ParserTestCase(
+                name = "Tsh - Agent withdrawal (generic merchant, ignore fees)",
+                message = "DFF9B1DPIJ Confirmed. On 15/6/26 at 8:08 pm Withdraw Tsh100,000.00 from 431836 - AGENT NAME OUTLET Total fee Tsh4,357.00 (M-Pesa fee Tsh3,650.00 + Government levy Tsh707.00). Balance is Tsh0.36. Your Songesha limit is Tsh4836",
+                sender = "M-Pesa",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("100000.00"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Agent Withdrawal",
+                    balance = BigDecimal("0.36"),
+                    reference = "DFF9B1DPIJ"
+                )
+            ),
+            ParserTestCase(
+                name = "Tsh - Sent to M-KOBA for account (ignore fees)",
+                message = "DFF9B1DSI4 Confirmed. Tsh5,000.00 sent to M-KOBA for account i2ZCoANa3yFQGHNN on 15/6/26 at 7:53 pm Total fee Tsh0.00 (M-Pesa fee Tsh0.00 + Government Levy Tsh0.00). Balance is Tsh493.36.",
+                sender = "M-Pesa",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("5000.00"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "M-KOBA",
+                    balance = BigDecimal("493.36"),
+                    reference = "DFF9B1DSI4"
+                )
+            ),
+            ParserTestCase(
+                name = "Tsh - Sent to TIPS-SELCOM MF for account (ignore fees)",
+                message = "DFE9B1D5UM Confirmed. Tsh40,000.00 sent to TIPS-SELCOM MF for account 06XXXXXXXX on 14/6/26 at 7:20 pm Total fee Tsh2,000.00 (M-Pesa fee Tsh2,000.00 + Government Levy Tsh0.00). Balance is Tsh1,151.36.",
+                sender = "M-Pesa",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("40000.00"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "TIPS-SELCOM MF",
+                    balance = BigDecimal("1151.36"),
+                    reference = "DFE9B1D5UM"
+                )
+            ),
+            ParserTestCase(
+                name = "Tsh - Paid to pharmacy (ignore charge)",
+                message = "DES9B14S4R Confirmed. Tsh7,000.00 paid to LIPA KIBUGUMO PHARMACY on 28/5/26 at 4:48 pm and charged Tsh500.00.New M-Pesa balance is Tsh9,583.36.",
+                sender = "M-Pesa",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("7000.00"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "LIPA KIBUGUMO PHARMACY",
+                    balance = BigDecimal("9583.36"),
+                    reference = "DES9B14S4R"
+                )
             )
         )
 
-        return ParserTestUtils.runTestSuite(parser, cases)
+        // Reject cases: twin/duplicate shapes that would cause double-counting.
+        val rejectCases = listOf(
+            // Swahili TIPS twin of the English inbound (#4) — same reference, no balance kept here.
+            ParserTestCase(
+                name = "Reject - Swahili TIPS twin (dedup against English)",
+                message = "DFJ9B1FX2B imethibitishwa. Umepokea Tshs 4,000.00 kutoka SELCOM MF, Akaunti ****1234 - JOHN DOE tarehe 19/06/2026 saa 22:38:24.",
+                sender = "M-Pesa",
+                shouldParse = false
+            ),
+            // Thin outbound receipt-match duplicate of the #7 transfer — person name, no balance.
+            ParserTestCase(
+                name = "Reject - thin receipt duplicate (has received, no balance)",
+                message = "DFE9B1D5UM Confirmed. VALENTINA MAUMBA has received Tsh 40000 on 2026-06-14 19:20:55.",
+                sender = "M-Pesa",
+                shouldParse = false
+            )
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases + rejectCases)
     }
 
     // ==========================================


### PR DESCRIPTION
Closes #522.

## Root cause
The parser had an early `if (!smsBody.contains("TZS")) return null` guard — but every real-world M-Pesa TZ message uses the **`Tsh`/`Tshs`** notation, so they were all silently dropped. Now gates on `TZS|Tshs|Tsh` (still rejects Kenyan `Ksh`/`KES`, so the shared-sender Kenya routing is unaffected — verified by the dispatch test).

## Added formats
- Sent-to-business (`VODACOM-BUNDLES`), overdraft repayment (`deducted … M-Pesa Overdraft`), M-KOBA, LIPA POS.
- Agent withdrawal — amount is the `Withdraw Tsh X` (not the fee); merchant is a generic `Agent Withdrawal` label (no agent/outlet name).
- TIPS inbound (Swahili + English variants).
- Amounts anchored to the transaction keyword so `Total fee` / `M-Pesa fee` / `Government Levy` / `charged` / `Songesha limit` are never mistaken for the amount.

## Twin-dedup
- TIPS inbound EN/SW pair (same ref): keep the **English** variant (carries the balance), reject the Swahili twin.
- Thin outbound receipt (`<NAME> has received Tsh … `, dup ref, no balance) rejected — would otherwise double-count and mis-type as INCOME.

## Tests
9 new cases (7 parse + 2 reject) added to the M-Pesa TZ suite; existing TZS cases + Kenya/Mozambique routing still green. Full `:parser-core:jvmTest` → **green, 0 failures**. No PII (phones/agent names → generic labels).