### PR TITLE
fix(currency): convert non-base account balances on the home screen

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -1263,9 +1263,12 @@ class HomeViewModel @Inject constructor(
                 // native currency so the row shows an honest "$400", not "MZN400".
                 val rate = currencyConversionService.getExchangeRate(account.currency, targetCurrency)
                 if (rate != null) {
+                    // Keep full precision here and let display formatting round. Rounding
+                    // balance and creditLimit separately would make "available = limit -
+                    // balance" round twice and drift a cent on foreign credit cards.
                     account.copy(
-                        balance = account.balance.multiply(rate).setScale(2, RoundingMode.HALF_UP),
-                        creditLimit = account.creditLimit?.multiply(rate)?.setScale(2, RoundingMode.HALF_UP),
+                        balance = account.balance.multiply(rate),
+                        creditLimit = account.creditLimit?.multiply(rate),
                         currency = targetCurrency
                     )
                 } else {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -818,39 +818,18 @@ class HomeViewModel @Inject constructor(
             val regularAccounts = convertAccountEntities(rawRegularAccounts, selectedCurrency, isUnified)
             val creditCards = convertAccountEntities(rawCreditCards, selectedCurrency, isUnified)
 
+            // Entities are pre-converted by convertAccountEntities, so just sum;
+            // anything still foreign is one we couldn't get a rate for (raw fallback).
             var totalBalance = BigDecimal.ZERO
             var hasApproximateBalance = false
             for (account in regularAccounts) {
-                if (account.currency == selectedCurrency) {
-                    totalBalance += account.balance
-                } else {
-                    val hasRate = currencyConversionService.hasValidRate(account.currency, selectedCurrency)
-                    if (!hasRate) {
-                        hasApproximateBalance = true
-                    }
-                    totalBalance += currencyConversionService.convertAmount(
-                        amount = account.balance,
-                        fromCurrency = account.currency,
-                        toCurrency = selectedCurrency
-                    )
-                }
+                totalBalance += account.balance
+                if (account.currency != selectedCurrency) hasApproximateBalance = true
             }
             var totalAvailableCredit = BigDecimal.ZERO
             for (card in creditCards) {
-                val availableInCardCurrency = (card.creditLimit ?: BigDecimal.ZERO) - card.balance
-                if (card.currency == selectedCurrency) {
-                    totalAvailableCredit += availableInCardCurrency
-                } else {
-                    val hasRate = currencyConversionService.hasValidRate(card.currency, selectedCurrency)
-                    if (!hasRate) {
-                        hasApproximateBalance = true
-                    }
-                    totalAvailableCredit += currencyConversionService.convertAmount(
-                        amount = availableInCardCurrency,
-                        fromCurrency = card.currency,
-                        toCurrency = selectedCurrency
-                    )
-                }
+                totalAvailableCredit += (card.creditLimit ?: BigDecimal.ZERO) - card.balance
+                if (card.currency != selectedCurrency) hasApproximateBalance = true
             }
 
             _uiState.value = _uiState.value.copy(
@@ -954,40 +933,19 @@ class HomeViewModel @Inject constructor(
             val regularAccounts = convertAccountEntities(rawRegularAccounts, selectedCurrency, isUnified)
             val creditCards = convertAccountEntities(rawCreditCards, selectedCurrency, isUnified)
 
+            // Entities are pre-converted by convertAccountEntities, so just sum;
+            // anything still foreign is one we couldn't get a rate for (raw fallback).
             var totalBalanceInSelectedCurrency = BigDecimal.ZERO
             var hasApproximateBalance = false
             for (account in regularAccounts) {
-                if (account.currency == selectedCurrency) {
-                    totalBalanceInSelectedCurrency += account.balance
-                } else {
-                    val hasRate = currencyConversionService.hasValidRate(account.currency, selectedCurrency)
-                    if (!hasRate) {
-                        hasApproximateBalance = true
-                    }
-                    totalBalanceInSelectedCurrency += currencyConversionService.convertAmount(
-                        amount = account.balance,
-                        fromCurrency = account.currency,
-                        toCurrency = selectedCurrency
-                    )
-                }
+                totalBalanceInSelectedCurrency += account.balance
+                if (account.currency != selectedCurrency) hasApproximateBalance = true
             }
 
             var totalAvailableCreditInSelectedCurrency = BigDecimal.ZERO
             for (card in creditCards) {
-                val availableInCardCurrency = (card.creditLimit ?: BigDecimal.ZERO) - card.balance
-                if (card.currency == selectedCurrency) {
-                    totalAvailableCreditInSelectedCurrency += availableInCardCurrency
-                } else {
-                    val hasRate = currencyConversionService.hasValidRate(card.currency, selectedCurrency)
-                    if (!hasRate) {
-                        hasApproximateBalance = true
-                    }
-                    totalAvailableCreditInSelectedCurrency += currencyConversionService.convertAmount(
-                        amount = availableInCardCurrency,
-                        fromCurrency = card.currency,
-                        toCurrency = selectedCurrency
-                    )
-                }
+                totalAvailableCreditInSelectedCurrency += (card.creditLimit ?: BigDecimal.ZERO) - card.balance
+                if (card.currency != selectedCurrency) hasApproximateBalance = true
             }
 
             _uiState.value = _uiState.value.copy(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -336,8 +336,12 @@ class HomeViewModel @Inject constructor(
             combine(
                 accountBalanceRepository.getAllLatestBalances(),
                 userPreferencesRepository.unifiedCurrencyMode,
-                userPreferencesRepository.displayCurrency
-            ) { allBalances, isUnified, displayCurrency ->
+                userPreferencesRepository.displayCurrency,
+                // Re-run conversion whenever exchange rates change, so a balance that
+                // first rendered raw (rates not fetched yet, or device was offline)
+                // self-heals the moment the rate lands instead of staying mislabelled.
+                currencyConversionService.getAllRatesFlow()
+            ) { allBalances, isUnified, displayCurrency, _ ->
                 Triple(allBalances, isUnified, displayCurrency)
             }.collect { (allBalances, isUnified, displayCurrency) ->
                 // Cache the raw (unfiltered) balances for refreshAccountBalances/refreshHiddenAccounts
@@ -367,43 +371,22 @@ class HomeViewModel @Inject constructor(
                 val regularAccounts = convertAccountEntities(rawRegularAccounts, selectedCurrency, isUnified)
                 val creditCards = convertAccountEntities(rawCreditCards, selectedCurrency, isUnified)
 
-                // Calculate totals from (possibly converted) entities.
-                // convertAmount returns the original amount when no rate is available,
-                // so we skip the hasValidRate check to avoid silently dropping accounts.
+                // regularAccounts/creditCards are already pre-converted by
+                // convertAccountEntities (currency == selectedCurrency for everything it
+                // could convert). So just sum their balances; anything still in a foreign
+                // currency is one we couldn't get a rate for — add its raw amount as a
+                // best-effort fallback and flag the total as approximate.
                 var totalBalanceInSelectedCurrency = BigDecimal.ZERO
                 var hasApproximateBalance = false
                 for (account in regularAccounts) {
-                    if (account.currency == selectedCurrency) {
-                        totalBalanceInSelectedCurrency += account.balance
-                    } else {
-                        val hasRate = currencyConversionService.hasValidRate(account.currency, selectedCurrency)
-                        if (!hasRate) {
-                            hasApproximateBalance = true
-                        }
-                        totalBalanceInSelectedCurrency += currencyConversionService.convertAmount(
-                            amount = account.balance,
-                            fromCurrency = account.currency,
-                            toCurrency = selectedCurrency
-                        )
-                    }
+                    totalBalanceInSelectedCurrency += account.balance
+                    if (account.currency != selectedCurrency) hasApproximateBalance = true
                 }
 
                 var totalAvailableCreditInSelectedCurrency = BigDecimal.ZERO
                 for (card in creditCards) {
-                    val availableInCardCurrency = (card.creditLimit ?: BigDecimal.ZERO) - card.balance
-                    if (card.currency == selectedCurrency) {
-                        totalAvailableCreditInSelectedCurrency += availableInCardCurrency
-                    } else {
-                        val hasRate = currencyConversionService.hasValidRate(card.currency, selectedCurrency)
-                        if (!hasRate) {
-                            hasApproximateBalance = true
-                        }
-                        totalAvailableCreditInSelectedCurrency += currencyConversionService.convertAmount(
-                            amount = availableInCardCurrency,
-                            fromCurrency = card.currency,
-                            toCurrency = selectedCurrency
-                        )
-                    }
+                    totalAvailableCreditInSelectedCurrency += (card.creditLimit ?: BigDecimal.ZERO) - card.balance
+                    if (card.currency != selectedCurrency) hasApproximateBalance = true
                 }
 
                 // Update available currencies to include account currencies
@@ -1314,25 +1297,17 @@ class HomeViewModel @Inject constructor(
             if (account.currency == targetCurrency) {
                 account
             } else {
-                val hasRate = currencyConversionService.hasValidRate(account.currency, targetCurrency)
-                if (hasRate) {
-                    val convertedBalance = currencyConversionService.convertAmount(
-                        amount = account.balance,
-                        fromCurrency = account.currency,
-                        toCurrency = targetCurrency
-                    )
-                    val convertedCreditLimit = if (account.isCreditCard && account.creditLimit != null) {
-                        currencyConversionService.convertAmount(
-                            amount = account.creditLimit,
-                            fromCurrency = account.currency,
-                            toCurrency = targetCurrency
-                        )
-                    } else {
-                        account.creditLimit
-                    }
+                // Fetch-on-miss: getExchangeRate lazily fetches the rate when it isn't
+                // cached yet, so the very first render converts instead of showing the
+                // raw native amount mislabelled with the display currency (the #545/MZN
+                // bug: a $400 account drawn as "MZN400"). Only relabel to the target
+                // currency when a rate actually exists — otherwise keep the account's
+                // native currency so the row shows an honest "$400", not "MZN400".
+                val rate = currencyConversionService.getExchangeRate(account.currency, targetCurrency)
+                if (rate != null) {
                     account.copy(
-                        balance = convertedBalance,
-                        creditLimit = convertedCreditLimit,
+                        balance = account.balance.multiply(rate).setScale(2, RoundingMode.HALF_UP),
+                        creditLimit = account.creditLimit?.multiply(rate)?.setScale(2, RoundingMode.HALF_UP),
                         currency = targetCurrency
                     )
                 } else {

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/AccountCarousel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/AccountCarousel.kt
@@ -223,8 +223,11 @@ private fun AccountCarouselCard(
                     // The label above is "Outstanding" for credit cards; that is the
                     // amount owed (account.balance), NOT the total creditLimit. Mirrors
                     // CreditCardsCard / AccountDetailScreen, which already do this.
+                    // The entity is already pre-converted in unified mode (its currency
+                    // is the display currency when a rate was found), so format with the
+                    // account's own currency. This keeps an un-convertible balance honest
+                    // (shows "$400", not "MZN400") instead of forcing the display label.
                     text = if (isAmountHidden) "••••••"
-                           else if (isUnifiedMode) CurrencyFormatter.formatCurrency(account.balance, selectedCurrency)
                            else account.formatBalance(),
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -37,6 +37,7 @@ import android.content.Intent
 import androidx.core.content.FileProvider
 import com.pennywiseai.tracker.core.Constants
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.first
@@ -100,12 +101,19 @@ class SettingsViewModel @Inject constructor(
     // Replace UPI VPAs with contact names (gated by READ_CONTACTS).
     val useContactsForVpa = userPreferencesRepository.useContactsForVpa
 
-    val availableCurrencies: StateFlow<List<String>> = transactionRepository.getAllCurrencies()
-        .map { transactionCurrencies ->
-            val supportedCurrencies = CurrencyUtils.getAllSupportedCurrencies()
-            val allCurrencies = (transactionCurrencies + supportedCurrencies).distinct()
-            CurrencyUtils.sortCurrencies(allCurrencies)
-        }
+    // Derive the selectable set from the user's ACTUAL data (transaction + account
+    // currencies) on top of the common seed list. This way any currency the user
+    // really holds — e.g. MZN held only in an account — is always selectable, instead
+    // of silently missing because it wasn't in the hand-maintained supported list.
+    val availableCurrencies: StateFlow<List<String>> = combine(
+        transactionRepository.getAllCurrencies(),
+        accountBalanceRepository.getAllLatestBalances()
+    ) { transactionCurrencies, accounts ->
+        val accountCurrencies = accounts.map { it.currency }
+        val supportedCurrencies = CurrencyUtils.getAllSupportedCurrencies()
+        val allCurrencies = (transactionCurrencies + accountCurrencies + supportedCurrencies).distinct()
+        CurrencyUtils.sortCurrencies(allCurrencies)
+    }
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),


### PR DESCRIPTION
## What

From a Discord report: display currency **MZN**, one **USD** account → on the home screen the USD account's balance wasn't converted to MZN (shown raw, relabelled), and the unified total was marked approximate.

## Root cause (reproduced on emulator)

`HomeViewModel.convertAccountEntities()` gated conversion on `hasValidRate()`, which **never triggers a fetch**. On first render the USD→MZN rate isn't cached yet → account returned unconverted → `AccountCarousel` then formatted the raw amount with the display currency anyway → `$400` drawn as `MZN400`. The per-account **total** loop used `convertAmount()` (which lazily fetches), so the two disagreed and the total carried an "approximate" asterisk.

## Changes

- **`convertAccountEntities`** — fetch-on-miss via `getExchangeRate`; convert `balance` + `creditLimit`; relabel to the target currency **only when a rate exists** (else keep native, so an un-convertible balance shows `$400`, not `MZN400`).
- **Balance flow** — added `getAllRatesFlow()` to the combine so balances re-convert when rates land (offline → online self-heals).
- **Total loop** — accounts are now pre-converted; just sum and flag approximate for any still-foreign currency.
- **`AccountCarousel`** — format with the account's own (pre-converted) currency instead of forcing `selectedCurrency`.
- **`SettingsViewModel.availableCurrencies`** — derive the picker from the user's actual **transaction + account** currencies (not just transactions), so a currency held only in an account (e.g. MZN) is always selectable rather than silently missing from the hardcoded list.

## Verification

Cold start (exchange_rates cleared) with MZN display + USD/NGN/INR/MZN accounts — all convert on **first** render, no re-navigation, total drops the asterisk:

| Account | Before | After |
|---|---|---|
| Wallet (USD 400) | `MZN400` | `MZN25,467.46` |
| CashNGN (NGN 50,000) | `MZN50,000` | `MZN2,318.42` |
| Kotak (INR 999,999) | `MZN999,999` | `MZN674,007.13` |
| Total | `MZN871,190.74*` | `MZN871,190.74` |

Full unit suite green.

## Note

The same report's Indian-grouping issue (`MZN3,67,072`) is **already fixed on `main` by #525** (changed the locale fallback to international) and just needs to ship in the next release — not part of this PR.