### PR TITLE
fix(slice): recognize the SLCBNK SFB sender

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SliceParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SliceParser.kt
@@ -15,7 +15,8 @@ class SliceParser : BankParser() {
         val normalizedSender = sender.uppercase()
         return normalizedSender.contains("SLICE") ||
                 normalizedSender.contains("SLICEIT") ||
-                normalizedSender.contains("SLCEIT")  // Matches JD-SLCEIT-S and similar
+                normalizedSender.contains("SLCEIT") ||  // Matches JD-SLCEIT-S and similar
+                normalizedSender.contains("SLCBNK")  // Slice SFB sender, e.g. VA-SLCBNK-S
     }
 
     private fun isSuccessMessage(message: String): Boolean {

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SliceParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SliceParserTest.kt
@@ -85,15 +85,15 @@ class SliceParserTest {
                 // Regression: VA-SLCBNK-S (Slice SFB sender) was unrecognized, so this
                 // "spent on your credit card" alert wasn't parsed at all.
                 name = "Slice SFB 'spent on credit card' from SLCBNK sender is CREDIT",
-                message = "Rs. 124 spent on your credit card xx7185 at Kishor rajgiri on 18-Jun-26 (UPI Ref: 616982957103). Not you? Call 080-4832-9999 - slice",
+                message = "Rs. 124 spent on your credit card xx1234 at Sample Merchant on 18-Jun-26 (UPI Ref: 100000000000). Not you? Call 080-0000-0000 - slice",
                 sender = "VA-SLCBNK-S",
                 expected = ExpectedTransaction(
                     amount = BigDecimal("124"),
                     currency = "INR",
                     type = TransactionType.CREDIT,
-                    merchant = "Kishor rajgiri",
-                    accountLast4 = "7185",
-                    reference = "616982957103"
+                    merchant = "Sample Merchant",
+                    accountLast4 = "1234",
+                    reference = "100000000000"
                 )
             ),
             ParserTestCase(

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SliceParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/SliceParserTest.kt
@@ -82,6 +82,21 @@ class SliceParserTest {
                 )
             ),
             ParserTestCase(
+                // Regression: VA-SLCBNK-S (Slice SFB sender) was unrecognized, so this
+                // "spent on your credit card" alert wasn't parsed at all.
+                name = "Slice SFB 'spent on credit card' from SLCBNK sender is CREDIT",
+                message = "Rs. 124 spent on your credit card xx7185 at Kishor rajgiri on 18-Jun-26 (UPI Ref: 616982957103). Not you? Call 080-4832-9999 - slice",
+                sender = "VA-SLCBNK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("124"),
+                    currency = "INR",
+                    type = TransactionType.CREDIT,
+                    merchant = "Kishor rajgiri",
+                    accountLast4 = "7185",
+                    reference = "616982957103"
+                )
+            ),
+            ParserTestCase(
                 name = "Slice card 'spent' wording with card context stays CREDIT",
                 message = "Rs.350 spent on your slice credit card at MERCHANT. Available limit: Rs.10000.",
                 sender = "AD-SLCEIT-S",
@@ -243,6 +258,7 @@ class SliceParserTest {
             "JK-SLICEIT" to true,
             "SLICEIT" to true,
             "SLCEIT" to true,
+            "VA-SLCBNK-S" to true,
             "slice" to true,
             "HDFCBK" to false,
             "VK-JTEDGE-S" to false


### PR DESCRIPTION
## Problem
A user reported Slice SMS not parsing at all. The sender was `VA-SLCBNK-S` and the body was a normal credit-card spend alert:

> Rs. 124 spent on your credit card xx7185 at Kishor rajgiri on 18-Jun-26 (UPI Ref: 616982957103). Not you? Call 080-4832-9999 - slice

The app returned **"No transaction detected."**

## Root cause
`SliceParser.canHandle` only matched senders containing `SLICE` / `SLICEIT` / `SLCEIT`. The Slice SFB (banking) sender ID `SLCBNK` matched none of them, so no parser claimed the SMS. The message body itself was fully parseable.

## Fix
Add `SLCBNK` to the sender match. The SMS now parses correctly as **₹124, CREDIT** (credit-card spend), merchant `Kishor rajgiri`, card `xx7185`, ref `616982957103`.

## Tests
- New regression `ParserTestCase` using the exact reported sender + body.
- Added `VA-SLCBNK-S -> true` to the `canHandle` mapping.
- `:parser-core:jvmTest --tests *SliceParserTest*` → 30/30 green.