### PR TITLE
fix(parser): ICICI ATM (CAM*) + InfoBIL* biller merchants (#505, #500)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ICICIBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ICICIBankParser.kt
@@ -276,6 +276,31 @@ class ICICIBankParser : BaseIndianBankParser() {
             return "Cash Withdrawal"
         }
 
+        // Pattern 2a: ATM cash withdrawal marker - "CAM*<code>*"
+        // ICICI uses a "CAM*<terminal/ref code>*" token to mark cash withdrawals.
+        // Emit a clean label instead of the raw marker code.
+        val camWithdrawalPattern = Regex(
+            """\bCAM\*[^*]+\*""",
+            RegexOption.IGNORE_CASE
+        )
+        if (camWithdrawalPattern.find(message) != null) {
+            return "ATM Withdrawal"
+        }
+
+        // Pattern 2b: Bill-pay biller - "InfoBIL*<biller name>"
+        // ICICI's generic bill-pay format. The biller name runs until the
+        // sentence boundary ("." before "Avl/Avb Bal") or end of segment.
+        val infoBilPattern = Regex(
+            """InfoBIL\*([^.]+)""",
+            RegexOption.IGNORE_CASE
+        )
+        infoBilPattern.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(merchant)) {
+                return merchant
+            }
+        }
+
         // Pattern 3: Card transactions - "on DD-Mon-YY at MERCHANT NAME. Avl" or "on DD-Mon-YY on MERCHANT NAME"
         val cardMerchantPattern = Regex(
             """on\s+\d{1,2}-\w{3}-\d{2}\s+(?:at|on)\s+([^.]+?)(?:\.|\s+Avl|$)""",

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ICICIBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/ICICIBankParser.kt
@@ -279,8 +279,9 @@ class ICICIBankParser : BaseIndianBankParser() {
         // Pattern 2a: ATM cash withdrawal marker - "CAM*<code>*"
         // ICICI uses a "CAM*<terminal/ref code>*" token to mark cash withdrawals.
         // Emit a clean label instead of the raw marker code.
+        // Closing "*" is optional — some variants omit it.
         val camWithdrawalPattern = Regex(
-            """\bCAM\*[^*]+\*""",
+            """\bCAM\*[A-Za-z0-9]+\*?""",
             RegexOption.IGNORE_CASE
         )
         if (camWithdrawalPattern.find(message) != null) {
@@ -289,9 +290,10 @@ class ICICIBankParser : BaseIndianBankParser() {
 
         // Pattern 2b: Bill-pay biller - "InfoBIL*<biller name>"
         // ICICI's generic bill-pay format. The biller name runs until the
-        // sentence boundary ("." before "Avl/Avb Bal") or end of segment.
+        // sentence boundary: a ".", the "Avl/Avb Bal" balance clause, or end of
+        // segment — so the capture doesn't absorb the tail when the "." is absent.
         val infoBilPattern = Regex(
-            """InfoBIL\*([^.]+)""",
+            """InfoBIL\*(.+?)(?=\.|\s*Av[bl]\s*Bal|$)""",
             RegexOption.IGNORE_CASE
         )
         infoBilPattern.find(message)?.let { match ->

--- a/parser-core/src/test/kotlin/TestICICIBankParser.kt
+++ b/parser-core/src/test/kotlin/TestICICIBankParser.kt
@@ -253,6 +253,32 @@ class ICICIBankParserTest {
                     accountLast4 = "123",
                     balance = BigDecimal("325000.04")
                 )
+            ),
+            ParserTestCase(
+                name = "ATM cash withdrawal (CAM* marker)",
+                message = "ICICI Bank Acc XX611 debited Rs. 6,500.00 on 19-Jun-26 CAM*62712SRY*. Avb Bal Rs. 10,079.44. To dispute Call 18002662 or SMS BLOCK 611 to 9215676766",
+                sender = "VM-ICICIT-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("6500.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "ATM Withdrawal",
+                    accountLast4 = "611",
+                    balance = BigDecimal("10079.44")
+                )
+            ),
+            ParserTestCase(
+                name = "Bill-pay biller (InfoBIL* marker)",
+                message = "ICICI Bank Acc XX342 debited Rs. 8,927.00 on 07-Jun-26 InfoBIL*Auto Loan.Avl Bal Rs. 1,248.78.To dispute call 18002662 or SMS BLOCK 342 to 9215676766",
+                sender = "JD-ICICIT-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("8927.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "Auto Loan",
+                    accountLast4 = "342",
+                    balance = BigDecimal("1248.78")
+                )
             )
         )
 


### PR DESCRIPTION
Closes #505, closes #500. Two ICICI debit formats showed **"unknown merchant"** — fixed in `ICICIBankParser.extractMerchant`.

| Issue | SMS marker | Now |
|---|---|---|
| **#505** | `CAM*62712SRY*` (ATM cash withdrawal) | merchant → **ATM Withdrawal** (raw code never emitted) |
| **#500** | `InfoBIL*Auto Loan` (bill pay) | merchant → **Auto Loan** — generic: `InfoBIL*<biller>` → cleaned name (e.g. `Electricity Bill`) |

Amount, balance, account last4, and EXPENSE type were already correct — merchant only. Existing ICICI patterns (NFS withdrawal, UPI, POS, salary, IMPS/NEFT, multi-currency card) all still pass.

## Tests
2 new cases in the ICICI suite. Full `:parser-core:jvmTest` → **1390 tests, 0 failures**. No PII.