### PR TITLE
feat(parser): NMB Bank Tanzania — TZS, resolves Nepal-NMB sender collision (#519)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -78,6 +78,7 @@ object BankParserFactory {
         PriorbankParser(),  // Priorbank (Belarus)
         AlinmaBankParser(),  // Alinma Bank (Saudi Arabia)
         NabilBankParser(),  // Nabil Bank (Nepal) — must be before NMBBankParser (NMB handles NABIL senders broadly)
+        NMBTanzaniaParser(),  // NMB Bank Plc (Tanzania) — shares NMB sender with Nepal NMB; must precede it so content-aware dispatch tries TZS/Swahili first
         NMBBankParser(),  // NMB Bank / Nabil Bank (Nepal)
         ManjushreeFinanceParser(), // Manjushree Finance (Nepal)
         SiddharthaBankParser(),  // Siddhartha Bank Limited (Nepal)

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NMBTanzaniaParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NMBTanzaniaParser.kt
@@ -95,10 +95,12 @@ class NMBTanzaniaParser : BankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
-        // P2P transfer out: "... kwenda <NAME> <phone>". Stop before a trailing
-        // phone number (07XXXXXXXX or masked) and before any trailing date/period.
+        // P2P transfer out: "... kwenda <NAME> <phone>". A lookahead terminates the
+        // name before a trailing phone/masked number (07XXXXXXXX), a date keyword,
+        // a period, or end of message — so the phone can never leak into the name
+        // even when the message ends without a period or "Tarehe".
         val kwendaPattern = Regex(
-            """kwenda\s+(.+?)(?:\s+0?[0-9X]{6,})?(?:\.|\s+Tarehe|$)""",
+            """kwenda\s+(.+?)(?=\s+0?[0-9X]{4,}|\s+Tarehe\b|\.|$)""",
             RegexOption.IGNORE_CASE
         )
         kwendaPattern.find(message)?.let { match ->
@@ -176,19 +178,22 @@ class NMBTanzaniaParser : BankParser() {
         // Tight Tanzania gating: require both a Tanzania signal AND a transaction verb.
         // This ensures Nepal-format NMB messages (English "fund transfer", NPR, etc.)
         // fall through to the Nepal parser.
+        // The currency signal matches an actual TZS/TSH *amount* token (e.g. "TSH8,000",
+        // "TZS 263"), not a bare "tsh" substring — so a Nepal message whose reference
+        // happens to contain those letters cannot be mis-claimed (Nepal uses NPR).
+        val hasTanzanianCurrency =
+            Regex("""\b(?:TZS|TShs?)\s*[0-9]""", RegexOption.IGNORE_CASE).containsMatchIn(message)
         val tanzaniaSignals = listOf(
             "mshiko fasta",
             "nmb pesa",
             "nmb karibu yako",
-            "tzs",
-            "tsh",
             "kiasi cha",
             "umepokea",
             "kimetumwa",
             "kimetolewa",
             "kwenda"
         )
-        if (tanzaniaSignals.none { lower.contains(it) }) return false
+        if (!hasTanzanianCurrency && tanzaniaSignals.none { lower.contains(it) }) return false
 
         val transactionVerbs = listOf(
             "umepokea",       // received

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NMBTanzaniaParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NMBTanzaniaParser.kt
@@ -34,10 +34,12 @@ class NMBTanzaniaParser : BankParser() {
         return sender.uppercase().contains("NMB")
     }
 
-    // Currency token allowing the doubled "TZS TZS" form: "TZS", "TSH", "Tsh"
-    // optionally followed by a second currency token, then the amount.
+    // Currency token allowing the doubled "TZS TZS" form: "TZS", "TSH", "Tsh",
+    // "TShs" optionally followed by a second currency token, then the amount.
+    // Kept in sync with the currency signal in isTransactionMessage (TZS|TShs?)
+    // so a message that passes the gate can always have its amount extracted.
     private val amountRegex = Regex(
-        """(?:TZS|TSH)\s*(?:(?:TZS|TSH)\s*)?([0-9][0-9,]*(?:\.\d+)?)""",
+        """(?:TZS|TSHS?)\s*(?:(?:TZS|TSHS?)\s*)?([0-9][0-9,]*(?:\.\d+)?)""",
         RegexOption.IGNORE_CASE
     )
 

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NMBTanzaniaParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NMBTanzaniaParser.kt
@@ -1,0 +1,201 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for NMB Bank Plc (Tanzania) SMS messages.
+ *
+ * NMB Tanzania shares the "NMB" sender with NMB Bank (Nepal), so this parser is
+ * registered immediately BEFORE the Nepal parser in [BankParserFactory] and gates
+ * tightly on Tanzania-specific markers (Swahili words, TSh/TZS notation,
+ * "Mshiko Fasta", "NMB Pesa Fasta", "NMB karibu yako"). The content-aware factory
+ * dispatch (firstNotNullOfOrNull) tries Tanzania first; this parser returns null for
+ * Nepal-format messages so they fall through to the Nepal parser.
+ *
+ * Currency: TZS (Tanzanian Shilling). Amount notation varies: "TZS", "TSH", "Tsh"
+ * (with/without space), comma thousands, optional decimals, plus a doubled
+ * "TZS TZS" form seen in loan-repayment SMS.
+ *
+ * Supported formats (bilingual Swahili/English):
+ * - Loan repayment (Swahili): "Kiasi cha TZS TZS <amt> kimetolewa ... kurejesha Mshiko Fasta ..."
+ * - P2P transfer out (Swahili): "Kiasi cha TSH<amt> kimetumwa kutoka ... kwenda <NAME> <phone>"
+ * - Merchant payment (English): "You have paid TZS <amt> ... to <MERCHANT> <id> on <date>"
+ * - Inbound voucher (Swahili): "Umepokea Tsh <amt> kupitia NMB Pesa Fasta ..."
+ * - Loan disbursement (Swahili): "Umepokea kiasi cha TZS <amt> kupitia Mshiko Fasta ..."
+ */
+class NMBTanzaniaParser : BankParser() {
+
+    override fun getBankName() = "NMB Bank Tanzania"
+
+    override fun getCurrency() = "TZS"
+
+    override fun canHandle(sender: String): Boolean {
+        return sender.uppercase().contains("NMB")
+    }
+
+    // Currency token allowing the doubled "TZS TZS" form: "TZS", "TSH", "Tsh"
+    // optionally followed by a second currency token, then the amount.
+    private val amountRegex = Regex(
+        """(?:TZS|TSH)\s*(?:(?:TZS|TSH)\s*)?([0-9][0-9,]*(?:\.\d+)?)""",
+        RegexOption.IGNORE_CASE
+    )
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // Anchor the amount on the transaction phrase. We never anchor on
+        // "Salio la mkopo" (loan balance) or "Gharama" (fee), so search forward
+        // from the first transaction marker.
+        val anchors = listOf(
+            "kiasi cha",      // "Kiasi cha TZS [TZS] <amt>" (loan repayment / disbursement)
+            "you have paid",  // "You have paid TZS <amt>"
+            "umepokea",       // "Umepokea Tsh <amt>" / "Umepokea kiasi cha TZS <amt>"
+            "kimetumwa"       // fallback; amount usually precedes this in Swahili sends
+        )
+
+        val lower = message.lowercase()
+        for (anchor in anchors) {
+            val idx = lower.indexOf(anchor)
+            if (idx < 0) continue
+            // For Swahili sends the amount precedes "kimetumwa", so for that anchor
+            // scan the whole message; for the others scan from the anchor onward.
+            val region = if (anchor == "kimetumwa") message else message.substring(idx)
+            amountRegex.find(region)?.let { match ->
+                parseAmount(match.groupValues[1])?.let { return it }
+            }
+        }
+
+        // Generic fallback: first TZS/TSH amount in the message.
+        amountRegex.find(message)?.let { match ->
+            parseAmount(match.groupValues[1])?.let { return it }
+        }
+        return null
+    }
+
+    private fun parseAmount(raw: String): BigDecimal? {
+        return try {
+            BigDecimal(raw.replace(",", ""))
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lower = message.lowercase()
+        return when {
+            // INCOME — first-person "received".
+            lower.contains("umepokea") -> TransactionType.INCOME
+
+            // EXPENSE — sent / paid / taken out.
+            lower.contains("kimetumwa") -> TransactionType.EXPENSE        // sent
+            lower.contains("you have paid") -> TransactionType.EXPENSE     // merchant payment
+            lower.contains("kimetolewa") -> TransactionType.EXPENSE        // taken out (loan repayment)
+
+            else -> null
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // P2P transfer out: "... kwenda <NAME> <phone>". Stop before a trailing
+        // phone number (07XXXXXXXX or masked) and before any trailing date/period.
+        val kwendaPattern = Regex(
+            """kwenda\s+(.+?)(?:\s+0?[0-9X]{6,})?(?:\.|\s+Tarehe|$)""",
+            RegexOption.IGNORE_CASE
+        )
+        kwendaPattern.find(message)?.let { match ->
+            val name = match.groupValues[1].trim().trimEnd('.').trim()
+            if (name.isNotEmpty() && name.any { it.isLetter() }) return name
+        }
+
+        // Merchant payment (English): "... to <MERCHANT> <id> on <date>".
+        // Drop the trailing numeric merchant id and the "on <date>" tail.
+        val toPattern = Regex(
+            """\bto\s+(.+?)(?:\s+\d{4,})?\s+on\s+""",
+            RegexOption.IGNORE_CASE
+        )
+        toPattern.find(message)?.let { match ->
+            val name = match.groupValues[1].trim()
+            if (name.isNotEmpty() && name.any { it.isLetter() }) return name
+        }
+
+        // Loan flows (repayment / disbursement) -> "Mshiko Fasta".
+        if (message.contains("Mshiko Fasta", ignoreCase = true)) {
+            return "Mshiko Fasta"
+        }
+
+        // Inbound voucher / remittance: "kupitia <CHANNEL>" e.g. "NMB Pesa Fasta".
+        val kupitiaPattern = Regex(
+            """kupitia\s+(.+?)(?:\s+\d|\.|$)""",
+            RegexOption.IGNORE_CASE
+        )
+        kupitiaPattern.find(message)?.let { match ->
+            val channel = match.groupValues[1].trim().trimEnd('.').trim()
+            if (channel.isNotEmpty() && channel.any { it.isLetter() }) return channel
+        }
+
+        return null
+    }
+
+    override fun extractReference(message: String): String? {
+        // "Kumb: <code>" (Swahili "reference").
+        Regex("""Kumb:\s*([A-Z0-9_]+)""", RegexOption.IGNORE_CASE)
+            .find(message)?.let { return it.groupValues[1] }
+
+        // Leading code at the very start: "201NDGL261360514." or "GWX_1780199859027."
+        Regex("""^([A-Z0-9_]{6,})\.""")
+            .find(message.trim())?.let { return it.groupValues[1] }
+
+        return null
+    }
+
+    override fun extractBalance(message: String) = null
+
+    override fun extractAccountLast4(message: String): String? {
+        // "akaunti yako inayoishia na XXXXX" / "akaunti inayoishia na XXXX".
+        // The samples mask the account tail, so we only capture digit tails.
+        val pattern = Regex(
+            """inayoishia na\s+([0-9X]{3,})""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            return extractLast4Digits(match.groupValues[1])
+        }
+        return null
+    }
+
+    override fun isTransactionMessage(message: String): Boolean {
+        val lower = message.lowercase()
+
+        // Reject OTP / secret-code noise (never emit "namba ya siri").
+        if (lower.contains("otp") ||
+            lower.contains("one time password") ||
+            lower.contains("verification code")
+        ) {
+            return false
+        }
+
+        // Tight Tanzania gating: require both a Tanzania signal AND a transaction verb.
+        // This ensures Nepal-format NMB messages (English "fund transfer", NPR, etc.)
+        // fall through to the Nepal parser.
+        val tanzaniaSignals = listOf(
+            "mshiko fasta",
+            "nmb pesa",
+            "nmb karibu yako",
+            "tzs",
+            "tsh",
+            "kiasi cha",
+            "umepokea",
+            "kimetumwa",
+            "kimetolewa",
+            "kwenda"
+        )
+        if (tanzaniaSignals.none { lower.contains(it) }) return false
+
+        val transactionVerbs = listOf(
+            "umepokea",       // received
+            "kimetumwa",      // sent
+            "kimetolewa",     // taken out
+            "you have paid"   // paid (English)
+        )
+        return transactionVerbs.any { lower.contains(it) }
+    }
+}

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/NMBTanzaniaParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/NMBTanzaniaParserTest.kt
@@ -85,6 +85,20 @@ class NMBTanzaniaParserTest {
                     merchant = "Mshiko Fasta",
                     reference = "201NDGL261500637"
                 )
+            ),
+            // 6) Plural "TShs" currency notation — the gate accepts it, so the amount
+            // regex must too (kept in sync).
+            ParserTestCase(
+                name = "P2P transfer out (TShs plural notation)",
+                message = "Kumb: GWX102237382946 Imethibitishwa. Kiasi cha TShs 8,000 kimetumwa kutoka katika akaunti inayoishia na XXXX kwenda JANE DOE 07XXXXXXXX. Tarehe:05-06-2026 19:46:00.",
+                sender = "NMB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("8000"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "JANE DOE",
+                    reference = "GWX102237382946"
+                )
             )
         )
 

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/NMBTanzaniaParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/NMBTanzaniaParserTest.kt
@@ -1,0 +1,127 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class NMBTanzaniaParserTest {
+
+    @TestFactory
+    fun `NMB Tanzania parser handles bilingual transactions`(): List<DynamicTest> {
+        val parser = NMBTanzaniaParser()
+
+        val cases = listOf(
+            // 1) Loan repayment (Swahili) with doubled "TZS TZS".
+            ParserTestCase(
+                name = "Loan repayment (doubled TZS TZS)",
+                message = "201NDGL261360514. Kiasi cha TZS TZS 263.36 kimetolewa kwenye akaunti yako inayoishia na XXXXX kurejesha Mshiko Fasta, Salio la mkopo ni 335,556.64 15-06-2026 03:45 Rejesha kwa wakati upate kiwango cha juu zaidi. NMB karibu yako",
+                sender = "NMB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("263.36"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Mshiko Fasta",
+                    reference = "201NDGL261360514"
+                )
+            ),
+
+            // 2) P2P transfer out (Swahili).
+            ParserTestCase(
+                name = "P2P transfer out",
+                message = "Kumb: GWX102237382945 Imethibitishwa. Kiasi cha TSH8,000 kimetumwa kutoka katika akaunti inayoishia na XXXX kwenda JOHN DOE 07XXXXXXXX. Tarehe:05-06-2026 19:46:00. Teleza Kidigitali na Mshiko Fasta",
+                sender = "NMB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("8000"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "JOHN DOE",
+                    reference = "GWX102237382945"
+                )
+            ),
+
+            // 3) Merchant payment (English).
+            ParserTestCase(
+                name = "Merchant payment (English)",
+                message = "You have paid TZS 85000 with account ending XXXX to LOCAL SUPERMARKET 01 15293743 on 31-05-2026 19:28:03. NMB Karibu Yako",
+                sender = "NMB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("85000"),
+                    currency = "TZS",
+                    type = TransactionType.EXPENSE,
+                    merchant = "LOCAL SUPERMARKET 01"
+                )
+            ),
+
+            // 4) Inbound voucher / remittance (Swahili).
+            ParserTestCase(
+                name = "Inbound voucher (NMB Pesa Fasta)",
+                message = "GWX_1780199859027.Umepokea Tsh 50,000 kupitia NMB Pesa Fasta 31/05/2026 06:57:39. Tumia namba ya siri XXXXX kutoa pesa NMB ATM kabla ya 2026-06-01 06:57:39.",
+                sender = "NMB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("50000"),
+                    currency = "TZS",
+                    type = TransactionType.INCOME,
+                    merchant = "NMB Pesa Fasta",
+                    reference = "GWX_1780199859027"
+                )
+            ),
+
+            // 5) Loan disbursement (Swahili).
+            ParserTestCase(
+                name = "Loan disbursement",
+                message = "201NDGL261500637. Umepokea kiasi cha TZS 209,236.55 kupitia Mshiko Fasta Kulipwa hadi 28-AUG-26. Gharama 33,059.45 30-MAY-26, Kopa na lipa kwa wakati uweze kukopa kiwango cha juu zaidi . NMB karibu yako",
+                sender = "NMB",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("209236.55"),
+                    currency = "TZS",
+                    type = TransactionType.INCOME,
+                    merchant = "Mshiko Fasta",
+                    reference = "201NDGL261500637"
+                )
+            )
+        )
+
+        val handleChecks = listOf(
+            "NMB" to true,
+            "NMB_ALERT" to true,
+            "HDFC" to false,
+            "UNKNOWN" to false
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases, handleChecks, "NMB Bank Tanzania Parser")
+    }
+
+    @TestFactory
+    fun `factory routes NMB senders by content`(): List<DynamicTest> {
+        // A Tanzania NMB message must route to "NMB Bank Tanzania".
+        val tzMessage = "201NDGL261500637. Umepokea kiasi cha TZS 209,236.55 kupitia Mshiko Fasta Kulipwa hadi 28-AUG-26. Gharama 33,059.45 30-MAY-26 . NMB karibu yako"
+
+        // A Nepal-format NMB message must still route to the Nepal "NMB Bank" parser.
+        // Reused from the existing Nepal NMB test corpus.
+        val nepalMessage = "Fund transfer of NPR 250.00 to A/C 01000000055 was successful on 19-Feb-2025 15:38:23 If you have not done this transfer please contact us immediately."
+
+        return listOf(
+            dynamicTest("Tanzania NMB routes to NMB Bank Tanzania") {
+                val parsed = BankParserFactory.parse(tzMessage, "NMB", System.currentTimeMillis())
+                assertNotNull(parsed, "Tanzania NMB message did not parse")
+                assertEquals("NMB Bank Tanzania", parsed!!.bankName)
+                assertEquals("TZS", parsed.currency)
+                assertEquals(TransactionType.INCOME, parsed.type)
+                assertEquals(BigDecimal("209236.55"), parsed.amount)
+            },
+            dynamicTest("Nepal NMB still routes to NMB Bank") {
+                val parsed = BankParserFactory.parse(nepalMessage, "NMB", System.currentTimeMillis())
+                assertNotNull(parsed, "Nepal NMB message did not parse")
+                assertEquals("NMB Bank", parsed!!.bankName)
+                assertEquals("NPR", parsed.currency)
+            }
+        )
+    }
+}


### PR DESCRIPTION
Closes #519. New TZS parser for **NMB Bank Plc (Tanzania)** (sender `NMB`, bilingual Swahili/English).

## Collision resolution
The `NMB` sender is already claimed by the existing **Nepal** `NMBBankParser` (NPR). New `NMBTanzaniaParser` (`getBankName()="NMB Bank Tanzania"`, TZS) is registered **before** it, and gates tightly on Tanzania signals (Swahili verbs `kimetumwa`/`kimetolewa`/`Umepokea`, `Mshiko Fasta`, `NMB Pesa Fasta`, `NMB karibu yako`, `kwenda`, `TSh`/`TZS`). It returns null on Nepal-format messages, so content-aware `firstNotNullOfOrNull` dispatch falls through to the Nepal parser. **Factory routing tests lock in both directions** (TZ→"NMB Bank Tanzania", Nepal→"NMB Bank").

## Handled
| Format | Type | Notes |
|---|---|---|
| Loan repayment (Swahili) | EXPENSE | doubled `TZS TZS` notation; ignores `Salio la mkopo` (loan balance) |
| P2P transfer out | EXPENSE | `kwenda <name>`, stops before masked phone |
| Merchant payment (English) | EXPENSE | drops trailing numeric merchant id |
| Inbound voucher | INCOME | `NMB Pesa Fasta`; secret code never emitted |
| Loan disbursement | INCOME | amount anchored on `kiasi cha` (not the `Gharama` fee) |

## Tests
`NMBTanzaniaParserTest` — 5 parse cases + handle checks + 2 factory routing tests; Nepal NMB suite still passes (no regression). Full `:parser-core:jvmTest` → **1370 tests, 0 failures**. No PII (phones/secret codes/accounts never emitted).