### PR TITLE
fix(accounts): account number on its own line — stop per-character wrap (#465)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
@@ -1034,7 +1034,8 @@ private fun AccountItem(
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold,
                         color = MaterialTheme.colorScheme.primary,
-                        maxLines = 1
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                     Text(
                         text = "Balance",

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
@@ -641,12 +641,8 @@ private fun CreditCardItem(
                                 style = MaterialTheme.typography.bodyLarge,
                                 fontWeight = FontWeight.Medium,
                                 maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                            Text(
-                                text = "••${card.accountLast4}",
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f, fill = false)
                             )
                             if (isHidden) {
                                 Icon(
@@ -657,6 +653,14 @@ private fun CreditCardItem(
                                 )
                             }
                         }
+                        // Masked card number on its own line below the name (#465).
+                        Text(
+                            text = "••${card.accountLast4}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
                     }
                 }
             }
@@ -968,15 +972,11 @@ private fun AccountItem(
                                 style = MaterialTheme.typography.bodyLarge,
                                 fontWeight = FontWeight.Medium,
                                 maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
+                                overflow = TextOverflow.Ellipsis,
+                                // Ellipsize a long name instead of pushing the badges
+                                // (and the masked number below) off-screen.
+                                modifier = Modifier.weight(1f, fill = false)
                             )
-                            if (alias == null) {
-                                Text(
-                                    text = "••${account.accountLast4}",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
                             if (account.profileId == ProfileEntity.BUSINESS_ID) {
                                 Surface(
                                     color = MaterialTheme.colorScheme.tertiaryContainer,
@@ -999,17 +999,20 @@ private fun AccountItem(
                                 )
                             }
                         }
-                        // When an alias is set, keep the underlying bank/last-4
-                        // visible as a subtitle so the account stays identifiable.
-                        if (alias != null) {
-                            Text(
-                                text = "${account.bankName} ••${account.accountLast4}",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                        }
+                        // Masked account number on its own line below the name. Inlining it
+                        // next to a long bank name squeezed it into a per-character vertical
+                        // stack; this keeps it as a clean second line. (#465)
+                        Text(
+                            text = if (alias != null) {
+                                "${account.bankName} ••${account.accountLast4}"
+                            } else {
+                                "••${account.accountLast4}"
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
                     }
                 }
 
@@ -1030,7 +1033,8 @@ private fun AccountItem(
                         ),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.primary
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1
                     )
                     Text(
                         text = "Balance",
@@ -1039,7 +1043,7 @@ private fun AccountItem(
                     )
                 }
             }
-            
+
             // Linked Cards Section
             if (linkedCards.isNotEmpty()) {
                 Column(


### PR DESCRIPTION
Closes #465.

## Bug
In **Manage Accounts**, the masked account number (`••1234`) sat **inline** in the same `Row` as the bank name with no width constraint. A long bank name (the reporter's `Standard Bank Mozambique`) squeezed the number into a **per-character vertical stack** (`1`/`0`/`0`/`8`), and the balance could wrap the same way.

## Fix
- The bank name now ellipsizes (`Modifier.weight(1f, fill = false)` + `maxLines = 1`) instead of pushing siblings off-screen.
- The masked number renders on its **own line below** the name — the clean two-line layout the reporter asked for — for both `AccountItem` (bank accounts) and `CreditCardItem`.
- The balance amount gets `maxLines = 1` as a guard against the same per-character wrap.

Display-only; no behaviour change.

## Verified on emulator
Built + installed, injected a long-named account (`Standard Chartered Bank`, same length as the reported case) and confirmed in Manage Accounts: name on one clean line, `••3421` on its own line below, balance intact — no per-character wrap. Existing short-named accounts render as a tidy two-line layout too.