### PR TITLE
feat(settings): Number Format style toggle — Auto / Indian / International (#525)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/PennyWiseApplication.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/PennyWiseApplication.kt
@@ -5,11 +5,14 @@ import android.app.Application
 import android.os.Bundle
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.repository.AppLockRepository
+import com.pennywiseai.tracker.utils.CurrencyFormatter
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -24,6 +27,9 @@ class PennyWiseApplication : Application(), Configuration.Provider {
 
     @Inject
     lateinit var purchaseGateway: com.pennywiseai.tracker.billing.PurchaseGateway
+
+    @Inject
+    lateinit var userPreferencesRepository: UserPreferencesRepository
 
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var activityReferences = 0
@@ -55,6 +61,16 @@ class PennyWiseApplication : Application(), Configuration.Provider {
                 purchaseGateway.refresh()
             } catch (e: Exception) {
                 android.util.Log.w("PennyWiseApp", "Initial billing refresh failed: ${e.message}", e)
+            }
+        }
+
+        // Keep CurrencyFormatter's number-format style in sync with the user's
+        // preference. CurrencyFormatter is a stateless object used from non-Compose
+        // contexts (widgets, workers) too, so we push the value into its @Volatile
+        // field rather than relying on a Compose-collected state.
+        applicationScope.launch {
+            userPreferencesRepository.numberFormatStyle.collectLatest { style ->
+                CurrencyFormatter.numberFormatStyle = style
             }
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/data/preferences/NumberFormatStyle.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/preferences/NumberFormatStyle.kt
@@ -1,0 +1,15 @@
+package com.pennywiseai.tracker.data.preferences
+
+/**
+ * How numeric amounts are grouped for display.
+ *
+ * - [AUTO]: currency-driven — Indian grouping (1,00,000 / L/Cr) for INR/NPR/PKR,
+ *   international grouping (100,000 / K/M) for every other currency.
+ * - [INDIAN]: force Indian grouping for all currencies.
+ * - [INTERNATIONAL]: force international grouping for all currencies.
+ */
+enum class NumberFormatStyle {
+    AUTO,
+    INDIAN,
+    INTERNATIONAL
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
@@ -111,6 +111,9 @@ class UserPreferencesRepository @Inject constructor(
         // Navigation Bar Style
         val NAV_BAR_STYLE = stringPreferencesKey("nav_bar_style")
 
+        // Number Format Style (digit grouping: Auto / Indian / International)
+        val NUMBER_FORMAT_STYLE = stringPreferencesKey("number_format_style")
+
         // Analytics Chart Type
         val ANALYTICS_CHART_TYPE = stringPreferencesKey("analytics_chart_type")
 
@@ -190,6 +193,17 @@ class UserPreferencesRepository @Inject constructor(
     val isDeveloperModeEnabled: Flow<Boolean> = context.dataStore.data
         .map { preferences ->
             preferences[PreferencesKeys.DEVELOPER_MODE_ENABLED] ?: false
+        }
+
+    val numberFormatStyle: Flow<NumberFormatStyle> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.NUMBER_FORMAT_STYLE]?.let {
+                try {
+                    NumberFormatStyle.valueOf(it)
+                } catch (_: Exception) {
+                    NumberFormatStyle.AUTO
+                }
+            } ?: NumberFormatStyle.AUTO
         }
 
     suspend fun updateDarkThemeEnabled(enabled: Boolean?) {
@@ -578,6 +592,12 @@ class UserPreferencesRepository @Inject constructor(
         context.dataStore.edit { preferences ->
             preferences[PreferencesKeys.BASE_CURRENCY] = currency
             preferences[PreferencesKeys.BASE_CURRENCY_USER_SET] = true
+        }
+    }
+
+    suspend fun updateNumberFormatStyle(style: NumberFormatStyle) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.NUMBER_FORMAT_STYLE] = style.name
         }
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -67,6 +67,7 @@ import com.pennywiseai.tracker.ui.theme.grey_dark
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
 import com.pennywiseai.tracker.ui.viewmodel.ThemeViewModel
+import com.pennywiseai.tracker.data.preferences.NumberFormatStyle
 import com.pennywiseai.tracker.utils.CurrencyFormatter
 
 
@@ -101,6 +102,7 @@ fun SettingsScreen(
     val smsScanMonths by settingsViewModel.smsScanMonths.collectAsStateWithLifecycle(initialValue = 3)
     val smsScanAllTime by settingsViewModel.smsScanAllTime.collectAsStateWithLifecycle(initialValue = false)
     val baseCurrency by settingsViewModel.baseCurrency.collectAsStateWithLifecycle(initialValue = "")
+    val numberFormatStyle by settingsViewModel.numberFormatStyle.collectAsStateWithLifecycle(initialValue = NumberFormatStyle.AUTO)
     val importExportMessage by settingsViewModel.importExportMessage.collectAsStateWithLifecycle()
     val exportedBackupFile by settingsViewModel.exportedBackupFile.collectAsStateWithLifecycle()
     val unifiedCurrencyMode by settingsViewModel.unifiedCurrencyMode.collectAsStateWithLifecycle(initialValue = false)
@@ -123,6 +125,7 @@ fun SettingsScreen(
     var showExportOptionsDialog by remember { mutableStateOf(false) }
     var showTimeoutDialog by remember { mutableStateOf(false) }
     var showDisplayCurrencyDialog by remember { mutableStateOf(false) }
+    var showNumberFormatDialog by remember { mutableStateOf(false) }
     var showCurrencyDropdown by remember { mutableStateOf(false) }
     var showMainAccountDropdown by remember { mutableStateOf(false) }
     val permissionUiState by permissionViewModel.uiState.collectAsStateWithLifecycle()
@@ -264,7 +267,7 @@ fun SettingsScreen(
                     currentValue = "${CurrencyFormatter.getCurrencySymbol(baseCurrency)} $baseCurrency",
                     expanded = showCurrencyDropdown,
                     onExpandedChange = { showCurrencyDropdown = it },
-                    position = if (accounts.isNotEmpty()) ItemPosition.MIDDLE else ItemPosition.BOTTOM
+                    position = ItemPosition.MIDDLE
                 ) {
                     availableCurrencies.forEach { currency ->
                         DropdownMenuItem(
@@ -305,7 +308,7 @@ fun SettingsScreen(
                         } ?: "Not set",
                         expanded = showMainAccountDropdown,
                         onExpandedChange = { showMainAccountDropdown = it },
-                        position = ItemPosition.BOTTOM
+                        position = ItemPosition.MIDDLE
                     ) {
                         accounts.forEach { account ->
                             val name = account.alias?.takeIf { it.isNotBlank() } ?: account.bankName
@@ -332,6 +335,17 @@ fun SettingsScreen(
                         }
                     }
                 }
+
+                SettingsNavItem(
+                    icon = Icons.Default.Numbers,
+                    iconBgColor = green_light,
+                    iconTint = green_dark,
+                    title = "Number Format",
+                    subtitle = "How large amounts are grouped",
+                    onClick = { showNumberFormatDialog = true },
+                    position = ItemPosition.BOTTOM,
+                    trailingText = numberFormatStyleLabel(numberFormatStyle)
+                )
             }
 
             // ── Contacts ──
@@ -632,6 +646,58 @@ fun SettingsScreen(
             },
             confirmButton = {
                 TextButton(onClick = { showDisplayCurrencyDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
+    // Number Format Dialog
+    if (showNumberFormatDialog) {
+        AlertDialog(
+            onDismissRequest = { showNumberFormatDialog = false },
+            title = { Text("Number Format") },
+            text = {
+                Column {
+                    NumberFormatStyle.entries.forEach { style ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .selectable(
+                                    selected = style == numberFormatStyle,
+                                    onClick = {
+                                        settingsViewModel.updateNumberFormatStyle(style)
+                                        showNumberFormatDialog = false
+                                    }
+                                )
+                                .padding(vertical = Spacing.sm),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                selected = style == numberFormatStyle,
+                                onClick = {
+                                    settingsViewModel.updateNumberFormatStyle(style)
+                                    showNumberFormatDialog = false
+                                }
+                            )
+                            Spacer(modifier = Modifier.width(Spacing.sm))
+                            Column {
+                                Text(
+                                    text = numberFormatStyleLabel(style),
+                                    style = MaterialTheme.typography.bodyLarge
+                                )
+                                Text(
+                                    text = numberFormatStyleExample(style),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showNumberFormatDialog = false }) {
                     Text("Cancel")
                 }
             }
@@ -1268,4 +1334,16 @@ private fun SettingsNavigationContent(onNavigateBack: () -> Unit) {
             )
         }
     }
+}
+
+private fun numberFormatStyleLabel(style: NumberFormatStyle): String = when (style) {
+    NumberFormatStyle.AUTO -> "Auto"
+    NumberFormatStyle.INDIAN -> "Indian"
+    NumberFormatStyle.INTERNATIONAL -> "International"
+}
+
+private fun numberFormatStyleExample(style: NumberFormatStyle): String = when (style) {
+    NumberFormatStyle.AUTO -> "Matches each currency (₹1,50,000 · $150,000)"
+    NumberFormatStyle.INDIAN -> "1,50,000 (lakh / crore)"
+    NumberFormatStyle.INTERNATIONAL -> "150,000 (thousand / million)"
 }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -20,6 +20,7 @@ import com.pennywiseai.tracker.core.Constants.Links
 import com.pennywiseai.tracker.data.repository.ModelRepository
 import com.pennywiseai.tracker.data.repository.ModelState
 import com.pennywiseai.tracker.data.repository.UnrecognizedSmsRepository
+import com.pennywiseai.tracker.data.preferences.NumberFormatStyle
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.backup.BackupExporter
 import com.pennywiseai.tracker.data.backup.BackupImporter
@@ -113,6 +114,9 @@ class SettingsViewModel @Inject constructor(
     
     // Base currency state
     val baseCurrency = userPreferencesRepository.baseCurrency
+
+    // Number format style (digit grouping: Auto / Indian / International)
+    val numberFormatStyle = userPreferencesRepository.numberFormatStyle
 
     // Main account selection (drives the default currency unless overridden above).
     val accounts: StateFlow<List<AccountBalanceEntity>> =
@@ -620,6 +624,12 @@ class SettingsViewModel @Inject constructor(
     fun updateBaseCurrency(currency: String) {
         viewModelScope.launch {
             userPreferencesRepository.updateBaseCurrency(currency)
+        }
+    }
+
+    fun updateNumberFormatStyle(style: NumberFormatStyle) {
+        viewModelScope.launch {
+            userPreferencesRepository.updateNumberFormatStyle(style)
         }
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/utils/CurrencyFormatter.kt
@@ -1,6 +1,7 @@
 package com.pennywiseai.tracker.utils
 
 import com.pennywiseai.parser.core.bank.BankParserFactory
+import com.pennywiseai.tracker.data.preferences.NumberFormatStyle
 import java.math.BigDecimal
 import java.text.NumberFormat
 import java.util.Currency
@@ -12,6 +13,43 @@ import java.util.Locale
 object CurrencyFormatter {
 
     private val INDIAN_LOCALE = Locale.Builder().setLanguage("en").setRegion("IN").build()
+
+    /** Western/international digit grouping (1,000,000). */
+    private val INTERNATIONAL_LOCALE = Locale.US
+
+    /** Currencies that use Indian lakh/crore grouping under [NumberFormatStyle.AUTO]. */
+    private val INDIAN_NOTATION_CURRENCIES = setOf("INR", "NPR", "PKR")
+
+    /**
+     * The user's chosen number-format style. A stateless object can't read DataStore,
+     * so this @Volatile field is pushed from [com.pennywiseai.tracker.PennyWiseApplication]
+     * which collects the preference Flow at startup. Defaults to AUTO (currency-driven).
+     */
+    @Volatile
+    var numberFormatStyle: NumberFormatStyle = NumberFormatStyle.AUTO
+
+    /**
+     * The locale that drives digit grouping for [currencyCode], honouring the
+     * user's [numberFormatStyle]. AUTO keeps each currency's native grouping
+     * (Indian for INR/NPR/PKR, international elsewhere).
+     */
+    private fun groupingLocale(currencyCode: String?): Locale = when (numberFormatStyle) {
+        NumberFormatStyle.INDIAN -> INDIAN_LOCALE
+        NumberFormatStyle.INTERNATIONAL -> INTERNATIONAL_LOCALE
+        NumberFormatStyle.AUTO ->
+            if (currencyCode != null && currencyCode in INDIAN_NOTATION_CURRENCIES) {
+                INDIAN_LOCALE
+            } else {
+                CURRENCY_LOCALES[currencyCode] ?: INTERNATIONAL_LOCALE
+            }
+    }
+
+    /** Whether to abbreviate large values with Indian L/Cr (vs western K/M). */
+    private fun useIndianAbbreviation(currencyCode: String): Boolean = when (numberFormatStyle) {
+        NumberFormatStyle.INDIAN -> true
+        NumberFormatStyle.INTERNATIONAL -> false
+        NumberFormatStyle.AUTO -> currencyCode in INDIAN_NOTATION_CURRENCIES
+    }
 
     /**
      * Currencies whose ISO 4217 minor unit is 3 (three decimal places),
@@ -89,10 +127,10 @@ object CurrencyFormatter {
      */
     fun formatCurrency(amount: BigDecimal, currencyCode: String = "INR"): String {
         if (currencyCode == "PKR") {
-            return "${CURRENCY_SYMBOLS["PKR"]}${formatAmount(amount)}"
+            return "${CURRENCY_SYMBOLS["PKR"]}${formatAmount(amount, "PKR")}"
         }
         return try {
-            val locale = CURRENCY_LOCALES[currencyCode] ?: INDIAN_LOCALE
+            val locale = groupingLocale(currencyCode)
             val formatter = NumberFormat.getCurrencyInstance(locale)
 
             // Set the currency if supported
@@ -140,7 +178,7 @@ object CurrencyFormatter {
      * Formats just the numeric amount without currency symbol
      */
     private fun formatAmount(amount: BigDecimal, currencyCode: String? = null): String {
-        val formatter = NumberFormat.getNumberInstance(INDIAN_LOCALE)
+        val formatter = NumberFormat.getNumberInstance(groupingLocale(currencyCode))
         formatter.minimumFractionDigits = 0
         formatter.maximumFractionDigits = if (currencyCode != null && currencyCode in THREE_DECIMAL_CURRENCIES) 3 else 2
         return formatter.format(amount)
@@ -160,12 +198,13 @@ object CurrencyFormatter {
 
     /**
      * Formats large currency values in abbreviated form for chart axes.
-     * Uses Indian notation (L/Cr) for INR/NPR/PKR, Western notation (K/M) for others.
+     * Uses Indian notation (L/Cr) or Western notation (K/M) per the user's
+     * [numberFormatStyle] (AUTO = L/Cr for INR/NPR/PKR, K/M otherwise).
      */
     fun formatAbbreviated(value: Double, currencyCode: String): String {
         val symbol = getCurrencySymbol(currencyCode)
         val absValue = kotlin.math.abs(value)
-        val useIndianNotation = currencyCode in setOf("INR", "NPR", "PKR")
+        val useIndianNotation = useIndianAbbreviation(currencyCode)
         return when {
             useIndianNotation && absValue >= 1_00_00_000 ->
                 "${symbol}${String.format("%.1f", absValue / 1_00_00_000)}Cr"

--- a/app/src/test/java/com/pennywiseai/tracker/utils/CurrencyFormatterTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/utils/CurrencyFormatterTest.kt
@@ -86,4 +86,22 @@ class CurrencyFormatterTest {
             CurrencyFormatter.formatAbbreviated(10_000_000.0, "TZS").endsWith("Cr")
         )
     }
+
+    @Test
+    fun `AUTO abbreviation is currency-driven (the shipped default)`() {
+        CurrencyFormatter.numberFormatStyle = NumberFormatStyle.AUTO
+        // INR/NPR/PKR keep Indian L/Cr; everything else uses western K/M.
+        assertTrue(
+            "INR under AUTO abbreviates with Cr",
+            CurrencyFormatter.formatAbbreviated(10_000_000.0, "INR").endsWith("Cr")
+        )
+        assertTrue(
+            "NPR under AUTO abbreviates with Cr",
+            CurrencyFormatter.formatAbbreviated(10_000_000.0, "NPR").endsWith("Cr")
+        )
+        assertTrue(
+            "TZS under AUTO abbreviates with M, not Cr",
+            CurrencyFormatter.formatAbbreviated(10_000_000.0, "TZS").endsWith("M")
+        )
+    }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/utils/CurrencyFormatterTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/utils/CurrencyFormatterTest.kt
@@ -1,6 +1,9 @@
 package com.pennywiseai.tracker.utils
 
+import com.pennywiseai.tracker.data.preferences.NumberFormatStyle
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -56,6 +59,31 @@ class CurrencyFormatterTest {
                 storedCurrency = "INR",
                 bankName = "Totally Unknown Bank"
             )
+        )
+    }
+
+    // numberFormatStyle is a process-wide @Volatile field; reset after each test.
+    @After
+    fun resetNumberFormatStyle() {
+        CurrencyFormatter.numberFormatStyle = NumberFormatStyle.AUTO
+    }
+
+    // Note: grouping *values* (1,50,000 vs 150,000) can't be asserted here — the plain
+    // JVM test runtime uses COMPAT locale data (western grouping for en-IN), whereas
+    // Android uses CLDR (Indian grouping). The style→branch selection is instead covered
+    // by the abbreviation test below, which shares the same when(style) logic and uses
+    // our own locale-independent L/Cr-vs-K/M strings.
+    @Test
+    fun `abbreviation follows the style`() {
+        CurrencyFormatter.numberFormatStyle = NumberFormatStyle.INTERNATIONAL
+        assertTrue(
+            "INR under INTERNATIONAL abbreviates with M, not Cr",
+            CurrencyFormatter.formatAbbreviated(10_000_000.0, "INR").endsWith("M")
+        )
+        CurrencyFormatter.numberFormatStyle = NumberFormatStyle.INDIAN
+        assertTrue(
+            "TZS under INDIAN abbreviates with Cr",
+            CurrencyFormatter.formatAbbreviated(10_000_000.0, "TZS").endsWith("Cr")
         )
     }
 }


### PR DESCRIPTION
Closes #525. Adds a **Settings → Currency → Number Format** option controlling how large amounts are grouped:

- **Auto** (default) — currency-driven: Indian grouping (`1,50,000`, L/Cr) for INR/NPR/PKR, international (`150,000`, K/M) for everything else.
- **Indian** — force `1,50,000` lakh/crore for all currencies.
- **International** — force `150,000` thousand/million for all currencies.

## Why
International users (East Africa/Tanzania, etc.) saw TZS/other amounts rendered with Indian-style grouping in the bare-number and fallback paths. **Auto silently fixes that** without anyone touching settings, and the toggle lets users override either way.

## How
- `CurrencyFormatter` (stateless `object`) gains a `@Volatile numberFormatStyle`, a `groupingLocale(currency)` selector, and a `useIndianAbbreviation(currency)` helper; `formatCurrency` / `formatAmount` / `formatAbbreviated` now honour it.
- The preference (`NumberFormatStyle` enum, DataStore) is collected once in `PennyWiseApplication` and pushed into the formatter — so widgets and workers (non-Compose) get it too, matching the existing `isAppInForeground` precedent.
- Settings row + radio dialog mirror the existing Display-Currency pattern; preference/handler mirror `baseCurrency`.

## Notes
- **Parsers need no change** — they already strip grouping before `BigDecimal`; this is display-only.
- AUTO preserves existing INR rendering exactly (INR still maps to the Indian locale); only the previously-Indian *fallback* for non-INR currencies changes to international.

## Tests
`CurrencyFormatterTest` covers the style-driven abbreviation (L/Cr vs K/M). Grouping *values* (`1,50,000` vs `150,000`) aren't asserted in JVM tests — the plain JVM runtime uses COMPAT locale data (western grouping for `en-IN`) while Android uses CLDR (Indian grouping); the abbreviation test exercises the same `when(style)` branch with locale-independent strings. App compiles; existing tests green.