### PR TITLE
feat(transactions): bulk add selected transactions to a group (#506)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
@@ -26,12 +26,14 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ShowChart
 import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.automirrored.filled.ReceiptLong
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.automirrored.filled.TrendingDown
 import androidx.compose.material.icons.automirrored.filled.TrendingUp
 import androidx.compose.material.icons.rounded.MoreHoriz
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.outlined.AccountBalance
 import androidx.compose.material.icons.outlined.AccountBalanceWallet
+import androidx.compose.material.icons.outlined.FolderOpen
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.LaunchedEffect
@@ -56,6 +58,7 @@ import kotlinx.coroutines.launch
 import com.pennywiseai.tracker.data.database.entity.CategoryEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
+import com.pennywiseai.tracker.data.database.entity.TransactionGroupEntity
 import com.pennywiseai.tracker.presentation.common.TimePeriod
 import com.pennywiseai.tracker.presentation.common.TransactionTypeFilter
 import com.pennywiseai.tracker.data.database.entity.ProfileEntity
@@ -117,6 +120,8 @@ fun TransactionsScreen(
     val bulkSnack by viewModel.bulkSnack.collectAsState()
     val selectionMode = selectedIds.isNotEmpty()
     var showBulkCategorySheet by remember { mutableStateOf(false) }
+    var showBulkGroupSheet by remember { mutableStateOf(false) }
+    val groups by viewModel.groups.collectAsState()
 
     // Self-transfer suggestions (#385): map of txn-id → partner-id.
     val transferPartnerOf by viewModel.suggestedTransferPartnerOf.collectAsState()
@@ -281,6 +286,12 @@ fun TransactionsScreen(
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             IconButton(onClick = { showBulkCategorySheet = true }) {
                                 Icon(Icons.Default.Category, contentDescription = "Change category")
+                            }
+                            IconButton(onClick = { showBulkGroupSheet = true }) {
+                                Icon(
+                                    Icons.AutoMirrored.Filled.PlaylistAdd,
+                                    contentDescription = "Add to group"
+                                )
                             }
                             IconButton(onClick = { viewModel.bulkDelete() }) {
                                 Icon(
@@ -684,6 +695,24 @@ fun TransactionsScreen(
         )
     }
 
+    // Bulk add-to-group picker (#506): add every selected row to an existing
+    // group or a brand-new one in a single action.
+    if (showBulkGroupSheet && selectedIds.isNotEmpty()) {
+        BulkGroupPickerSheet(
+            selectedCount = selectedIds.size,
+            groups = groups,
+            onGroupSelected = { group ->
+                viewModel.bulkAddToGroup(group.id, group.name)
+                showBulkGroupSheet = false
+            },
+            onCreateGroup = { name ->
+                viewModel.bulkCreateGroupAndAdd(name)
+                showBulkGroupSheet = false
+            },
+            onDismiss = { showBulkGroupSheet = false }
+        )
+    }
+
     // Bulk action snackbar with Undo (#369).
     LaunchedEffect(bulkSnack) {
         bulkSnack?.let { snack ->
@@ -700,6 +729,102 @@ fun TransactionsScreen(
     // Hardware back exits selection mode instead of leaving the screen.
     BackHandler(enabled = selectionMode) {
         viewModel.clearSelection()
+    }
+}
+
+/**
+ * Bulk "Add to group" picker (#506). Lists existing groups (tap to add all
+ * selected transactions) and a "Create new group" affordance. Unlike the
+ * single-transaction [GroupBottomSheet], there is no "current group" — the
+ * selection can span rows in different groups, so adding simply moves them all
+ * to the chosen group.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BulkGroupPickerSheet(
+    selectedCount: Int,
+    groups: List<TransactionGroupEntity>,
+    onGroupSelected: (TransactionGroupEntity) -> Unit,
+    onCreateGroup: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var showCreateField by remember { mutableStateOf(false) }
+    var newGroupName by remember { mutableStateOf("") }
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Dimensions.Padding.content)
+                .padding(bottom = Dimensions.Padding.content)
+        ) {
+            Text(
+                text = "Add $selectedCount to group",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.padding(bottom = Spacing.md)
+            )
+
+            if (groups.isNotEmpty()) {
+                groups.forEach { group ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onGroupSelected(group) }
+                            .padding(vertical = Spacing.sm),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.md)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.FolderOpen,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(Dimensions.Icon.medium)
+                        )
+                        Text(
+                            text = group.name,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(Spacing.sm))
+            }
+
+            if (showCreateField) {
+                OutlinedTextField(
+                    value = newGroupName,
+                    onValueChange = { newGroupName = it },
+                    label = { Text("Group name") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    trailingIcon = {
+                        IconButton(
+                            onClick = {
+                                if (newGroupName.isNotBlank()) {
+                                    onCreateGroup(newGroupName.trim())
+                                }
+                            },
+                            enabled = newGroupName.isNotBlank()
+                        ) {
+                            Icon(Icons.Default.Check, contentDescription = "Create")
+                        }
+                    }
+                )
+            } else {
+                TextButton(
+                    onClick = { showCreateField = true },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(
+                        Icons.Default.Add,
+                        contentDescription = null,
+                        modifier = Modifier.size(Dimensions.Icon.small)
+                    )
+                    Spacer(modifier = Modifier.width(Spacing.xs))
+                    Text("Create new group")
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
@@ -10,6 +10,10 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListState
@@ -45,6 +49,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalDensity
@@ -766,25 +771,33 @@ private fun BulkGroupPickerSheet(
             )
 
             if (groups.isNotEmpty()) {
-                groups.forEach { group ->
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { onGroupSelected(group) }
-                            .padding(vertical = Spacing.sm),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(Spacing.md)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.FolderOpen,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.size(Dimensions.Icon.medium)
-                        )
-                        Text(
-                            text = group.name,
-                            style = MaterialTheme.typography.bodyMedium
-                        )
+                // Cap the list height and let it scroll so a long group list
+                // doesn't push "Create new group" off the bottom of the sheet.
+                Column(
+                    modifier = Modifier
+                        .heightIn(max = 280.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    groups.forEach { group ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onGroupSelected(group) }
+                                .padding(vertical = Spacing.sm),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(Spacing.md)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.FolderOpen,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(Dimensions.Icon.medium)
+                            )
+                            Text(
+                                text = group.name,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
                     }
                 }
                 Spacer(modifier = Modifier.height(Spacing.sm))
@@ -797,6 +810,14 @@ private fun BulkGroupPickerSheet(
                     label = { Text("Group name") },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(
+                        onDone = {
+                            if (newGroupName.isNotBlank()) {
+                                onCreateGroup(newGroupName.trim())
+                            }
+                        }
+                    ),
                     trailingIcon = {
                         IconButton(
                             onClick = {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -24,6 +24,8 @@ import com.pennywiseai.tracker.data.currency.CurrencyConversionService
 import com.pennywiseai.tracker.data.database.entity.ProfileEntity
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.ProfileRepository
+import com.pennywiseai.tracker.data.repository.TransactionGroupRepository
+import com.pennywiseai.tracker.data.database.entity.TransactionGroupEntity
 import com.pennywiseai.tracker.utils.CurrencyUtils
 import com.pennywiseai.tracker.utils.SmsReportUrlBuilder
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -47,6 +49,7 @@ class TransactionsViewModel @Inject constructor(
     private val currencyConversionService: CurrencyConversionService,
     private val accountBalanceRepository: AccountBalanceRepository,
     private val profileRepository: ProfileRepository,
+    private val transactionGroupRepository: TransactionGroupRepository,
     private val savedStateHandle: androidx.lifecycle.SavedStateHandle,
     @dagger.hilt.android.qualifiers.ApplicationContext private val context: android.content.Context
 ) : ViewModel() {
@@ -434,7 +437,79 @@ class TransactionsViewModel @Inject constructor(
             )
         }
     }
-    
+
+    // ─── Bulk add-to-group (#506) ────────────────────────────────────────────
+    //
+    // All existing groups, for the bulk "Add to group" picker. A transaction
+    // belongs to at most one group, so adding to a new group moves it off any
+    // group it was already in — the undo below restores the prior membership.
+    val groups: StateFlow<List<TransactionGroupEntity>> =
+        transactionGroupRepository.getAllGroups()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    /**
+     * Add every currently-selected transaction to the group [groupId]. Captures
+     * each row's previous groupId first so Undo can restore the original
+     * membership (re-linking to the old group, or unlinking if it had none).
+     */
+    fun bulkAddToGroup(groupId: Long, groupName: String) {
+        val ids = _selectedIds.value
+        if (ids.isEmpty()) return
+        viewModelScope.launch {
+            val previous = _uiState.value.transactions
+                .filter { it.id in ids }
+                .associate { it.id to it.groupId }
+            previous.keys.forEach { id ->
+                transactionGroupRepository.addTransactionToGroup(id, groupId)
+            }
+            clearSelection()
+            _bulkSnack.value = BulkSnack(
+                message = "${previous.size} added to \"$groupName\"",
+                undo = { restoreGroupMembership(previous) }
+            )
+        }
+    }
+
+    /**
+     * Create a new group named [name] and add every currently-selected
+     * transaction to it. Undo restores the prior membership and deletes the
+     * now-empty group that was just created.
+     */
+    fun bulkCreateGroupAndAdd(name: String, note: String? = null) {
+        val ids = _selectedIds.value
+        if (ids.isEmpty() || name.isBlank()) return
+        viewModelScope.launch {
+            val previous = _uiState.value.transactions
+                .filter { it.id in ids }
+                .associate { it.id to it.groupId }
+            val groupId = transactionGroupRepository.createGroup(name, note)
+            previous.keys.forEach { id ->
+                transactionGroupRepository.addTransactionToGroup(id, groupId)
+            }
+            clearSelection()
+            _bulkSnack.value = BulkSnack(
+                message = "${previous.size} added to \"${name.trim()}\"",
+                undo = {
+                    viewModelScope.launch {
+                        restoreGroupMembership(previous).join()
+                        transactionGroupRepository.deleteGroup(groupId)
+                    }
+                }
+            )
+        }
+    }
+
+    private fun restoreGroupMembership(previous: Map<Long, Long?>) =
+        viewModelScope.launch {
+            previous.forEach { (id, oldGroupId) ->
+                if (oldGroupId != null) {
+                    transactionGroupRepository.addTransactionToGroup(id, oldGroupId)
+                } else {
+                    transactionGroupRepository.removeTransactionFromGroup(id)
+                }
+            }
+        }
+
     // Track if initial filters have been applied to prevent resetting on back navigation
     private var hasAppliedInitialFilters = false
 


### PR DESCRIPTION
## What
Adds a **bulk "Add to group"** action to the Transactions multi-select bar.

When one or more rows are selected, the contextual top bar now shows a third action (between *Change category* and *Delete*). Tapping it opens a picker:
- lists every existing group → tap to add all selected transactions to it
- **Create new group** → name it inline, then all selected rows are added

A snackbar with **Undo** restores each row's prior group membership (and deletes the freshly-created group if you undo a create-and-add).

## Why — scoping #506
The reporter asked to "merge multiple transactions into one." Most of that intent is already served by the **Groups** feature (folders that bundle related transactions). The one real gap was doing it in bulk from multi-select — you previously had to open each transaction and add it to a group one at a time. This PR fills that gap; the destructive "collapse N rows into a single row" interpretation stays out of scope (Groups already cover the use case without data loss).

## How
- `TransactionsViewModel`: inject `TransactionGroupRepository`; expose `groups`; add `bulkAddToGroup(groupId, name)` and `bulkCreateGroupAndAdd(name)` mirroring `bulkUpdateCategory`/`bulkDelete`, with prior-membership-capturing Undo.
- `TransactionsScreen`: new `PlaylistAdd` action in the selection top bar + `BulkGroupPickerSheet` modal (modeled on the single-row `GroupBottomSheet`).

## Test
- `./gradlew :app:compileStandardDebugKotlin` ✅

Closes #506