### PR TITLE
feat(parser): Al Rajhi English PoS Purchase format (#502)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/AlRajhiBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/AlRajhiBankParser.kt
@@ -33,7 +33,15 @@ class AlRajhiBankParser : BankParser() {
      */
     private fun isEnglishPosFormat(message: String): Boolean {
         return message.contains("PoS Purchase", ignoreCase = true) &&
-                Regex("""Amount:\s*SR\s""", RegexOption.IGNORE_CASE).containsMatchIn(message)
+                POS_DETECT.containsMatchIn(message)
+    }
+
+    private companion object {
+        // English PoS format patterns, compiled once.
+        val POS_DETECT = Regex("""Amount:\s*SR\s""", RegexOption.IGNORE_CASE)
+        val POS_AMOUNT = Regex("""Amount:\s*SR\s+([0-9,]+(?:\.\d{1,2})?)""", RegexOption.IGNORE_CASE)
+        val POS_CARD = Regex("""By:\s*(\d+)\s*;""")
+        val POS_MERCHANT = Regex("""At:\s*([^\n]+)""")
     }
 
     override fun canHandle(sender: String): Boolean {
@@ -44,13 +52,13 @@ class AlRajhiBankParser : BankParser() {
     }
 
     override fun extractAmount(message: String): BigDecimal? {
-        // English PoS: "Amount:SR 2" or "Amount: SR 4.50"
-        val srPattern = Regex(
-            """Amount:\s*SR\s+([0-9,]+(?:\.\d{1,2})?)""",
-            RegexOption.IGNORE_CASE
-        )
-        srPattern.find(message)?.let { match ->
-            return parseSarAmount(match.groupValues[1])
+        // English PoS: "Amount:SR 2" / "Amount: SR 4.50" — gated to the PoS format
+        // (like the other English overrides) so it can't match a future Arabic
+        // SMS that happens to contain the same substring.
+        if (isEnglishPosFormat(message)) {
+            POS_AMOUNT.find(message)?.let { match ->
+                return parseSarAmount(match.groupValues[1])
+            }
         }
 
         // Pattern 1: "بـSAR 5.75" or "بـSAR 140"
@@ -116,8 +124,7 @@ class AlRajhiBankParser : BankParser() {
     override fun extractMerchant(message: String, sender: String): String? {
         // English PoS: merchant is the value after "At:" up to end of line
         if (isEnglishPosFormat(message)) {
-            val atPattern = Regex("""At:\s*([^\n]+)""")
-            atPattern.find(message)?.let { match ->
+            POS_MERCHANT.find(message)?.let { match ->
                 var raw = match.groupValues[1].trim()
                 // Strip a leading purely-numeric terminal id (e.g. "170658 riyadh" -> "riyadh")
                 val stripped = raw.replaceFirst(Regex("""^\d+\s+"""), "").trim()
@@ -213,11 +220,11 @@ class AlRajhiBankParser : BankParser() {
     }
 
     override fun extractAccountLast4(message: String): String? {
-        // English PoS: "By:<digits>;<method>" — the digits identify the card
+        // English PoS: "By:<digits>;<method>" — the digits identify the card;
+        // keep only the last 4 (the leading digits may be a longer card number).
         if (isEnglishPosFormat(message)) {
-            val byPattern = Regex("""By:\s*(\d+)\s*;""")
-            byPattern.find(message)?.let { match ->
-                return match.groupValues[1]
+            POS_CARD.find(message)?.let { match ->
+                extractLast4Digits(match.groupValues[1])?.let { return it }
             }
         }
         return super.extractAccountLast4(message)

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/AlRajhiBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/AlRajhiBankParser.kt
@@ -17,6 +17,9 @@ import java.math.BigDecimal
  * - Loan installment: "خصم: قسط تمويل ... القسط: 2304.58 SAR"
  * - Bill payment: "سداد فاتورة"
  *
+ * Supported formats (English, multi-line PoS):
+ * - "PoS Purchase\nBy:<digits>;<method>\nAmount:SR <number>\nAt:<merchant>\n<date>"
+ *
  * Sender: AlRajhiBank
  */
 class AlRajhiBankParser : BankParser() {
@@ -24,6 +27,14 @@ class AlRajhiBankParser : BankParser() {
     override fun getBankName() = "Al Rajhi Bank"
 
     override fun getCurrency() = "SAR"
+
+    /**
+     * Detects the English multi-line PoS purchase format.
+     */
+    private fun isEnglishPosFormat(message: String): Boolean {
+        return message.contains("PoS Purchase", ignoreCase = true) &&
+                Regex("""Amount:\s*SR\s""", RegexOption.IGNORE_CASE).containsMatchIn(message)
+    }
 
     override fun canHandle(sender: String): Boolean {
         val normalized = sender.uppercase()
@@ -33,6 +44,15 @@ class AlRajhiBankParser : BankParser() {
     }
 
     override fun extractAmount(message: String): BigDecimal? {
+        // English PoS: "Amount:SR 2" or "Amount: SR 4.50"
+        val srPattern = Regex(
+            """Amount:\s*SR\s+([0-9,]+(?:\.\d{1,2})?)""",
+            RegexOption.IGNORE_CASE
+        )
+        srPattern.find(message)?.let { match ->
+            return parseSarAmount(match.groupValues[1])
+        }
+
         // Pattern 1: "بـSAR 5.75" or "بـSAR 140"
         val bPattern = Regex(
             """بـSAR\s+([0-9,]+(?:\.\d{1,2})?)""",
@@ -73,6 +93,11 @@ class AlRajhiBankParser : BankParser() {
     }
 
     override fun extractTransactionType(message: String): TransactionType? {
+        // English PoS purchase is always an expense
+        if (isEnglishPosFormat(message)) {
+            return TransactionType.EXPENSE
+        }
+
         return when {
             // Incoming (واردة = incoming)
             message.contains("واردة") -> TransactionType.INCOME
@@ -89,6 +114,24 @@ class AlRajhiBankParser : BankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
+        // English PoS: merchant is the value after "At:" up to end of line
+        if (isEnglishPosFormat(message)) {
+            val atPattern = Regex("""At:\s*([^\n]+)""")
+            atPattern.find(message)?.let { match ->
+                var raw = match.groupValues[1].trim()
+                // Strip a leading purely-numeric terminal id (e.g. "170658 riyadh" -> "riyadh")
+                val stripped = raw.replaceFirst(Regex("""^\d+\s+"""), "").trim()
+                if (stripped.isNotBlank() && stripped.any { it.isLetter() }) {
+                    raw = stripped
+                }
+                val merchant = cleanMerchantName(raw)
+                if (isValidMerchantName(merchant)) {
+                    return merchant
+                }
+            }
+            return null
+        }
+
         // Pattern 1: "لـMERCHANT" (to/for merchant) — stop at newline or date pattern
         val toPattern = Regex(
             """لـ([^\n*]+?)(?:\n|\d{2}/\d|$)"""
@@ -169,6 +212,17 @@ class AlRajhiBankParser : BankParser() {
         return null
     }
 
+    override fun extractAccountLast4(message: String): String? {
+        // English PoS: "By:<digits>;<method>" — the digits identify the card
+        if (isEnglishPosFormat(message)) {
+            val byPattern = Regex("""By:\s*(\d+)\s*;""")
+            byPattern.find(message)?.let { match ->
+                return match.groupValues[1]
+            }
+        }
+        return super.extractAccountLast4(message)
+    }
+
     override fun extractBalance(message: String): BigDecimal? {
         // Pattern: "المبلغ المتبقي: SAR 13827.48" (remaining amount)
         val remainingPattern = Regex(
@@ -183,6 +237,10 @@ class AlRajhiBankParser : BankParser() {
     }
 
     override fun detectIsCard(message: String): Boolean {
+        // English PoS purchase is a card transaction
+        if (isEnglishPosFormat(message)) {
+            return true
+        }
         // مدى = Mada (Saudi debit card network)
         // بطاقة = card
         if (message.contains("مدى") || message.contains("بطاقة")) {
@@ -192,11 +250,17 @@ class AlRajhiBankParser : BankParser() {
     }
 
     override fun isTransactionMessage(message: String): Boolean {
-        // Skip OTP / verification
+        // Skip OTP / verification (Arabic + English)
         if (message.contains("رمز") || message.contains("OTP", ignoreCase = true) ||
-            message.contains("كلمة المرور")
+            message.contains("كلمة المرور") ||
+            message.contains("verification code", ignoreCase = true)
         ) {
             return false
+        }
+
+        // Accept the English multi-line PoS purchase format
+        if (isEnglishPosFormat(message)) {
+            return true
         }
 
         val keywords = listOf(

--- a/parser-core/src/test/kotlin/TestAlRajhiBankParser.kt
+++ b/parser-core/src/test/kotlin/TestAlRajhiBankParser.kt
@@ -102,6 +102,32 @@ class AlRajhiBankParserTest {
                     currency = "SAR",
                     type = TransactionType.EXPENSE
                 )
+            ),
+            ParserTestCase(
+                name = "English PoS purchase (alpha merchant)",
+                message = "PoS Purchase\nBy:4196;mada(Google Pay)\nAmount:SR 2\nAt:FAST WAY\n26/6/19 23:54",
+                sender = "AlRajhiBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2"),
+                    currency = "SAR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "FAST WAY",
+                    accountLast4 = "4196",
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "English PoS purchase (terminal id + city)",
+                message = "PoS Purchase\nBy:4196;mada(Google Pay)\nAmount:SR 4\nAt:170658 riyadh\n26/6/18 11:48",
+                sender = "AlRajhiBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("4"),
+                    currency = "SAR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "riyadh",
+                    accountLast4 = "4196",
+                    isFromCard = true
+                )
             )
         )
 


### PR DESCRIPTION
Closes #502. The existing `AlRajhiBankParser` only handled **Arabic** SMS; Al Rajhi also sends an **English multi-line PoS** format that wasn't parsed.

## Now handled
```
PoS Purchase
By:4196;mada(Google Pay)
Amount:SR 2
At:FAST WAY
26/6/19 23:54
```
→ EXPENSE, amount 2, **SAR**, accountLast4 `4196` (from `By:`), merchant **FAST WAY** (from `At:`), `isFromCard`.

- `At:170658 riyadh` → merchant **riyadh** (leading numeric terminal id stripped).
- The `mada(Google Pay)` method and the ambiguous date line are ignored (timestamp comes from the SMS receipt).
- Arabic handling is **untouched** (English path is an early branch); added an English `verification code` OTP guard.

## Tests
2 English PoS cases added; all 8 existing Arabic cases still pass. Full `:parser-core:jvmTest` → **1390 tests, 0 failures**. No PII.