### PR TITLE
feat(parser): Kerala Bank (KELBNK) — loan-recovery credit, negative balance (#534)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParserFactory.kt
@@ -25,6 +25,7 @@ object BankParserFactory {
         ICICIBankParser(),
         KarnatakaBankParser(),
         KeralaGraminBankParser(),
+        KeralaBankParser(),  // Kerala State Co-operative Bank (India) — KELBNK; distinct from Kerala Gramin (KGBANK)
         IDBIBankParser(),
         JupiterBankParser(),
         AxisBankParser(),

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KeralaBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KeralaBankParser.kt
@@ -59,9 +59,11 @@ class KeralaBankParser : BaseIndianBankParser() {
 
     override fun extractMerchant(message: String, sender: String): String? {
         // "by Loan Recovery From : 139451061" -> "Loan Recovery"
-        // Also handle "by <SOURCE>." with no "From" — stop at "From"/"."/end.
+        // Stop at the "From :" clause, a ".", the trailing " - Kerala Bank"
+        // signature, or end — so a message lacking both "From :" and a period
+        // doesn't over-capture the bank-name suffix into the merchant.
         val byPattern = Regex(
-            """\bby\s+(.+?)(?:\s+From\s*:|\.|$)""",
+            """\bby\s+(.+?)(?:\s+From\s*:|\s*-\s*Kerala\s+Bank|\.|$)""",
             RegexOption.IGNORE_CASE
         )
         byPattern.find(message)?.let { match ->

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KeralaBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KeralaBankParser.kt
@@ -1,0 +1,94 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+
+/**
+ * Parser for Kerala Bank (The Kerala State Co-operative Bank, India) SMS messages.
+ *
+ * Handles formats like:
+ * - "Dear Customer Your A/c no XXXX0024 is credited with 15000.00 on 06-06-2026 by Loan Recovery
+ *    From : 139451061. Balance is -579822.00 - Kerala Bank"
+ *
+ * Notes:
+ * - Amounts are printed without a currency symbol (e.g. "credited with 15000.00").
+ * - Balances can be NEGATIVE for loan accounts (e.g. "Balance is -579822.00").
+ *
+ * Common senders: VM-KELBNK-S
+ * Currency: INR (Indian Rupee)
+ *
+ * Distinct from Kerala Gramin Bank (KGBANK / KERALAGR) — gates only on the KELBNK token.
+ */
+class KeralaBankParser : BaseIndianBankParser() {
+
+    override fun getBankName() = "Kerala Bank"
+
+    override fun getCurrency() = "INR"
+
+    override fun canHandle(sender: String): Boolean {
+        return sender.uppercase().contains("KELBNK")
+    }
+
+    override fun extractAmount(message: String): BigDecimal? {
+        // "credited with 15000.00" / "debited with 15000.00" — no currency symbol.
+        val pattern = Regex(
+            """(?:credited|debited)\s+with\s+([0-9,]+(?:\.[0-9]{2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            val amountStr = match.groupValues[1].replace(",", "")
+            return try {
+                BigDecimal(amountStr)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+
+        // Fall back to base patterns (Rs/INR forms) for safety.
+        return super.extractAmount(message)
+    }
+
+    override fun extractTransactionType(message: String): TransactionType? {
+        val lowerMessage = message.lowercase()
+        return when {
+            lowerMessage.contains("is credited") -> TransactionType.INCOME
+            lowerMessage.contains("is debited") -> TransactionType.EXPENSE
+            else -> super.extractTransactionType(message)
+        }
+    }
+
+    override fun extractMerchant(message: String, sender: String): String? {
+        // "by Loan Recovery From : 139451061" -> "Loan Recovery"
+        // Also handle "by <SOURCE>." with no "From" — stop at "From"/"."/end.
+        val byPattern = Regex(
+            """\bby\s+(.+?)(?:\s+From\s*:|\.|$)""",
+            RegexOption.IGNORE_CASE
+        )
+        byPattern.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(merchant)) {
+                return merchant
+            }
+        }
+
+        return super.extractMerchant(message, sender)
+    }
+
+    override fun extractBalance(message: String): BigDecimal? {
+        // "Balance is -579822.00" — supports an optional leading minus sign.
+        val pattern = Regex(
+            """Balance\s+is\s+(-?[0-9,]+(?:\.[0-9]{2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        pattern.find(message)?.let { match ->
+            val balanceStr = match.groupValues[1].replace(",", "")
+            return try {
+                BigDecimal(balanceStr)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+
+        return super.extractBalance(message)
+    }
+}

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/KeralaBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/KeralaBankParserTest.kt
@@ -1,0 +1,43 @@
+package com.pennywiseai.parser.core.bank
+
+import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.parser.core.test.ExpectedTransaction
+import com.pennywiseai.parser.core.test.ParserTestCase
+import com.pennywiseai.parser.core.test.ParserTestUtils
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.math.BigDecimal
+
+class KeralaBankParserTest {
+
+    private val parser = KeralaBankParser()
+
+    @TestFactory
+    fun `kerala bank parser handles common cases`(): List<DynamicTest> {
+        val cases = listOf(
+            ParserTestCase(
+                name = "Loan recovery credit with negative balance",
+                message = "Dear Customer Your A/c no XXXX0024 is credited with 15000.00 on 06-06-2026 by Loan Recovery From : 139451061. Balance is -579822.00 - Kerala Bank",
+                sender = "VM-KELBNK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("15000.00"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    merchant = "Loan Recovery",
+                    accountLast4 = "0024",
+                    balance = BigDecimal("-579822.00")
+                )
+            )
+        )
+
+        val handleChecks = listOf(
+            "KELBNK" to true,
+            "VM-KELBNK-S" to true,
+            "KGBANK" to false,
+            "HDFC" to false,
+            "" to false
+        )
+
+        return ParserTestUtils.runTestSuite(parser, cases, handleChecks, "Kerala Bank Parser")
+    }
+}


### PR DESCRIPTION
Closes #534. New INR parser for **Kerala Bank** (The Kerala State Co-operative Bank; sender `KELBNK`), extending `BaseIndianBankParser`.

## Handled
`Dear Customer Your A/c no XXXX0024 is credited with 15000.00 ... by Loan Recovery From : … . Balance is -579822.00 - Kerala Bank`
→ INCOME, amount 15000.00, merchant **Loan Recovery**, accountLast4 `0024`, **balance −579822.00**.

## Notes
- **Negative balance** captured (loan account — `extractBalance` accepts a leading minus).
- Amount form has no currency symbol (`credited with 15000.00`) — handled, with fallback to base Rs/INR patterns.
- **No collision** with the existing `KeralaGraminBankParser` (it gates on `KGBANK`/`KERALAGR`; this one only on `KELBNK`) — proven by a `KGBANK → false` handle-check.

## Tests
`KeralaBankParserTest` (parse case + 5 handle-checks). Full `:parser-core:jvmTest` → **1394 tests, 0 failures**. No PII.

Only one sample was provided (a loan-recovery credit); EXPENSE/POS/UPI formats can be added when samples surface.