### PR TITLE
fix(home): stop the This-month summary from crushing long amounts

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceCard.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.layout.Spacer
@@ -60,8 +62,10 @@ import com.pennywiseai.tracker.ui.theme.expense_light
 import com.pennywiseai.tracker.ui.components.AnimatedCurrencyText
 import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.utils.CurrencyFormatter
+import com.pennywiseai.tracker.utils.formatBalance
 import java.math.BigDecimal
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun BalanceCard(
     userName: String = "User",
@@ -297,10 +301,15 @@ fun BalanceCard(
                         )
                         Spacer(modifier = Modifier.height(Spacing.sm))
 
-                        // Summary row: Income | Expenses | Saved — with colored accent bars
-                        Row(
+                        // Summary row: Income | Expenses | Lent | Saved — with colored
+                        // accent bars. FlowRow so long amounts (e.g. a 3-char "MZN"
+                        // prefix + big numbers across all four items) wrap onto a second
+                        // line instead of crushing the last column into vertical,
+                        // one-character-per-line text.
+                        FlowRow(
                             modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceEvenly
+                            horizontalArrangement = Arrangement.spacedBy(Spacing.lg),
+                            verticalArrangement = Arrangement.spacedBy(Spacing.sm)
                         ) {
                             val incomeColor = if (isDark) income_dark else income_light
                             val expenseColor = if (isDark) expense_dark else expense_light
@@ -365,7 +374,11 @@ fun BalanceCard(
                                         color = MaterialTheme.colorScheme.onSurface
                                     )
                                     Text(
-                                        text = if (isBalanceHidden) "••••••" else CurrencyFormatter.formatCurrency(account.balance, currency),
+                                        // Use the account's own (pre-converted) currency
+                                        // so an un-convertible balance shows honestly as
+                                        // "$400" rather than a raw amount mislabelled with
+                                        // the display currency ("MZN400").
+                                        text = if (isBalanceHidden) "••••••" else account.formatBalance(),
                                         style = MaterialTheme.typography.titleSmall,
                                         fontWeight = FontWeight.Bold,
                                         color = MaterialTheme.colorScheme.onSurface
@@ -610,6 +623,10 @@ private fun SummaryItem(
                 style = MaterialTheme.typography.titleSmall,
                 color = accentColor,
                 fontWeight = FontWeight.Bold,
+                // Keep the amount on one line — never break a "MZN52,245.26" into
+                // one-character-per-line text when the column gets narrow.
+                maxLines = 1,
+                softWrap = false,
             )
             Text(
                 text = label,


### PR DESCRIPTION
## What

From the same MZN report: the home "This month" summary rendered the **Saved** amount vertically, one character per line (`M Z N 5 2 , 2 4 5 . 2 6`).

## Root cause

The summary is a single `Row` with `Arrangement.SpaceEvenly` holding up to **four** `SummaryItem`s — Income, Expenses, **Lent**, Saved (Lent only shows when you've lent money this month). With four columns and long currency strings (the `MZN` 3-char prefix on big numbers), the row runs out of width and crushes the last column to ~1 char wide. `SummaryItem`'s value `Text` had no `maxLines`/`softWrap`, so it broke at every character instead of staying on one line.

3 columns fit fine; the 4th column is what overflowed — which is why it shows for users with a Lent total.

## Fix

- Summary row → `FlowRow`, so four items **wrap to a second line (2×2)** instead of crushing the last column.
- `SummaryItem` value → `maxLines = 1`, `softWrap = false` (an amount never breaks mid-number).
- Per-account row → `account.formatBalance()` (the account's own, pre-converted currency) so an un-convertible balance reads `$400`, not a raw amount mislabelled with the display currency.

## Verification

Emulator, MZN display, all four columns present → clean 2×2 grid, every amount on one line. (See before/after.)

## Note

Independent of the conversion fix in #553; both came from the same MZN/USD report.