### PR TITLE
chore: switch the bug-report web tool to pennywise.zynth.dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,10 @@ release.properties
 # pennywise-web/scripts/deploy.sh are still tracked.)
 /deploy.sh
 
+# Generated Docker build context for the web container (staged copy of
+# parser-core created by pennywise-web/scripts/deploy.sh).
+/pennywise-web/.parser-core/
+
 # IDE folders
 .idea
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,10 @@ release.properties
 
 *.pem
 
-deploy.sh
+# Root-level deploy script may hold credentials; keep it local.
+# (Scoped to root so committed helper scripts like
+# pennywise-web/scripts/deploy.sh are still tracked.)
+/deploy.sh
 
 # IDE folders
 .idea

--- a/app/src/main/java/com/pennywiseai/tracker/core/Constants.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/core/Constants.kt
@@ -83,6 +83,6 @@ object Constants {
     object Links {
         const val DISCORD_URL = "https://discord.gg/H3xWeMWjKQ"
         const val GITHUB_URL = "https://github.com/sarim2000/pennywiseai-tracker"
-        const val WEB_PARSER_URL = "https://pennywise.querymind.pro"
+        const val WEB_PARSER_URL = "https://pennywise.zynth.dev"
     }
 }

--- a/pennywise-web/package.json
+++ b/pennywise-web/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",
+    "redeploy": "bash scripts/deploy.sh",
     "dev": "wrangler dev",
     "cf-typegen": "wrangler types"
   },

--- a/pennywise-web/scripts/deploy.sh
+++ b/pennywise-web/scripts/deploy.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Redeploy pennywise-web to Cloudflare.
+#
+# Cloudflare secrets (DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD) are
+# stored separately from the Worker code and PERSIST across `wrangler deploy`.
+# This script therefore never re-uploads them on a normal redeploy, so you can
+# ship a new build without knowing the current DB password.
+#
+# It only offers to set a secret when it's missing entirely (e.g. first deploy).
+# To intentionally rotate a secret, run:  wrangler secret put DATABASE_PASSWORD
+#
+set -euo pipefail
+
+# Always operate from the project root (the dir containing wrangler.jsonc).
+cd "$(dirname "$0")/.."
+
+REQUIRED_SECRETS=(DATABASE_URL DATABASE_USER DATABASE_PASSWORD)
+
+echo "==> Checking existing Cloudflare secrets (these are preserved on redeploy)"
+
+# `wrangler secret list` returns a JSON array of {name, type}. Fall back to an
+# empty list if the call fails (e.g. first-ever deploy before the Worker exists).
+existing="$(bunx wrangler secret list --format json 2>/dev/null || echo '[]')"
+
+missing=()
+for name in "${REQUIRED_SECRETS[@]}"; do
+  if printf '%s' "$existing" | grep -q "\"$name\""; then
+    echo "    ✓ $name  (already set — will NOT be changed)"
+  else
+    echo "    ✗ $name  (missing)"
+    missing+=("$name")
+  fi
+done
+
+# Prompt to set any missing secrets before deploying.
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo
+  echo "==> ${#missing[@]} secret(s) are not set yet."
+  for name in "${missing[@]}"; do
+    read -r -p "    Set $name now? [y/N] " answer
+    case "$answer" in
+      [yY]*)
+        bunx wrangler secret put "$name"
+        ;;
+      *)
+        echo "    Skipping $name — deploy will continue, but the server"
+        echo "    will fall back to its localhost default for this value."
+        ;;
+    esac
+  done
+fi
+
+echo
+echo "==> Deploying Worker (secrets above are left untouched)"
+bunx wrangler deploy "$@"
+
+echo
+echo "==> Done. Secrets were preserved; only code/vars/bindings were updated."

--- a/pennywise-web/scripts/deploy.sh
+++ b/pennywise-web/scripts/deploy.sh
@@ -94,6 +94,26 @@ if [ "${#missing_required[@]}" -gt 0 ]; then
   done
 fi
 
+# --- Stage parser-core into the Docker build context ----------------------
+# parser-core is a sibling module (../parser-core), so it lives outside this
+# Worker's Docker build context and the container Dockerfile can't COPY it
+# directly. The Dockerfile instead expects a staged copy at ./.parser-core,
+# built from parser-core's standalone-JVM gradle variants. Re-stage fresh on
+# every deploy so it can never go stale.
+PARSER_SRC="../parser-core"
+PARSER_STAGE=".parser-core"
+echo
+echo "==> Staging parser-core into the Docker build context ($PARSER_STAGE)"
+if [ ! -d "$PARSER_SRC" ]; then
+  echo "error: $PARSER_SRC not found (expected the parser-core module one level up)." >&2
+  exit 1
+fi
+rm -rf "$PARSER_STAGE"
+mkdir -p "$PARSER_STAGE"
+cp "$PARSER_SRC/build.docker.gradle.kts"    "$PARSER_STAGE/build.gradle.kts"
+cp "$PARSER_SRC/settings.docker.gradle.kts" "$PARSER_STAGE/settings.gradle.kts"
+cp -R "$PARSER_SRC/src"                      "$PARSER_STAGE/src"
+
 echo
 echo "==> Deploying Worker (secrets above are left untouched)"
 wrangler deploy "$@"

--- a/pennywise-web/scripts/deploy.sh
+++ b/pennywise-web/scripts/deploy.sh
@@ -2,7 +2,7 @@
 #
 # Redeploy pennywise-web to Cloudflare.
 #
-# Cloudflare secrets (DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD) are
+# Cloudflare secrets (DATABASE_URL / DATABASE_PASSWORD / DATABASE_USER) are
 # stored separately from the Worker code and PERSIST across `wrangler deploy`.
 # This script therefore never re-uploads them on a normal redeploy, so you can
 # ship a new build without knowing the current DB password.
@@ -15,37 +15,80 @@ set -euo pipefail
 # Always operate from the project root (the dir containing wrangler.jsonc).
 cd "$(dirname "$0")/.."
 
-REQUIRED_SECRETS=(DATABASE_URL DATABASE_USER DATABASE_PASSWORD)
+# Secrets that MUST exist for a working production deploy. Missing ones block
+# the deploy (prompt when interactive, hard-fail when not).
+REQUIRED_SECRETS=(DATABASE_URL DATABASE_PASSWORD)
+# Optional — the server falls back to a sensible default (DATABASE_USER=postgres),
+# so a missing one is reported but never blocks the deploy.
+OPTIONAL_SECRETS=(DATABASE_USER)
+
+# Resolve wrangler without depending on any single package manager:
+#   1. the dependency installed in this package (preferred — no network),
+#   2. npx --yes (npm users; --yes skips the install confirmation prompt that
+#      would otherwise hang),
+#   3. bunx (bun users).
+LOCAL_WRANGLER="node_modules/.bin/wrangler"
+if [ -x "$LOCAL_WRANGLER" ]; then
+  wrangler() { "$LOCAL_WRANGLER" "$@"; }
+elif command -v npx >/dev/null 2>&1; then
+  wrangler() { npx --yes wrangler "$@"; }
+elif command -v bunx >/dev/null 2>&1; then
+  wrangler() { bunx wrangler "$@"; }
+else
+  echo "error: wrangler not found. Run 'npm install' (or 'bun install') first." >&2
+  exit 1
+fi
+
+# Is stdin a terminal? If not (CI, piped), we can't prompt, so a missing
+# required secret must abort rather than silently deploy a broken Worker.
+interactive=0
+[ -t 0 ] && interactive=1
 
 echo "==> Checking existing Cloudflare secrets (these are preserved on redeploy)"
 
 # `wrangler secret list` returns a JSON array of {name, type}. Fall back to an
 # empty list if the call fails (e.g. first-ever deploy before the Worker exists).
-existing="$(bunx wrangler secret list --format json 2>/dev/null || echo '[]')"
+existing="$(wrangler secret list --format json 2>/dev/null || echo '[]')"
 
-missing=()
+has_secret() { printf '%s' "$existing" | grep -q "\"$1\""; }
+
+missing_required=()
 for name in "${REQUIRED_SECRETS[@]}"; do
-  if printf '%s' "$existing" | grep -q "\"$name\""; then
+  if has_secret "$name"; then
     echo "    ✓ $name  (already set — will NOT be changed)"
   else
-    echo "    ✗ $name  (missing)"
-    missing+=("$name")
+    echo "    ✗ $name  (missing — required)"
+    missing_required+=("$name")
+  fi
+done
+for name in "${OPTIONAL_SECRETS[@]}"; do
+  if has_secret "$name"; then
+    echo "    ✓ $name  (already set — will NOT be changed)"
+  else
+    echo "    • $name  (not set — server uses its default)"
   fi
 done
 
-# Prompt to set any missing secrets before deploying.
-if [ "${#missing[@]}" -gt 0 ]; then
+# Handle missing required secrets.
+if [ "${#missing_required[@]}" -gt 0 ]; then
   echo
-  echo "==> ${#missing[@]} secret(s) are not set yet."
-  for name in "${missing[@]}"; do
+  if [ "$interactive" -eq 0 ]; then
+    echo "error: ${#missing_required[@]} required secret(s) missing and no TTY to set them:" >&2
+    printf '       - %s\n' "${missing_required[@]}" >&2
+    echo "       Refusing to deploy a Worker without its database secrets." >&2
+    echo "       Set them first:  wrangler secret put <NAME>" >&2
+    exit 1
+  fi
+  echo "==> ${#missing_required[@]} required secret(s) are not set yet."
+  for name in "${missing_required[@]}"; do
     read -r -p "    Set $name now? [y/N] " answer
     case "$answer" in
       [yY]*)
-        bunx wrangler secret put "$name"
+        wrangler secret put "$name"
         ;;
       *)
-        echo "    Skipping $name — deploy will continue, but the server"
-        echo "    will fall back to its localhost default for this value."
+        echo "error: $name is required; aborting deploy." >&2
+        exit 1
         ;;
     esac
   done
@@ -53,7 +96,7 @@ fi
 
 echo
 echo "==> Deploying Worker (secrets above are left untouched)"
-bunx wrangler deploy "$@"
+wrangler deploy "$@"
 
 echo
 echo "==> Done. Secrets were preserved; only code/vars/bindings were updated."

--- a/pennywise-web/wrangler.jsonc
+++ b/pennywise-web/wrangler.jsonc
@@ -7,8 +7,8 @@
 	],
 	"routes": [
 		{
-			"pattern": "pennywise.querymind.pro",
-			"zone_name": "querymind.pro",
+			"pattern": "pennywise.zynth.dev",
+			"zone_name": "zynth.dev",
 			"custom_domain": true
 		}
 	],


### PR DESCRIPTION
Moves the SMS-parser / bug-report web tool from `pennywise.querymind.pro` to `pennywise.zynth.dev`.

## Changes
- **App** (`Constants.Links.WEB_PARSER_URL`): the in-app "report this SMS" deep link now points at `https://pennywise.zynth.dev`. `SmsReportUrlBuilder` appends `/#message=...&autoparse=true` as before — base kept slash-less so the URL builds cleanly.
- **Web** (`pennywise-web/wrangler.jsonc`): Cloudflare custom-domain route updated to `pennywise.zynth.dev` / zone `zynth.dev`.

## ⚠️ Deploy prerequisite (web side)
The wrangler route change only works once the **`zynth.dev` zone exists in the Cloudflare account** and the custom domain/cert is provisioned. Steps after merge:
1. Add `zynth.dev` as a zone in Cloudflare (if not already).
2. `cd pennywise-web && npx wrangler deploy` to bind the new custom domain.
3. Keep the old `pennywise.querymind.pro` live (or 301 → zynth.dev) until the next app release ships, so users on the current build still reach a working tool.

The app-side constant ships with the next release; older installs keep hitting the old domain, so don't tear it down immediately.

No tests reference the URL; `:app:compileStandardDebugKotlin` is green.