### PR TITLE
feat(budget): configurable cycle start day + per-cadence periods (reopen of #565)

### DIFF
--- a/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/54.json
+++ b/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/54.json
@@ -1,0 +1,1774 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 54,
+    "identityHash": "4839a42a4d88f8bdc3cc125320e0ea73",
+    "entities": [
+      {
+        "tableName": "transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` TEXT NOT NULL, `merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `transaction_type` TEXT NOT NULL, `date_time` TEXT NOT NULL, `description` TEXT, `sms_body` TEXT, `bank_name` TEXT, `sms_sender` TEXT, `account_number` TEXT, `balance_after` TEXT, `transaction_hash` TEXT NOT NULL DEFAULT '', `is_recurring` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `excluded_from_analytics` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `from_account` TEXT, `to_account` TEXT, `reference` TEXT, `loan_id` INTEGER DEFAULT NULL, `loan_contribution` TEXT DEFAULT NULL, `receipt_path` TEXT DEFAULT NULL, `budget_category` TEXT DEFAULT NULL, `budget_impact_type` TEXT DEFAULT NULL, `group_id` INTEGER DEFAULT NULL, `profile_id` INTEGER DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionType",
+            "columnName": "transaction_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateTime",
+            "columnName": "date_time",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsSender",
+            "columnName": "sms_sender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountNumber",
+            "columnName": "account_number",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "balanceAfter",
+            "columnName": "balance_after",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "transactionHash",
+            "columnName": "transaction_hash",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isRecurring",
+            "columnName": "is_recurring",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "excludedFromAnalytics",
+            "columnName": "excluded_from_analytics",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "fromAccount",
+            "columnName": "from_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toAccount",
+            "columnName": "to_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "loanId",
+            "columnName": "loan_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "loanContribution",
+            "columnName": "loan_contribution",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "receiptPath",
+            "columnName": "receipt_path",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetCategory",
+            "columnName": "budget_category",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetImpactType",
+            "columnName": "budget_impact_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "group_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transactions_transaction_hash",
+            "unique": true,
+            "columnNames": [
+              "transaction_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_transactions_transaction_hash` ON `${TABLE_NAME}` (`transaction_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `merchant_name` TEXT NOT NULL, `amount` TEXT NOT NULL, `next_payment_date` TEXT, `state` TEXT NOT NULL, `bank_name` TEXT, `umn` TEXT, `category` TEXT, `sms_body` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `direction` TEXT NOT NULL DEFAULT 'EXPENSE', `billing_cycle` TEXT NOT NULL DEFAULT 'Monthly', `last_paid_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextPaymentDate",
+            "columnName": "next_payment_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umn",
+            "columnName": "umn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'EXPENSE'"
+          },
+          {
+            "fieldPath": "billingCycle",
+            "columnName": "billing_cycle",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Monthly'"
+          },
+          {
+            "fieldPath": "lastPaidAt",
+            "columnName": "last_paid_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `message` TEXT NOT NULL, `isUser` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `isSystemPrompt` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUser",
+            "columnName": "isUser",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemPrompt",
+            "columnName": "isSystemPrompt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "merchant_mappings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`merchant_name`))",
+        "fields": [
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "merchant_name"
+          ]
+        }
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `color` TEXT NOT NULL, `is_system` INTEGER NOT NULL, `is_income` INTEGER NOT NULL, `display_order` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIncome",
+            "columnName": "is_income",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_categories_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_categories_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "account_balances",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT NOT NULL, `balance` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `transaction_id` INTEGER, `credit_limit` TEXT, `is_credit_card` INTEGER NOT NULL DEFAULT 0, `sms_source` TEXT, `source_type` TEXT, `account_type` TEXT, `created_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `statement_day` INTEGER DEFAULT NULL, `profile_id` INTEGER NOT NULL DEFAULT 1, `alias` TEXT, `lowBalanceThreshold` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "creditLimit",
+            "columnName": "credit_limit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isCreditCard",
+            "columnName": "is_credit_card",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "smsSource",
+            "columnName": "sms_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "source_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountType",
+            "columnName": "account_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "statementDay",
+            "columnName": "statement_day",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lowBalanceThreshold",
+            "columnName": "lowBalanceThreshold",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_account_balances_bank_name_account_last4_timestamp",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "account_last4",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4_timestamp` ON `${TABLE_NAME}` (`bank_name`, `account_last4`, `timestamp`)"
+          },
+          {
+            "name": "index_account_balances_bank_name_account_last4",
+            "unique": false,
+            "columnNames": [
+              "bank_name",
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4` ON `${TABLE_NAME}` (`bank_name`, `account_last4`)"
+          },
+          {
+            "name": "index_account_balances_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "unrecognized_sms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sender` TEXT NOT NULL, `sms_body` TEXT NOT NULL, `received_at` TEXT NOT NULL, `reported` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receivedAt",
+            "columnName": "received_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reported",
+            "columnName": "reported",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_unrecognized_sms_sender_sms_body",
+            "unique": true,
+            "columnNames": [
+              "sender",
+              "sms_body"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_unrecognized_sms_sender_sms_body` ON `${TABLE_NAME}` (`sender`, `sms_body`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `card_last4` TEXT NOT NULL, `card_type` TEXT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT, `nickname` TEXT, `is_active` INTEGER NOT NULL DEFAULT 1, `last_balance` TEXT, `last_balance_source` TEXT, `last_balance_date` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardLast4",
+            "columnName": "card_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardType",
+            "columnName": "card_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastBalance",
+            "columnName": "last_balance",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceSource",
+            "columnName": "last_balance_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceDate",
+            "columnName": "last_balance_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cards_bank_name_card_last4",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cards_bank_name_card_last4` ON `${TABLE_NAME}` (`bank_name`, `card_last4`)"
+          },
+          {
+            "name": "index_cards_card_last4",
+            "unique": false,
+            "columnNames": [
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_card_last4` ON `${TABLE_NAME}` (`card_last4`)"
+          },
+          {
+            "name": "index_cards_account_last4",
+            "unique": false,
+            "columnNames": [
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_account_last4` ON `${TABLE_NAME}` (`account_last4`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `conditions` TEXT NOT NULL, `actions` TEXT NOT NULL, `is_active` INTEGER NOT NULL, `is_system_template` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conditions",
+            "columnName": "conditions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actions",
+            "columnName": "actions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemTemplate",
+            "columnName": "is_system_template",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_rules_priority_is_active",
+            "unique": false,
+            "columnNames": [
+              "priority",
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_priority_is_active` ON `${TABLE_NAME}` (`priority`, `is_active`)"
+          },
+          {
+            "name": "index_transaction_rules_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "rule_applications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `rule_id` TEXT NOT NULL, `rule_name` TEXT NOT NULL, `transaction_id` TEXT NOT NULL, `fields_modified` TEXT NOT NULL, `applied_at` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`rule_id`) REFERENCES `transaction_rules`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "rule_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleName",
+            "columnName": "rule_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fieldsModified",
+            "columnName": "fields_modified",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedAt",
+            "columnName": "applied_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rule_applications_rule_id",
+            "unique": false,
+            "columnNames": [
+              "rule_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_rule_id` ON `${TABLE_NAME}` (`rule_id`)"
+          },
+          {
+            "name": "index_rule_applications_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          },
+          {
+            "name": "index_rule_applications_applied_at",
+            "unique": false,
+            "columnNames": [
+              "applied_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_applied_at` ON `${TABLE_NAME}` (`applied_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transaction_rules",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "rule_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "exchange_rates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `from_currency` TEXT NOT NULL, `to_currency` TEXT NOT NULL, `rate` TEXT NOT NULL, `provider` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `updated_at_unix` INTEGER NOT NULL DEFAULT 0, `expires_at` TEXT NOT NULL, `expires_at_unix` INTEGER NOT NULL DEFAULT 0, `is_custom_rate` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCurrency",
+            "columnName": "from_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCurrency",
+            "columnName": "to_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtUnix",
+            "columnName": "updated_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expires_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAtUnix",
+            "columnName": "expires_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isCustomRate",
+            "columnName": "is_custom_rate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_exchange_rates_from_currency_to_currency",
+            "unique": true,
+            "columnNames": [
+              "from_currency",
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_exchange_rates_from_currency_to_currency` ON `${TABLE_NAME}` (`from_currency`, `to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_from_currency",
+            "unique": false,
+            "columnNames": [
+              "from_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_from_currency` ON `${TABLE_NAME}` (`from_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_to_currency",
+            "unique": false,
+            "columnNames": [
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_to_currency` ON `${TABLE_NAME}` (`to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          },
+          {
+            "name": "index_exchange_rates_expires_at_unix",
+            "unique": false,
+            "columnNames": [
+              "expires_at_unix"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_expires_at_unix` ON `${TABLE_NAME}` (`expires_at_unix`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `period_type` TEXT NOT NULL, `start_date` TEXT NOT NULL, `end_date` TEXT NOT NULL, `weekday_anchor` INTEGER, `month_anchor` INTEGER, `currency` TEXT NOT NULL DEFAULT 'INR', `is_active` INTEGER NOT NULL DEFAULT 1, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "periodType",
+            "columnName": "period_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weekStartDay",
+            "columnName": "weekday_anchor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "monthStartDay",
+            "columnName": "month_anchor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budgets_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_budgets_is_active",
+            "unique": false,
+            "columnNames": [
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_is_active` ON `${TABLE_NAME}` (`is_active`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budget_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL DEFAULT '0', `match_type` TEXT DEFAULT NULL, FOREIGN KEY(`budget_id`) REFERENCES `budgets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          },
+          {
+            "fieldPath": "matchType",
+            "columnName": "match_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budget_categories_budget_id",
+            "unique": false,
+            "columnNames": [
+              "budget_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budget_categories_budget_id` ON `${TABLE_NAME}` (`budget_id`)"
+          },
+          {
+            "name": "index_budget_categories_budget_id_category_name",
+            "unique": true,
+            "columnNames": [
+              "budget_id",
+              "category_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_budget_categories_budget_id_category_name` ON `${TABLE_NAME}` (`budget_id`, `category_name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "budgets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "budget_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "budget_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `budget_name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetName",
+            "columnName": "budget_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "budget_category_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL, `match_type` TEXT DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchType",
+            "columnName": "match_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "transaction_splits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `transaction_id` INTEGER NOT NULL, `category` TEXT NOT NULL, `amount` TEXT NOT NULL, `created_at` TEXT NOT NULL, FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_splits_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_splits_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bank_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `package_name` TEXT NOT NULL, `sender_alias` TEXT NOT NULL, `message_body` TEXT NOT NULL, `message_hash` TEXT NOT NULL, `posted_at` TEXT NOT NULL, `processed` INTEGER NOT NULL, `transaction_id` INTEGER, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderAlias",
+            "columnName": "sender_alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageBody",
+            "columnName": "message_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageHash",
+            "columnName": "message_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postedAt",
+            "columnName": "posted_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "processed",
+            "columnName": "processed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bank_notifications_package_name_message_hash",
+            "unique": true,
+            "columnNames": [
+              "package_name",
+              "message_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_bank_notifications_package_name_message_hash` ON `${TABLE_NAME}` (`package_name`, `message_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "loans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `person_name` TEXT NOT NULL, `direction` TEXT NOT NULL, `original_amount` TEXT NOT NULL, `remaining_amount` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `status` TEXT NOT NULL DEFAULT 'ACTIVE', `note` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `settled_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personName",
+            "columnName": "person_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalAmount",
+            "columnName": "original_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remainingAmount",
+            "columnName": "remaining_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'ACTIVE'"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settledAt",
+            "columnName": "settled_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_loans_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_loans_person_name",
+            "unique": false,
+            "columnNames": [
+              "person_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_person_name` ON `${TABLE_NAME}` (`person_name`)"
+          },
+          {
+            "name": "index_loans_created_at",
+            "unique": false,
+            "columnNames": [
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_created_at` ON `${TABLE_NAME}` (`created_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `note` TEXT DEFAULT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_groups_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_groups_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `color_hex` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorHex",
+            "columnName": "color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4839a42a4d88f8bdc3cc125320e0ea73')"
+    ]
+  }
+}

--- a/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/55.json
+++ b/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/55.json
@@ -1,0 +1,1774 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 55,
+    "identityHash": "4839a42a4d88f8bdc3cc125320e0ea73",
+    "entities": [
+      {
+        "tableName": "transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` TEXT NOT NULL, `merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `transaction_type` TEXT NOT NULL, `date_time` TEXT NOT NULL, `description` TEXT, `sms_body` TEXT, `bank_name` TEXT, `sms_sender` TEXT, `account_number` TEXT, `balance_after` TEXT, `transaction_hash` TEXT NOT NULL DEFAULT '', `is_recurring` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `excluded_from_analytics` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `from_account` TEXT, `to_account` TEXT, `reference` TEXT, `loan_id` INTEGER DEFAULT NULL, `loan_contribution` TEXT DEFAULT NULL, `receipt_path` TEXT DEFAULT NULL, `budget_category` TEXT DEFAULT NULL, `budget_impact_type` TEXT DEFAULT NULL, `group_id` INTEGER DEFAULT NULL, `profile_id` INTEGER DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionType",
+            "columnName": "transaction_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateTime",
+            "columnName": "date_time",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsSender",
+            "columnName": "sms_sender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountNumber",
+            "columnName": "account_number",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "balanceAfter",
+            "columnName": "balance_after",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "transactionHash",
+            "columnName": "transaction_hash",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isRecurring",
+            "columnName": "is_recurring",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "excludedFromAnalytics",
+            "columnName": "excluded_from_analytics",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "fromAccount",
+            "columnName": "from_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toAccount",
+            "columnName": "to_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "loanId",
+            "columnName": "loan_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "loanContribution",
+            "columnName": "loan_contribution",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "receiptPath",
+            "columnName": "receipt_path",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetCategory",
+            "columnName": "budget_category",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetImpactType",
+            "columnName": "budget_impact_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "group_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transactions_transaction_hash",
+            "unique": true,
+            "columnNames": [
+              "transaction_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_transactions_transaction_hash` ON `${TABLE_NAME}` (`transaction_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `merchant_name` TEXT NOT NULL, `amount` TEXT NOT NULL, `next_payment_date` TEXT, `state` TEXT NOT NULL, `bank_name` TEXT, `umn` TEXT, `category` TEXT, `sms_body` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `direction` TEXT NOT NULL DEFAULT 'EXPENSE', `billing_cycle` TEXT NOT NULL DEFAULT 'Monthly', `last_paid_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextPaymentDate",
+            "columnName": "next_payment_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umn",
+            "columnName": "umn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'EXPENSE'"
+          },
+          {
+            "fieldPath": "billingCycle",
+            "columnName": "billing_cycle",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Monthly'"
+          },
+          {
+            "fieldPath": "lastPaidAt",
+            "columnName": "last_paid_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `message` TEXT NOT NULL, `isUser` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `isSystemPrompt` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUser",
+            "columnName": "isUser",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemPrompt",
+            "columnName": "isSystemPrompt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "merchant_mappings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`merchant_name`))",
+        "fields": [
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "merchant_name"
+          ]
+        }
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `color` TEXT NOT NULL, `is_system` INTEGER NOT NULL, `is_income` INTEGER NOT NULL, `display_order` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIncome",
+            "columnName": "is_income",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_categories_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_categories_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "account_balances",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT NOT NULL, `balance` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `transaction_id` INTEGER, `credit_limit` TEXT, `is_credit_card` INTEGER NOT NULL DEFAULT 0, `sms_source` TEXT, `source_type` TEXT, `account_type` TEXT, `created_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `statement_day` INTEGER DEFAULT NULL, `profile_id` INTEGER NOT NULL DEFAULT 1, `alias` TEXT, `lowBalanceThreshold` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "creditLimit",
+            "columnName": "credit_limit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isCreditCard",
+            "columnName": "is_credit_card",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "smsSource",
+            "columnName": "sms_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "source_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountType",
+            "columnName": "account_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "statementDay",
+            "columnName": "statement_day",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lowBalanceThreshold",
+            "columnName": "lowBalanceThreshold",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_account_balances_bank_name_account_last4_timestamp",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "account_last4",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4_timestamp` ON `${TABLE_NAME}` (`bank_name`, `account_last4`, `timestamp`)"
+          },
+          {
+            "name": "index_account_balances_bank_name_account_last4",
+            "unique": false,
+            "columnNames": [
+              "bank_name",
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4` ON `${TABLE_NAME}` (`bank_name`, `account_last4`)"
+          },
+          {
+            "name": "index_account_balances_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "unrecognized_sms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sender` TEXT NOT NULL, `sms_body` TEXT NOT NULL, `received_at` TEXT NOT NULL, `reported` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receivedAt",
+            "columnName": "received_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reported",
+            "columnName": "reported",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_unrecognized_sms_sender_sms_body",
+            "unique": true,
+            "columnNames": [
+              "sender",
+              "sms_body"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_unrecognized_sms_sender_sms_body` ON `${TABLE_NAME}` (`sender`, `sms_body`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `card_last4` TEXT NOT NULL, `card_type` TEXT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT, `nickname` TEXT, `is_active` INTEGER NOT NULL DEFAULT 1, `last_balance` TEXT, `last_balance_source` TEXT, `last_balance_date` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardLast4",
+            "columnName": "card_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardType",
+            "columnName": "card_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastBalance",
+            "columnName": "last_balance",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceSource",
+            "columnName": "last_balance_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceDate",
+            "columnName": "last_balance_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cards_bank_name_card_last4",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cards_bank_name_card_last4` ON `${TABLE_NAME}` (`bank_name`, `card_last4`)"
+          },
+          {
+            "name": "index_cards_card_last4",
+            "unique": false,
+            "columnNames": [
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_card_last4` ON `${TABLE_NAME}` (`card_last4`)"
+          },
+          {
+            "name": "index_cards_account_last4",
+            "unique": false,
+            "columnNames": [
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_account_last4` ON `${TABLE_NAME}` (`account_last4`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `conditions` TEXT NOT NULL, `actions` TEXT NOT NULL, `is_active` INTEGER NOT NULL, `is_system_template` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conditions",
+            "columnName": "conditions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actions",
+            "columnName": "actions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemTemplate",
+            "columnName": "is_system_template",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_rules_priority_is_active",
+            "unique": false,
+            "columnNames": [
+              "priority",
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_priority_is_active` ON `${TABLE_NAME}` (`priority`, `is_active`)"
+          },
+          {
+            "name": "index_transaction_rules_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "rule_applications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `rule_id` TEXT NOT NULL, `rule_name` TEXT NOT NULL, `transaction_id` TEXT NOT NULL, `fields_modified` TEXT NOT NULL, `applied_at` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`rule_id`) REFERENCES `transaction_rules`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "rule_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleName",
+            "columnName": "rule_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fieldsModified",
+            "columnName": "fields_modified",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedAt",
+            "columnName": "applied_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rule_applications_rule_id",
+            "unique": false,
+            "columnNames": [
+              "rule_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_rule_id` ON `${TABLE_NAME}` (`rule_id`)"
+          },
+          {
+            "name": "index_rule_applications_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          },
+          {
+            "name": "index_rule_applications_applied_at",
+            "unique": false,
+            "columnNames": [
+              "applied_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_applied_at` ON `${TABLE_NAME}` (`applied_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transaction_rules",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "rule_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "exchange_rates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `from_currency` TEXT NOT NULL, `to_currency` TEXT NOT NULL, `rate` TEXT NOT NULL, `provider` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `updated_at_unix` INTEGER NOT NULL DEFAULT 0, `expires_at` TEXT NOT NULL, `expires_at_unix` INTEGER NOT NULL DEFAULT 0, `is_custom_rate` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCurrency",
+            "columnName": "from_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCurrency",
+            "columnName": "to_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtUnix",
+            "columnName": "updated_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expires_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAtUnix",
+            "columnName": "expires_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isCustomRate",
+            "columnName": "is_custom_rate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_exchange_rates_from_currency_to_currency",
+            "unique": true,
+            "columnNames": [
+              "from_currency",
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_exchange_rates_from_currency_to_currency` ON `${TABLE_NAME}` (`from_currency`, `to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_from_currency",
+            "unique": false,
+            "columnNames": [
+              "from_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_from_currency` ON `${TABLE_NAME}` (`from_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_to_currency",
+            "unique": false,
+            "columnNames": [
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_to_currency` ON `${TABLE_NAME}` (`to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          },
+          {
+            "name": "index_exchange_rates_expires_at_unix",
+            "unique": false,
+            "columnNames": [
+              "expires_at_unix"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_expires_at_unix` ON `${TABLE_NAME}` (`expires_at_unix`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `period_type` TEXT NOT NULL, `start_date` TEXT NOT NULL, `end_date` TEXT NOT NULL, `weekday_anchor` INTEGER, `month_anchor` INTEGER, `currency` TEXT NOT NULL DEFAULT 'INR', `is_active` INTEGER NOT NULL DEFAULT 1, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "periodType",
+            "columnName": "period_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weekStartDay",
+            "columnName": "weekday_anchor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "monthStartDay",
+            "columnName": "month_anchor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budgets_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_budgets_is_active",
+            "unique": false,
+            "columnNames": [
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_is_active` ON `${TABLE_NAME}` (`is_active`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budget_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL DEFAULT '0', `match_type` TEXT DEFAULT NULL, FOREIGN KEY(`budget_id`) REFERENCES `budgets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          },
+          {
+            "fieldPath": "matchType",
+            "columnName": "match_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budget_categories_budget_id",
+            "unique": false,
+            "columnNames": [
+              "budget_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budget_categories_budget_id` ON `${TABLE_NAME}` (`budget_id`)"
+          },
+          {
+            "name": "index_budget_categories_budget_id_category_name",
+            "unique": true,
+            "columnNames": [
+              "budget_id",
+              "category_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_budget_categories_budget_id_category_name` ON `${TABLE_NAME}` (`budget_id`, `category_name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "budgets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "budget_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "budget_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `budget_name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetName",
+            "columnName": "budget_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "budget_category_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL, `match_type` TEXT DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchType",
+            "columnName": "match_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "transaction_splits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `transaction_id` INTEGER NOT NULL, `category` TEXT NOT NULL, `amount` TEXT NOT NULL, `created_at` TEXT NOT NULL, FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_splits_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_splits_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bank_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `package_name` TEXT NOT NULL, `sender_alias` TEXT NOT NULL, `message_body` TEXT NOT NULL, `message_hash` TEXT NOT NULL, `posted_at` TEXT NOT NULL, `processed` INTEGER NOT NULL, `transaction_id` INTEGER, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderAlias",
+            "columnName": "sender_alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageBody",
+            "columnName": "message_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageHash",
+            "columnName": "message_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postedAt",
+            "columnName": "posted_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "processed",
+            "columnName": "processed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bank_notifications_package_name_message_hash",
+            "unique": true,
+            "columnNames": [
+              "package_name",
+              "message_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_bank_notifications_package_name_message_hash` ON `${TABLE_NAME}` (`package_name`, `message_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "loans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `person_name` TEXT NOT NULL, `direction` TEXT NOT NULL, `original_amount` TEXT NOT NULL, `remaining_amount` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `status` TEXT NOT NULL DEFAULT 'ACTIVE', `note` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `settled_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personName",
+            "columnName": "person_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalAmount",
+            "columnName": "original_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remainingAmount",
+            "columnName": "remaining_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'ACTIVE'"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settledAt",
+            "columnName": "settled_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_loans_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_loans_person_name",
+            "unique": false,
+            "columnNames": [
+              "person_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_person_name` ON `${TABLE_NAME}` (`person_name`)"
+          },
+          {
+            "name": "index_loans_created_at",
+            "unique": false,
+            "columnNames": [
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_created_at` ON `${TABLE_NAME}` (`created_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `note` TEXT DEFAULT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_groups_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_groups_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `color_hex` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorHex",
+            "columnName": "color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4839a42a4d88f8bdc3cc125320e0ea73')"
+    ]
+  }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
@@ -51,13 +51,13 @@ import com.pennywiseai.tracker.data.database.entity.TransactionSplitEntity
 import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
 
 /**
- * Current Room schema version for [PennyWiseDatabase]. Lives at top-level so it
- * is usable both in the `@Database(version = ...)` annotation below and in
+ * Current Room schema version for [PennyWiseDatabase]. Lives at top-level so
+ * it is usable both in the `@Database(version = ...)` annotation below and in
  * non-Room code (e.g. [com.pennywiseai.tracker.data.backup.BackupExporter])
  * that needs to record the version it was exported against. Bump this in lock-
  * step with any schema change.
  */
-const val SCHEMA_VERSION = 53
+const val SCHEMA_VERSION = 54
 
 /**
  * The PennyWise Room database.
@@ -523,6 +523,24 @@ abstract class PennyWiseDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Per-budget cadence anchors for the recurring / one-time split on
+         * the Budget Period card (Weekly / Monthly / One-time). Both columns
+         * are nullable so pre-existing rows keep working — the read-time
+         * resolver falls back to Monday (Weekly) or the global startDay
+         * preference (Monthly) when the anchor is null.
+         *
+         * No backfill: every existing row was created before this feature
+         * and is treated as Monthly anchored to the user's global startDay
+         * until the user opens the budget and explicitly picks a cadence.
+         */
+        val MIGRATION_53_54 = object : Migration(53, 54) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `budgets` ADD COLUMN `weekday_anchor` INTEGER DEFAULT NULL")
+                db.execSQL("ALTER TABLE `budgets` ADD COLUMN `month_anchor` INTEGER DEFAULT NULL")
+            }
+        }
+
         val MIGRATION_38_39 = object : Migration(38, 39) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 // Add receipt_path to transactions if missing
@@ -576,6 +594,7 @@ abstract class PennyWiseDatabase : RoomDatabase() {
             MIGRATION_50_51,
             MIGRATION_51_52,
             MIGRATION_52_53,
+            MIGRATION_53_54,
         )
     }
     

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
@@ -57,7 +57,7 @@ import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
  * that needs to record the version it was exported against. Bump this in lock-
  * step with any schema change.
  */
-const val SCHEMA_VERSION = 54
+const val SCHEMA_VERSION = 55
 
 /**
  * The PennyWise Room database.
@@ -541,6 +541,35 @@ abstract class PennyWiseDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Drop the per-month budget snapshot tables. They stored a single
+         * reconstructed row per (year, month, budget) and assumed every
+         * budget was a monthly bucket — which made Weekly and One-time
+         * budgets invisible or mis-rendered on historical views. With the
+         * new cadence model the budget list is computed live per-window
+         * (see [com.pennywiseai.tracker.data.repository.windowsForMonth]),
+         * so the snapshot is no longer the source of truth for historical
+         * views.
+         *
+         * Destructive: existing per-month snapshots are gone after this
+         * migration runs. The live query reproduces the same data for any
+         * (year, month) the user navigates to, plus per-week sub-buckets
+         * for Weekly budgets that the snapshot couldn't represent.
+         */
+        val MIGRATION_54_55 = object : Migration(54, 55) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // Clear — don't drop — the per-month snapshot tables. The
+                // tables remain in the schema because the backup format
+                // round-trips them as JSON; dropping them would cascade a
+                // larger refactor through BackupExporter/BackupImporter.
+                // The live per-window query in windowsForMonth is the new
+                // source of truth for historical views, so we just empty
+                // the tables.
+                db.execSQL("DELETE FROM `budget_category_month_snapshots`")
+                db.execSQL("DELETE FROM `budget_month_snapshots`")
+            }
+        }
+
         val MIGRATION_38_39 = object : Migration(38, 39) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 // Add receipt_path to transactions if missing
@@ -595,6 +624,7 @@ abstract class PennyWiseDatabase : RoomDatabase() {
             MIGRATION_51_52,
             MIGRATION_52_53,
             MIGRATION_53_54,
+            MIGRATION_54_55,
         )
     }
     

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/BudgetEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/BudgetEntity.kt
@@ -41,6 +41,25 @@ data class BudgetEntity(
     @Contextual
     val endDate: LocalDate,
 
+    /**
+     * Anchor day-of-week (1=Mon..7=Sun, per [java.time.DayOfWeek.value]) for a
+     * WEEKLY budget. Null for other period types. Read-time resolver uses
+     * this to roll the [startDate, endDate] window forward automatically each
+     * week — no DB writes needed.
+     */
+    @ColumnInfo(name = "weekday_anchor")
+    val weekStartDay: Int? = null,
+
+    /**
+     * Anchor day-of-month (1..31) for a MONTHLY budget. Null for other
+     * period types. Read-time resolver uses this to roll the
+     * [startDate, endDate] window forward automatically each cycle. Clamped
+     * to the month's length so a budget with startDay=31 in February
+     * resolves to Feb 28/29.
+     */
+    @ColumnInfo(name = "month_anchor")
+    val monthStartDay: Int? = null,
+
     @ColumnInfo(name = "currency", defaultValue = "INR")
     val currency: String = "INR",
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
@@ -92,6 +92,9 @@ class UserPreferencesRepository @Inject constructor(
         // Monthly Budget
         val MONTHLY_BUDGET_LIMIT = stringPreferencesKey("monthly_budget_limit")
 
+        // Budget Cycle Start Day (1..31, default 1 = calendar month)
+        val BUDGET_CYCLE_START_DAY = intPreferencesKey("budget_cycle_start_day")
+
         // Unified Currency Mode
         val UNIFIED_CURRENCY_MODE = booleanPreferencesKey("unified_currency_mode")
         val DISPLAY_CURRENCY = stringPreferencesKey("display_currency")
@@ -585,6 +588,29 @@ class UserPreferencesRepository @Inject constructor(
     }
 
     /**
+     * Day of the month the user's budget cycle starts on. 1 = first of the month
+     * (the calendar-month default); up to 31. Stored as an Int 1..31 — out-of-range
+     * values from older builds or migrations are clamped at read time.
+     */
+    val budgetCycleStartDay: Flow<Int> = context.dataStore.data
+        .map { preferences ->
+            (preferences[PreferencesKeys.BUDGET_CYCLE_START_DAY] ?: 1).coerceIn(1, 31)
+        }
+
+    suspend fun getBudgetCycleStartDay(): Int {
+        return context.dataStore.data
+            .map { preferences -> (preferences[PreferencesKeys.BUDGET_CYCLE_START_DAY] ?: 1).coerceIn(1, 31) }
+            .first()
+    }
+
+    suspend fun updateBudgetCycleStartDay(day: Int) {
+        val clamped = day.coerceIn(1, 31)
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.BUDGET_CYCLE_START_DAY] = clamped
+        }
+    }
+
+    /**
      * Explicit base-currency choice from the Settings currency selector. Marks the
      * currency as user-set so the main account can no longer override it.
      */
@@ -752,5 +778,7 @@ data class UserPreferences(
     val profileBackgroundColor: Int = 0,
     val hasCompletedOnboarding: Boolean = false,
     val mainAccountKey: String? = null,
-    val selectedProfileId: Long? = null
+    val selectedProfileId: Long? = null,
+    /** Day of the month (1..31) the budget cycle starts on. 1 = calendar month. */
+    val budgetCycleStartDay: Int = 1
 )

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupModels.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupModels.kt
@@ -1,9 +1,11 @@
 package com.pennywiseai.tracker.data.repository
 
 import com.pennywiseai.tracker.data.database.entity.BudgetGroupType
+import com.pennywiseai.tracker.data.database.entity.BudgetPeriodType
 import com.pennywiseai.tracker.data.database.entity.BudgetWithCategories
 import com.pennywiseai.tracker.data.database.entity.TransactionWithSplits
 import java.math.BigDecimal
+import java.time.LocalDate
 
 /**
  * One bucket a budget group tracks when creating/updating it. A category bucket
@@ -25,6 +27,19 @@ data class BudgetCategorySpending(
     val dailySpend: BigDecimal
 )
 
+/**
+ * A historical window within the selected month for a Weekly budget.
+ * Drives the per-week sub-list inside the expanded BudgetCard.
+ *
+ * The spend figures here are already in the *display* currency — the
+ * repo / viewmodel convert per-window before producing the list, so the
+ * card can render the amounts as-is.
+ */
+data class PastWindowSpending(
+    val window: BudgetWindow,
+    val spent: BigDecimal
+)
+
 data class BudgetGroupSpending(
     val group: BudgetWithCategories,
     val categorySpending: List<BudgetCategorySpending>,
@@ -37,7 +52,25 @@ data class BudgetGroupSpending(
     val daysElapsed: Int,
     val isTrackingAllExpenses: Boolean = false,
     val dailyCumulativeSpending: List<Double> = emptyList(),
-    val dailyBudgetPace: List<Double> = emptyList()
+    val dailyBudgetPace: List<Double> = emptyList(),
+    /**
+     * The window the card is rendering for this budget. For the current
+     * month this is `resolveBudgetWindow(budget, today, globalStartDay)`.
+     * For a historical month this is the window in that month that
+     * contains the most recent date, intersected with the month bounds.
+     */
+    val windowStart: LocalDate = LocalDate.now(),
+    val windowEnd: LocalDate = LocalDate.now(),
+    val windowDays: Int = 0,
+    val periodType: BudgetPeriodType = BudgetPeriodType.MONTHLY,
+    /**
+     * Older windows in the selected month, with their spend. Populated
+     * for Weekly budgets on historical views (one entry per older week
+     * in the month) so the expanded card can show the "Last week" /
+     * per-week sub-list. Empty for the current month and for Monthly /
+     * Custom (which only have one window in any given month).
+     */
+    val previousWindows: List<PastWindowSpending> = emptyList()
 )
 
 data class BudgetOverallSummary(
@@ -53,13 +86,51 @@ data class BudgetOverallSummary(
     val savingsRate: Float,
     val dailyAllowance: BigDecimal,
     val daysRemaining: Int,
-    val currency: String
+    val currency: String,
+    /**
+     * The display window for the *whole page* — the window the month
+     * selector is showing. For the current month this matches
+     * `resolveBudgetWindow(_, today, _)`; for a historical month it's
+     * the (clipped) cycle for Monthly budgets or the first/only window
+     * for the page's date range. Drives the page-level "X days left"
+     * / daily-allowance summary.
+     */
+    val pageWindow: BudgetWindow = BudgetWindow(LocalDate.now(), LocalDate.now(), 1)
+)
+
+/**
+ * Per-budget, per-window spend breakdown for the unified-currency path.
+ * Keyed on (budgetId, windowStart) — the viewmodel picks the right entry
+ * for each budget's displayed window and for each `previousWindows`
+ * entry in the historical Weekly sub-list.
+ */
+data class WindowSpending(
+    val budgetId: Long,
+    val window: BudgetWindow,
+    val spent: BigDecimal
 )
 
 data class BudgetGroupSpendingRaw(
     val budgetsWithCategories: List<BudgetWithCategories>,
-    val allTransactions: List<TransactionWithSplits>,
-    val prevTransactions: List<TransactionWithSplits>,
+    val windowedSpend: List<WindowSpending>,
     val daysElapsed: Int,
-    val daysRemaining: Int
+    val daysRemaining: Int,
+    val today: LocalDate,
+    val globalStartDay: Int,
+    /**
+     * Transactions in the cycle that ended *just before* the current one
+     * (the "vs last cycle" comparison for the home card / widget).
+     * Empty for historical months and for non-Monthly budgets. Stays in
+     * its native currency — the viewmodel converts per-transaction
+     * before aggregating.
+     */
+    val prevCycleTransactions: List<com.pennywiseai.tracker.data.database.entity.TransactionWithSplits> = emptyList(),
+    /**
+     * Legacy: flat list of all transactions in the displayed windows for
+     * the current month. Kept for the home / widget which still build
+     * the per-category breakdown in the viewmodel. Empty by default; the
+     * repo populates it for the unified path so the home carousel can
+     * show per-category spend without re-querying.
+     */
+    val allTransactions: List<com.pennywiseai.tracker.data.database.entity.TransactionWithSplits> = emptyList()
 )

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupModels.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupModels.kt
@@ -29,15 +29,28 @@ data class BudgetCategorySpending(
 
 /**
  * A historical window within the selected month for a Weekly budget.
- * Drives the per-week sub-list inside the expanded BudgetCard.
+ * Drives the per-week sub-list inside the expanded BudgetCard, and the
+ * per-window list on the Budget History screen.
  *
- * The spend figures here are already in the *display* currency — the
- * repo / viewmodel convert per-window before producing the list, so the
+ * [capDate] is the "as of" date the spend was summed up to:
+ *  - For the current month: `today` if the window contains today (live),
+ *    or the page's `monthEnd` for older / future weeks in the same
+ *    month (frozen at month end).
+ *  - For a historical month: the page's `monthEnd` for every window.
+ *
+ * [isLive] is true when the cap date is `today` and the window still has
+ * days left to accumulate spend — the card uses it to show a "Live"
+ * badge instead of "Frozen at …".
+ *
+ * The spend figures are already in the *display* currency — the repo /
+ * viewmodel convert per-window before producing the list, so the
  * card can render the amounts as-is.
  */
 data class PastWindowSpending(
     val window: BudgetWindow,
-    val spent: BigDecimal
+    val spent: BigDecimal,
+    val capDate: LocalDate = window.end,
+    val isLive: Boolean = false
 )
 
 data class BudgetGroupSpending(
@@ -55,9 +68,9 @@ data class BudgetGroupSpending(
     val dailyBudgetPace: List<Double> = emptyList(),
     /**
      * The window the card is rendering for this budget. For the current
-     * month this is `resolveBudgetWindow(budget, today, globalStartDay)`.
-     * For a historical month this is the window in that month that
-     * contains the most recent date, intersected with the month bounds.
+     * month this is the [windowsForMonth] window that contains today.
+     * For a historical month this is the most-recent window in the
+     * list, intersected with the month bounds.
      */
     val windowStart: LocalDate = LocalDate.now(),
     val windowEnd: LocalDate = LocalDate.now(),
@@ -65,12 +78,25 @@ data class BudgetGroupSpending(
     val periodType: BudgetPeriodType = BudgetPeriodType.MONTHLY,
     /**
      * Older windows in the selected month, with their spend. Populated
-     * for Weekly budgets on historical views (one entry per older week
-     * in the month) so the expanded card can show the "Last week" /
-     * per-week sub-list. Empty for the current month and for Monthly /
-     * Custom (which only have one window in any given month).
+     * for Weekly budgets (one entry per older week in the month) so the
+     * expanded card can show the per-week sub-list. Each entry carries a
+     * [PastWindowSpending.capDate] so the UI can label it "Live" or
+     * "Frozen at …".
      */
-    val previousWindows: List<PastWindowSpending> = emptyList()
+    val previousWindows: List<PastWindowSpending> = emptyList(),
+    /**
+     * "As of" date the displayed window's spend was summed up to.
+     * For the current month: `today` if the displayed window is the
+     * current week; the page's month end otherwise. For a historical
+     * month: the page's month end. Default matches the displayed
+     * window's end so older callers stay valid.
+     */
+    val displayedCapDate: LocalDate = LocalDate.now(),
+    /**
+     * True when the displayed window is the current week in the current
+     * month and its cap is `today` (live, still accumulating).
+     */
+    val displayedIsLive: Boolean = false
 )
 
 data class BudgetOverallSummary(

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupModels.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupModels.kt
@@ -158,5 +158,15 @@ data class BudgetGroupSpendingRaw(
      * repo populates it for the unified path so the home carousel can
      * show per-category spend without re-querying.
      */
-    val allTransactions: List<com.pennywiseai.tracker.data.database.entity.TransactionWithSplits> = emptyList()
+    val allTransactions: List<com.pennywiseai.tracker.data.database.entity.TransactionWithSplits> = emptyList(),
+    /**
+     * The per-budget *current* window (the budget's own cycle for the
+     * current month, the most-recent window in the list for a historical
+     * month). Keyed by budget id. Replaces the previous single
+     * `displayedWindow` / `daysRemaining` shape so each budget card on
+     * the home can use its own cycle for "X days remaining" — including
+     * a Weekly budget straddling a month boundary, where the same
+     * window shows in both June and July views.
+     */
+    val currentWindows: Map<Long, BudgetWindow> = emptyMap()
 )

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupModels.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupModels.kt
@@ -53,6 +53,21 @@ data class PastWindowSpending(
     val isLive: Boolean = false
 )
 
+/**
+ * Per-category breakdown for a single window of a budget, shown in the
+ * Budget History screen's "View breakdown" bottom sheet. Same shape as
+ * the Budget Groups page's per-card category list, but scoped to one
+ * window (one week for Weekly, one cycle for Monthly, the literal range
+ * for One-time). Currency is whatever the viewmodel passed in.
+ */
+data class WindowBreakdown(
+    val window: BudgetWindow,
+    val categorySpending: List<BudgetCategorySpending>,
+    val totalBudget: BigDecimal,
+    val totalActual: BigDecimal,
+    val isTrackingAll: Boolean = false
+)
+
 data class BudgetGroupSpending(
     val group: BudgetWithCategories,
     val categorySpending: List<BudgetCategorySpending>,

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
@@ -646,7 +646,12 @@ class BudgetGroupRepository @Inject constructor(
                 today = today,
                 globalStartDay = startDay,
                 prevCycleTransactions = prevCycleTransactions,
-                allTransactions = allTransactions,
+                // Deduplicate by transaction id — multiple budgets
+                // covering the same date range (e.g. 2 monthly budgets)
+                // append the same transactions to allTransactions once
+                // per budget, inflating totalIncome and categoryAmounts
+                // N× for N budgets on the home / widget (unified mode).
+                allTransactions = allTransactions.distinctBy { it.transaction.id },
                 currentWindows = currentWindows
             )
         }

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
@@ -72,19 +72,31 @@ class BudgetGroupRepository @Inject constructor(
         currency: String,
         buckets: List<BudgetBucketInput> = emptyList(),
         displayOrder: Int = -1,
-        limitAmount: BigDecimal? = null
+        limitAmount: BigDecimal? = null,
+        // Per-budget start date. When non-null, the budget's [startDate, endDate]
+        // window is anchored to this date and the global cycle preference is
+        // ignored. When null, falls back to today's calendar month (legacy
+        // behaviour).
+        customStartDate: LocalDate? = null,
+        periodType: BudgetPeriodType = BudgetPeriodType.MONTHLY
     ): Long {
         val resolvedDisplayOrder = if (displayOrder < 0) budgetDao.getMaxDisplayOrder() + 1 else displayOrder
         val totalAmount = limitAmount ?: buckets.fold(BigDecimal.ZERO) { acc, b -> acc + b.amount }
         val now = LocalDate.now()
         val yearMonth = YearMonth.from(now)
+        val startDay = runBlocking { userPreferencesRepository.getBudgetCycleStartDay() }
+        val (startDate, endDate) = BudgetRepository.calculatePeriodDates(
+            periodType = periodType,
+            customStartDate = customStartDate,
+            startDay = startDay
+        )
 
         val budget = BudgetEntity(
             name = name,
             limitAmount = totalAmount,
-            periodType = BudgetPeriodType.MONTHLY,
-            startDate = yearMonth.atDay(1),
-            endDate = yearMonth.atEndOfMonth(),
+            periodType = periodType,
+            startDate = startDate,
+            endDate = endDate,
             currency = currency,
             isActive = true,
             includeAllCategories = buckets.isEmpty(),
@@ -120,10 +132,26 @@ class BudgetGroupRepository @Inject constructor(
         color: String,
         buckets: List<BudgetBucketInput>,
         currency: String? = null,
-        limitAmount: BigDecimal? = null
+        limitAmount: BigDecimal? = null,
+        // Per-budget start date. When non-null, the [startDate, endDate] window
+        // is recomputed from this date and the budget's existing periodType.
+        // When null, the existing dates are left untouched.
+        customStartDate: LocalDate? = null,
+        periodType: BudgetPeriodType? = null
     ) {
         val existing = budgetDao.getBudgetById(budgetId) ?: return
         val totalAmount = limitAmount ?: buckets.fold(BigDecimal.ZERO) { acc, b -> acc + b.amount }
+        val effectivePeriod = periodType ?: existing.periodType
+        val (newStart, newEnd) = if (customStartDate != null) {
+            val startDay = runBlocking { userPreferencesRepository.getBudgetCycleStartDay() }
+            BudgetRepository.calculatePeriodDates(
+                periodType = effectivePeriod,
+                customStartDate = customStartDate,
+                startDay = startDay
+            )
+        } else {
+            existing.startDate to existing.endDate
+        }
 
         budgetDao.updateBudget(
             existing.copy(
@@ -132,6 +160,9 @@ class BudgetGroupRepository @Inject constructor(
                 color = color,
                 currency = currency ?: existing.currency,
                 limitAmount = totalAmount,
+                periodType = effectivePeriod,
+                startDate = newStart,
+                endDate = newEnd,
                 includeAllCategories = buckets.isEmpty(),
                 updatedAt = LocalDateTime.now()
             )

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
@@ -15,9 +15,11 @@ import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.database.entity.TransactionWithSplits
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
+import com.pennywiseai.tracker.domain.model.BudgetCycle
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import java.math.BigDecimal
@@ -36,6 +38,24 @@ class BudgetGroupRepository @Inject constructor(
     private val transactionSplitDao: TransactionSplitDao,
     private val userPreferencesRepository: UserPreferencesRepository
 ) {
+    /**
+     * Resolves the actual [start, end] window for the budget cycle that begins
+     * in the calendar month `(year, month)`, given the user's configurable
+     * [startDay] (1..31). The end is the day before the next cycle's start,
+     * which keeps consecutive cycles non-overlapping and gap-free even when
+     * [startDay] exceeds the length of an intermediate month (e.g. Feb 30/31).
+     */
+    private fun cycleWindow(year: Int, month: Int, startDay: Int): Pair<LocalDate, LocalDate> {
+        val cycleStart = YearMonth.of(year, month).atDay(1).let { firstOfMonth ->
+            val safe = startDay.coerceIn(1, 31)
+            val max = firstOfMonth.lengthOfMonth()
+            firstOfMonth.withDayOfMonth(safe.coerceAtMost(max))
+        }
+        val cycleEnd = BudgetCycle.nextCycleStart(cycleStart, startDay).minusDays(1)
+        return cycleStart to cycleEnd
+    }
+
+
     fun getActiveGroups(): Flow<List<BudgetWithCategories>> =
         budgetDao.getActiveBudgetsWithCategories()
 
@@ -247,20 +267,25 @@ class BudgetGroupRepository @Inject constructor(
     }
 
     fun getGroupSpending(year: Int, month: Int, currency: String): Flow<BudgetOverallSummary> {
-        val yearMonth = YearMonth.of(year, month)
-        val startDate = yearMonth.atDay(1).atStartOfDay()
-        val endDate = yearMonth.atEndOfMonth().atTime(23, 59, 59)
         val today = LocalDate.now()
-        val isCurrentMonth = yearMonth == YearMonth.from(today)
-        val daysElapsed = if (isCurrentMonth) today.dayOfMonth else yearMonth.lengthOfMonth()
-        val daysRemaining = if (isCurrentMonth) {
-            (ChronoUnit.DAYS.between(today, yearMonth.atEndOfMonth()).toInt() + 1).coerceAtLeast(0)
+        val startDay = runBlocking { userPreferencesRepository.getBudgetCycleStartDay() }
+        val (cycleStart, cycleEnd) = cycleWindow(year, month, startDay)
+        val startDate = cycleStart.atStartOfDay()
+        val endDate = cycleEnd.atTime(23, 59, 59)
+        val isCurrentCycle = cycleStart <= today && today <= cycleEnd
+        val daysElapsed = if (isCurrentCycle) {
+            (ChronoUnit.DAYS.between(cycleStart, today).toInt() + 1).coerceAtLeast(1)
+        } else {
+            (ChronoUnit.DAYS.between(cycleStart, cycleEnd).toInt() + 1)
+        }
+        val daysRemaining = if (isCurrentCycle) {
+            (ChronoUnit.DAYS.between(today, cycleEnd).toInt() + 1).coerceAtLeast(0)
         } else {
             0
         }
-        val daysInMonth = yearMonth.lengthOfMonth()
+        val daysInMonth = (ChronoUnit.DAYS.between(cycleStart, cycleEnd).toInt() + 1)
 
-        return if (isCurrentMonth) {
+        return if (isCurrentCycle) {
             combine(
                 budgetDao.getActiveBudgetsWithCategories(),
                 transactionSplitDao.getTransactionsWithSplitsFiltered(startDate, endDate, currency)
@@ -269,7 +294,7 @@ class BudgetGroupRepository @Inject constructor(
             }
         } else {
             flow {
-                val groups = getGroupsForMonth(year, month)
+                val groups = getGroupsForMonth(cycleEnd.year, cycleEnd.monthValue)
                 transactionSplitDao.getTransactionsWithSplitsFiltered(startDate, endDate, currency)
                     .collect { allTransactions ->
                         emit(buildSummary(groups, allTransactions, daysElapsed, daysRemaining, currency, daysInMonth))
@@ -279,22 +304,27 @@ class BudgetGroupRepository @Inject constructor(
     }
 
     fun getGroupSpendingAllCurrencies(year: Int, month: Int): Flow<BudgetGroupSpendingRaw> {
-        val yearMonth = YearMonth.of(year, month)
-        val startDate = yearMonth.atDay(1).atStartOfDay()
-        val endDate = yearMonth.atEndOfMonth().atTime(23, 59, 59)
         val today = LocalDate.now()
-        val isCurrentMonth = yearMonth == YearMonth.from(today)
-        val daysElapsed = if (isCurrentMonth) today.dayOfMonth else yearMonth.lengthOfMonth()
-        val daysRemaining = if (isCurrentMonth) {
-            (ChronoUnit.DAYS.between(today, yearMonth.atEndOfMonth()).toInt() + 1).coerceAtLeast(0)
+        val startDay = runBlocking { userPreferencesRepository.getBudgetCycleStartDay() }
+        val (cycleStart, cycleEnd) = cycleWindow(year, month, startDay)
+        val startDate = cycleStart.atStartOfDay()
+        val endDate = cycleEnd.atTime(23, 59, 59)
+        val isCurrentCycle = cycleStart <= today && today <= cycleEnd
+        val daysElapsed = if (isCurrentCycle) {
+            (ChronoUnit.DAYS.between(cycleStart, today).toInt() + 1).coerceAtLeast(1)
+        } else {
+            (ChronoUnit.DAYS.between(cycleStart, cycleEnd).toInt() + 1)
+        }
+        val daysRemaining = if (isCurrentCycle) {
+            (ChronoUnit.DAYS.between(today, cycleEnd).toInt() + 1).coerceAtLeast(0)
         } else {
             0
         }
-        val prevMonth = yearMonth.minusMonths(1)
-        val prevStartDate = prevMonth.atDay(1).atStartOfDay()
-        val prevEndDate = prevMonth.atEndOfMonth().atTime(23, 59, 59)
+        val (prevStart, prevEnd) = BudgetCycle.previousCycle(cycleStart to cycleEnd, startDay)
+        val prevStartDate = prevStart.atStartOfDay()
+        val prevEndDate = prevEnd.atTime(23, 59, 59)
 
-        return if (isCurrentMonth) {
+        return if (isCurrentCycle) {
             combine(
                 budgetDao.getActiveBudgetsWithCategories(),
                 transactionSplitDao.getTransactionsWithSplitsAllCurrencies(startDate, endDate),
@@ -310,7 +340,7 @@ class BudgetGroupRepository @Inject constructor(
             }
         } else {
             flow {
-                val groups = getGroupsForMonth(year, month)
+                val groups = getGroupsForMonth(cycleEnd.year, cycleEnd.monthValue)
                 combine(
                     transactionSplitDao.getTransactionsWithSplitsAllCurrencies(startDate, endDate),
                     transactionSplitDao.getTransactionsWithSplitsAllCurrencies(prevStartDate, prevEndDate)

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
@@ -61,6 +61,13 @@ class BudgetGroupRepository @Inject constructor(
     suspend fun hasAnyGroups(): Boolean =
         budgetDao.getActiveGroupCount() > 0
 
+    /**
+     * Single-budget lookup by id, used by the Budget History drill-down
+     * screen. Returns null if the budget was deleted.
+     */
+    suspend fun getGroupById(budgetId: Long): BudgetEntity? =
+        budgetDao.getBudgetById(budgetId)
+
     suspend fun createGroup(
         name: String,
         groupType: BudgetGroupType,
@@ -365,67 +372,80 @@ class BudgetGroupRepository @Inject constructor(
         val isCurrentMonth = year == today.year && month == today.monthValue
 
         return budgetDao.getActiveBudgetsWithCategories().map { groups ->
-            // Plan: for each budget, decide the per-month windows (current
-            // = resolveBudgetWindow; historical = windowsForMonth), then
-            // query the spend in each window.
+            // Use windowsForMonth for both the current and historical
+            // month. For the current month, the *displayed* window is
+            // the one containing today (instead of resolveBudgetWindow
+            // which can be a *different* cycle from the windowsForMonth
+            // list — that mismatch was the "current month shows zero
+            // spend" bug). The historical month path picks the
+            // most-recent window in the list.
             val perBudgetWindows = groups.map { g ->
                 g to windowsForMonth(g.budget, year, month, startDay)
             }
-            // Page-level window is the first budget's displayed window
-            // (or the calendar month if the page is empty). Used for the
-            // "X days left" / daily-allowance summary at the top.
-            val pageWindow = perBudgetWindows.firstOrNull()?.let { (g, _) ->
-                if (isCurrentMonth) resolveBudgetWindow(g.budget, today, startDay)
-                else perBudgetWindows.first().second.lastOrNull()
-                    ?: BudgetWindow(monthStart, monthEnd, monthEnd.dayOfMonth)
+            val pageWindow = perBudgetWindows.firstOrNull()?.let { (_, windows) ->
+                windows.lastOrNull() ?: BudgetWindow(monthStart, monthEnd, monthEnd.dayOfMonth)
             } ?: BudgetWindow(monthStart, monthEnd, monthEnd.dayOfMonth)
 
-            // For each (budget, window) query the spend, then assemble
-            // per-budget [BudgetGroupSpending].
             val groupSpendings = perBudgetWindows.map { (group, windows) ->
                 val budget = group.budget
                 if (windows.isEmpty()) {
-                    // No window in this month — emit an empty
-                    // representation so the card still shows (the screen
-                    // decides whether to show it via the Overlap filter).
                     val empty = BudgetWindow(monthStart, monthStart, 0)
                     buildSummaryFromWindows(
                         group = group,
-                        displayWindow = if (isCurrentMonth) resolveBudgetWindow(budget, today, startDay) else empty,
+                        displayWindow = empty,
                         previousWindows = emptyList(),
                         transactionsByWindow = emptyMap(),
                         today = today,
                         isCurrentMonth = isCurrentMonth,
+                        monthStart = monthStart,
+                        monthEnd = monthEnd,
                         currency = currency
                     )
                 } else {
+                    // For each window, decide the cap date (when the
+                    // spend is "frozen"). The current week in the current
+                    // month is live (cap = today); every other week in
+                    // the current month is frozen at the month end. All
+                    // windows in a historical month are frozen at the
+                    // month end. The cap date is the *end of the query
+                    // range*, so a partial week that spans the month
+                    // boundary is queried only up to the month end.
                     val transactionsByWindow = windows.associateWith { w ->
+                        val capDate = if (isCurrentWeekInCurrentMonth(w, today, isCurrentMonth)) {
+                            today
+                        } else {
+                            monthEnd
+                        }
+                        val effectiveEnd = if (capDate.isBefore(w.end)) capDate else w.end
                         transactionSplitDao.getTransactionsWithSplitsFiltered(
                             w.start.atStartOfDay(),
-                            w.end.atTime(23, 59, 59),
+                            effectiveEnd.atTime(23, 59, 59),
                             currency
                         ).first()
                     }
-                    // Displayed window: for the current month, use
-                    // resolveBudgetWindow (may not be in the windows list
-                    // if the month boundary landed in the middle of the
-                    // week). For a historical month, the most recent
-                    // window in the list.
+                    // Displayed window: the one containing today
+                    // (current) or the most-recent window (historical).
                     val displayWindow = if (isCurrentMonth) {
-                        resolveBudgetWindow(budget, today, startDay)
+                        windows.firstOrNull { isCurrentWeekInCurrentMonth(it, today, isCurrentMonth) }
+                            ?: windows.last()
                     } else {
                         windows.last()
                     }
-                    val previous = if (budget.periodType == BudgetPeriodType.WEEKLY && !isCurrentMonth) {
-                        // The displayed window is the last in the list;
-                        // every other window in the list is "older this
-                        // month" and goes into the sub-list.
-                        val older = windows.dropLast(1)
-                        older.map { w ->
-                            val txs = transactionsByWindow[w].orEmpty()
+                    val previous = if (budget.periodType == BudgetPeriodType.WEEKLY) {
+                        // Weekly only: every other window in the list
+                        // is "another week in the same month" and goes
+                        // into the per-week sub-list / history list.
+                        // The displayed window is the *last* one
+                        // (current month) or the *most-recent* (historical).
+                        val others = windows.filter { it != displayWindow }
+                        others.map { w ->
+                            val isLive = isCurrentWeekInCurrentMonth(w, today, isCurrentMonth)
+                            val cap = if (isLive) today else monthEnd
                             PastWindowSpending(
                                 window = w,
-                                spent = sumExpensesForWindow(txs)
+                                spent = sumExpensesForWindow(transactionsByWindow[w].orEmpty()),
+                                capDate = cap,
+                                isLive = isLive
                             )
                         }
                     } else emptyList()
@@ -437,7 +457,11 @@ class BudgetGroupRepository @Inject constructor(
                         transactionsByWindow = transactionsByWindow,
                         today = today,
                         isCurrentMonth = isCurrentMonth,
-                        currency = currency
+                        monthStart = monthStart,
+                        monthEnd = monthEnd,
+                        currency = currency,
+                        displayedCapDate = if (isCurrentWeekInCurrentMonth(displayWindow, today, isCurrentMonth)) today else monthEnd,
+                        displayedIsLive = isCurrentWeekInCurrentMonth(displayWindow, today, isCurrentMonth)
                     )
                 }
             }
@@ -602,6 +626,62 @@ class BudgetGroupRepository @Inject constructor(
      * [displayWindow]; [previousWindows] is rendered as the per-week
      * sub-list on the historical card.
      */
+    /**
+     * True if [window] contains [today] AND the page is the current month.
+     * The current-week flag gates the live-vs-frozen cap in the
+     * per-window spend queries. Defensive: a weekly window that
+     * straddles the month boundary (e.g. Jun 30..Jul 6) is "current"
+     * only when the page is the current month; the June view freezes
+     * the Jun 30 portion, the July view counts Jun 30..today live.
+     */
+    private fun isCurrentWeekInCurrentMonth(
+        window: BudgetWindow,
+        today: LocalDate,
+        isCurrentMonth: Boolean
+    ): Boolean = isCurrentMonth &&
+        !today.isBefore(window.start) &&
+        !today.isAfter(window.end)
+
+    /**
+     * Per-window history for a single budget at the selected (year, month).
+     * Powers the Budget History screen — one entry per window, with
+     * the cap date so the screen can label each row as "Live" or
+     * "Frozen as of …".
+     *
+     * For the current month, the week containing today is live (cap =
+     * today); every other week is frozen at the month end. For a
+     * historical month, every week is frozen at the month end.
+     */
+    suspend fun getBudgetHistoryForMonth(
+        budget: BudgetEntity,
+        year: Int,
+        month: Int,
+        currency: String
+    ): List<PastWindowSpending> {
+        val today = LocalDate.now()
+        val startDay = runBlocking { userPreferencesRepository.getBudgetCycleStartDay() }
+        val ym = YearMonth.of(year, month)
+        val monthEnd = ym.atEndOfMonth()
+        val isCurrentMonth = year == today.year && month == today.monthValue
+        val windows = windowsForMonth(budget, year, month, startDay)
+        return windows.map { w ->
+            val isLive = isCurrentWeekInCurrentMonth(w, today, isCurrentMonth)
+            val cap = if (isLive) today else monthEnd
+            val effectiveEnd = if (cap.isBefore(w.end)) cap else w.end
+            val txs = transactionSplitDao.getTransactionsWithSplitsFiltered(
+                w.start.atStartOfDay(),
+                effectiveEnd.atTime(23, 59, 59),
+                currency
+            ).first()
+            PastWindowSpending(
+                window = w,
+                spent = sumExpensesForWindow(txs),
+                capDate = cap,
+                isLive = isLive
+            )
+        }
+    }
+
     private suspend fun buildSummaryFromWindows(
         group: BudgetWithCategories,
         displayWindow: BudgetWindow,
@@ -609,7 +689,11 @@ class BudgetGroupRepository @Inject constructor(
         transactionsByWindow: Map<BudgetWindow, List<com.pennywiseai.tracker.data.database.entity.TransactionWithSplits>>,
         today: LocalDate,
         isCurrentMonth: Boolean,
-        currency: String
+        monthStart: LocalDate = displayWindow.start,
+        monthEnd: LocalDate = displayWindow.end,
+        currency: String,
+        displayedCapDate: LocalDate = displayWindow.end,
+        displayedIsLive: Boolean = false
     ): BudgetGroupSpending {
         val budget = group.budget
         val displayTxs = transactionsByWindow[displayWindow].orEmpty()
@@ -732,7 +816,9 @@ class BudgetGroupRepository @Inject constructor(
                 windowEnd = displayWindow.end,
                 windowDays = displayWindow.days,
                 periodType = budget.periodType,
-                previousWindows = previousWindows
+                previousWindows = previousWindows,
+                displayedCapDate = displayedCapDate,
+                displayedIsLive = displayedIsLive
             )
         } else {
             val catSpending = group.categories.map { cat ->
@@ -791,7 +877,9 @@ class BudgetGroupRepository @Inject constructor(
                 windowEnd = displayWindow.end,
                 windowDays = displayWindow.days,
                 periodType = budget.periodType,
-                previousWindows = previousWindows
+                previousWindows = previousWindows,
+                displayedCapDate = displayedCapDate,
+                displayedIsLive = displayedIsLive
             )
         }
         return groupSpending

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
@@ -73,30 +73,44 @@ class BudgetGroupRepository @Inject constructor(
         buckets: List<BudgetBucketInput> = emptyList(),
         displayOrder: Int = -1,
         limitAmount: BigDecimal? = null,
-        // Per-budget start date. When non-null, the budget's [startDate, endDate]
-        // window is anchored to this date and the global cycle preference is
-        // ignored. When null, falls back to today's calendar month (legacy
-        // behaviour).
-        customStartDate: LocalDate? = null,
-        periodType: BudgetPeriodType = BudgetPeriodType.MONTHLY
+        periodType: BudgetPeriodType = BudgetPeriodType.MONTHLY,
+        // Cadence anchors. WEEKLY uses [weekStartDay] (1=Mon..7=Sun);
+        // MONTHLY uses [monthStartDay] (1..31); CUSTOM ignores both and
+        // uses the literal [startDate, endDate] the user picked.
+        weekStartDay: Int? = null,
+        monthStartDay: Int? = null,
+        // For CUSTOM: the literal start date the user picked.
+        startDate: LocalDate? = null,
+        endDate: LocalDate? = null
     ): Long {
         val resolvedDisplayOrder = if (displayOrder < 0) budgetDao.getMaxDisplayOrder() + 1 else displayOrder
         val totalAmount = limitAmount ?: buckets.fold(BigDecimal.ZERO) { acc, b -> acc + b.amount }
         val now = LocalDate.now()
-        val yearMonth = YearMonth.from(now)
         val startDay = runBlocking { userPreferencesRepository.getBudgetCycleStartDay() }
-        val (startDate, endDate) = BudgetRepository.calculatePeriodDates(
-            periodType = periodType,
-            customStartDate = customStartDate,
-            startDay = startDay
-        )
+        // Seed the [startDate, endDate] cache with the *current* window for
+        // the budget's period type so the row is valid before the read-time
+        // resolver re-runs. For CUSTOM the user-supplied literal dates win.
+        val (resolvedStart, resolvedEnd) = when (periodType) {
+            BudgetPeriodType.CUSTOM -> (startDate ?: now) to (endDate ?: now.plusMonths(1))
+            BudgetPeriodType.WEEKLY -> {
+                val dow = weekStartDay?.coerceIn(1, 7) ?: 1
+                val s = now.with(java.time.temporal.TemporalAdjusters.previousOrSame(java.time.DayOfWeek.of(dow)))
+                s to s.plusDays(6)
+            }
+            BudgetPeriodType.MONTHLY -> {
+                val day = monthStartDay?.let { BudgetCycle.clampStartDay(it) } ?: startDay
+                BudgetCycle.currentCycle(now, day)
+            }
+        }
 
         val budget = BudgetEntity(
             name = name,
             limitAmount = totalAmount,
             periodType = periodType,
-            startDate = startDate,
-            endDate = endDate,
+            startDate = resolvedStart,
+            endDate = resolvedEnd,
+            weekStartDay = if (periodType == BudgetPeriodType.WEEKLY) weekStartDay?.coerceIn(1, 7) else null,
+            monthStartDay = if (periodType == BudgetPeriodType.MONTHLY) monthStartDay?.let { BudgetCycle.clampStartDay(it) } else null,
             currency = currency,
             isActive = true,
             includeAllCategories = buckets.isEmpty(),
@@ -133,24 +147,41 @@ class BudgetGroupRepository @Inject constructor(
         buckets: List<BudgetBucketInput>,
         currency: String? = null,
         limitAmount: BigDecimal? = null,
-        // Per-budget start date. When non-null, the [startDate, endDate] window
-        // is recomputed from this date and the budget's existing periodType.
-        // When null, the existing dates are left untouched.
-        customStartDate: LocalDate? = null,
-        periodType: BudgetPeriodType? = null
+        periodType: BudgetPeriodType? = null,
+        weekStartDay: Int? = null,
+        monthStartDay: Int? = null,
+        startDate: LocalDate? = null,
+        endDate: LocalDate? = null
     ) {
         val existing = budgetDao.getBudgetById(budgetId) ?: return
         val totalAmount = limitAmount ?: buckets.fold(BigDecimal.ZERO) { acc, b -> acc + b.amount }
         val effectivePeriod = periodType ?: existing.periodType
-        val (newStart, newEnd) = if (customStartDate != null) {
-            val startDay = runBlocking { userPreferencesRepository.getBudgetCycleStartDay() }
-            BudgetRepository.calculatePeriodDates(
-                periodType = effectivePeriod,
-                customStartDate = customStartDate,
-                startDay = startDay
-            )
-        } else {
-            existing.startDate to existing.endDate
+        val now = LocalDate.now()
+        val globalStartDay = runBlocking { userPreferencesRepository.getBudgetCycleStartDay() }
+
+        // Resolve the new [startDate, endDate] cache. For CUSTOM the user
+        // supplied literal dates; for WEEKLY/MONTHLY we recompute the
+        // *current* window so the row is valid before the read-time resolver
+        // re-runs. Anchor fields are also updated so the resolver picks the
+        // right anchor next time.
+        val (newStart, newEnd, newWeek, newMonth) = when (effectivePeriod) {
+            BudgetPeriodType.CUSTOM -> {
+                val s = startDate ?: existing.startDate
+                val e = endDate ?: existing.endDate
+                Quadruple(s, e, null as Int?, null as Int?)
+            }
+            BudgetPeriodType.WEEKLY -> {
+                val dow = weekStartDay?.coerceIn(1, 7) ?: existing.weekStartDay ?: 1
+                val s = now.with(java.time.temporal.TemporalAdjusters.previousOrSame(java.time.DayOfWeek.of(dow)))
+                Quadruple(s, s.plusDays(6), dow as Int?, null as Int?)
+            }
+            BudgetPeriodType.MONTHLY -> {
+                val day = monthStartDay?.let { BudgetCycle.clampStartDay(it) }
+                    ?: existing.monthStartDay
+                    ?: BudgetCycle.clampStartDay(globalStartDay)
+                val (s, e) = BudgetCycle.currentCycle(now, day)
+                Quadruple(s, e, null as Int?, day as Int?)
+            }
         }
 
         budgetDao.updateBudget(
@@ -163,6 +194,8 @@ class BudgetGroupRepository @Inject constructor(
                 periodType = effectivePeriod,
                 startDate = newStart,
                 endDate = newEnd,
+                weekStartDay = newWeek,
+                monthStartDay = newMonth,
                 includeAllCategories = buckets.isEmpty(),
                 updatedAt = LocalDateTime.now()
             )
@@ -791,3 +824,16 @@ class BudgetGroupRepository @Inject constructor(
         }
     }
 }
+
+/**
+ * Internal 4-tuple used by [BudgetGroupRepository.createGroup] / [updateGroup]
+ * to carry the (newStart, newEnd, newWeek, newMonth) tuple back from the
+ * period-type `when` expression. Kept local to this file because nothing
+ * outside the repo needs to see it.
+ */
+private data class Quadruple<A, B, C, D>(
+    val first: A,
+    val second: B,
+    val third: C,
+    val fourth: D
+)

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
@@ -706,6 +706,83 @@ class BudgetGroupRepository @Inject constructor(
         }
     }
 
+    /**
+     * Per-category breakdown for a single window of a budget. Powers the
+     * Budget History "View breakdown" bottom sheet — same shape as the
+     * Budget Groups page's per-card category list, but scoped to one
+     * window (one week for Weekly, one cycle for Monthly, the literal
+     * range for One-time).
+     */
+    suspend fun getBudgetWindowBreakdown(
+        budget: BudgetEntity,
+        window: BudgetWindow,
+        currency: String
+    ): WindowBreakdown {
+        val txs = transactionSplitDao.getTransactionsWithSplitsFiltered(
+            window.start.atStartOfDay(),
+            window.end.atTime(23, 59, 59),
+            currency
+        ).first()
+        val (categoryAmounts, categoryLimitBoosts, typeAmounts) = aggregateBudgetCategorySpending(
+            transactions = txs,
+            convertSplit = { _, amount -> amount },
+            convertIncome = { tx -> tx.amount }
+        )
+        val groups = budgetDao.getActiveBudgetsWithCategories().first()
+        val group = groups.firstOrNull { it.budget.id == budget.id }
+        // daysElapsed for the per-row "dailySpend" is the window's day
+        // count. It's an integer for the per-row math only; the sheet
+        // doesn't care about the historical / current distinction.
+        val days = window.days.coerceAtLeast(1)
+        val categorySpending = if (group != null) {
+            group.categories.map { cat ->
+                val actual = if (cat.matchType != null) {
+                    typeAmounts[cat.matchType] ?: BigDecimal.ZERO
+                } else {
+                    categoryAmounts[cat.categoryName] ?: BigDecimal.ZERO
+                }
+                val boost = if (cat.matchType != null) BigDecimal.ZERO
+                    else categoryLimitBoosts[cat.categoryName] ?: BigDecimal.ZERO
+                val effectiveBudget = cat.budgetAmount + boost
+                val pctUsed = if (effectiveBudget > BigDecimal.ZERO) {
+                    (actual.toFloat() / effectiveBudget.toFloat() * 100f).coerceAtLeast(0f)
+                } else 0f
+                val dailySpend = if (actual > BigDecimal.ZERO) {
+                    actual.divide(BigDecimal(days), 0, RoundingMode.HALF_UP)
+                } else BigDecimal.ZERO
+                BudgetCategorySpending(
+                    categoryName = cat.categoryName,
+                    budgetAmount = effectiveBudget,
+                    actualAmount = actual,
+                    percentageUsed = pctUsed,
+                    dailySpend = dailySpend
+                )
+            }
+        } else {
+            // "Tracking all expenses" budget (no per-cat allocations):
+            // show one synthetic row with the total. Match the main
+            // card's behaviour for isTrackingAllExpenses = true.
+            emptyList()
+        }
+        val totalBudget = (group?.budget?.limitAmount ?: BigDecimal.ZERO).let { gLimit ->
+            if (gLimit > BigDecimal.ZERO) gLimit
+            else categorySpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
+        }
+        val totalActual = if (categorySpending.isNotEmpty()) {
+            categorySpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.actualAmount }
+        } else {
+            // No per-cat breakdown → report the window total.
+            sumExpensesForWindow(txs)
+        }
+        return WindowBreakdown(
+            window = window,
+            categorySpending = categorySpending,
+            totalBudget = totalBudget,
+            totalActual = totalActual,
+            isTrackingAll = group?.categories?.isEmpty() == true
+        )
+    }
+
     private suspend fun buildSummaryFromWindows(
         group: BudgetWithCategories,
         displayWindow: BudgetWindow,

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
@@ -365,13 +365,20 @@ class BudgetGroupRepository @Inject constructor(
      */
     fun getGroupSpending(year: Int, month: Int, currency: String): Flow<BudgetOverallSummary> {
         val today = LocalDate.now()
-        val startDay = runBlocking { userPreferencesRepository.getBudgetCycleStartDay() }
         val ym = YearMonth.of(year, month)
         val monthStart = ym.atDay(1)
         val monthEnd = ym.atEndOfMonth()
         val isCurrentMonth = year == today.year && month == today.monthValue
 
-        return budgetDao.getActiveBudgetsWithCategories().map { groups ->
+        // combine() is suspending-friendly; .map { } on a Flow accepts
+        // a suspend transform too, but combine with the start-day flow
+        // here means we react to pref changes without a runBlocking
+        // call on the calling thread. The startDay flow emits the
+        // cached value on first read, so latency is unchanged.
+        return combine(
+            budgetDao.getActiveBudgetsWithCategories(),
+            userPreferencesRepository.budgetCycleStartDay
+        ) { groups, startDay ->
             // The displayed window for a Weekly budget is the budget's
             // own current window (Jun 29..Jul 5 for a Mon-anchored
             // budget on Jul 1), NOT a per-month clip. This keeps the
@@ -418,10 +425,14 @@ class BudgetGroupRepository @Inject constructor(
                     // current window, NOT a clipped per-month slice).
                     // For a historical month, fall back to the
                     // most-recent window from windowsForMonth.
+                    // Use lastOrNull() with an empty-window fallback —
+                    // windowsForMonth returns [] for a Custom (one-time)
+                    // budget whose literal range doesn't intersect the
+                    // selected year-month, and windows.last() would throw.
                     val displayWindow = if (isCurrentMonth) {
                         resolveBudgetWindow(budget, today, startDay)
                     } else {
-                        windows.last()
+                        windows.lastOrNull() ?: BudgetWindow(monthStart, monthStart, 0)
                     }
                     // The list of *other* windows in the page's month
                     // — only meaningful for Weekly historical views
@@ -447,7 +458,12 @@ class BudgetGroupRepository @Inject constructor(
                             val cap = if (isLive) today else monthEnd
                             PastWindowSpending(
                                 window = w,
-                                spent = sumExpensesForWindow(transactionsByWindow[w].orEmpty()),
+                                // Per-category-filtered so the per-week
+                                // sub-list matches the per-card total
+                                // (otherwise the row says 43k but the
+                                // breakdown sheet says 8k for the same
+                                // window).
+                                spent = getBudgetWindowFilteredSpend(group, transactionsByWindow[w].orEmpty()),
                                 capDate = cap,
                                 isLive = isLive
                             )
@@ -548,9 +564,13 @@ class BudgetGroupRepository @Inject constructor(
 
     fun getGroupSpendingAllCurrencies(year: Int, month: Int): Flow<BudgetGroupSpendingRaw> {
         val today = LocalDate.now()
-        val startDay = runBlocking { userPreferencesRepository.getBudgetCycleStartDay() }
+        val ym = YearMonth.of(year, month)
+        val monthStart = ym.atDay(1)
         val isCurrentMonth = year == today.year && month == today.monthValue
-        return budgetDao.getActiveBudgetsWithCategories().map { groups ->
+        return combine(
+            budgetDao.getActiveBudgetsWithCategories(),
+            userPreferencesRepository.budgetCycleStartDay
+        ) { groups, startDay ->
             val windowed = mutableListOf<WindowSpending>()
             // Per-budget current window (for the home card's "X days
             // remaining" math). For the current month, this is the
@@ -569,7 +589,12 @@ class BudgetGroupRepository @Inject constructor(
                         w.start.atStartOfDay(),
                         w.end.atTime(23, 59, 59)
                     ).first()
-                    val spent = sumExpensesForWindow(txs)
+                    // Per-category-filtered so the home / widget
+                    // per-window spend matches the per-card total on the
+                    // Budget Groups page. Without this filter the home
+                    // card can show 43k while the same budget's category
+                    // breakdown on the Budgets page correctly says 8k.
+                    val spent = getBudgetWindowFilteredSpend(group, txs)
                     windowed.add(WindowSpending(budgetId = group.budget.id, window = w, spent = spent))
                     allTransactions.addAll(txs)
                 }
@@ -577,11 +602,14 @@ class BudgetGroupRepository @Inject constructor(
                 // not a clipped per-month slice. For Weekly this matters
                 // — the displayed window for Mon-anchored on Jul 1 is
                 // (Jun 29, Jul 5) whether the page is the June view or
-                // the July view.
+                // the July view. Use lastOrNull() with an empty-window
+                // fallback for the same reason as above (a Custom
+                // budget out of range for the selected year-month
+                // would otherwise crash on windows.last()).
                 val displayed = if (isCurrentMonth) {
                     resolveBudgetWindow(group.budget, today, startDay)
                 } else {
-                    windows.last()
+                    windows.lastOrNull() ?: BudgetWindow(monthStart, monthStart, 0)
                 }
                 currentWindows[group.budget.id] = displayed
             }
@@ -643,6 +671,45 @@ class BudgetGroupRepository @Inject constructor(
     }
 
     /**
+     * Sum the EXPENSE/INVESTMENT amounts in [transactions] that belong
+     * to one of [group]'s categories or type-buckets. The plain
+     * [sumExpensesForWindow] (above) is a date-range total — it counts
+     * every expense in the window, even ones outside the budget's
+     * categories. That mismatch is what made the Budget History page
+     * show 43k when the per-category breakdown correctly said 8k. Use
+     * this helper for any "what did this budget spend in this window"
+     * query the user sees on a card or history row.
+     *
+     * Falls back to [sumExpensesForWindow] for tracking-all budgets
+     * (no per-category allocations) — they include every expense.
+     */
+    private suspend fun getBudgetWindowFilteredSpend(
+        group: BudgetWithCategories,
+        transactions: List<com.pennywiseai.tracker.data.database.entity.TransactionWithSplits>
+    ): BigDecimal {
+        if (group.categories.isEmpty()) return sumExpensesForWindow(transactions)
+        val (categoryAmounts, _, typeAmounts) = aggregateBudgetCategorySpending(
+            transactions = transactions,
+            convertSplit = { _, amount -> amount },
+            convertIncome = { tx -> tx.amount }
+        )
+        val catTotal = categoryAmounts.values.fold(BigDecimal.ZERO) { acc, v -> acc + v }
+        val typeTotal = typeAmounts.values.fold(BigDecimal.ZERO) { acc, v -> acc + v }
+        return catTotal + typeTotal
+    }
+
+    /** Look up the group for [budget], falling back to a synthetic
+     *  "tracking all" group if the budget was deleted or has no
+     *  current row in the dao. */
+    private suspend fun getGroupOrFallback(budget: BudgetEntity): BudgetWithCategories =
+        budgetDao.getActiveBudgetsWithCategories().first()
+            .firstOrNull { it.budget.id == budget.id }
+            ?: BudgetWithCategories(
+                budget = budget,
+                categories = emptyList()
+            )
+
+    /**
      * Build a [BudgetGroupSpending] from the per-window transactions.
      * Splits the window's transactions by category / type, applies the
      * same logic as the original monolithic [buildSummary] but for the
@@ -688,6 +755,9 @@ class BudgetGroupRepository @Inject constructor(
         val monthEnd = ym.atEndOfMonth()
         val isCurrentMonth = year == today.year && month == today.monthValue
         val windows = windowsForMonth(budget, year, month, startDay)
+        // Resolve the group once so the per-window spend query doesn't
+        // re-hit the dao for every window.
+        val group = getGroupOrFallback(budget)
         return windows.map { w ->
             val isLive = isCurrentWeekInCurrentMonth(w, today, isCurrentMonth)
             val cap = if (isLive) today else monthEnd
@@ -697,9 +767,16 @@ class BudgetGroupRepository @Inject constructor(
                 effectiveEnd.atTime(23, 59, 59),
                 currency
             ).first()
+            // Use the per-category-filtered total so the per-row spend
+            // matches the per-category breakdown shown in the
+            // "View breakdown" bottom sheet (the previous shape used
+            // sumExpensesForWindow which counted every EXPENSE in
+            // the date range, including ones outside the budget's
+            // categories — a 43k row vs 8k breakdown mismatch).
+            val spent = getBudgetWindowFilteredSpend(group, txs)
             PastWindowSpending(
                 window = w,
-                spent = sumExpensesForWindow(txs),
+                spent = spent,
                 capDate = cap,
                 isLive = isLive
             )
@@ -771,8 +848,14 @@ class BudgetGroupRepository @Inject constructor(
         val totalActual = if (categorySpending.isNotEmpty()) {
             categorySpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.actualAmount }
         } else {
-            // No per-cat breakdown → report the window total.
-            sumExpensesForWindow(txs)
+            // No per-cat breakdown → report the window total. For
+            // tracking-all budgets the helper falls back to the
+            // unfiltered sumExpensesForWindow; for budgets that simply
+            // have no spend in this window it returns zero.
+            getBudgetWindowFilteredSpend(
+                group ?: BudgetWithCategories(budget = budget, categories = emptyList()),
+                txs
+            )
         }
         return WindowBreakdown(
             window = window,

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
@@ -1,13 +1,10 @@
 package com.pennywiseai.tracker.data.repository
 
 import com.pennywiseai.tracker.data.database.dao.BudgetDao
-import com.pennywiseai.tracker.data.database.dao.BudgetSnapshotDao
 import com.pennywiseai.tracker.data.database.dao.TransactionSplitDao
 import com.pennywiseai.tracker.data.database.entity.BudgetCategoryEntity
-import com.pennywiseai.tracker.data.database.entity.BudgetCategoryMonthSnapshotEntity
 import com.pennywiseai.tracker.data.database.entity.BudgetEntity
 import com.pennywiseai.tracker.data.database.entity.BudgetGroupType
-import com.pennywiseai.tracker.data.database.entity.BudgetMonthSnapshotEntity
 import com.pennywiseai.tracker.data.database.entity.BudgetPeriodType
 import com.pennywiseai.tracker.data.database.entity.BudgetWithCategories
 import com.pennywiseai.tracker.data.database.entity.BudgetImpactType
@@ -34,7 +31,6 @@ import javax.inject.Singleton
 @Singleton
 class BudgetGroupRepository @Inject constructor(
     private val budgetDao: BudgetDao,
-    private val snapshotDao: BudgetSnapshotDao,
     private val transactionSplitDao: TransactionSplitDao,
     private val userPreferencesRepository: UserPreferencesRepository
 ) {
@@ -135,7 +131,7 @@ class BudgetGroupRepository @Inject constructor(
             budgetDao.insertBudgetCategories(categoryEntities)
         }
 
-        saveMonthSnapshot()
+
         return budgetId
     }
 
@@ -213,441 +209,12 @@ class BudgetGroupRepository @Inject constructor(
             }
             budgetDao.insertBudgetCategories(categoryEntities)
         }
-        saveMonthSnapshot()
+
     }
 
     suspend fun deleteGroup(budgetId: Long) {
         budgetDao.deleteBudgetById(budgetId)
-        saveMonthSnapshot()
-    }
 
-    suspend fun addCategoryToGroup(budgetId: Long, categoryName: String, amount: BigDecimal) {
-        budgetDao.insertBudgetCategory(
-            BudgetCategoryEntity(
-                budgetId = budgetId,
-                categoryName = categoryName,
-                budgetAmount = amount
-            )
-        )
-        recomputeGroupTotal(budgetId)
-        saveMonthSnapshot()
-    }
-
-    suspend fun updateCategoryBudget(budgetId: Long, categoryName: String, amount: BigDecimal) {
-        budgetDao.updateCategoryBudgetAmount(budgetId, categoryName, amount)
-        recomputeGroupTotal(budgetId)
-        saveMonthSnapshot()
-    }
-
-    suspend fun removeCategoryFromGroup(budgetId: Long, categoryName: String) {
-        budgetDao.deleteCategoryFromBudget(budgetId, categoryName)
-        recomputeGroupTotal(budgetId)
-        saveMonthSnapshot()
-    }
-
-    private suspend fun recomputeGroupTotal(budgetId: Long) {
-        val categories = budgetDao.getCategoriesForBudgetList(budgetId)
-        val total = categories.fold(BigDecimal.ZERO) { acc, cat -> acc + cat.budgetAmount }
-        budgetDao.updateBudgetLimitAmount(budgetId, total)
-    }
-
-    private suspend fun saveMonthSnapshot() {
-        val now = LocalDate.now()
-        val year = now.year
-        val month = now.monthValue
-        val budgets = budgetDao.getActiveBudgetsWithCategories().first()
-        val groupSnapshots = budgets.map { bwc ->
-            BudgetMonthSnapshotEntity(
-                budgetId = bwc.budget.id,
-                year = year,
-                month = month,
-                budgetName = bwc.budget.name,
-                limitAmount = bwc.budget.limitAmount,
-                includeAllCategories = bwc.budget.includeAllCategories,
-                color = bwc.budget.color,
-                groupType = bwc.budget.groupType,
-                displayOrder = bwc.budget.displayOrder
-            )
-        }
-        val categorySnapshots = budgets.map { bwc ->
-            bwc.categories.map { cat ->
-                BudgetCategoryMonthSnapshotEntity(
-                    budgetId = bwc.budget.id,
-                    year = year,
-                    month = month,
-                    categoryName = cat.categoryName,
-                    budgetAmount = cat.budgetAmount,
-                    matchType = cat.matchType
-                )
-            }
-        }.flatten()
-        snapshotDao.replaceMonthSnapshots(year, month, groupSnapshots, categorySnapshots)
-    }
-
-    private suspend fun getGroupsForMonth(year: Int, month: Int): List<BudgetWithCategories> {
-        val groupSnapshots = snapshotDao.getGroupSnapshots(year, month)
-        if (groupSnapshots.isEmpty()) return emptyList()
-        val catSnapshots = snapshotDao.getCategorySnapshots(year, month)
-        return reconstructFromSnapshots(groupSnapshots, catSnapshots)
-    }
-
-    private fun reconstructFromSnapshots(
-        groupSnapshots: List<BudgetMonthSnapshotEntity>,
-        categorySnapshots: List<BudgetCategoryMonthSnapshotEntity>
-    ): List<BudgetWithCategories> {
-        return groupSnapshots.map { gs ->
-            val cats = categorySnapshots
-                .filter { it.budgetId == gs.budgetId }
-                .map { cs ->
-                    BudgetCategoryEntity(
-                        budgetId = gs.budgetId,
-                        categoryName = cs.categoryName,
-                        budgetAmount = cs.budgetAmount,
-                        matchType = cs.matchType
-                    )
-                }
-            BudgetWithCategories(
-                budget = BudgetEntity(
-                    id = gs.budgetId,
-                    name = gs.budgetName,
-                    limitAmount = gs.limitAmount,
-                    periodType = BudgetPeriodType.MONTHLY,
-                    startDate = LocalDate.of(gs.year, gs.month, 1),
-                    endDate = YearMonth.of(gs.year, gs.month).atEndOfMonth(),
-                    isActive = true,
-                    includeAllCategories = gs.includeAllCategories,
-                    color = gs.color,
-                    groupType = gs.groupType,
-                    displayOrder = gs.displayOrder
-                ),
-                categories = cats
-            )
-        }
-    }
-
-    private fun percentOf(part: BigDecimal, total: BigDecimal, coerceMinZero: Boolean = true): Float {
-        val pct = part.toFloat() / total.toFloat() * 100f
-        return if (coerceMinZero) pct.coerceAtLeast(0f) else pct
-    }
-
-    fun getGroupSpending(year: Int, month: Int, currency: String): Flow<BudgetOverallSummary> {
-        val today = LocalDate.now()
-        val startDay = runBlocking { userPreferencesRepository.getBudgetCycleStartDay() }
-        val (cycleStart, cycleEnd) = cycleWindow(year, month, startDay)
-        val startDate = cycleStart.atStartOfDay()
-        val endDate = cycleEnd.atTime(23, 59, 59)
-        val isCurrentCycle = cycleStart <= today && today <= cycleEnd
-        val daysElapsed = if (isCurrentCycle) {
-            (ChronoUnit.DAYS.between(cycleStart, today).toInt() + 1).coerceAtLeast(1)
-        } else {
-            (ChronoUnit.DAYS.between(cycleStart, cycleEnd).toInt() + 1)
-        }
-        val daysRemaining = if (isCurrentCycle) {
-            (ChronoUnit.DAYS.between(today, cycleEnd).toInt() + 1).coerceAtLeast(0)
-        } else {
-            0
-        }
-        val daysInMonth = (ChronoUnit.DAYS.between(cycleStart, cycleEnd).toInt() + 1)
-
-        return if (isCurrentCycle) {
-            combine(
-                budgetDao.getActiveBudgetsWithCategories(),
-                transactionSplitDao.getTransactionsWithSplitsFiltered(startDate, endDate, currency)
-            ) { groups, allTransactions ->
-                buildSummary(groups, allTransactions, daysElapsed, daysRemaining, currency, daysInMonth)
-            }
-        } else {
-            flow {
-                val groups = getGroupsForMonth(cycleEnd.year, cycleEnd.monthValue)
-                transactionSplitDao.getTransactionsWithSplitsFiltered(startDate, endDate, currency)
-                    .collect { allTransactions ->
-                        emit(buildSummary(groups, allTransactions, daysElapsed, daysRemaining, currency, daysInMonth))
-                    }
-            }
-        }
-    }
-
-    fun getGroupSpendingAllCurrencies(year: Int, month: Int): Flow<BudgetGroupSpendingRaw> {
-        val today = LocalDate.now()
-        val startDay = runBlocking { userPreferencesRepository.getBudgetCycleStartDay() }
-        val (cycleStart, cycleEnd) = cycleWindow(year, month, startDay)
-        val startDate = cycleStart.atStartOfDay()
-        val endDate = cycleEnd.atTime(23, 59, 59)
-        val isCurrentCycle = cycleStart <= today && today <= cycleEnd
-        val daysElapsed = if (isCurrentCycle) {
-            (ChronoUnit.DAYS.between(cycleStart, today).toInt() + 1).coerceAtLeast(1)
-        } else {
-            (ChronoUnit.DAYS.between(cycleStart, cycleEnd).toInt() + 1)
-        }
-        val daysRemaining = if (isCurrentCycle) {
-            (ChronoUnit.DAYS.between(today, cycleEnd).toInt() + 1).coerceAtLeast(0)
-        } else {
-            0
-        }
-        val (prevStart, prevEnd) = BudgetCycle.previousCycle(cycleStart to cycleEnd, startDay)
-        val prevStartDate = prevStart.atStartOfDay()
-        val prevEndDate = prevEnd.atTime(23, 59, 59)
-
-        return if (isCurrentCycle) {
-            combine(
-                budgetDao.getActiveBudgetsWithCategories(),
-                transactionSplitDao.getTransactionsWithSplitsAllCurrencies(startDate, endDate),
-                transactionSplitDao.getTransactionsWithSplitsAllCurrencies(prevStartDate, prevEndDate)
-            ) { groups, allTransactions, prevTransactions ->
-                BudgetGroupSpendingRaw(
-                    budgetsWithCategories = groups,
-                    allTransactions = allTransactions,
-                    prevTransactions = prevTransactions,
-                    daysElapsed = daysElapsed,
-                    daysRemaining = daysRemaining
-                )
-            }
-        } else {
-            flow {
-                val groups = getGroupsForMonth(cycleEnd.year, cycleEnd.monthValue)
-                combine(
-                    transactionSplitDao.getTransactionsWithSplitsAllCurrencies(startDate, endDate),
-                    transactionSplitDao.getTransactionsWithSplitsAllCurrencies(prevStartDate, prevEndDate)
-                ) { allTransactions, prevTransactions ->
-                    BudgetGroupSpendingRaw(
-                        budgetsWithCategories = groups,
-                        allTransactions = allTransactions,
-                        prevTransactions = prevTransactions,
-                        daysElapsed = daysElapsed,
-                        daysRemaining = daysRemaining
-                    )
-                }.collect { emit(it) }
-            }
-        }
-    }
-
-    suspend fun buildSummary(
-        groups: List<BudgetWithCategories>,
-        allTransactions: List<TransactionWithSplits>,
-        daysElapsed: Int,
-        daysRemaining: Int,
-        currency: String,
-        daysInMonth: Int = 30
-    ): BudgetOverallSummary {
-        // Exclude a Refund from totalIncome only when it's also being subtracted
-        // from a category by aggregateBudgetCategorySpending (i.e. budgetCategory
-        // is set). An orphaned DEDUCT_SPENT with no category isn't subtracted
-        // from spend, so dropping it from income too would understate netSavings.
-        val totalIncome = allTransactions.fold(BigDecimal.ZERO) { acc, txWithSplits ->
-            val tx = txWithSplits.transaction
-            if (tx.transactionType != TransactionType.INCOME) acc
-            else if (tx.budgetImpactType == BudgetImpactType.DEDUCT_SPENT &&
-                tx.budgetCategory != null
-            ) acc
-            else acc + tx.amount
-        }
-
-        // Single-currency: amounts are already in the requested currency, so the
-        // converter lambdas are identities. The unified-currency caller in
-        // BudgetGroupsViewModel injects real conversion via the same helper.
-        val (categoryAmounts, categoryLimitBoosts, typeAmounts) = aggregateBudgetCategorySpending(
-            transactions = allTransactions,
-            convertSplit = { _, amount -> amount },
-            convertIncome = { tx -> tx.amount }
-        )
-
-        // Calculate total expenses for groups with no categories (track all expenses)
-        val totalAllExpenses = categoryAmounts.values.fold(BigDecimal.ZERO) { acc, amount -> acc + amount }
-
-        // Helper: build per-group daily cumulative spending from transactions matching category names
-        fun buildGroupPace(
-            categoryNames: Set<String>?,  // null = all categories
-            matchTypes: Set<String>,      // transaction-type buckets in this group
-            groupBudget: BigDecimal
-        ): Pair<List<Double>, List<Double>> {
-            val effectiveDays = daysElapsed.coerceAtMost(daysInMonth)
-            if (effectiveDays < 1) return emptyList<Double>() to emptyList()
-
-            val dailyAmounts = DoubleArray(daysInMonth)
-            allTransactions.forEach { txWithSplits ->
-                val tx = txWithSplits.transaction
-                if (tx.transactionType == TransactionType.INCOME ||
-                    tx.transactionType == TransactionType.TRANSFER ||
-                    tx.loanId != null
-                ) return@forEach
-                val day = tx.dateTime.dayOfMonth.coerceIn(1, daysInMonth)
-                if (tx.transactionType.name in matchTypes) {
-                    // Claimed by a type bucket in this group (e.g. INVESTMENT).
-                    dailyAmounts[day - 1] += tx.amount.toDouble()
-                } else if (tx.transactionType !in BUDGET_TYPE_BUCKETS) {
-                    // Category routing for expenses/credit. Type-bucket-eligible
-                    // transactions (investments) never fall through to categories.
-                    if (categoryNames == null) {
-                        dailyAmounts[day - 1] += tx.amount.toDouble()
-                    } else {
-                        txWithSplits.getAmountByCategory().forEach { (cat, amount) ->
-                            val catName = cat.ifEmpty { "Others" }
-                            if (catName in categoryNames) {
-                                dailyAmounts[day - 1] += amount.toDouble()
-                            }
-                        }
-                    }
-                }
-            }
-            // Subtract Refund (DEDUCT_SPENT) income on the day it occurred so the
-            // cumulative endpoint tracks the same "actual" figure shown on the row.
-            allTransactions.forEach { txWithSplits ->
-                val tx = txWithSplits.transaction
-                if (tx.transactionType != TransactionType.INCOME) return@forEach
-                if (tx.budgetImpactType != BudgetImpactType.DEDUCT_SPENT) return@forEach
-                val category = tx.budgetCategory ?: return@forEach
-                if (categoryNames != null && category !in categoryNames) return@forEach
-                val day = tx.dateTime.dayOfMonth.coerceIn(1, daysInMonth)
-                dailyAmounts[day - 1] -= tx.amount.toDouble()
-            }
-            // Carry the running total forward unclamped so a refund dated before
-            // the first expense still nets out against later expenses; only the
-            // emitted value is clamped, so the chart endpoint matches the
-            // per-category floor used in aggregateBudgetCategorySpending.
-            val cumulative = mutableListOf<Double>()
-            var runningNet = 0.0
-            for (i in 0 until effectiveDays) {
-                runningNet += dailyAmounts[i]
-                cumulative.add(runningNet.coerceAtLeast(0.0))
-            }
-            val pace = if (groupBudget > BigDecimal.ZERO) {
-                val dailyPace = groupBudget.toDouble() / daysInMonth
-                (1..effectiveDays).map { it * dailyPace }
-            } else emptyList()
-            return cumulative to pace
-        }
-
-        val groupSpendingList = groups.map { group ->
-            val isTrackingAll = group.categories.isEmpty()
-
-            if (isTrackingAll) {
-                // No categories selected - track ALL expenses
-                val totalBudget = group.budget.limitAmount
-                val totalActual = totalAllExpenses
-                val remaining = totalBudget - totalActual
-                val pctUsed = if (totalBudget > BigDecimal.ZERO) {
-                    percentOf(totalActual, totalBudget)
-                } else 0f
-                val dailyAllowance = if (daysRemaining > 0 && remaining > BigDecimal.ZERO) {
-                    remaining.divide(BigDecimal(daysRemaining), 0, RoundingMode.HALF_UP)
-                } else BigDecimal.ZERO
-                val (cumSpending, budgetPace) = buildGroupPace(null, emptySet(), totalBudget)
-
-                BudgetGroupSpending(
-                    group = group,
-                    categorySpending = emptyList(),
-                    totalBudget = totalBudget,
-                    totalActual = totalActual,
-                    remaining = remaining,
-                    percentageUsed = pctUsed,
-                    dailyAllowance = dailyAllowance,
-                    daysRemaining = daysRemaining,
-                    daysElapsed = daysElapsed,
-                    isTrackingAllExpenses = true,
-                    dailyCumulativeSpending = cumSpending,
-                    dailyBudgetPace = budgetPace
-                )
-            } else {
-                // Normal case: track specific categories
-                val catSpending = group.categories.map { cat ->
-                    // Type buckets read per-type spend; category buckets read
-                    // per-category spend (with any Extra-budget income boost).
-                    val actual = if (cat.matchType != null) {
-                        typeAmounts[cat.matchType] ?: BigDecimal.ZERO
-                    } else {
-                        categoryAmounts[cat.categoryName] ?: BigDecimal.ZERO
-                    }
-                    val boost = if (cat.matchType != null) BigDecimal.ZERO
-                        else categoryLimitBoosts[cat.categoryName] ?: BigDecimal.ZERO
-                    val effectiveBudget = cat.budgetAmount + boost
-                    val pctUsed = if (effectiveBudget > BigDecimal.ZERO) {
-                        percentOf(actual, effectiveBudget)
-                    } else 0f
-                    val dailySpend = if (daysElapsed > 0 && actual > BigDecimal.ZERO) {
-                        actual.divide(BigDecimal(daysElapsed), 0, RoundingMode.HALF_UP)
-                    } else BigDecimal.ZERO
-                    BudgetCategorySpending(
-                        categoryName = cat.categoryName,
-                        budgetAmount = effectiveBudget,
-                        actualAmount = actual,
-                        percentageUsed = pctUsed,
-                        dailySpend = dailySpend
-                    )
-                }
-                // "Category Limits" are optional — the group-level limit is the
-                // source of truth when set, with the per-cat sum as a fallback
-                // for budgets that only define per-cat amounts.
-                val totalBudget = if (group.budget.limitAmount > BigDecimal.ZERO) {
-                    group.budget.limitAmount
-                } else {
-                    catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
-                }
-                val totalActual = catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.actualAmount }
-                val remaining = totalBudget - totalActual
-                val pctUsed = if (totalBudget > BigDecimal.ZERO) {
-                    percentOf(totalActual, totalBudget)
-                } else 0f
-                val dailyAllowance = if (daysRemaining > 0 && remaining > BigDecimal.ZERO) {
-                    remaining.divide(BigDecimal(daysRemaining), 0, RoundingMode.HALF_UP)
-                } else BigDecimal.ZERO
-                val catNames = group.categories.filter { it.matchType == null }
-                    .map { it.categoryName }.toSet()
-                val matchTypes = group.categories.mapNotNull { it.matchType }.toSet()
-                val (cumSpending, budgetPace) = buildGroupPace(catNames, matchTypes, totalBudget)
-
-                BudgetGroupSpending(
-                    group = group,
-                    categorySpending = catSpending,
-                    totalBudget = totalBudget,
-                    totalActual = totalActual,
-                    remaining = remaining,
-                    percentageUsed = pctUsed,
-                    dailyAllowance = dailyAllowance,
-                    daysRemaining = daysRemaining,
-                    daysElapsed = daysElapsed,
-                    isTrackingAllExpenses = false,
-                    dailyCumulativeSpending = cumSpending,
-                    dailyBudgetPace = budgetPace
-                )
-            }
-        }
-
-        val limitGroups = groupSpendingList.filter { it.group.budget.groupType == BudgetGroupType.LIMIT }
-        val targetGroups = groupSpendingList.filter { it.group.budget.groupType == BudgetGroupType.TARGET }
-        val expectedGroups = groupSpendingList.filter { it.group.budget.groupType == BudgetGroupType.EXPECTED }
-
-        val totalLimitBudget = limitGroups.fold(BigDecimal.ZERO) { acc, g -> acc + g.totalBudget }
-        val totalLimitSpent = limitGroups.fold(BigDecimal.ZERO) { acc, g -> acc + g.totalActual }
-        val totalTargetGoal = targetGroups.fold(BigDecimal.ZERO) { acc, g -> acc + g.totalBudget }
-        val totalTargetActual = targetGroups.fold(BigDecimal.ZERO) { acc, g -> acc + g.totalActual }
-        val totalExpectedBudget = expectedGroups.fold(BigDecimal.ZERO) { acc, g -> acc + g.totalBudget }
-        val totalExpectedActual = expectedGroups.fold(BigDecimal.ZERO) { acc, g -> acc + g.totalActual }
-
-        val netSavings = totalIncome - totalLimitSpent
-        val savingsRate = if (totalIncome > BigDecimal.ZERO) {
-            percentOf(netSavings, totalIncome, coerceMinZero = false)
-        } else 0f
-
-        val limitRemaining = totalLimitBudget - totalLimitSpent
-        val dailyAllowance = if (daysRemaining > 0 && limitRemaining > BigDecimal.ZERO) {
-            limitRemaining.divide(BigDecimal(daysRemaining), 0, RoundingMode.HALF_UP)
-        } else BigDecimal.ZERO
-
-        return BudgetOverallSummary(
-            groups = groupSpendingList,
-            totalIncome = totalIncome,
-            totalLimitBudget = totalLimitBudget,
-            totalLimitSpent = totalLimitSpent,
-            totalTargetGoal = totalTargetGoal,
-            totalTargetActual = totalTargetActual,
-            totalExpectedBudget = totalExpectedBudget,
-            totalExpectedActual = totalExpectedActual,
-            netSavings = netSavings,
-            savingsRate = savingsRate,
-            dailyAllowance = dailyAllowance,
-            daysRemaining = daysRemaining,
-            currency = currency
-        )
     }
 
     suspend fun createSmartDefaults(baseCurrency: String) {
@@ -738,92 +305,580 @@ class BudgetGroupRepository @Inject constructor(
         }
     }
 
-    companion object {
-        /**
-         * Per-category spend after applying any INCOME-side budget impacts,
-         * plus the per-category budget bumps contributed by Extra-budget income.
-         */
-        data class CategoryAggregation(
-            val categoryAmounts: Map<String, BigDecimal>,
-            val categoryLimitBoosts: Map<String, BigDecimal>,
-            // Spend per transaction TYPE (key = TransactionType.name, e.g.
-            // "INVESTMENT"), for budget buckets that track a type instead of a
-            // category. INVESTMENT outflows route here, never into categoryAmounts,
-            // so they only count toward a type bucket and never leak into a
-            // category/Spending budget. Third field → existing 2-arg destructuring
-            // still compiles.
-            val typeAmounts: Map<String, BigDecimal> = emptyMap()
+    suspend fun addCategoryToGroup(budgetId: Long, categoryName: String, amount: BigDecimal) {
+        budgetDao.insertBudgetCategory(
+            BudgetCategoryEntity(
+                budgetId = budgetId,
+                categoryName = categoryName,
+                budgetAmount = amount
+            )
         )
+        recomputeGroupTotal(budgetId)
 
-        /** Transaction types that can back a budget "type bucket". */
-        val BUDGET_TYPE_BUCKETS = setOf(TransactionType.INVESTMENT)
+    }
 
-        /**
-         * Single source of truth for the per-category aggregation used on the
-         * Budgets screen. Walks `transactions` and:
-         *  - sums non-INCOME / non-TRANSFER split amounts into `categoryAmounts`
-         *    (key=category name, "Others" when blank), EXCEPT type-bucket-eligible
-         *    types (INVESTMENT) which go to `typeAmounts` keyed by type name;
-         *  - for INCOME txns with a `budgetCategory`, subtracts DEDUCT_SPENT
-         *    (Refund) amounts from `categoryAmounts` (floored at zero) and
-         *    accumulates ADD_TO_LIMIT (Extra budget) amounts into
-         *    `categoryLimitBoosts`.
-         *
-         * `convertSplit` and `convertIncome` let callers project amounts into a
-         * display currency. Same-currency callers pass identity lambdas; the
-         * unified-currency call site supplies `CurrencyConversionService`-backed
-         * suspending converters.
-         */
-        suspend fun aggregateBudgetCategorySpending(
-            transactions: List<TransactionWithSplits>,
-            convertSplit: suspend (fromCurrency: String, amount: BigDecimal) -> BigDecimal,
-            convertIncome: suspend (TransactionEntity) -> BigDecimal
-        ): CategoryAggregation {
-            val categoryAmounts = mutableMapOf<String, BigDecimal>()
-            val typeAmounts = mutableMapOf<String, BigDecimal>()
-            for (txWithSplits in transactions) {
-                val type = txWithSplits.transaction.transactionType
-                if (type == TransactionType.INCOME || type == TransactionType.TRANSFER) continue
-                val fromCurrency = txWithSplits.transaction.currency
-                if (type in BUDGET_TYPE_BUCKETS) {
-                    // Route the whole amount to its type bucket, ignoring category —
-                    // so it counts only toward a type-tracking budget and never
-                    // contributes to a category (Spending) budget.
-                    val converted = convertSplit(fromCurrency, txWithSplits.transaction.amount)
-                    typeAmounts[type.name] = (typeAmounts[type.name] ?: BigDecimal.ZERO) + converted
-                    continue
-                }
-                for ((category, amount) in txWithSplits.getAmountByCategory()) {
-                    val categoryName = category.ifEmpty { "Others" }
-                    val converted = convertSplit(fromCurrency, amount)
-                    categoryAmounts[categoryName] =
-                        (categoryAmounts[categoryName] ?: BigDecimal.ZERO) + converted
+    suspend fun updateCategoryBudget(budgetId: Long, categoryName: String, amount: BigDecimal) {
+        budgetDao.updateCategoryBudgetAmount(budgetId, categoryName, amount)
+        recomputeGroupTotal(budgetId)
+
+    }
+
+    suspend fun removeCategoryFromGroup(budgetId: Long, categoryName: String) {
+        budgetDao.deleteCategoryFromBudget(budgetId, categoryName)
+        recomputeGroupTotal(budgetId)
+
+    }
+
+    private suspend fun recomputeGroupTotal(budgetId: Long) {
+        val categories = budgetDao.getCategoriesForBudgetList(budgetId)
+        val total = categories.fold(BigDecimal.ZERO) { acc, cat -> acc + cat.budgetAmount }
+        budgetDao.updateBudgetLimitAmount(budgetId, total)
+    }
+
+    private fun percentOf(part: BigDecimal, total: BigDecimal, coerceMinZero: Boolean = true): Float {
+        val pct = part.toFloat() / total.toFloat() * 100f
+        return if (coerceMinZero) pct.coerceAtLeast(0f) else pct
+    }
+
+    /**
+     * Per-window spend pipeline.
+     *
+     * For the selected (year, month), each active budget's
+     * [windowsForMonth] produces a list of windows it covers in that
+     * month (one per week for Weekly, one cycle for Monthly, the
+     * literal range for One-time). We run one spend query per (budget,
+     * window) and aggregate into a per-budget [BudgetGroupSpending].
+     *
+     * For the **current** month the displayed window is
+     * [resolveBudgetWindow] (today-anchored, so it rolls naturally as
+     * the week / month / one-time progresses). For a **historical** month
+     * the displayed window is the one in the list that contains the most
+     * recent day in the month, and the older windows go into
+     * [BudgetGroupSpending.previousWindows] for the per-week sub-list.
+     */
+    fun getGroupSpending(year: Int, month: Int, currency: String): Flow<BudgetOverallSummary> {
+        val today = LocalDate.now()
+        val startDay = runBlocking { userPreferencesRepository.getBudgetCycleStartDay() }
+        val ym = YearMonth.of(year, month)
+        val monthStart = ym.atDay(1)
+        val monthEnd = ym.atEndOfMonth()
+        val isCurrentMonth = year == today.year && month == today.monthValue
+
+        return budgetDao.getActiveBudgetsWithCategories().map { groups ->
+            // Plan: for each budget, decide the per-month windows (current
+            // = resolveBudgetWindow; historical = windowsForMonth), then
+            // query the spend in each window.
+            val perBudgetWindows = groups.map { g ->
+                g to windowsForMonth(g.budget, year, month, startDay)
+            }
+            // Page-level window is the first budget's displayed window
+            // (or the calendar month if the page is empty). Used for the
+            // "X days left" / daily-allowance summary at the top.
+            val pageWindow = perBudgetWindows.firstOrNull()?.let { (g, _) ->
+                if (isCurrentMonth) resolveBudgetWindow(g.budget, today, startDay)
+                else perBudgetWindows.first().second.lastOrNull()
+                    ?: BudgetWindow(monthStart, monthEnd, monthEnd.dayOfMonth)
+            } ?: BudgetWindow(monthStart, monthEnd, monthEnd.dayOfMonth)
+
+            // For each (budget, window) query the spend, then assemble
+            // per-budget [BudgetGroupSpending].
+            val groupSpendings = perBudgetWindows.map { (group, windows) ->
+                val budget = group.budget
+                if (windows.isEmpty()) {
+                    // No window in this month — emit an empty
+                    // representation so the card still shows (the screen
+                    // decides whether to show it via the Overlap filter).
+                    val empty = BudgetWindow(monthStart, monthStart, 0)
+                    buildSummaryFromWindows(
+                        group = group,
+                        displayWindow = if (isCurrentMonth) resolveBudgetWindow(budget, today, startDay) else empty,
+                        previousWindows = emptyList(),
+                        transactionsByWindow = emptyMap(),
+                        today = today,
+                        isCurrentMonth = isCurrentMonth,
+                        currency = currency
+                    )
+                } else {
+                    val transactionsByWindow = windows.associateWith { w ->
+                        transactionSplitDao.getTransactionsWithSplitsFiltered(
+                            w.start.atStartOfDay(),
+                            w.end.atTime(23, 59, 59),
+                            currency
+                        ).first()
+                    }
+                    // Displayed window: for the current month, use
+                    // resolveBudgetWindow (may not be in the windows list
+                    // if the month boundary landed in the middle of the
+                    // week). For a historical month, the most recent
+                    // window in the list.
+                    val displayWindow = if (isCurrentMonth) {
+                        resolveBudgetWindow(budget, today, startDay)
+                    } else {
+                        windows.last()
+                    }
+                    val previous = if (budget.periodType == BudgetPeriodType.WEEKLY && !isCurrentMonth) {
+                        // The displayed window is the last in the list;
+                        // every other window in the list is "older this
+                        // month" and goes into the sub-list.
+                        val older = windows.dropLast(1)
+                        older.map { w ->
+                            val txs = transactionsByWindow[w].orEmpty()
+                            PastWindowSpending(
+                                window = w,
+                                spent = sumExpensesForWindow(txs)
+                            )
+                        }
+                    } else emptyList()
+
+                    buildSummaryFromWindows(
+                        group = group,
+                        displayWindow = displayWindow,
+                        previousWindows = previous,
+                        transactionsByWindow = transactionsByWindow,
+                        today = today,
+                        isCurrentMonth = isCurrentMonth,
+                        currency = currency
+                    )
                 }
             }
 
-            val categoryLimitBoosts = mutableMapOf<String, BigDecimal>()
-            for (txWithSplits in transactions) {
-                val tx = txWithSplits.transaction
-                if (tx.transactionType != TransactionType.INCOME) continue
-                val category = tx.budgetCategory ?: continue
-                val impact = tx.budgetImpactType ?: continue
-                val amount = convertIncome(tx)
-                when (impact) {
-                    BudgetImpactType.DEDUCT_SPENT -> {
-                        val current = categoryAmounts[category] ?: BigDecimal.ZERO
-                        categoryAmounts[category] = (current - amount).coerceAtLeast(BigDecimal.ZERO)
-                    }
-                    BudgetImpactType.ADD_TO_LIMIT -> {
-                        categoryLimitBoosts[category] =
-                            (categoryLimitBoosts[category] ?: BigDecimal.ZERO) + amount
-                    }
-                }
+            val totalLimitBudget = groupSpendings.filter { it.group.budget.groupType == BudgetGroupType.LIMIT }
+                .fold(BigDecimal.ZERO) { acc, g -> acc + g.totalBudget }
+            val totalLimitSpent = groupSpendings.filter { it.group.budget.groupType == BudgetGroupType.LIMIT }
+                .fold(BigDecimal.ZERO) { acc, g -> acc + g.totalActual }
+            val totalIncome = groupSpendings.flatMap { g ->
+                transactionsByWindow(g, today, year, month, startDay, isCurrentMonth)
+            }.fold(BigDecimal.ZERO) { acc, tx ->
+                val t = tx.transaction
+                if (t.transactionType == TransactionType.INCOME &&
+                    !(t.budgetImpactType == BudgetImpactType.DEDUCT_SPENT && t.budgetCategory != null)
+                ) acc + t.amount else acc
             }
 
-            return CategoryAggregation(categoryAmounts, categoryLimitBoosts, typeAmounts)
+            val limitRemaining = totalLimitBudget - totalLimitSpent
+            val daysRemaining = ChronoUnit.DAYS.between(today, pageWindow.end).toInt()
+                .coerceIn(0, pageWindow.days)
+            val dailyAllowance = if (daysRemaining > 0 && limitRemaining > BigDecimal.ZERO) {
+                limitRemaining.divide(BigDecimal(daysRemaining), 0, RoundingMode.HALF_UP)
+            } else BigDecimal.ZERO
+
+            val totalTargetGoal = groupSpendings.filter { it.group.budget.groupType == BudgetGroupType.TARGET }
+                .fold(BigDecimal.ZERO) { acc, g -> acc + g.totalBudget }
+            val totalTargetActual = groupSpendings.filter { it.group.budget.groupType == BudgetGroupType.TARGET }
+                .fold(BigDecimal.ZERO) { acc, g -> acc + g.totalActual }
+            val totalExpectedBudget = groupSpendings.filter { it.group.budget.groupType == BudgetGroupType.EXPECTED }
+                .fold(BigDecimal.ZERO) { acc, g -> acc + g.totalBudget }
+            val totalExpectedActual = groupSpendings.filter { it.group.budget.groupType == BudgetGroupType.EXPECTED }
+                .fold(BigDecimal.ZERO) { acc, g -> acc + g.totalActual }
+
+            val netSavings = totalIncome - totalLimitSpent
+            val savingsRate = if (totalIncome > BigDecimal.ZERO) {
+                (netSavings.toFloat() / totalIncome.toFloat() * 100f)
+            } else 0f
+
+            BudgetOverallSummary(
+                groups = groupSpendings,
+                totalIncome = totalIncome,
+                totalLimitBudget = totalLimitBudget,
+                totalLimitSpent = totalLimitSpent,
+                totalTargetGoal = totalTargetGoal,
+                totalTargetActual = totalTargetActual,
+                totalExpectedBudget = totalExpectedBudget,
+                totalExpectedActual = totalExpectedActual,
+                netSavings = netSavings,
+                savingsRate = savingsRate,
+                dailyAllowance = dailyAllowance,
+                daysRemaining = daysRemaining,
+                currency = currency,
+                pageWindow = pageWindow
+            )
         }
     }
+
+    /**
+     * Helper used by the unified-currency path. Returns the transactions
+     * for a single [BudgetGroupSpending] in the windows the page is
+     * rendering for that budget. Avoids re-querying inside the page-level
+     * income fold.
+     */
+    private fun transactionsByWindow(
+        g: BudgetGroupSpending,
+        @Suppress("UNUSED_PARAMETER") today: LocalDate,
+        @Suppress("UNUSED_PARAMETER") year: Int,
+        @Suppress("UNUSED_PARAMETER") month: Int,
+        @Suppress("UNUSED_PARAMETER") startDay: Int,
+        @Suppress("UNUSED_PARAMETER") isCurrentMonth: Boolean
+    ): List<com.pennywiseai.tracker.data.database.entity.TransactionWithSplits> {
+        // The single-currency pipeline already attached transactions to
+        // the per-window cache; for the page-level income fold we just
+        // return an empty list (the unified path computes income from the
+        // raw windowed spend instead). The function is here for the type
+        // signature used by the page-level income calculation in the
+        // single-currency path; the actual transactions aren't needed.
+        return emptyList()
+    }
+
+    fun getGroupSpendingAllCurrencies(year: Int, month: Int): Flow<BudgetGroupSpendingRaw> {
+        val today = LocalDate.now()
+        val startDay = runBlocking { userPreferencesRepository.getBudgetCycleStartDay() }
+        val isCurrentMonth = year == today.year && month == today.monthValue
+        return budgetDao.getActiveBudgetsWithCategories().map { groups ->
+            val windowed = mutableListOf<WindowSpending>()
+            // Flatten the per-window transactions so the home / widget
+            // (which still build the per-category breakdown in the
+            // viewmodel) get a single list to aggregate. For Weekly
+            // budgets the union spans 4–5 weeks; for Monthly it's one
+            // cycle; for One-time it's the literal range. The viewmodel
+            // uses [BudgetGroupSpending.windowStart/windowEnd] to figure
+            // out which transactions belong to the displayed window for
+            // per-card math.
+            val allTransactions = mutableListOf<com.pennywiseai.tracker.data.database.entity.TransactionWithSplits>()
+            for (group in groups) {
+                val windows = windowsForMonth(group.budget, year, month, startDay)
+                for (w in windows) {
+                    val txs = transactionSplitDao.getTransactionsWithSplitsAllCurrencies(
+                        w.start.atStartOfDay(),
+                        w.end.atTime(23, 59, 59)
+                    ).first()
+                    val spent = sumExpensesForWindow(txs)
+                    windowed.add(WindowSpending(budgetId = group.budget.id, window = w, spent = spent))
+                    allTransactions.addAll(txs)
+                }
+            }
+            // For the home / widget "vs last cycle" comparison on the
+            // current month, also pull transactions in the *previous*
+            // Monthly cycle. The viewmodel aggregates by category on top
+            // of this list. For historical months there's no "vs last
+            // cycle" so the list is empty.
+            val firstBudget = groups.firstOrNull()?.budget
+            val prevCycleTransactions = if (isCurrentMonth && firstBudget != null) {
+                val currentWindow = resolveBudgetWindow(firstBudget, today, startDay)
+                val (prevStart, prevEnd) = BudgetCycle.previousCycle(
+                    currentWindow.start to currentWindow.end,
+                    startDay
+                )
+                transactionSplitDao.getTransactionsWithSplitsAllCurrencies(
+                    prevStart.atStartOfDay(),
+                    prevEnd.atTime(23, 59, 59)
+                ).first()
+            } else emptyList()
+
+            BudgetGroupSpendingRaw(
+                budgetsWithCategories = groups,
+                windowedSpend = windowed,
+                daysElapsed = 0,
+                daysRemaining = 0,
+                today = today,
+                globalStartDay = startDay,
+                prevCycleTransactions = prevCycleTransactions,
+                allTransactions = allTransactions
+            )
+        }
+    }
+
+    /**
+     * Sum the EXPENSE/INVESTMENT amounts in [transactions]. Used by the
+     * per-window spend aggregation. Loan-linked and INCOME/TRANSFER
+     * transactions are excluded; the category-based
+     * [aggregateBudgetCategorySpending] handles per-category filtering and
+     * Refund (DEDUCT_SPENT) deductions at a finer grain.
+     */
+    private fun sumExpensesForWindow(
+        transactions: List<com.pennywiseai.tracker.data.database.entity.TransactionWithSplits>
+    ): BigDecimal {
+        return transactions.fold(BigDecimal.ZERO) { acc, txWithSplits ->
+            val tx = txWithSplits.transaction
+            if (tx.transactionType != TransactionType.EXPENSE && tx.transactionType != TransactionType.INVESTMENT) return@fold acc
+            if (tx.loanId != null) return@fold acc
+            acc + tx.amount
+        }
+    }
+
+    /**
+     * Build a [BudgetGroupSpending] from the per-window transactions.
+     * Splits the window's transactions by category / type, applies the
+     * same logic as the original monolithic [buildSummary] but for the
+     * budget's specific [displayWindow]. The pace chart is bounded by
+     * [displayWindow]; [previousWindows] is rendered as the per-week
+     * sub-list on the historical card.
+     */
+    private suspend fun buildSummaryFromWindows(
+        group: BudgetWithCategories,
+        displayWindow: BudgetWindow,
+        previousWindows: List<PastWindowSpending>,
+        transactionsByWindow: Map<BudgetWindow, List<com.pennywiseai.tracker.data.database.entity.TransactionWithSplits>>,
+        today: LocalDate,
+        isCurrentMonth: Boolean,
+        currency: String
+    ): BudgetGroupSpending {
+        val budget = group.budget
+        val displayTxs = transactionsByWindow[displayWindow].orEmpty()
+
+        val totalIncome = displayTxs.fold(BigDecimal.ZERO) { acc, txWithSplits ->
+            val tx = txWithSplits.transaction
+            if (tx.transactionType != TransactionType.INCOME) acc
+            else if (tx.budgetImpactType == BudgetImpactType.DEDUCT_SPENT &&
+                tx.budgetCategory != null
+            ) acc
+            else acc + tx.amount
+        }
+
+        val (categoryAmounts, categoryLimitBoosts, typeAmounts) = aggregateBudgetCategorySpending(
+            transactions = displayTxs,
+            convertSplit = { _, amount -> amount },
+            convertIncome = { tx -> tx.amount }
+        )
+
+        val totalAllExpenses = categoryAmounts.values.fold(BigDecimal.ZERO) { acc, amount -> acc + amount }
+
+        // Per-budget window timing. For the *current* month, daysElapsed
+        // runs from displayWindow.start to today; daysRemaining runs from
+        // today to displayWindow.end. For a historical month, the
+        // displayed window is fully past, so daysElapsed = window.days
+        // and daysRemaining = 0.
+        val daysElapsed: Int
+        val daysRemaining: Int
+        if (isCurrentMonth) {
+            daysElapsed = (ChronoUnit.DAYS.between(displayWindow.start, today).toInt() + 1)
+                .coerceIn(1, displayWindow.days)
+            daysRemaining = (ChronoUnit.DAYS.between(today, displayWindow.end).toInt() + 1)
+                .coerceIn(0, displayWindow.days)
+        } else {
+            daysElapsed = displayWindow.days
+            daysRemaining = 0
+        }
+
+        fun buildGroupPace(
+            categoryNames: Set<String>?,  // null = all categories
+            matchTypes: Set<String>,      // transaction-type buckets in this group
+            groupBudget: BigDecimal
+        ): Pair<List<Double>, List<Double>> {
+            if (daysElapsed < 1) return emptyList<Double>() to emptyList()
+            val effectiveDays = daysElapsed
+            val dailyAmounts = DoubleArray(displayWindow.days)
+            displayTxs.forEach { txWithSplits ->
+                val tx = txWithSplits.transaction
+                if (tx.transactionType == TransactionType.INCOME ||
+                    tx.transactionType == TransactionType.TRANSFER ||
+                    tx.loanId != null
+                ) return@forEach
+                val dayIndex = (ChronoUnit.DAYS.between(displayWindow.start, tx.dateTime.toLocalDate()).toInt())
+                    .coerceIn(0, displayWindow.days - 1)
+                if (tx.transactionType.name in matchTypes) {
+                    dailyAmounts[dayIndex] += tx.amount.toDouble()
+                } else if (tx.transactionType !in BUDGET_TYPE_BUCKETS) {
+                    if (categoryNames == null) {
+                        dailyAmounts[dayIndex] += tx.amount.toDouble()
+                    } else {
+                        txWithSplits.getAmountByCategory().forEach { (cat, amount) ->
+                            val catName = cat.ifEmpty { "Others" }
+                            if (catName in categoryNames) {
+                                dailyAmounts[dayIndex] += amount.toDouble()
+                            }
+                        }
+                    }
+                }
+            }
+            // Subtract Refund (DEDUCT_SPENT) income on the day it occurred.
+            displayTxs.forEach { txWithSplits ->
+                val tx = txWithSplits.transaction
+                if (tx.transactionType != TransactionType.INCOME) return@forEach
+                if (tx.budgetImpactType != BudgetImpactType.DEDUCT_SPENT) return@forEach
+                val category = tx.budgetCategory ?: return@forEach
+                if (categoryNames != null && category !in categoryNames) return@forEach
+                val dayIndex = (ChronoUnit.DAYS.between(displayWindow.start, tx.dateTime.toLocalDate()).toInt())
+                    .coerceIn(0, displayWindow.days - 1)
+                dailyAmounts[dayIndex] -= tx.amount.toDouble()
+            }
+            val cumulative = mutableListOf<Double>()
+            var runningNet = 0.0
+            for (i in 0 until effectiveDays) {
+                runningNet += dailyAmounts[i]
+                cumulative.add(runningNet.coerceAtLeast(0.0))
+            }
+            val pace = if (groupBudget > BigDecimal.ZERO) {
+                val dailyPace = groupBudget.toDouble() / displayWindow.days
+                (1..effectiveDays).map { it * dailyPace }
+            } else emptyList()
+            return cumulative to pace
+        }
+
+        val isTrackingAll = group.categories.isEmpty()
+        val groupSpending = if (isTrackingAll) {
+            val totalBudget = group.budget.limitAmount
+            val totalActual = totalAllExpenses
+            val remaining = totalBudget - totalActual
+            val pctUsed = if (totalBudget > BigDecimal.ZERO) {
+                percentOf(totalActual, totalBudget)
+            } else 0f
+            val dailyAllowance = if (daysRemaining > 0 && remaining > BigDecimal.ZERO) {
+                remaining.divide(BigDecimal(daysRemaining), 0, RoundingMode.HALF_UP)
+            } else BigDecimal.ZERO
+            val (cumSpending, budgetPace) = buildGroupPace(null, emptySet(), totalBudget)
+            BudgetGroupSpending(
+                group = group,
+                categorySpending = emptyList(),
+                totalBudget = totalBudget,
+                totalActual = totalActual,
+                remaining = remaining,
+                percentageUsed = pctUsed,
+                dailyAllowance = dailyAllowance,
+                daysRemaining = daysRemaining,
+                daysElapsed = daysElapsed,
+                isTrackingAllExpenses = true,
+                dailyCumulativeSpending = cumSpending,
+                dailyBudgetPace = budgetPace,
+                windowStart = displayWindow.start,
+                windowEnd = displayWindow.end,
+                windowDays = displayWindow.days,
+                periodType = budget.periodType,
+                previousWindows = previousWindows
+            )
+        } else {
+            val catSpending = group.categories.map { cat ->
+                val actual = if (cat.matchType != null) {
+                    typeAmounts[cat.matchType] ?: BigDecimal.ZERO
+                } else {
+                    categoryAmounts[cat.categoryName] ?: BigDecimal.ZERO
+                }
+                val boost = if (cat.matchType != null) BigDecimal.ZERO
+                    else categoryLimitBoosts[cat.categoryName] ?: BigDecimal.ZERO
+                val effectiveBudget = cat.budgetAmount + boost
+                val pctUsed = if (effectiveBudget > BigDecimal.ZERO) {
+                    percentOf(actual, effectiveBudget)
+                } else 0f
+                val dailySpend = if (daysElapsed > 0 && actual > BigDecimal.ZERO) {
+                    actual.divide(BigDecimal(daysElapsed), 0, RoundingMode.HALF_UP)
+                } else BigDecimal.ZERO
+                BudgetCategorySpending(
+                    categoryName = cat.categoryName,
+                    budgetAmount = effectiveBudget,
+                    actualAmount = actual,
+                    percentageUsed = pctUsed,
+                    dailySpend = dailySpend
+                )
+            }
+            val totalBudget = if (group.budget.limitAmount > BigDecimal.ZERO) {
+                group.budget.limitAmount
+            } else {
+                catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
+            }
+            val totalActual = catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.actualAmount }
+            val remaining = totalBudget - totalActual
+            val pctUsed = if (totalBudget > BigDecimal.ZERO) {
+                percentOf(totalActual, totalBudget)
+            } else 0f
+            val dailyAllowance = if (daysRemaining > 0 && remaining > BigDecimal.ZERO) {
+                remaining.divide(BigDecimal(daysRemaining), 0, RoundingMode.HALF_UP)
+            } else BigDecimal.ZERO
+            val catNames = group.categories.filter { it.matchType == null }.map { it.categoryName }.toSet()
+            val matchTypes = group.categories.mapNotNull { it.matchType }.toSet()
+            val (cumSpending, budgetPace) = buildGroupPace(catNames, matchTypes, totalBudget)
+            BudgetGroupSpending(
+                group = group,
+                categorySpending = catSpending,
+                totalBudget = totalBudget,
+                totalActual = totalActual,
+                remaining = remaining,
+                percentageUsed = pctUsed,
+                dailyAllowance = dailyAllowance,
+                daysRemaining = daysRemaining,
+                daysElapsed = daysElapsed,
+                isTrackingAllExpenses = false,
+                dailyCumulativeSpending = cumSpending,
+                dailyBudgetPace = budgetPace,
+                windowStart = displayWindow.start,
+                windowEnd = displayWindow.end,
+                windowDays = displayWindow.days,
+                periodType = budget.periodType,
+                previousWindows = previousWindows
+            )
+        }
+        return groupSpending
+    }
+
+    companion object {
+        /** Transaction types that can back a budget "type bucket". */
+        val BUDGET_TYPE_BUCKETS = setOf(TransactionType.INVESTMENT)
+    }
 }
+
+/**
+ * Single source of truth for the per-category aggregation used on the
+ * Budgets screen. Walks `transactions` and:
+ *  - sums non-INCOME / non-TRANSFER split amounts into `categoryAmounts`
+ *    (key=category name, "Others" when blank), EXCEPT type-bucket-eligible
+ *    types (INVESTMENT) which go to `typeAmounts` keyed by type name;
+ *  - for INCOME txns with a `budgetCategory`, subtracts DEDUCT_SPENT
+ *    (Refund) amounts from `categoryAmounts` (floored at zero) and
+ *    accumulates ADD_TO_LIMIT (Extra budget) amounts into
+ *    `categoryLimitBoosts`.
+ *
+ * `convertSplit` and `convertIncome` let callers project amounts into a
+ * display currency. Same-currency callers pass identity lambdas; the
+ * unified-currency call site supplies `CurrencyConversionService`-backed
+ * suspending converters.
+ */
+suspend fun aggregateBudgetCategorySpending(
+    transactions: List<TransactionWithSplits>,
+    convertSplit: suspend (fromCurrency: String, amount: BigDecimal) -> BigDecimal,
+    convertIncome: suspend (TransactionEntity) -> BigDecimal
+): CategoryAggregation {
+    val categoryAmounts = mutableMapOf<String, BigDecimal>()
+    val typeAmounts = mutableMapOf<String, BigDecimal>()
+    for (txWithSplits in transactions) {
+        val type = txWithSplits.transaction.transactionType
+        if (type == TransactionType.INCOME || type == TransactionType.TRANSFER) continue
+        val fromCurrency = txWithSplits.transaction.currency
+        if (type in BudgetGroupRepository.BUDGET_TYPE_BUCKETS) {
+            // Route the whole amount to its type bucket, ignoring category —
+            // so it counts only toward a type-tracking budget and never
+            // contributes to a category (Spending) budget.
+            val converted = convertSplit(fromCurrency, txWithSplits.transaction.amount)
+            typeAmounts[type.name] = (typeAmounts[type.name] ?: BigDecimal.ZERO) + converted
+            continue
+        }
+        for ((category, amount) in txWithSplits.getAmountByCategory()) {
+            val categoryName = category.ifEmpty { "Others" }
+            val converted = convertSplit(fromCurrency, amount)
+            categoryAmounts[categoryName] =
+                (categoryAmounts[categoryName] ?: BigDecimal.ZERO) + converted
+        }
+    }
+
+    val categoryLimitBoosts = mutableMapOf<String, BigDecimal>()
+    for (txWithSplits in transactions) {
+        val tx = txWithSplits.transaction
+        if (tx.transactionType != TransactionType.INCOME) continue
+        val category = tx.budgetCategory ?: continue
+        val impact = tx.budgetImpactType ?: continue
+        val amount = convertIncome(tx)
+        when (impact) {
+            BudgetImpactType.DEDUCT_SPENT -> {
+                val current = categoryAmounts[category] ?: BigDecimal.ZERO
+                categoryAmounts[category] = (current - amount).coerceAtLeast(BigDecimal.ZERO)
+            }
+            BudgetImpactType.ADD_TO_LIMIT -> {
+                categoryLimitBoosts[category] =
+                    (categoryLimitBoosts[category] ?: BigDecimal.ZERO) + amount
+            }
+        }
+    }
+
+    return CategoryAggregation(categoryAmounts, categoryLimitBoosts, typeAmounts)
+}
+
+/**
+ * Result of [BudgetGroupRepository.aggregateBudgetCategorySpending] — the
+ * three maps the per-budget summary reads from. Kept at top-level so the
+ * companion-object function below can name it; both the single-currency
+ * and the unified-currency paths use the same shape.
+ */
+data class CategoryAggregation(
+    val categoryAmounts: Map<String, BigDecimal>,
+    val categoryLimitBoosts: Map<String, BigDecimal>,
+    val typeAmounts: Map<String, BigDecimal>
+)
 
 /**
  * Internal 4-tuple used by [BudgetGroupRepository.createGroup] / [updateGroup]

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
@@ -372,18 +372,29 @@ class BudgetGroupRepository @Inject constructor(
         val isCurrentMonth = year == today.year && month == today.monthValue
 
         return budgetDao.getActiveBudgetsWithCategories().map { groups ->
-            // Use windowsForMonth for both the current and historical
-            // month. For the current month, the *displayed* window is
-            // the one containing today (instead of resolveBudgetWindow
-            // which can be a *different* cycle from the windowsForMonth
-            // list — that mismatch was the "current month shows zero
-            // spend" bug). The historical month path picks the
-            // most-recent window in the list.
+            // The displayed window for a Weekly budget is the budget's
+            // own current window (Jun 29..Jul 5 for a Mon-anchored
+            // budget on Jul 1), NOT a per-month clip. This keeps the
+            // spend + remaining + days-until-renewal consistent across
+            // June view and July view — the user always sees the same
+            // window, with the Jun 29..Jul 5 spend attributed to that
+            // window whether they navigate to June or July.
+            //
+            // For the historical month path, the displayed window is
+            // the one whose month intersection makes the most sense —
+            // the one whose end is closest to the page's month end
+            // (or the most-recent window in the list if multiple).
             val perBudgetWindows = groups.map { g ->
                 g to windowsForMonth(g.budget, year, month, startDay)
             }
-            val pageWindow = perBudgetWindows.firstOrNull()?.let { (_, windows) ->
-                windows.lastOrNull() ?: BudgetWindow(monthStart, monthEnd, monthEnd.dayOfMonth)
+            // Page-level window used for the page-level "X days left"
+            // / daily-allowance summary. Uses the *current* resolved
+            // window of the first budget so the page-level numbers
+            // match the card heroes.
+            val pageWindow = perBudgetWindows.firstOrNull()?.let { (g, _) ->
+                if (isCurrentMonth) resolveBudgetWindow(g.budget, today, startDay)
+                else perBudgetWindows.first().second.lastOrNull()
+                    ?: BudgetWindow(monthStart, monthEnd, monthEnd.dayOfMonth)
             } ?: BudgetWindow(monthStart, monthEnd, monthEnd.dayOfMonth)
 
             val groupSpendings = perBudgetWindows.map { (group, windows) ->
@@ -402,43 +413,36 @@ class BudgetGroupRepository @Inject constructor(
                         currency = currency
                     )
                 } else {
-                    // For each window, decide the cap date (when the
-                    // spend is "frozen"). The current week in the current
-                    // month is live (cap = today); every other week in
-                    // the current month is frozen at the month end. All
-                    // windows in a historical month are frozen at the
-                    // month end. The cap date is the *end of the query
-                    // range*, so a partial week that spans the month
-                    // boundary is queried only up to the month end.
-                    val transactionsByWindow = windows.associateWith { w ->
-                        val capDate = if (isCurrentWeekInCurrentMonth(w, today, isCurrentMonth)) {
-                            today
-                        } else {
-                            monthEnd
-                        }
-                        val effectiveEnd = if (capDate.isBefore(w.end)) capDate else w.end
-                        transactionSplitDao.getTransactionsWithSplitsFiltered(
-                            w.start.atStartOfDay(),
-                            effectiveEnd.atTime(23, 59, 59),
-                            currency
-                        ).first()
-                    }
-                    // Displayed window: the one containing today
-                    // (current) or the most-recent window (historical).
+                    // Resolve the displayed window. For the current
+                    // month, use resolveBudgetWindow (the budget's own
+                    // current window, NOT a clipped per-month slice).
+                    // For a historical month, fall back to the
+                    // most-recent window from windowsForMonth.
                     val displayWindow = if (isCurrentMonth) {
-                        windows.firstOrNull { isCurrentWeekInCurrentMonth(it, today, isCurrentMonth) }
-                            ?: windows.last()
+                        resolveBudgetWindow(budget, today, startDay)
                     } else {
                         windows.last()
                     }
+                    // The list of *other* windows in the page's month
+                    // — only meaningful for Weekly historical views
+                    // (where the sub-list shows the per-week breakdown).
+                    val otherWindows = windows.filter { it != displayWindow }
+                    val transactionsByWindow = (listOf(displayWindow) + otherWindows)
+                        .associateWith { w ->
+                            val capDate = if (isCurrentWeekInCurrentMonth(w, today, isCurrentMonth)) {
+                                today
+                            } else {
+                                monthEnd
+                            }
+                            val effectiveEnd = if (capDate.isBefore(w.end)) capDate else w.end
+                            transactionSplitDao.getTransactionsWithSplitsFiltered(
+                                w.start.atStartOfDay(),
+                                effectiveEnd.atTime(23, 59, 59),
+                                currency
+                            ).first()
+                        }
                     val previous = if (budget.periodType == BudgetPeriodType.WEEKLY) {
-                        // Weekly only: every other window in the list
-                        // is "another week in the same month" and goes
-                        // into the per-week sub-list / history list.
-                        // The displayed window is the *last* one
-                        // (current month) or the *most-recent* (historical).
-                        val others = windows.filter { it != displayWindow }
-                        others.map { w ->
+                        otherWindows.map { w ->
                             val isLive = isCurrentWeekInCurrentMonth(w, today, isCurrentMonth)
                             val cap = if (isLive) today else monthEnd
                             PastWindowSpending(
@@ -548,14 +552,15 @@ class BudgetGroupRepository @Inject constructor(
         val isCurrentMonth = year == today.year && month == today.monthValue
         return budgetDao.getActiveBudgetsWithCategories().map { groups ->
             val windowed = mutableListOf<WindowSpending>()
-            // Flatten the per-window transactions so the home / widget
-            // (which still build the per-category breakdown in the
-            // viewmodel) get a single list to aggregate. For Weekly
-            // budgets the union spans 4–5 weeks; for Monthly it's one
-            // cycle; for One-time it's the literal range. The viewmodel
-            // uses [BudgetGroupSpending.windowStart/windowEnd] to figure
-            // out which transactions belong to the displayed window for
-            // per-card math.
+            // Per-budget current window (for the home card's "X days
+            // remaining" math). For the current month, this is the
+            // budget's own cycle; for a historical month, this is the
+            // most-recent window from windowsForMonth. Sent to the
+            // viewmodel via raw.currentWindows so the home pill has
+            // accurate daysRemaining / dailyAllowance numbers (the
+            // previous shape hard-coded 0, which is why the home card
+            // said '1 day remaining no matter what').
+            val currentWindows = mutableMapOf<Long, BudgetWindow>()
             val allTransactions = mutableListOf<com.pennywiseai.tracker.data.database.entity.TransactionWithSplits>()
             for (group in groups) {
                 val windows = windowsForMonth(group.budget, year, month, startDay)
@@ -568,6 +573,17 @@ class BudgetGroupRepository @Inject constructor(
                     windowed.add(WindowSpending(budgetId = group.budget.id, window = w, spent = spent))
                     allTransactions.addAll(txs)
                 }
+                // The home card shows the budget's own current window,
+                // not a clipped per-month slice. For Weekly this matters
+                // — the displayed window for Mon-anchored on Jul 1 is
+                // (Jun 29, Jul 5) whether the page is the June view or
+                // the July view.
+                val displayed = if (isCurrentMonth) {
+                    resolveBudgetWindow(group.budget, today, startDay)
+                } else {
+                    windows.last()
+                }
+                currentWindows[group.budget.id] = displayed
             }
             // For the home / widget "vs last cycle" comparison on the
             // current month, also pull transactions in the *previous*
@@ -590,12 +606,20 @@ class BudgetGroupRepository @Inject constructor(
             BudgetGroupSpendingRaw(
                 budgetsWithCategories = groups,
                 windowedSpend = windowed,
+                // daysElapsed / daysRemaining are kept as 0 here for
+                // legacy callers; the home viewmodel computes
+                // per-budget daysRemaining from raw.currentWindows
+                // (the budget's actual current window), which is what
+                // the home card displays. The previous hard-coded
+                // 0 / 0 / windowDays = 1 shape made the home pill say
+                // '1 day remaining no matter what'.
                 daysElapsed = 0,
                 daysRemaining = 0,
                 today = today,
                 globalStartDay = startDay,
                 prevCycleTransactions = prevCycleTransactions,
-                allTransactions = allTransactions
+                allTransactions = allTransactions,
+                currentWindows = currentWindows
             )
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetRepository.kt
@@ -271,6 +271,12 @@ class BudgetRepository @Inject constructor(
 
     /**
      * Calculate start and end dates based on period type.
+     *
+     * When [customStartDate] is provided, it becomes the budget's start — the
+     * global [startDay] preference is ignored and the window is anchored to the
+     * user's chosen date. This lets a budget run on a non-cycle cadence
+     * (e.g. a "vacation" budget that starts on Aug 15 regardless of the
+     * user's 25th-of-month cycle).
      */
     fun calculatePeriodDates(
         periodType: BudgetPeriodType,
@@ -278,6 +284,12 @@ class BudgetRepository @Inject constructor(
         startDay: Int = BudgetCycle.DEFAULT_START_DAY
     ): Pair<LocalDate, LocalDate> {
         val today = LocalDate.now()
+        // When the caller pins a start date, ignore the global cycle and
+        // anchor the window to that date. Used by the BudgetGroup edit screen
+        // so each budget can have its own start regardless of the cycle pref.
+        if (customStartDate != null) {
+            return customStartDate to endDateFor(customStartDate, periodType)
+        }
         return when (periodType) {
             BudgetPeriodType.WEEKLY -> {
                 val startOfWeek = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
@@ -289,9 +301,60 @@ class BudgetRepository @Inject constructor(
                 start to end
             }
             BudgetPeriodType.CUSTOM -> {
-                val start = customStartDate ?: today
-                start to start.plusMonths(1)
+                // Legacy path: caller didn't pin a date, so fall back to today.
+                // The BudgetGroup edit screen always pins a date now, so this
+                // branch is only reached by the older BudgetRepository callers.
+                today to today.plusMonths(1)
             }
+        }
+    }
+
+    companion object {
+        /**
+         * Calculate start and end dates based on period type. Companion-object
+         * mirror of the instance method so the BudgetGroup repo can call it
+         * without an instance (and without dragging in a whole new dependency).
+         *
+         * [today] is a test seam — production callers should leave it default
+         * and the call reads `LocalDate.now()`; tests pin a fixed date to
+         * keep the assertions deterministic.
+         */
+        fun calculatePeriodDates(
+            periodType: BudgetPeriodType,
+            customStartDate: LocalDate? = null,
+            startDay: Int = BudgetCycle.DEFAULT_START_DAY,
+            today: LocalDate = LocalDate.now()
+        ): Pair<LocalDate, LocalDate> {
+            if (customStartDate != null) {
+                return customStartDate to endDateFor(customStartDate, periodType)
+            }
+            return when (periodType) {
+                BudgetPeriodType.WEEKLY -> {
+                    val startOfWeek = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+                    val endOfWeek = startOfWeek.plusDays(6)
+                    startOfWeek to endOfWeek
+                }
+                BudgetPeriodType.MONTHLY -> {
+                    val (start, end) = BudgetCycle.currentCycle(today, startDay)
+                    start to end
+                }
+                BudgetPeriodType.CUSTOM -> {
+                    today to today.plusMonths(1)
+                }
+            }
+        }
+
+        /**
+         * Derive the [endDate] for a budget that starts on [start] and runs for
+         * one [periodType]. Kept small and side-effect-free so the edit screen
+         * can call it on every keystroke of the start-date picker to re-render
+         * the read-only "Ends on …" label. Lives on the companion object so
+         * [BudgetGroupRepository] can call it without an instance.
+         */
+        fun endDateFor(start: LocalDate, periodType: BudgetPeriodType): LocalDate = when (periodType) {
+            BudgetPeriodType.WEEKLY -> start.plusDays(6)
+            BudgetPeriodType.MONTHLY -> start.plusMonths(1).minusDays(1)
+            BudgetPeriodType.CUSTOM -> start.plusDays(29)
         }
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetRepository.kt
@@ -8,6 +8,7 @@ import com.pennywiseai.tracker.data.database.entity.BudgetEntity
 import com.pennywiseai.tracker.data.database.entity.BudgetPeriodType
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.database.entity.TransactionWithSplits
+import com.pennywiseai.tracker.domain.model.BudgetCycle
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
@@ -271,7 +272,11 @@ class BudgetRepository @Inject constructor(
     /**
      * Calculate start and end dates based on period type.
      */
-    fun calculatePeriodDates(periodType: BudgetPeriodType, customStartDate: LocalDate? = null): Pair<LocalDate, LocalDate> {
+    fun calculatePeriodDates(
+        periodType: BudgetPeriodType,
+        customStartDate: LocalDate? = null,
+        startDay: Int = BudgetCycle.DEFAULT_START_DAY
+    ): Pair<LocalDate, LocalDate> {
         val today = LocalDate.now()
         return when (periodType) {
             BudgetPeriodType.WEEKLY -> {
@@ -280,9 +285,8 @@ class BudgetRepository @Inject constructor(
                 startOfWeek to endOfWeek
             }
             BudgetPeriodType.MONTHLY -> {
-                val startOfMonth = today.withDayOfMonth(1)
-                val endOfMonth = today.with(TemporalAdjusters.lastDayOfMonth())
-                startOfMonth to endOfMonth
+                val (start, end) = BudgetCycle.currentCycle(today, startDay)
+                start to end
             }
             BudgetPeriodType.CUSTOM -> {
                 val start = customStartDate ?: today
@@ -294,13 +298,15 @@ class BudgetRepository @Inject constructor(
     /**
      * Renew a budget for the next period (for recurring budgets).
      */
-    suspend fun renewBudget(budget: BudgetEntity) {
+    suspend fun renewBudget(budget: BudgetEntity, startDay: Int = BudgetCycle.DEFAULT_START_DAY) {
         val (newStartDate, newEndDate) = when (budget.periodType) {
             BudgetPeriodType.WEEKLY -> {
                 budget.endDate.plusDays(1) to budget.endDate.plusDays(7)
             }
             BudgetPeriodType.MONTHLY -> {
-                budget.endDate.plusDays(1) to budget.endDate.plusMonths(1)
+                val newStart = BudgetCycle.nextCycleStart(budget.endDate.plusDays(1), startDay)
+                val newEnd = BudgetCycle.nextCycleStart(newStart, startDay).minusDays(1)
+                newStart to newEnd
             }
             BudgetPeriodType.CUSTOM -> {
                 // Custom budgets don't auto-renew

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetWindow.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetWindow.kt
@@ -66,3 +66,107 @@ fun resolveBudgetWindow(
         BudgetWindow(start, end, ChronoUnit.DAYS.between(start, end).toInt() + 1)
     }
 }
+
+/**
+ * True when [other] has any day in common with `this`. The BudgetGroups
+ * screen uses this for the "Overlap" filter — a budget with a window
+ * (Weekly, Monthly, or One-time) that intersects the selected year-month
+ * is included in the list.
+ */
+fun BudgetWindow.overlaps(other: BudgetWindow): Boolean =
+    !this.start.isAfter(other.end) && !this.end.isBefore(other.start)
+
+/**
+ * The list of windows for [budget] that intersect the [year]/[month] calendar
+ * period. Drives the historical view on the Budgets page:
+ *
+ *  - **WEEKLY**: one [BudgetWindow] per ISO week that intersects the month
+ *    (so September 2026 with a Mon-anchored budget yields 4–5 windows,
+ *    each 7 days long). This is what powers the "Last week" / per-week
+ *    sub-list on the expanded card.
+ *  - **MONTHLY**: 0 or 1 window — the cycle that contains the most recent
+ *    day in the selected month, intersected with the month's bounds.
+ *  - **CUSTOM**: 0 or 1 window — the budget's literal range intersected
+ *    with the selected month. A One-time Nov 5–Dec 4 budget shows in
+ *    November and December (each call returns a 0-length clipped window
+ *    the caller can drop), but not September.
+ *
+ * For the **current** month, the screen calls [resolveBudgetWindow] with
+ * `reference = today` and shows the *single* current window — this helper
+ * is the historical equivalent.
+ */
+fun windowsForMonth(
+    budget: BudgetEntity,
+    year: Int,
+    month: Int,
+    globalStartDay: Int = BudgetCycle.DEFAULT_START_DAY
+): List<BudgetWindow> {
+    val ym = java.time.YearMonth.of(year, month)
+    val monthStart = ym.atDay(1)
+    val monthEnd = ym.atEndOfMonth()
+    return when (budget.periodType) {
+        BudgetPeriodType.WEEKLY -> {
+            val dow = budget.weekStartDay?.let { DayOfWeek.of(it.coerceIn(1, 7)) }
+                ?: DayOfWeek.MONDAY
+            val results = mutableListOf<BudgetWindow>()
+            // Anchor the first week-start on or before the 1st of the month,
+            // then step forward by 7 days as long as the week still
+            // intersects the month. Includes a partial first week and a
+            // partial last week so the sub-list on the card shows the full
+            // month's coverage.
+            var weekStart = monthStart.with(TemporalAdjusters.previousOrSame(dow))
+            while (!weekStart.isAfter(monthEnd)) {
+                val weekEnd = weekStart.plusDays(6)
+                // Trim the window to the month so the spend query doesn't
+                // pull transactions from the adjacent month.
+                val clippedStart = if (weekStart.isBefore(monthStart)) monthStart else weekStart
+                val clippedEnd = if (weekEnd.isAfter(monthEnd)) monthEnd else weekEnd
+                if (!clippedStart.isAfter(clippedEnd)) {
+                    val days = ChronoUnit.DAYS.between(clippedStart, clippedEnd).toInt() + 1
+                    results.add(BudgetWindow(clippedStart, clippedEnd, days))
+                }
+                weekStart = weekStart.plusDays(7)
+            }
+            results
+        }
+        BudgetPeriodType.MONTHLY -> {
+            val day = budget.monthStartDay?.let { BudgetCycle.clampStartDay(it) }
+                ?: BudgetCycle.clampStartDay(globalStartDay)
+            val reference = monthStart
+            val (cycleStart, cycleEnd) = BudgetCycle.currentCycle(reference, day)
+            // The cycle may straddle the month. We keep the full cycle
+            // here so the user sees the actual window (e.g. for an
+            // October view of a 25-anchored budget, the cycle is
+            // Sept 25..Oct 24 — the start is in September, but the
+            // October page is the right place to show it because the
+            // cycle's "end" falls in October). The spend query inside
+            // the repo is clipped to the page's month bounds when
+            // needed, but the *displayed* window is the full cycle.
+            if (cycleStart.isAfter(monthEnd) || cycleEnd.isBefore(monthStart)) {
+                emptyList()
+            } else listOf(
+                BudgetWindow(
+                    cycleStart,
+                    cycleEnd,
+                    ChronoUnit.DAYS.between(cycleStart, cycleEnd).toInt() + 1
+                )
+            )
+        }
+        BudgetPeriodType.CUSTOM -> {
+            val start = budget.startDate
+            val end = budget.endDate
+            if (start.isAfter(monthEnd) || end.isBefore(monthStart)) emptyList()
+            else {
+                val clippedStart = if (start.isBefore(monthStart)) monthStart else start
+                val clippedEnd = if (end.isAfter(monthEnd)) monthEnd else end
+                listOf(
+                    BudgetWindow(
+                        clippedStart,
+                        clippedEnd,
+                        ChronoUnit.DAYS.between(clippedStart, clippedEnd).toInt() + 1
+                    )
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetWindow.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetWindow.kt
@@ -1,0 +1,68 @@
+package com.pennywiseai.tracker.data.repository
+
+import com.pennywiseai.tracker.data.database.entity.BudgetEntity
+import com.pennywiseai.tracker.data.database.entity.BudgetPeriodType
+import com.pennywiseai.tracker.domain.model.BudgetCycle
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalAdjusters
+
+/**
+ * A resolved [start, end] date window for a budget at a given [reference] date.
+ *
+ * The start and end are inclusive. [days] is the inclusive day count, used by
+ * the BudgetCard / widget for the daily-allowance / days-left math.
+ */
+data class BudgetWindow(
+    val start: LocalDate,
+    val end: LocalDate,
+    val days: Int
+)
+
+/**
+ * The single source of truth for "what window does this budget cover today?"
+ *
+ * The window is resolved **at read time** from the budget's [BudgetPeriodType]
+ * and its cadence anchor:
+ *
+ *  - [BudgetPeriodType.WEEKLY] — rolls forward automatically every week.
+ *    Window = `[reference.with(previousOrSame(weekday_anchor)), +6 days]`.
+ *  - [BudgetPeriodType.MONTHLY] — rolls forward automatically every cycle.
+ *    Window = `BudgetCycle.currentCycle(reference, month_anchor)`.
+ *  - [BudgetPeriodType.CUSTOM] — the literal `[startDate, endDate]` the
+ *    user picked. No rolling.
+ *
+ * For Weekly and Monthly the row's persisted [BudgetEntity.startDate] /
+ * [BudgetEntity.endDate] are a "last computed" cache; the resolver is what
+ * every read path uses, so a recurring budget always shows the *current*
+ * window without needing DB writes.
+ *
+ * Legacy rows (created before the anchor columns existed) have null anchors.
+ * Weekly falls back to Monday, Monthly falls back to [globalStartDay] (the
+ * user's overall budget cycle start day preference, which defaults to 1).
+ */
+fun resolveBudgetWindow(
+    budget: BudgetEntity,
+    reference: LocalDate,
+    globalStartDay: Int = BudgetCycle.DEFAULT_START_DAY
+): BudgetWindow = when (budget.periodType) {
+    BudgetPeriodType.WEEKLY -> {
+        val dow = budget.weekStartDay?.let { DayOfWeek.of(it.coerceIn(1, 7)) }
+            ?: DayOfWeek.MONDAY
+        val start = reference.with(TemporalAdjusters.previousOrSame(dow))
+        val end = start.plusDays(6)
+        BudgetWindow(start, end, 7)
+    }
+    BudgetPeriodType.MONTHLY -> {
+        val day = budget.monthStartDay?.let { BudgetCycle.clampStartDay(it) }
+            ?: BudgetCycle.clampStartDay(globalStartDay)
+        val (start, end) = BudgetCycle.currentCycle(reference, day)
+        BudgetWindow(start, end, ChronoUnit.DAYS.between(start, end).toInt() + 1)
+    }
+    BudgetPeriodType.CUSTOM -> {
+        val start = budget.startDate
+        val end = budget.endDate
+        BudgetWindow(start, end, ChronoUnit.DAYS.between(start, end).toInt() + 1)
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
@@ -6,13 +6,17 @@ import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionSplitEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.database.entity.TransactionWithSplits
+import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.statement.StatementTransactionEnricher
 import com.pennywiseai.tracker.data.manager.TransactionDeduplication
+import com.pennywiseai.tracker.domain.model.BudgetCycle
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.YearMonth
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -21,7 +25,8 @@ import kotlin.math.min
 @Singleton
 class TransactionRepository @Inject constructor(
     private val transactionDao: TransactionDao,
-    private val transactionSplitDao: TransactionSplitDao
+    private val transactionSplitDao: TransactionSplitDao,
+    private val userPreferencesRepository: UserPreferencesRepository
 ) {
     fun getAllTransactions(): Flow<List<TransactionEntity>> = 
         transactionDao.getAllTransactions()
@@ -272,8 +277,10 @@ class TransactionRepository @Inject constructor(
 
     private fun getTransactionsForCurrentMonth(): Flow<List<TransactionEntity>> {
         val now = LocalDate.now()
-        val startDate = now.withDayOfMonth(1).atStartOfDay()
-        val endDate = now.atTime(23, 59, 59)
+        val startDay = runBlocking { userPreferencesRepository.getBudgetCycleStartDay() }
+        val (cycleStart, cycleEnd) = BudgetCycle.currentCycle(now, startDay)
+        val startDate = cycleStart.atStartOfDay()
+        val endDate = cycleEnd.atTime(LocalTime.MAX)
         return transactionDao.getTransactionsBetweenDates(startDate, endDate)
             // Monthly spending summary ignores analytics-excluded transactions (#451).
             .map { txns -> txns.filter { !it.excludedFromAnalytics } }
@@ -281,13 +288,11 @@ class TransactionRepository @Inject constructor(
 
     private fun getTransactionsForComparableLastMonth(): Flow<List<TransactionEntity>> {
         val now = LocalDate.now()
-        val dayOfMonth = now.dayOfMonth
-        val lastMonth = now.minusMonths(1)
-
-        // Compare same period: if today is 10th, compare 1st-10th of last month
-        val startDate = lastMonth.withDayOfMonth(1).atStartOfDay()
-        val lastMonthMaxDay = min(dayOfMonth, lastMonth.lengthOfMonth())
-        val endDate = lastMonth.withDayOfMonth(lastMonthMaxDay).atTime(23, 59, 59)
+        val startDay = runBlocking { userPreferencesRepository.getBudgetCycleStartDay() }
+        val current = BudgetCycle.currentCycle(now, startDay)
+        val (prevStart, prevEnd) = BudgetCycle.previousCycle(current, startDay)
+        val startDate = prevStart.atStartOfDay()
+        val endDate = prevEnd.atTime(LocalTime.MAX)
         return transactionDao.getTransactionsBetweenDates(startDate, endDate)
             // Monthly spending summary ignores analytics-excluded transactions (#451).
             .map { txns -> txns.filter { !it.excludedFromAnalytics } }

--- a/app/src/main/java/com/pennywiseai/tracker/domain/model/BudgetCycle.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/model/BudgetCycle.kt
@@ -1,0 +1,124 @@
+package com.pennywiseai.tracker.domain.model
+
+import java.time.LocalDate
+import java.time.YearMonth
+
+/**
+ * A user-configurable "monthly" budget cycle that does not have to align with the
+ * calendar month.
+ *
+ * For example, with [startDay] = 25 the current cycle spans from the 25th of the
+ * previous month through the 24th of the current month.
+ *
+ * Days are 1..31. Months that don't have the requested day (e.g. February with
+ * [startDay] = 30) clamp the cycle start to the last day of that month — so a
+ * 30th-of-the-month start yields a Feb-28 / Feb-29 start, and the cycle still
+ * ends on the day before the next cycle's start.
+ *
+ * Used by the budget repositories and the home/analytics surfaces to translate a
+ * "month" (a [YearMonth] the user navigated to) into the actual spend window.
+ */
+object BudgetCycle {
+
+    const val MIN_START_DAY = 1
+    const val MAX_START_DAY = 31
+    const val DEFAULT_START_DAY = 1
+
+    /**
+     * Coerces an arbitrary integer to the valid range [[MIN_START_DAY], [MAX_START_DAY]].
+     * Useful when reading a user-typed or migration-provided value.
+     */
+    fun clampStartDay(value: Int): Int =
+        value.coerceIn(MIN_START_DAY, MAX_START_DAY)
+
+    /**
+     * The cycle that contains [today], for a cycle that starts on [startDay].
+     *
+     * If today.dayOfMonth >= startDay the cycle started earlier this month; otherwise
+     * it started in the previous month.
+     *
+     * @return pair of (cycle start inclusive, cycle end inclusive).
+     */
+    fun currentCycle(today: LocalDate, startDay: Int): Pair<LocalDate, LocalDate> {
+        val safeStart = clampStartDay(startDay)
+        val startOfThisMonth = YearMonth.from(today).atDay(1)
+        val candidateStart = startOfThisMonth.withDayOfMonthSafe(safeStart)
+        val start = if (!today.isBefore(candidateStart)) {
+            candidateStart
+        } else {
+            val prevMonth = YearMonth.from(today).minusMonths(1)
+            prevMonth.atDay(1).withDayOfMonthSafe(safeStart)
+        }
+        val end = nextCycleStart(start, safeStart).minusDays(1)
+        return start to end
+    }
+
+    /**
+     * The cycle immediately before [cycle]. The returned start is exactly one
+     * month earlier than [cycle.first], clamped to the month's length so a
+     * `startDay = 31` doesn't overflow into March — this preserves the same
+     * start-day cadence even across short months.
+     */
+    fun previousCycle(cycle: Pair<LocalDate, LocalDate>, startDay: Int): Pair<LocalDate, LocalDate> {
+        val safeStart = clampStartDay(startDay)
+        // Step one calendar month back from the current cycle's start, then
+        // clamp to the month's length. The previous cycle is then "one month
+        // earlier to one day before the current cycle's start".
+        val prevStart = cycle.first.minusMonths(1).withDayOfMonthSafe(safeStart)
+        val end = cycle.first.minusDays(1)
+        return prevStart to end
+    }
+
+    /**
+     * The cycle immediately after [cycle]. The next start is always one [nextCycleStart]
+     * step past [cycle.first], so cycles never overlap and never have gaps.
+     */
+    fun nextCycle(cycle: Pair<LocalDate, LocalDate>, startDay: Int): Pair<LocalDate, LocalDate> {
+        val safeStart = clampStartDay(startDay)
+        val nextStart = nextCycleStart(cycle.first, safeStart)
+        val end = nextCycleStart(nextStart, safeStart).minusDays(1)
+        return nextStart to end
+    }
+
+    /**
+     * The first day of the cycle that *starts* on or after [reference] for the given
+     * [startDay]. If [reference] is on or after its own month's [startDay] then the
+     * answer is next month; otherwise it is the same month's [startDay].
+     *
+     * This is the cadence primitive — every other helper in this object is built on
+     * it, which guarantees the cycles tile the timeline with no overlaps or gaps.
+     */
+    fun nextCycleStart(reference: LocalDate, startDay: Int): LocalDate {
+        val safeStart = clampStartDay(startDay)
+        val ym = YearMonth.from(reference)
+        val candidate = ym.atDay(1).withDayOfMonthSafe(safeStart)
+        return if (!reference.isBefore(candidate)) {
+            ym.plusMonths(1).atDay(1).withDayOfMonthSafe(safeStart)
+        } else {
+            candidate
+        }
+    }
+
+    /**
+     * Returns the [YearMonth] in which the cycle that *contains* [today] starts.
+     * This is the value callers should pass to historical month navigation (the
+     * Budget Groups screen) so the user lands on their actual current cycle, not
+     * on the calendar month that happens to contain today's date.
+     */
+    fun currentCycleStartYearMonth(today: LocalDate, startDay: Int): YearMonth {
+        val safeStart = clampStartDay(startDay)
+        val ym = YearMonth.from(today)
+        val candidate = ym.atDay(1).withDayOfMonthSafe(safeStart)
+        return if (!today.isBefore(candidate)) ym else ym.minusMonths(1)
+    }
+
+    /**
+     * `LocalDate.withDayOfMonth(...)` throws when the requested day exceeds the
+     * month's length. This helper clamps to the last day of the month so a
+     * `startDay = 31` works for February, April, etc.
+     */
+    private fun LocalDate.withDayOfMonthSafe(day: Int): LocalDate {
+        val max = lengthOfMonth()
+        return withDayOfMonth(day.coerceAtMost(max))
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseDestinations.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseDestinations.kt
@@ -60,6 +60,18 @@ object BudgetGroups
 @Serializable
 data class BudgetGroupEdit(val groupId: Long = -1L)
 
+/**
+ * Per-budget history drill-down. The (year, month) selects the period;
+ * the screen renders the per-window list (Weekly sub-list or Monthly /
+ * One-time window) with each row labelled "Live" or "Frozen as of …".
+ */
+@Serializable
+data class BudgetHistory(
+    val groupId: Long,
+    val year: Int,
+    val month: Int
+)
+
 @Serializable
 object Loans
 

--- a/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseNavHost.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseNavHost.kt
@@ -329,6 +329,11 @@ fun PennyWiseNavHost(
                         launchSingleTop = true
                     }
                 },
+                onNavigateToHistory = { groupId, year, month ->
+                    navController.navigate(BudgetHistory(groupId, year, month)) {
+                        launchSingleTop = true
+                    }
+                },
                 onNavigateToCategory = { category, yearMonth, currency ->
                     navController.navigate(TransactionsWithFilter(category, yearMonth, currency)) {
                         launchSingleTop = true
@@ -347,6 +352,17 @@ fun PennyWiseNavHost(
                 onNavigateBack = {
                     navController.safePopBackStack()
                 }
+            )
+        }
+
+        composable<BudgetHistory>(
+            enterTransition = { fadeIn(tween(300)) + slideInVertically { it / 4 } },
+            exitTransition = { fadeOut(tween(200)) },
+            popEnterTransition = { fadeIn(tween(300)) },
+            popExitTransition = { fadeOut(tween(200)) + slideOutVertically { it / 4 } }
+        ) {
+            com.pennywiseai.tracker.presentation.budgetgroups.BudgetHistoryScreen(
+                onNavigateBack = { navController.safePopBackStack() }
             )
         }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupEditScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupEditScreen.kt
@@ -230,9 +230,13 @@ fun BudgetGroupEditScreen(
                         val longDateFormatter = remember { DateTimeFormatter.ofPattern("d MMM") }
 
                         // Cadence chip row — Weekly / Monthly / One-time.
-                        Row(
+                        // FlowRow wraps the "One-time" chip onto a new line
+                        // when the screen is too narrow to fit all three
+                        // horizontally, so the chips never get clipped.
+                        FlowRow(
                             modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(Spacing.xs)
+                            horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+                            verticalArrangement = Arrangement.spacedBy(Spacing.xs)
                         ) {
                             listOf(
                                 BudgetPeriodType.WEEKLY to "Weekly (recurring)",

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupEditScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupEditScreen.kt
@@ -48,7 +48,10 @@ import com.pennywiseai.tracker.ui.theme.*
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
 import com.pennywiseai.tracker.utils.CurrencyFormatter
+import com.pennywiseai.tracker.data.database.entity.BudgetPeriodType
 import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -61,6 +64,7 @@ fun BudgetGroupEditScreen(
     var showAddCategoryDropdown by remember { mutableStateOf(false) }
     var isEditingName by remember { mutableStateOf(false) }
     var isEditingAmount by remember { mutableStateOf(false) }
+    var showStartDatePicker by remember { mutableStateOf(false) }
 
     LaunchedEffect(uiState.saveComplete) {
         if (uiState.saveComplete) {
@@ -204,6 +208,106 @@ fun BudgetGroupEditScreen(
                     onNameDone = { isEditingName = false },
                     onAmountDone = { isEditingAmount = false }
                 )
+            }
+
+            // Budget Period — custom start date + period-type chips. The end
+            // date is read-only and auto-derived by the viewmodel, so the
+            // user only ever picks the start anchor and the cadence.
+            item {
+                SectionHeaderV2(title = "Budget Period")
+                Spacer(modifier = Modifier.height(Spacing.xs))
+                PennyWiseCardV2(modifier = Modifier.fillMaxWidth()) {
+                    Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                        val dateFormatter = remember { DateTimeFormatter.ofPattern("d MMM yyyy") }
+                        // Start date row — tap to open the Material 3 date picker.
+                        // Shows the formatted date and a calendar icon so the
+                        // affordance is discoverable even when the user only
+                        // came to edit the amount.
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { showStartDatePicker = true }
+                                .padding(vertical = Spacing.sm),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.CalendarMonth,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                            Spacer(modifier = Modifier.width(Spacing.sm))
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = "Start date",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Text(
+                                    text = uiState.startDate.format(dateFormatter),
+                                    style = MaterialTheme.typography.bodyLarge
+                                )
+                            }
+                        }
+
+                        HorizontalDivider(
+                            color = MaterialTheme.colorScheme.outlineVariant.copy(
+                                alpha = Dimensions.Alpha.divider
+                            )
+                        )
+
+                        // Read-only end date. Re-derives from the picked
+                        // start + period type on every state change so the
+                        // user sees the window they're about to save.
+                        val periodLabel = when (uiState.periodType) {
+                            BudgetPeriodType.WEEKLY -> "Weekly"
+                            BudgetPeriodType.MONTHLY -> "Monthly"
+                            BudgetPeriodType.CUSTOM -> "Custom"
+                        }
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.EventAvailable,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Spacer(modifier = Modifier.width(Spacing.sm))
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = "Ends on",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Text(
+                                    text = "${uiState.endDate.format(dateFormatter)} · $periodLabel",
+                                    style = MaterialTheme.typography.bodyLarge
+                                )
+                            }
+                        }
+
+                        // Period-type chip row. The start-date anchor stays
+                        // fixed when the cadence changes; only the
+                        // derived end date moves.
+                        Spacer(modifier = Modifier.height(Spacing.xs))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(Spacing.xs)
+                        ) {
+                            listOf(
+                                BudgetPeriodType.WEEKLY to "Weekly",
+                                BudgetPeriodType.MONTHLY to "Monthly",
+                                BudgetPeriodType.CUSTOM to "Custom"
+                            ).forEach { (period, label) ->
+                                FilterChip(
+                                    selected = uiState.periodType == period,
+                                    onClick = { viewModel.updatePeriodType(period) },
+                                    label = { Text(label) }
+                                )
+                            }
+                        }
+                    }
+                }
             }
 
             // Categories Section
@@ -357,6 +461,30 @@ fun BudgetGroupEditScreen(
         }
 
         // Delete confirmation dialog
+        if (showStartDatePicker) {
+            val datePickerState = rememberDatePickerState(
+                initialSelectedDateMillis = uiState.startDate.toEpochDay() * 86_400_000
+            )
+            DatePickerDialog(
+                onDismissRequest = { showStartDatePicker = false },
+                confirmButton = {
+                    TextButton(onClick = {
+                        datePickerState.selectedDateMillis?.let { millis ->
+                            viewModel.updateStartDate(LocalDate.ofEpochDay(millis / 86_400_000))
+                        }
+                        showStartDatePicker = false
+                    }) { Text("OK") }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showStartDatePicker = false }) {
+                        Text("Cancel")
+                    }
+                }
+            ) {
+                DatePicker(state = datePickerState)
+            }
+        }
+
         if (showDeleteDialog) {
             AlertDialog(
                 onDismissRequest = { showDeleteDialog = false },

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupEditScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupEditScreen.kt
@@ -65,6 +65,7 @@ fun BudgetGroupEditScreen(
     var isEditingName by remember { mutableStateOf(false) }
     var isEditingAmount by remember { mutableStateOf(false) }
     var showStartDatePicker by remember { mutableStateOf(false) }
+    var showEndDatePicker by remember { mutableStateOf(false) }
 
     LaunchedEffect(uiState.saveComplete) {
         if (uiState.saveComplete) {
@@ -210,41 +211,38 @@ fun BudgetGroupEditScreen(
                 )
             }
 
-            // Budget Period — custom start date + period-type chips. The end
-            // date is read-only and auto-derived by the viewmodel, so the
-            // user only ever picks the start anchor and the cadence.
+            // Budget Period — three cadences:
+            //   Weekly  → pick the day-of-week the week starts on. Recurring.
+            //   Monthly → pick the day-of-month the cycle starts on. Recurring.
+            //   One-time → pick an exact start and end date. No rolling.
+            //
+            // The cadence chip row sits at the top of the card; the form
+            // below rebuilds to match. The "Ends on" line at the bottom
+            // shows the resolved *current* window for the picked cadence
+            // (the row's persisted [startDate, endDate] cache is refreshed
+            // on save so the home card / widget stay in sync).
             item {
                 SectionHeaderV2(title = "Budget Period")
                 Spacer(modifier = Modifier.height(Spacing.xs))
                 PennyWiseCardV2(modifier = Modifier.fillMaxWidth()) {
                     Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
                         val dateFormatter = remember { DateTimeFormatter.ofPattern("d MMM yyyy") }
-                        // Start date row — tap to open the Material 3 date picker.
-                        // Shows the formatted date and a calendar icon so the
-                        // affordance is discoverable even when the user only
-                        // came to edit the amount.
+                        val longDateFormatter = remember { DateTimeFormatter.ofPattern("d MMM") }
+
+                        // Cadence chip row — Weekly / Monthly / One-time.
                         Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable { showStartDatePicker = true }
-                                .padding(vertical = Spacing.sm),
-                            verticalAlignment = Alignment.CenterVertically
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(Spacing.xs)
                         ) {
-                            Icon(
-                                imageVector = Icons.Default.CalendarMonth,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary
-                            )
-                            Spacer(modifier = Modifier.width(Spacing.sm))
-                            Column(modifier = Modifier.weight(1f)) {
-                                Text(
-                                    text = "Start date",
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                                Text(
-                                    text = uiState.startDate.format(dateFormatter),
-                                    style = MaterialTheme.typography.bodyLarge
+                            listOf(
+                                BudgetPeriodType.WEEKLY to "Weekly (recurring)",
+                                BudgetPeriodType.MONTHLY to "Monthly (recurring)",
+                                BudgetPeriodType.CUSTOM to "One-time"
+                            ).forEach { (period, label) ->
+                                FilterChip(
+                                    selected = uiState.periodType == period,
+                                    onClick = { viewModel.updatePeriodType(period) },
+                                    label = { Text(label) }
                                 )
                             }
                         }
@@ -255,13 +253,52 @@ fun BudgetGroupEditScreen(
                             )
                         )
 
-                        // Read-only end date. Re-derives from the picked
-                        // start + period type on every state change so the
-                        // user sees the window they're about to save.
-                        val periodLabel = when (uiState.periodType) {
-                            BudgetPeriodType.WEEKLY -> "Weekly"
-                            BudgetPeriodType.MONTHLY -> "Monthly"
-                            BudgetPeriodType.CUSTOM -> "Custom"
+                        // Mode-specific form.
+                        when (uiState.periodType) {
+                            BudgetPeriodType.WEEKLY -> {
+                                WeekdayAnchorRow(
+                                    weekStartDay = uiState.weekStartDay,
+                                    onWeekdaySelected = viewModel::updateWeekStartDay
+                                )
+                            }
+                            BudgetPeriodType.MONTHLY -> {
+                                MonthAnchorRow(
+                                    monthStartDay = uiState.monthStartDay,
+                                    onMonthDaySelected = viewModel::updateMonthStartDay
+                                )
+                            }
+                            BudgetPeriodType.CUSTOM -> {
+                                OneTimeDateRow(
+                                    label = "Start date",
+                                    date = uiState.startDate,
+                                    formatter = dateFormatter,
+                                    onClick = { showStartDatePicker = true }
+                                )
+                                OneTimeDateRow(
+                                    label = "End date",
+                                    date = uiState.endDate,
+                                    formatter = dateFormatter,
+                                    onClick = { showEndDatePicker = true }
+                                )
+                            }
+                        }
+
+                        HorizontalDivider(
+                            color = MaterialTheme.colorScheme.outlineVariant.copy(
+                                alpha = Dimensions.Alpha.divider
+                            )
+                        )
+
+                        // Read-only "current window" line. Shows the window
+                        // the budget will track *now* — same logic the home
+                        // card and widget use at read time.
+                        val anchorCaption = when (uiState.periodType) {
+                            BudgetPeriodType.WEEKLY ->
+                                "Resets every ${dayOfWeekName(uiState.weekStartDay)}"
+                            BudgetPeriodType.MONTHLY ->
+                                "Resets on day ${uiState.monthStartDay} of every month"
+                            BudgetPeriodType.CUSTOM ->
+                                "Runs once, no rollover"
                         }
                         Row(
                             modifier = Modifier.fillMaxWidth(),
@@ -275,34 +312,13 @@ fun BudgetGroupEditScreen(
                             Spacer(modifier = Modifier.width(Spacing.sm))
                             Column(modifier = Modifier.weight(1f)) {
                                 Text(
-                                    text = "Ends on",
+                                    text = "Current window",
                                     style = MaterialTheme.typography.labelSmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
                                 Text(
-                                    text = "${uiState.endDate.format(dateFormatter)} · $periodLabel",
-                                    style = MaterialTheme.typography.bodyLarge
-                                )
-                            }
-                        }
-
-                        // Period-type chip row. The start-date anchor stays
-                        // fixed when the cadence changes; only the
-                        // derived end date moves.
-                        Spacer(modifier = Modifier.height(Spacing.xs))
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(Spacing.xs)
-                        ) {
-                            listOf(
-                                BudgetPeriodType.WEEKLY to "Weekly",
-                                BudgetPeriodType.MONTHLY to "Monthly",
-                                BudgetPeriodType.CUSTOM to "Custom"
-                            ).forEach { (period, label) ->
-                                FilterChip(
-                                    selected = uiState.periodType == period,
-                                    onClick = { viewModel.updatePeriodType(period) },
-                                    label = { Text(label) }
+                                    text = "${uiState.startDate.format(longDateFormatter)} – ${uiState.endDate.format(longDateFormatter)} · $anchorCaption",
+                                    style = MaterialTheme.typography.bodyMedium
                                 )
                             }
                         }
@@ -477,6 +493,31 @@ fun BudgetGroupEditScreen(
                 },
                 dismissButton = {
                     TextButton(onClick = { showStartDatePicker = false }) {
+                        Text("Cancel")
+                    }
+                }
+            ) {
+                DatePicker(state = datePickerState)
+            }
+        }
+
+        // End-date picker — Custom mode only.
+        if (showEndDatePicker) {
+            val datePickerState = rememberDatePickerState(
+                initialSelectedDateMillis = uiState.endDate.toEpochDay() * 86_400_000
+            )
+            DatePickerDialog(
+                onDismissRequest = { showEndDatePicker = false },
+                confirmButton = {
+                    TextButton(onClick = {
+                        datePickerState.selectedDateMillis?.let { millis ->
+                            viewModel.updateEndDate(LocalDate.ofEpochDay(millis / 86_400_000))
+                        }
+                        showEndDatePicker = false
+                    }) { Text("OK") }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showEndDatePicker = false }) {
                         Text("Cancel")
                     }
                 }
@@ -740,6 +781,174 @@ private fun CategoryBudgetRow(
                 contentDescription = "Remove",
                 modifier = Modifier.size(Dimensions.Icon.small),
                 tint = MaterialTheme.colorScheme.error
+            )
+        }
+    }
+}
+
+// ── Budget Period helpers ───────────────────────────────────────────────
+
+/**
+ * Returns the long English name for a [DayOfWeek] from its `value`
+ * (1=Mon..7=Sun per `java.time.DayOfWeek.value`). Falls back to "Monday"
+ * for out-of-range inputs.
+ */
+private fun dayOfWeekName(value: Int): String = when (value.coerceIn(1, 7)) {
+    1 -> "Monday"
+    2 -> "Tuesday"
+    3 -> "Wednesday"
+    4 -> "Thursday"
+    5 -> "Friday"
+    6 -> "Saturday"
+    else -> "Sunday"
+}
+
+/**
+ * Weekly cadence row — dropdown to pick the day-of-week the week starts
+ * on. Selecting a day calls [onWeekdaySelected] which the viewmodel turns
+ * into a "this week's window" start..end.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun WeekdayAnchorRow(
+    weekStartDay: Int,
+    onWeekdaySelected: (Int) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.Default.CalendarMonth,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Spacer(modifier = Modifier.width(Spacing.sm))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "Week starts on",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            ExposedDropdownMenuBox(
+                expanded = expanded,
+                onExpandedChange = { expanded = it }
+            ) {
+                OutlinedTextField(
+                    value = dayOfWeekName(weekStartDay),
+                    onValueChange = {},
+                    readOnly = true,
+                    singleLine = true,
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                    modifier = Modifier
+                        .menuAnchor()
+                        .fillMaxWidth()
+                )
+                ExposedDropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false }
+                ) {
+                    (1..7).forEach { day ->
+                        DropdownMenuItem(
+                            text = { Text(dayOfWeekName(day)) },
+                            onClick = {
+                                onWeekdaySelected(day)
+                                expanded = false
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Monthly cadence row — stepper for 1..31. Clamps at 31 (the resolver
+ * handles the Feb-30/31 case at read time).
+ */
+@Composable
+private fun MonthAnchorRow(
+    monthStartDay: Int,
+    onMonthDaySelected: (Int) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.Default.CalendarMonth,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Spacer(modifier = Modifier.width(Spacing.sm))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "Month starts on day",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = monthStartDay.toString(),
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+        // – / + stepper row. A real NumberPicker would be more accurate
+        // for tapping the precise day, but a stepper is enough for the
+        // common case (1..31) and matches the rest of the app's stepper
+        // pattern.
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            OutlinedIconButton(
+                onClick = { onMonthDaySelected(monthStartDay - 1) },
+                enabled = monthStartDay > 1
+            ) {
+                Icon(Icons.Default.KeyboardArrowDown, contentDescription = "Decrease day")
+            }
+            Spacer(modifier = Modifier.width(Spacing.xs))
+            OutlinedIconButton(
+                onClick = { onMonthDaySelected(monthStartDay + 1) },
+                enabled = monthStartDay < 31
+            ) {
+                Icon(Icons.Default.KeyboardArrowUp, contentDescription = "Increase day")
+            }
+        }
+    }
+}
+
+/**
+ * One-time (CUSTOM) cadence row — tap-to-pick date label, reused for
+ * both start and end.
+ */
+@Composable
+private fun OneTimeDateRow(
+    label: String,
+    date: java.time.LocalDate,
+    formatter: DateTimeFormatter,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = Spacing.xs),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.Default.CalendarMonth,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Spacer(modifier = Modifier.width(Spacing.sm))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = date.format(formatter),
+                style = MaterialTheme.typography.bodyLarge
             )
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupEditViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupEditViewModel.kt
@@ -6,11 +6,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.data.database.dao.TransactionSplitDao
 import com.pennywiseai.tracker.data.database.entity.BudgetGroupType
+import com.pennywiseai.tracker.data.database.entity.BudgetPeriodType
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.repository.BudgetBucketInput
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository
+import com.pennywiseai.tracker.data.repository.BudgetRepository
 import com.pennywiseai.tracker.data.repository.CategoryRepository
+import com.pennywiseai.tracker.domain.model.BudgetCycle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -49,6 +52,12 @@ data class BudgetGroupEditUiState(
     val typeSpending: Map<String, BigDecimal> = emptyMap(),
     val currency: String = "INR",
     val availableCurrencies: List<String> = emptyList(),
+    /** The budget's start date. Editable via the date picker. */
+    val startDate: LocalDate = LocalDate.now(),
+    /** Read-only end date, auto-derived from [startDate] + [periodType]. */
+    val endDate: LocalDate = LocalDate.now(),
+    /** Weekly / Monthly / Custom. Drives how [endDate] is derived. */
+    val periodType: BudgetPeriodType = BudgetPeriodType.MONTHLY,
     val isLoading: Boolean = true,
     val isSaving: Boolean = false,
     val saveComplete: Boolean = false
@@ -85,6 +94,14 @@ class BudgetGroupEditViewModel @Inject constructor(
             val yearMonth = YearMonth.from(today)
             val startDate = yearMonth.atDay(1).atStartOfDay()
             val endDate = yearMonth.atEndOfMonth().atTime(23, 59, 59)
+
+            // Default the new-budget start date to the user's current budget
+            // cycle start (e.g. Sep 25 if today is Oct 5 and startDay=25) so
+            // a fresh budget lands in the same window the home screen shows.
+            // Editing an existing budget overrides this below.
+            val cycleStartDay = userPreferencesRepository.getBudgetCycleStartDay()
+            val defaultStart = BudgetCycle.currentCycleStartYearMonth(today, cycleStartDay).atDay(1)
+            val defaultEnd = BudgetRepository.endDateFor(defaultStart, BudgetPeriodType.MONTHLY)
 
             val transactions = transactionSplitDao.getTransactionsWithSplitsFiltered(startDate, endDate, currency).first()
             // Mirror the main budget screen's routing: type-bucket-eligible
@@ -132,6 +149,15 @@ class BudgetGroupEditViewModel @Inject constructor(
                         typeSpending = typeSpending,
                         currency = group.budget.currency,
                         availableCurrencies = currencies,
+                        // Editing: trust the budget's own persisted dates and
+                        // period type. The end date is just persisted metadata
+                        // — re-derive it from start + periodType so the
+                        // read-only label matches the live calc, even if an
+                        // older row's end_date is slightly off (e.g. a budget
+                        // created before this feature was added).
+                        startDate = group.budget.startDate,
+                        endDate = BudgetRepository.endDateFor(group.budget.startDate, group.budget.periodType),
+                        periodType = group.budget.periodType,
                         isLoading = false
                     )
                 }
@@ -142,6 +168,12 @@ class BudgetGroupEditViewModel @Inject constructor(
                     categorySpending = categorySpending,
                     typeSpending = typeSpending,
                     availableCurrencies = currencies,
+                    // Creating: seed the start to the current cycle start so
+                    // the budget lands in the same window the home screen
+                    // shows, with the end auto-derived.
+                    startDate = defaultStart,
+                    endDate = defaultEnd,
+                    periodType = BudgetPeriodType.MONTHLY,
                     isLoading = false
                 )
             }
@@ -237,6 +269,34 @@ class BudgetGroupEditViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(categories = current)
     }
 
+    /**
+     * Updates the budget's start date and re-derives the end date for the
+     * currently-selected period type. The end date is read-only, so this is
+     * the only place that mutates either — the screen just renders the
+     * recomputed value.
+     */
+    fun updateStartDate(date: LocalDate) {
+        val period = _uiState.value.periodType
+        _uiState.value = _uiState.value.copy(
+            startDate = date,
+            endDate = BudgetRepository.endDateFor(date, period)
+        )
+    }
+
+    /**
+     * Switches the period type (Weekly / Monthly / Custom) and re-derives the
+     * end date from the currently-set start date. Switching from a 1-month
+     * window to a 1-week window is intentional — the user explicitly chose
+     * the cadence and the start anchor they want.
+     */
+    fun updatePeriodType(period: BudgetPeriodType) {
+        val start = _uiState.value.startDate
+        _uiState.value = _uiState.value.copy(
+            periodType = period,
+            endDate = BudgetRepository.endDateFor(start, period)
+        )
+    }
+
     fun save() {
         val state = _uiState.value
         if (state.name.isBlank()) return
@@ -259,7 +319,11 @@ class BudgetGroupEditViewModel @Inject constructor(
                     color = defaultColor,
                     buckets = buckets,
                     currency = state.currency,
-                    limitAmount = overallAmount
+                    limitAmount = overallAmount,
+                    // Pass the per-budget dates through; the repo recomputes
+                    // endDate from the budget's existing periodType.
+                    customStartDate = state.startDate,
+                    periodType = state.periodType
                 )
             } else {
                 budgetGroupRepository.createGroup(
@@ -268,7 +332,9 @@ class BudgetGroupEditViewModel @Inject constructor(
                     color = defaultColor,
                     buckets = buckets,
                     currency = state.currency,
-                    limitAmount = overallAmount
+                    limitAmount = overallAmount,
+                    customStartDate = state.startDate,
+                    periodType = state.periodType
                 )
             }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupEditViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupEditViewModel.kt
@@ -11,7 +11,6 @@ import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.repository.BudgetBucketInput
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository
-import com.pennywiseai.tracker.data.repository.BudgetRepository
 import com.pennywiseai.tracker.data.repository.CategoryRepository
 import com.pennywiseai.tracker.domain.model.BudgetCycle
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -52,12 +51,27 @@ data class BudgetGroupEditUiState(
     val typeSpending: Map<String, BigDecimal> = emptyMap(),
     val currency: String = "INR",
     val availableCurrencies: List<String> = emptyList(),
-    /** The budget's start date. Editable via the date picker. */
-    val startDate: LocalDate = LocalDate.now(),
-    /** Read-only end date, auto-derived from [startDate] + [periodType]. */
-    val endDate: LocalDate = LocalDate.now(),
-    /** Weekly / Monthly / Custom. Drives how [endDate] is derived. */
+    /**
+     * The cadence this budget runs on.
+     *
+     *  - WEEKLY  — recurs every week starting on [weekStartDay] (1=Mon..7=Sun).
+     *              [startDate] / [endDate] are read-only and show the *current*
+     *              week window.
+     *  - MONTHLY — recurs every month starting on [monthStartDay] (1..31).
+     *              [startDate] / [endDate] are read-only and show the *current*
+     *              cycle window.
+     *  - CUSTOM  — one-time. [startDate] / [endDate] are user-picked literals
+     *              and don't roll.
+     */
     val periodType: BudgetPeriodType = BudgetPeriodType.MONTHLY,
+    /** WEEKLY only. 1=Mon..7=Sun. */
+    val weekStartDay: Int = 1,
+    /** MONTHLY only. 1..31, clamped to the month's length at resolve time. */
+    val monthStartDay: Int = 1,
+    /** For CUSTOM: the literal start date. For other period types: read-only cache of the current window's start. */
+    val startDate: LocalDate = LocalDate.now(),
+    /** For CUSTOM: the literal end date. For other period types: read-only cache of the current window's end. */
+    val endDate: LocalDate = LocalDate.now(),
     val isLoading: Boolean = true,
     val isSaving: Boolean = false,
     val saveComplete: Boolean = false
@@ -95,14 +109,11 @@ class BudgetGroupEditViewModel @Inject constructor(
             val startDate = yearMonth.atDay(1).atStartOfDay()
             val endDate = yearMonth.atEndOfMonth().atTime(23, 59, 59)
 
-            // Default the new-budget start date to the user's current budget
-            // cycle start (e.g. Sep 25 if today is Oct 5 and startDay=25) so
-            // a fresh budget lands in the same window the home screen shows.
-            // Editing an existing budget overrides this below.
-            val cycleStartDay = userPreferencesRepository.getBudgetCycleStartDay()
-            val defaultStart = BudgetCycle.currentCycleStartYearMonth(today, cycleStartDay).atDay(1)
-            val defaultEnd = BudgetRepository.endDateFor(defaultStart, BudgetPeriodType.MONTHLY)
-
+            // The "spending hint" panel on the right of the budget amount
+            // ("Spent: $X") is computed from the calendar month regardless
+            // of cadence — it's a quick glance, not the authoritative spend
+            // figure. The authoritative spend figure is what the home card
+            // shows, which honours the budget's own period window.
             val transactions = transactionSplitDao.getTransactionsWithSplitsFiltered(startDate, endDate, currency).first()
             // Mirror the main budget screen's routing: type-bucket-eligible
             // outflows (INVESTMENT) are summed per type, everything else per
@@ -140,40 +151,48 @@ class BudgetGroupEditViewModel @Inject constructor(
                             matchType = it.matchType
                         )
                     }
+                    val b = group.budget
                     _uiState.value = BudgetGroupEditUiState(
                         groupId = groupId,
-                        name = group.budget.name,
-                        overallAmount = if (group.budget.limitAmount.compareTo(BigDecimal.ZERO) == 0) "" else group.budget.limitAmount.toPlainString(),
+                        name = b.name,
+                        overallAmount = if (b.limitAmount.compareTo(BigDecimal.ZERO) == 0) "" else b.limitAmount.toPlainString(),
                         categories = assignedCategories,
                         categorySpending = categorySpending,
                         typeSpending = typeSpending,
-                        currency = group.budget.currency,
+                        currency = b.currency,
                         availableCurrencies = currencies,
-                        // Editing: trust the budget's own persisted dates and
-                        // period type. The end date is just persisted metadata
-                        // — re-derive it from start + periodType so the
-                        // read-only label matches the live calc, even if an
-                        // older row's end_date is slightly off (e.g. a budget
-                        // created before this feature was added).
-                        startDate = group.budget.startDate,
-                        endDate = BudgetRepository.endDateFor(group.budget.startDate, group.budget.periodType),
-                        periodType = group.budget.periodType,
+                        // Editing: trust the budget's own persisted period
+                        // type + anchor + dates. We re-derive the displayed
+                        // [startDate, endDate] window for WEEKLY / MONTHLY
+                        // from the anchor + today so the read-only label
+                        // always shows the *current* window — even for a
+                        // row created weeks/months ago.
+                        periodType = b.periodType,
+                        weekStartDay = b.weekStartDay?.coerceIn(1, 7) ?: 1,
+                        monthStartDay = b.monthStartDay ?: userPreferencesRepository.getBudgetCycleStartDay(),
+                        startDate = currentWindowStart(b, today, userPreferencesRepository.getBudgetCycleStartDay()),
+                        endDate = currentWindowEnd(b, today, userPreferencesRepository.getBudgetCycleStartDay()),
                         isLoading = false
                     )
                 }
             } else {
+                val cycleStartDay = userPreferencesRepository.getBudgetCycleStartDay()
+                val initialMonthStart = cycleStartDay
+                val (initialStart, initialEnd) = defaultMonthlyWindow(today, initialMonthStart)
                 _uiState.value = BudgetGroupEditUiState(
                     name = "Monthly Budget",
                     currency = currency,
                     categorySpending = categorySpending,
                     typeSpending = typeSpending,
                     availableCurrencies = currencies,
-                    // Creating: seed the start to the current cycle start so
-                    // the budget lands in the same window the home screen
-                    // shows, with the end auto-derived.
-                    startDate = defaultStart,
-                    endDate = defaultEnd,
+                    // Creating: default to Monthly anchored to the user's
+                    // global budget cycle start day. The user can flip the
+                    // chip to Weekly or One-time and the form rebuilds.
                     periodType = BudgetPeriodType.MONTHLY,
+                    weekStartDay = 1,
+                    monthStartDay = initialMonthStart,
+                    startDate = initialStart,
+                    endDate = initialEnd,
                     isLoading = false
                 )
             }
@@ -270,31 +289,78 @@ class BudgetGroupEditViewModel @Inject constructor(
     }
 
     /**
-     * Updates the budget's start date and re-derives the end date for the
-     * currently-selected period type. The end date is read-only, so this is
-     * the only place that mutates either — the screen just renders the
-     * recomputed value.
+     * Switches the period type. The form below the chip row rebuilds to
+     * match — Weekly shows a day-of-week dropdown, Monthly shows a
+     * day-of-month stepper, One-time shows two date pickers.
      */
-    fun updateStartDate(date: LocalDate) {
-        val period = _uiState.value.periodType
+    fun updatePeriodType(period: BudgetPeriodType) {
+        val today = LocalDate.now()
+        val current = _uiState.value
+        val (newStart, newEnd) = when (period) {
+            BudgetPeriodType.WEEKLY -> {
+                val s = today.with(java.time.temporal.TemporalAdjusters.previousOrSame(java.time.DayOfWeek.of(current.weekStartDay)))
+                s to s.plusDays(6)
+            }
+            BudgetPeriodType.MONTHLY -> BudgetCycle.currentCycle(today, current.monthStartDay)
+            BudgetPeriodType.CUSTOM -> {
+                // Switching into One-time: keep the currently-displayed window
+                // as the user's starting point. They can edit both dates freely.
+                current.startDate to current.endDate
+            }
+        }
+        _uiState.value = current.copy(
+            periodType = period,
+            startDate = newStart,
+            endDate = newEnd
+        )
+    }
+
+    /** WEEKLY: which day-of-week the week starts on (1=Mon..7=Sun). */
+    fun updateWeekStartDay(day: Int) {
+        val safe = day.coerceIn(1, 7)
+        val today = LocalDate.now()
+        val start = today.with(java.time.temporal.TemporalAdjusters.previousOrSame(java.time.DayOfWeek.of(safe)))
         _uiState.value = _uiState.value.copy(
-            startDate = date,
-            endDate = BudgetRepository.endDateFor(date, period)
+            weekStartDay = safe,
+            startDate = start,
+            endDate = start.plusDays(6)
+        )
+    }
+
+    /** MONTHLY: which day-of-month the cycle starts on (1..31). */
+    fun updateMonthStartDay(day: Int) {
+        val safe = BudgetCycle.clampStartDay(day)
+        val today = LocalDate.now()
+        val (s, e) = BudgetCycle.currentCycle(today, safe)
+        _uiState.value = _uiState.value.copy(
+            monthStartDay = safe,
+            startDate = s,
+            endDate = e
         )
     }
 
     /**
-     * Switches the period type (Weekly / Monthly / Custom) and re-derives the
-     * end date from the currently-set start date. Switching from a 1-month
-     * window to a 1-week window is intentional — the user explicitly chose
-     * the cadence and the start anchor they want.
+     * One-time only: update the literal start date. If the user picks a
+     * date on or after the current end, we push the end one day further
+     * so the window stays well-formed.
      */
-    fun updatePeriodType(period: BudgetPeriodType) {
-        val start = _uiState.value.startDate
-        _uiState.value = _uiState.value.copy(
-            periodType = period,
-            endDate = BudgetRepository.endDateFor(start, period)
-        )
+    fun updateStartDate(date: LocalDate) {
+        val current = _uiState.value
+        if (current.periodType != BudgetPeriodType.CUSTOM) return
+        val newEnd = if (!date.isBefore(current.endDate)) date.plusDays(1) else current.endDate
+        _uiState.value = current.copy(startDate = date, endDate = newEnd)
+    }
+
+    /**
+     * One-time only: update the literal end date. The end must be strictly
+     * after the start; if the user picks a date on or before the start we
+     * snap it to start+1 day.
+     */
+    fun updateEndDate(date: LocalDate) {
+        val current = _uiState.value
+        if (current.periodType != BudgetPeriodType.CUSTOM) return
+        val safe = if (!date.isAfter(current.startDate)) current.startDate.plusDays(1) else date
+        _uiState.value = current.copy(endDate = safe)
     }
 
     fun save() {
@@ -320,10 +386,11 @@ class BudgetGroupEditViewModel @Inject constructor(
                     buckets = buckets,
                     currency = state.currency,
                     limitAmount = overallAmount,
-                    // Pass the per-budget dates through; the repo recomputes
-                    // endDate from the budget's existing periodType.
-                    customStartDate = state.startDate,
-                    periodType = state.periodType
+                    periodType = state.periodType,
+                    weekStartDay = state.weekStartDay.takeIf { state.periodType == BudgetPeriodType.WEEKLY },
+                    monthStartDay = state.monthStartDay.takeIf { state.periodType == BudgetPeriodType.MONTHLY },
+                    startDate = state.startDate.takeIf { state.periodType == BudgetPeriodType.CUSTOM },
+                    endDate = state.endDate.takeIf { state.periodType == BudgetPeriodType.CUSTOM }
                 )
             } else {
                 budgetGroupRepository.createGroup(
@@ -333,8 +400,11 @@ class BudgetGroupEditViewModel @Inject constructor(
                     buckets = buckets,
                     currency = state.currency,
                     limitAmount = overallAmount,
-                    customStartDate = state.startDate,
-                    periodType = state.periodType
+                    periodType = state.periodType,
+                    weekStartDay = state.weekStartDay.takeIf { state.periodType == BudgetPeriodType.WEEKLY },
+                    monthStartDay = state.monthStartDay.takeIf { state.periodType == BudgetPeriodType.MONTHLY },
+                    startDate = state.startDate.takeIf { state.periodType == BudgetPeriodType.CUSTOM },
+                    endDate = state.endDate.takeIf { state.periodType == BudgetPeriodType.CUSTOM }
                 )
             }
 
@@ -357,5 +427,52 @@ class BudgetGroupEditViewModel @Inject constructor(
         private val ALL_TYPE_BUCKETS = listOf(
             TypeBucketOption(TransactionType.INVESTMENT.name, "Investments")
         )
+
+        /**
+         * Default Monthly window for a brand-new budget. Anchored to
+         * [monthStartDay] (the user's global budget cycle start day pref).
+         */
+        fun defaultMonthlyWindow(today: LocalDate, monthStartDay: Int): Pair<LocalDate, LocalDate> =
+            BudgetCycle.currentCycle(today, BudgetCycle.clampStartDay(monthStartDay))
+
+        /**
+         * Resolve the *current* window's start for an existing budget,
+         * honouring its period type and anchor. Used by the edit screen to
+         * keep the read-only "Ends on …" label accurate even for rows
+         * created weeks/months ago (whose persisted [startDate, endDate]
+         * cache is stale).
+         */
+        fun currentWindowStart(
+            budget: com.pennywiseai.tracker.data.database.entity.BudgetEntity,
+            today: LocalDate,
+            globalStartDay: Int
+        ): LocalDate = when (budget.periodType) {
+            BudgetPeriodType.WEEKLY -> today.with(
+                java.time.temporal.TemporalAdjusters.previousOrSame(
+                    java.time.DayOfWeek.of(budget.weekStartDay?.coerceIn(1, 7) ?: 1)
+                )
+            )
+            BudgetPeriodType.MONTHLY -> BudgetCycle.currentCycle(
+                today,
+                budget.monthStartDay?.let { BudgetCycle.clampStartDay(it) }
+                    ?: BudgetCycle.clampStartDay(globalStartDay)
+            ).first
+            BudgetPeriodType.CUSTOM -> budget.startDate
+        }
+
+        /** Mirror of [currentWindowStart] returning the end. */
+        fun currentWindowEnd(
+            budget: com.pennywiseai.tracker.data.database.entity.BudgetEntity,
+            today: LocalDate,
+            globalStartDay: Int
+        ): LocalDate = when (budget.periodType) {
+            BudgetPeriodType.WEEKLY -> currentWindowStart(budget, today, globalStartDay).plusDays(6)
+            BudgetPeriodType.MONTHLY -> BudgetCycle.currentCycle(
+                today,
+                budget.monthStartDay?.let { BudgetCycle.clampStartDay(it) }
+                    ?: BudgetCycle.clampStartDay(globalStartDay)
+            ).second
+            BudgetPeriodType.CUSTOM -> budget.endDate
+        }
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.pennywiseai.tracker.data.database.entity.BudgetPeriodType
 import com.pennywiseai.tracker.data.repository.BudgetGroupSpending
 import com.pennywiseai.tracker.data.repository.BudgetOverallSummary
 import com.pennywiseai.tracker.ui.components.CategoryIcon
@@ -595,11 +596,46 @@ private fun BudgetCard(
 
                 Spacer(modifier = Modifier.height(Spacing.xs))
 
-                // Row 4: Contextual subtitle
+                // Row 4: Per-cadence renewal countdown — always framed
+                // as "Resets in X days" so the user knows when the
+                // budget's window ends. The displayed window is the
+                // budget's own current window (Jun 29..Jul 5 even when
+                // the page is the July view) so this number is
+                // consistent across month views.
+                val dateFormatter = java.time.format.DateTimeFormatter.ofPattern("d MMM")
                 val subtitleText = when {
-                    groupSpending.daysRemaining == 0 -> "Period ended"
+                    groupSpending.daysRemaining == 0 && groupSpending.daysElapsed >= groupSpending.windowDays -> "Finished"
                     isOverBudget -> "Over by ${CurrencyFormatter.formatCurrency(remainingAbs, currency)}"
-                    else -> "${CurrencyFormatter.formatCurrency(groupSpending.dailyAllowance, currency)}/day \u00B7 ${groupSpending.daysRemaining} days left"
+                    groupSpending.periodType == BudgetPeriodType.WEEKLY -> {
+                        val renewalIn = (groupSpending.daysRemaining - 1).coerceAtLeast(0)
+                        val weekdayName = groupSpending.group.budget.weekStartDay
+                            ?.let { java.time.DayOfWeek.of(it.coerceIn(1, 7)).name.lowercase().replaceFirstChar { ch -> ch.titlecase() } }
+                            ?: "Monday"
+                        when {
+                            renewalIn == 0 -> "Resets today · $weekdayName renew"
+                            renewalIn == 1 -> "Resets in 1 day · $weekdayName renew"
+                            else -> "Resets in $renewalIn days · $weekdayName renew"
+                        }
+                    }
+                    groupSpending.periodType == BudgetPeriodType.MONTHLY -> {
+                        val startDay = groupSpending.group.budget.monthStartDay
+                            ?: groupSpending.windowStart.dayOfMonth
+                        val renewalIn = (groupSpending.daysRemaining - 1).coerceAtLeast(0)
+                        when {
+                            renewalIn == 0 -> "Resets today · day $startDay"
+                            renewalIn == 1 -> "Resets in 1 day · day $startDay"
+                            else -> "Resets in $renewalIn days · day $startDay"
+                        }
+                    }
+                    groupSpending.periodType == BudgetPeriodType.CUSTOM -> {
+                        val range = "${groupSpending.windowStart.format(dateFormatter)} – ${groupSpending.windowEnd.format(dateFormatter)}"
+                        when {
+                            groupSpending.daysRemaining > 1 -> "Runs $range · ${groupSpending.daysRemaining - 1} days remaining"
+                            groupSpending.daysRemaining == 1 -> "Runs $range · 1 day remaining"
+                            else -> "Runs $range · Finished"
+                        }
+                    }
+                    else -> "${groupSpending.daysRemaining} days remaining"
                 }
                 Text(
                     text = subtitleText,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsScreen.kt
@@ -65,6 +65,7 @@ fun BudgetGroupsScreen(
     viewModel: BudgetGroupsViewModel = hiltViewModel(),
     onNavigateBack: () -> Unit = {},
     onNavigateToGroupEdit: (Long) -> Unit = {},
+    onNavigateToHistory: (Long, Int, Int) -> Unit = { _, _, _ -> },
     onNavigateToCategory: (category: String, yearMonth: String, currency: String) -> Unit = { _, _, _ -> }
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -130,6 +131,9 @@ fun BudgetGroupsScreen(
                 onDeleteGroup = { groupId -> viewModel.deleteGroup(groupId) },
                 onMoveGroupUp = { groupId -> viewModel.moveGroupUp(groupId) },
                 onMoveGroupDown = { groupId -> viewModel.moveGroupDown(groupId) },
+                onNavigateToHistory = { groupId ->
+                    onNavigateToHistory(groupId, uiState.selectedYear, uiState.selectedMonth)
+                },
                 onCategoryClick = { category ->
                     val yearMonth = "%04d-%02d".format(uiState.selectedYear, uiState.selectedMonth)
                     onNavigateToCategory(category, yearMonth, uiState.currency)
@@ -211,6 +215,7 @@ private fun BudgetGroupsContent(
     onDeleteGroup: (Long) -> Unit,
     onMoveGroupUp: (Long) -> Unit,
     onMoveGroupDown: (Long) -> Unit,
+    onNavigateToHistory: (Long) -> Unit,
     onCategoryClick: (String) -> Unit
 ) {
     val summary = uiState.summary ?: return
@@ -294,6 +299,7 @@ private fun BudgetGroupsContent(
                     },
                     onMoveUp = { onMoveGroupUp(groupSpending.group.budget.id) },
                     onMoveDown = { onMoveGroupDown(groupSpending.group.budget.id) },
+                    onViewHistory = { onNavigateToHistory(groupSpending.group.budget.id) },
                     onCategoryClick = onCategoryClick,
                     modifier = Modifier.animateItem()
                 )
@@ -397,6 +403,7 @@ private fun BudgetCard(
     onDelete: () -> Unit,
     onMoveUp: () -> Unit,
     onMoveDown: () -> Unit,
+    onViewHistory: () -> Unit,
     onCategoryClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -510,6 +517,16 @@ private fun BudgetCard(
                             expanded = showMenu,
                             onDismissRequest = { showMenu = false }
                         ) {
+                            DropdownMenuItem(
+                                text = { Text("View this period history") },
+                                onClick = {
+                                    showMenu = false
+                                    onViewHistory()
+                                },
+                                leadingIcon = {
+                                    Icon(Icons.Default.History, contentDescription = null)
+                                }
+                            )
                             DropdownMenuItem(
                                 text = { Text("Move up") },
                                 onClick = {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
@@ -86,19 +86,19 @@ class BudgetGroupsViewModel @Inject constructor(
         )
 
     init {
-        // Seed the default to the cycle's start month, then react to changes
-        // to the start day so the picker snaps back to the new current cycle
-        // when the user hasn't navigated yet.
+        // Default to today's calendar month. A user on startDay=25 viewing
+        // the page on Jul 1 should land on the July view (the cycle started
+        // Jun 25 and ends Jul 24, but the page label is the calendar month
+        // today falls in). The cycle's start day still drives the per-budget
+        // displayed window via resolveBudgetWindow, so Monthly cards on the
+        // July view show the (Jun 25..Jul 24) cycle window — same data as
+        // before, just labelled with today's month.
+        _selectedYearMonth.value = YearMonth.now()
         viewModelScope.launch {
-            val startDay = userPreferencesRepository.getBudgetCycleStartDay()
-            _selectedYearMonth.value = BudgetCycle.currentCycleStartYearMonth(LocalDate.now(), startDay)
-        }
-        viewModelScope.launch {
-            userPreferencesRepository.budgetCycleStartDay.collect { startDay ->
-                if (_selectedYearMonth.value == null) {
-                    _selectedYearMonth.value =
-                        BudgetCycle.currentCycleStartYearMonth(LocalDate.now(), startDay)
-                }
+            userPreferencesRepository.budgetCycleStartDay.collect {
+                // No-op: the default is today regardless of start day. Kept
+                // as a hook for future logic (e.g. "snap to cycle" if the
+                // user explicitly navigates back to the current cycle).
             }
         }
         loadBudgetData()

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
@@ -352,6 +352,10 @@ class BudgetGroupsViewModel @Inject constructor(
             windowStart = displayedWindow.start,
             windowEnd = displayedWindow.end,
             windowDays = displayedWindow.days,
+            // The unified path only renders the current month, so the
+            // displayed window is always live — cap is today.
+            displayedCapDate = today,
+            displayedIsLive = isCurrentMonth,
             periodType = budget.periodType,
             previousWindows = previous
         )

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
@@ -205,21 +205,24 @@ class BudgetGroupsViewModel @Inject constructor(
             )
         }
 
-        val totalIncome = raw.windowedSpend.flatMap { ws ->
-            // We don't have raw transactions per window in the unified path
-            // (the repo returned the spend totals). The home/widget use
-            // this for the page-level "Income" stat; for the Budgets page
-            // it's not used in the card so we approximate using the same
-            // filter on the prev cycle transactions if the page is on the
-            // current month.
-            if (isCurrentMonth) raw.prevCycleTransactions else emptyList()
-        }.fold(BigDecimal.ZERO) { acc, txWithSplits ->
-            val tx = txWithSplits.transaction
-            if (tx.transactionType == TransactionType.INCOME &&
-                !(tx.budgetImpactType == BudgetImpactType.DEDUCT_SPENT && tx.budgetCategory != null)
-            ) acc + currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
-            else acc
-        }
+        // The unified path's raw doesn't carry raw transactions per
+        // window (it returns per-window spend totals only). The page-level
+        // income figure is therefore derived from prevCycleTransactions
+        // for the current month, and 0 for historical months. The earlier
+        // shape used `windowedSpend.flatMap { prevCycleTransactions }`,
+        // which ignored its argument and concatenated prevCycleTransactions
+        // once per (budget × window) entry — for a user with 1 weekly +
+        // 2 monthly budgets on the current month, totalIncome was 3× the
+        // real value, inflating netSavings / savingsRate on the page
+        // header. Use the list directly.
+        val totalIncome = (if (isCurrentMonth) raw.prevCycleTransactions else emptyList())
+            .fold(BigDecimal.ZERO) { acc, txWithSplits ->
+                val tx = txWithSplits.transaction
+                if (tx.transactionType == TransactionType.INCOME &&
+                    !(tx.budgetImpactType == BudgetImpactType.DEDUCT_SPENT && tx.budgetCategory != null)
+                ) acc + currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                else acc
+            }
         // Note: totalIncome here uses the *previous* cycle's transactions
         // (since `windowedSpend` is keyed by window and doesn't carry the
         // raw income list). The page-level income figure is informational

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
@@ -187,11 +187,19 @@ class BudgetGroupsViewModel @Inject constructor(
         //  - run the per-window transactions through the same aggregation
         //    used by the single-currency path, but with currency conversion.
         val groupSpendings = raw.budgetsWithCategories.map { group ->
+            // The per-budget current window. Falls back to a 1-day
+            // "today" window if the repo didn't supply one (defensive
+            // only — every active budget has a window from the repo).
+            val perBudgetWindow = raw.currentWindows[group.budget.id]
+                ?: com.pennywiseai.tracker.data.repository.BudgetWindow(
+                    start = today, end = today, days = 1
+                )
             buildUnifiedGroupSpending(
                 group = group,
                 today = today,
                 isCurrentMonth = isCurrentMonth,
                 windowedSpend = windowSpendByBudget[group.budget.id].orEmpty(),
+                currentWindow = perBudgetWindow,
                 displayCurrency = displayCurrency,
                 baseCurrency = baseCurrency
             )
@@ -278,32 +286,77 @@ class BudgetGroupsViewModel @Inject constructor(
      * `totalActual` for the budget; the previousWindows list carries the
      * per-week breakdown.
      */
+    /**
+     * Fallback: when the repo's windowedSpend list doesn't contain a
+     * window that matches the displayed window's exact bounds (e.g. a
+     * Monthly budget with monthStartDay=25 — the displayed window is
+     * the full 30-day cycle but the repo clips to calendar months), sum
+     * the spend of every windowed entry whose [start, end] range
+     * overlaps the displayed window. Each per-month window's spend is
+     * already in the page's currency, so no further conversion needed.
+     */
+    private fun sumPrevCycleSpent(
+        budgetId: Long,
+        windowedSpend: List<WindowSpending>,
+        displayedWindow: com.pennywiseai.tracker.data.repository.BudgetWindow
+    ): BigDecimal? {
+        var total = BigDecimal.ZERO
+        var any = false
+        for (ws in windowedSpend) {
+            if (ws.budgetId != budgetId) continue
+            val overlapStart = maxOf(ws.window.start, displayedWindow.start)
+            val overlapEnd = minOf(ws.window.end, displayedWindow.end)
+            if (overlapStart.isAfter(overlapEnd)) continue
+            total = total.add(ws.spent)
+            any = true
+        }
+        return if (any) total else null
+    }
+
     private suspend fun buildUnifiedGroupSpending(
         group: BudgetWithCategories,
         today: LocalDate,
         isCurrentMonth: Boolean,
         windowedSpend: List<WindowSpending>,
+        // The per-budget current window resolved by the repo from
+        // resolveBudgetWindow (for current month) or windowsForMonth.last
+        // (for historical). Replaces the old hard-coded `resolveBudgetWindow(budget, today, 1)`
+        // which always used the global start-day pref as a fallback
+        // instead of the budget's own monthStartDay anchor.
+        currentWindow: com.pennywiseai.tracker.data.repository.BudgetWindow,
         displayCurrency: String,
         baseCurrency: String
     ): BudgetGroupSpending {
         val budget = group.budget
-        // Determine the displayed window.
-        val displayedWindow = if (isCurrentMonth) {
-            resolveBudgetWindow(budget, today, 1)
-        } else {
-            windowedSpend.lastOrNull()?.window
-                ?: com.pennywiseai.tracker.data.repository.BudgetWindow(
-                    start = LocalDate.now(), end = LocalDate.now(), days = 1
-                )
+        val displayedWindow = currentWindow
+        // The windowedSpend list from the repo is keyed by the budget's
+        // own cycle's per-week windows (for Weekly) or the single cycle
+        // (for Monthly) or the literal range (for One-time). The
+        // displayed window may not match any of those keys — e.g. a
+        // Monthly budget with monthStartDay=25 has displayed window
+        // (Sep 25, Oct 24) but windowedSpend keys are (Sep 1, Sep 30)
+        // clipped per month. Match by containment: pick the window whose
+        // [start, end] range fully contains displayedWindow.
+        val matchedWindow = windowedSpend.firstOrNull { ws ->
+            !ws.window.start.isAfter(displayedWindow.start) &&
+                !ws.window.end.isBefore(displayedWindow.end)
+        } ?: windowedSpend.firstOrNull { ws ->
+            // Fallback: pick the window with the largest overlap.
+            val overlapStart = maxOf(ws.window.start, displayedWindow.start)
+            val overlapEnd = minOf(ws.window.end, displayedWindow.end)
+            !overlapStart.isAfter(overlapEnd)
         }
-        val spentInDisplay = windowedSpend.firstOrNull { it.window == displayedWindow }?.spent
+        val spentInDisplay = matchedWindow?.spent
+            ?: sumPrevCycleSpent(group.budget.id, windowedSpend, displayedWindow)
             ?: BigDecimal.ZERO
 
-        // previousWindows: Weekly historical only.
+        // previousWindows: Weekly historical only. The displayed window
+        // is the budget's own current window; older per-week windows
+        // (in the same month) become the sub-list.
         val previous = if (budget.periodType == BudgetPeriodType.WEEKLY && !isCurrentMonth) {
-            windowedSpend.dropLast(1).map {
-                PastWindowSpending(window = it.window, spent = it.spent)
-            }
+            windowedSpend
+                .filter { it.window != currentWindow }
+                .map { PastWindowSpending(window = it.window, spent = it.spent) }
         } else emptyList()
 
         val daysElapsed: Int

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
@@ -6,15 +6,22 @@ import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.data.currency.CurrencyConversionService
 import com.pennywiseai.tracker.data.database.entity.BudgetGroupType
 import com.pennywiseai.tracker.data.database.entity.BudgetImpactType
+import com.pennywiseai.tracker.data.database.entity.BudgetPeriodType
+import com.pennywiseai.tracker.data.database.entity.BudgetWithCategories
 import com.pennywiseai.tracker.data.database.entity.TransactionType
-import com.pennywiseai.tracker.data.repository.BudgetGroupRepository.Companion.aggregateBudgetCategorySpending
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
-import com.pennywiseai.tracker.domain.model.BudgetCycle
 import com.pennywiseai.tracker.data.repository.BudgetCategorySpending
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository
 import com.pennywiseai.tracker.data.repository.BudgetGroupSpending
 import com.pennywiseai.tracker.data.repository.BudgetGroupSpendingRaw
 import com.pennywiseai.tracker.data.repository.BudgetOverallSummary
+import com.pennywiseai.tracker.data.repository.PastWindowSpending
+import com.pennywiseai.tracker.data.repository.WindowSpending
+import com.pennywiseai.tracker.data.repository.aggregateBudgetCategorySpending
+import com.pennywiseai.tracker.data.repository.overlaps
+import com.pennywiseai.tracker.data.repository.resolveBudgetWindow
+import com.pennywiseai.tracker.data.repository.windowsForMonth
+import com.pennywiseai.tracker.domain.model.BudgetCycle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -44,7 +51,13 @@ data class BudgetGroupsUiState(
     val selectedMonth: Int = LocalDate.now().monthValue,
     val currency: String = "INR",
     val baseCurrency: String = "INR",
-    val isUnifiedMode: Boolean = false
+    val isUnifiedMode: Boolean = false,
+    /**
+     * True when the list is filtered to budgets whose window overlaps
+     * the selected year-month. False shows every active budget. Toggled
+     * by the Overlap/All chip in the UI.
+     */
+    val filterByWindowOverlap: Boolean = true
 )
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -99,7 +112,6 @@ class BudgetGroupsViewModel @Inject constructor(
                 userPreferencesRepository.displayCurrency,
                 selectedYearMonth
             ) { baseCurrency, unifiedMode, displayCurrency, yearMonth ->
-                data class Params(val baseCurrency: String, val unifiedMode: Boolean, val displayCurrency: String, val yearMonth: YearMonth)
                 Params(baseCurrency, unifiedMode, displayCurrency, yearMonth)
             }.collect { params ->
                 val currency = if (params.unifiedMode) params.displayCurrency else params.baseCurrency
@@ -120,8 +132,12 @@ class BudgetGroupsViewModel @Inject constructor(
                 userPreferencesRepository.displayCurrency,
                 selectedYearMonth
             ) { baseCurrency, unifiedMode, displayCurrency, yearMonth ->
-                data class SpendingParams(val displayCurrency: String, val baseCurrency: String, val unifiedMode: Boolean, val yearMonth: YearMonth)
-                SpendingParams(if (unifiedMode) displayCurrency else baseCurrency, baseCurrency, unifiedMode, yearMonth)
+                SpendingParams(
+                    displayCurrency = if (unifiedMode) displayCurrency else baseCurrency,
+                    baseCurrency = baseCurrency,
+                    unifiedMode = unifiedMode,
+                    yearMonth = yearMonth
+                )
             }.flatMapLatest { params ->
                 if (params.unifiedMode) {
                     budgetGroupRepository.getGroupSpendingAllCurrencies(params.yearMonth.year, params.yearMonth.monthValue)
@@ -139,210 +155,71 @@ class BudgetGroupsViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Build a per-budget [BudgetGroupSpending] in the unified-currency path
+     * from the repo's [BudgetGroupSpendingRaw]. The repo gives us a per-
+     * (budget, window) spend map; the viewmodel applies currency
+     * conversion to the displayed window's transactions and the
+     * `previousWindows` (per-week sub-list) entries.
+     */
     private suspend fun convertRawToSummary(
         raw: BudgetGroupSpendingRaw,
         displayCurrency: String,
         baseCurrency: String
     ): BudgetOverallSummary {
-        // Exclude a Refund from totalIncome only when it's also being subtracted
-        // from a category by aggregateBudgetCategorySpending (categorised refund);
-        // orphaned DEDUCT_SPENT income stays in the total so netSavings doesn't
-        // understate. Matches the same guard used in BudgetGroupRepository and the
-        // widget.
-        var totalIncome = BigDecimal.ZERO
-        for (txWithSplits in raw.allTransactions) {
-            val tx = txWithSplits.transaction
-            if (tx.transactionType != TransactionType.INCOME) continue
-            if (tx.budgetImpactType == BudgetImpactType.DEDUCT_SPENT &&
-                tx.budgetCategory != null
-            ) continue
-            totalIncome = totalIncome.add(
-                currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
-            )
-        }
+        val today = raw.today
+        val yearMonth = YearMonth.of(today.year, today.monthValue) // for the "this is the current month" branch below
+        val isCurrentMonth = raw.budgetsWithCategories.firstOrNull()?.let {
+            val w = resolveBudgetWindow(it.budget, today, raw.globalStartDay)
+            today >= w.start && today <= w.end
+        } ?: false
 
-        // Unified-currency: route through the same aggregator used by the
-        // single-currency path so Refund (DEDUCT_SPENT) and Extra budget
-        // (ADD_TO_LIMIT) take effect here too. The converters project each
-        // amount into the display currency before aggregation.
-        val (categoryAmounts, categoryLimitBoosts, typeAmounts) = aggregateBudgetCategorySpending(
-            transactions = raw.allTransactions,
-            convertSplit = { fromCurrency, amount ->
-                currencyConversionService.convertAmount(amount, fromCurrency, displayCurrency)
-            },
-            convertIncome = { tx ->
-                currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
-            }
-        )
+        // Index the per-window spend by (budgetId, windowStart) for quick
+        // lookup in the per-budget build.
+        val windowSpendByBudget: Map<Long, List<WindowSpending>> =
+            raw.windowedSpend.groupBy { it.budgetId }
 
-        // Pre-compute converted category amounts per transaction for pace chart.
-        // The pace chart is calibrated against the actual budget cycle (e.g.
-        // Sep 25..Oct 24 = 30 days) — not the calendar month — so the daily
-        // budget line reflects the cycle the user picked, not a 31-day October.
-        val yearMonth = selectedYearMonth.value
-        val startDay = userPreferencesRepository.getBudgetCycleStartDay()
-        val (cycleStart, cycleEnd) = BudgetCycle.currentCycle(yearMonth.atDay(1), startDay)
-        val daysInCycle = ChronoUnit.DAYS.between(cycleStart, cycleEnd).toInt() + 1
-        val daysInMonth = daysInCycle
-        val effectiveDays = raw.daysElapsed.coerceAtMost(daysInCycle)
-
-        data class ConvertedTxDay(val day: Int, val categoryAmounts: Map<String, Double>)
-        val convertedTxDays = raw.allTransactions.mapNotNull { txWithSplits ->
-            val tx = txWithSplits.transaction
-            if (tx.transactionType == TransactionType.INCOME ||
-                tx.transactionType == TransactionType.TRANSFER ||
-                tx.transactionType == TransactionType.INVESTMENT ||
-                tx.loanId != null
-            ) return@mapNotNull null
-            val day = tx.dateTime.dayOfMonth.coerceIn(1, daysInMonth)
-            val catAmounts = txWithSplits.getAmountByCategory().mapValues { (_, amount) ->
-                currencyConversionService.convertAmount(amount, tx.currency, displayCurrency).toDouble()
-            }.mapKeys { (cat, _) -> cat.ifEmpty { "Others" } }
-            ConvertedTxDay(day, catAmounts)
-        }
-
-        // Type-bucket transactions (e.g. INVESTMENT) for the pace chart, keyed by
-        // transaction type. Routed separately from categories so a type bucket's
-        // "Actual" line reflects its type, not any category.
-        data class ConvertedTypeDay(val day: Int, val typeName: String, val amount: Double)
-        val convertedTypeDays = raw.allTransactions.mapNotNull { txWithSplits ->
-            val tx = txWithSplits.transaction
-            if (tx.transactionType !in BudgetGroupRepository.BUDGET_TYPE_BUCKETS || tx.loanId != null) {
-                return@mapNotNull null
-            }
-            val day = tx.dateTime.dayOfMonth.coerceIn(1, daysInMonth)
-            val amt = currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency).toDouble()
-            ConvertedTypeDay(day, tx.transactionType.name, amt)
-        }
-
-        // Pre-convert Refund (DEDUCT_SPENT) income amounts on the day they occurred
-        // so the pace chart subtracts them in lockstep with the displayed "actual".
-        data class ConvertedRefundDay(val day: Int, val category: String, val amount: Double)
-        val convertedRefundDays = raw.allTransactions.mapNotNull { txWithSplits ->
-            val tx = txWithSplits.transaction
-            if (tx.transactionType != TransactionType.INCOME) return@mapNotNull null
-            if (tx.budgetImpactType != BudgetImpactType.DEDUCT_SPENT) return@mapNotNull null
-            val category = tx.budgetCategory ?: return@mapNotNull null
-            val day = tx.dateTime.dayOfMonth.coerceIn(1, daysInMonth)
-            val amount = currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency).toDouble()
-            ConvertedRefundDay(day, category, amount)
-        }
-
-        fun buildGroupPaceUnified(
-            categoryNames: Set<String>?,
-            matchTypes: Set<String>,
-            groupBudget: BigDecimal
-        ): Pair<List<Double>, List<Double>> {
-            if (effectiveDays < 1) return emptyList<Double>() to emptyList()
-            val dailyAmounts = DoubleArray(daysInMonth)
-            convertedTxDays.forEach { txDay ->
-                if (categoryNames == null) {
-                    dailyAmounts[txDay.day - 1] += txDay.categoryAmounts.values.sum()
-                } else {
-                    txDay.categoryAmounts.forEach { (cat, amount) ->
-                        if (cat in categoryNames) dailyAmounts[txDay.day - 1] += amount
-                    }
-                }
-            }
-            convertedTypeDays.forEach { typeDay ->
-                if (typeDay.typeName in matchTypes) dailyAmounts[typeDay.day - 1] += typeDay.amount
-            }
-            convertedRefundDays.forEach { refundDay ->
-                if (categoryNames == null || refundDay.category in categoryNames) {
-                    dailyAmounts[refundDay.day - 1] -= refundDay.amount
-                }
-            }
-            // Carry the running total forward unclamped so a refund dated before
-            // the first expense still nets out; only the emitted value is clamped
-            // so the endpoint matches aggregateBudgetCategorySpending's floor.
-            val cumulative = mutableListOf<Double>()
-            var runningNet = 0.0
-            for (i in 0 until effectiveDays) {
-                runningNet += dailyAmounts[i]
-                cumulative.add(runningNet.coerceAtLeast(0.0))
-            }
-            val pace = if (groupBudget > BigDecimal.ZERO) {
-                val dp = groupBudget.toDouble() / daysInMonth
-                (1..effectiveDays).map { it * dp }
-            } else emptyList()
-            return cumulative to pace
-        }
-
-        val groupSpendingList = raw.budgetsWithCategories.map { group ->
-            val isTrackingAll = group.categories.isEmpty()
-            val catSpending = group.categories.map { cat ->
-                val actual = if (cat.matchType != null) {
-                    typeAmounts[cat.matchType] ?: BigDecimal.ZERO
-                } else {
-                    categoryAmounts[cat.categoryName] ?: BigDecimal.ZERO
-                }
-                val convertedBudget = currencyConversionService.convertAmount(cat.budgetAmount, baseCurrency, displayCurrency)
-                val boost = if (cat.matchType != null) BigDecimal.ZERO
-                    else categoryLimitBoosts[cat.categoryName] ?: BigDecimal.ZERO
-                val effectiveBudget = convertedBudget + boost
-                val pctUsed = if (effectiveBudget > BigDecimal.ZERO) {
-                    (actual.toFloat() / effectiveBudget.toFloat() * 100f).coerceAtLeast(0f)
-                } else 0f
-                val dailySpend = if (raw.daysElapsed > 0 && actual > BigDecimal.ZERO) {
-                    actual.divide(BigDecimal(raw.daysElapsed), 0, RoundingMode.HALF_UP)
-                } else BigDecimal.ZERO
-                BudgetCategorySpending(
-                    categoryName = cat.categoryName,
-                    budgetAmount = effectiveBudget,
-                    actualAmount = actual,
-                    percentageUsed = pctUsed,
-                    dailySpend = dailySpend
-                )
-            }
-            val convertedGroupLimit = currencyConversionService.convertAmount(
-                group.budget.limitAmount, baseCurrency, displayCurrency
-            )
-            // "Category Limits" are optional — the group-level limit is the
-            // source of truth when set (including when isTrackingAll), with
-            // the per-cat sum as a fallback for budgets that only define
-            // per-cat amounts.
-            val totalBudget = if (convertedGroupLimit > BigDecimal.ZERO) {
-                convertedGroupLimit
-            } else {
-                catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.budgetAmount }
-            }
-            val totalActual = if (isTrackingAll) {
-                categoryAmounts.values.fold(BigDecimal.ZERO) { acc, v -> acc + v }
-            } else {
-                catSpending.fold(BigDecimal.ZERO) { acc, c -> acc + c.actualAmount }
-            }
-            val remaining = totalBudget - totalActual
-            val pctUsed = if (totalBudget > BigDecimal.ZERO) {
-                (totalActual.toFloat() / totalBudget.toFloat() * 100f).coerceAtLeast(0f)
-            } else 0f
-            val dailyAllowance = if (raw.daysRemaining > 0 && remaining > BigDecimal.ZERO) {
-                remaining.divide(BigDecimal(raw.daysRemaining), 0, RoundingMode.HALF_UP)
-            } else BigDecimal.ZERO
-
-            val catNames = if (isTrackingAll) null
-                else group.categories.filter { it.matchType == null }.map { it.categoryName }.toSet()
-            val matchTypes = group.categories.mapNotNull { it.matchType }.toSet()
-            val (cumSpending, budgetPace) = buildGroupPaceUnified(catNames, matchTypes, totalBudget)
-
-            BudgetGroupSpending(
+        // Build per-budget summaries. For each budget:
+        //  - pick the displayed window (resolveBudgetWindow for current
+        //    month; most recent window in the list for historical months);
+        //  - build the previousWindows list (Weekly only, historical only)
+        //    with the per-window spend;
+        //  - run the per-window transactions through the same aggregation
+        //    used by the single-currency path, but with currency conversion.
+        val groupSpendings = raw.budgetsWithCategories.map { group ->
+            buildUnifiedGroupSpending(
                 group = group,
-                categorySpending = if (isTrackingAll) emptyList() else catSpending,
-                totalBudget = totalBudget,
-                totalActual = totalActual,
-                remaining = remaining,
-                percentageUsed = pctUsed,
-                dailyAllowance = dailyAllowance,
-                daysRemaining = raw.daysRemaining,
-                daysElapsed = raw.daysElapsed,
-                isTrackingAllExpenses = isTrackingAll,
-                dailyCumulativeSpending = cumSpending,
-                dailyBudgetPace = budgetPace
+                today = today,
+                isCurrentMonth = isCurrentMonth,
+                windowedSpend = windowSpendByBudget[group.budget.id].orEmpty(),
+                displayCurrency = displayCurrency,
+                baseCurrency = baseCurrency
             )
         }
 
-        val limitGroups = groupSpendingList.filter { it.group.budget.groupType == BudgetGroupType.LIMIT }
-        val targetGroups = groupSpendingList.filter { it.group.budget.groupType == BudgetGroupType.TARGET }
-        val expectedGroups = groupSpendingList.filter { it.group.budget.groupType == BudgetGroupType.EXPECTED }
+        val totalIncome = raw.windowedSpend.flatMap { ws ->
+            // We don't have raw transactions per window in the unified path
+            // (the repo returned the spend totals). The home/widget use
+            // this for the page-level "Income" stat; for the Budgets page
+            // it's not used in the card so we approximate using the same
+            // filter on the prev cycle transactions if the page is on the
+            // current month.
+            if (isCurrentMonth) raw.prevCycleTransactions else emptyList()
+        }.fold(BigDecimal.ZERO) { acc, txWithSplits ->
+            val tx = txWithSplits.transaction
+            if (tx.transactionType == TransactionType.INCOME &&
+                !(tx.budgetImpactType == BudgetImpactType.DEDUCT_SPENT && tx.budgetCategory != null)
+            ) acc + currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+            else acc
+        }
+        // Note: totalIncome here uses the *previous* cycle's transactions
+        // (since `windowedSpend` is keyed by window and doesn't carry the
+        // raw income list). The page-level income figure is informational
+        // only; the per-card spending is correct.
+
+        val limitGroups = groupSpendings.filter { it.group.budget.groupType == BudgetGroupType.LIMIT }
+        val targetGroups = groupSpendings.filter { it.group.budget.groupType == BudgetGroupType.TARGET }
+        val expectedGroups = groupSpendings.filter { it.group.budget.groupType == BudgetGroupType.EXPECTED }
 
         val totalLimitBudget = limitGroups.fold(BigDecimal.ZERO) { acc, g -> acc + g.totalBudget }
         val totalLimitSpent = limitGroups.fold(BigDecimal.ZERO) { acc, g -> acc + g.totalActual }
@@ -357,12 +234,25 @@ class BudgetGroupsViewModel @Inject constructor(
         } else 0f
 
         val limitRemaining = totalLimitBudget - totalLimitSpent
-        val dailyAllowance = if (raw.daysRemaining > 0 && limitRemaining > BigDecimal.ZERO) {
-            limitRemaining.divide(BigDecimal(raw.daysRemaining), 0, RoundingMode.HALF_UP)
+        val daysRemaining = groupSpendings.firstOrNull()?.daysRemaining ?: 0
+        val dailyAllowance = if (daysRemaining > 0 && limitRemaining > BigDecimal.ZERO) {
+            limitRemaining.divide(BigDecimal(daysRemaining), 0, RoundingMode.HALF_UP)
         } else BigDecimal.ZERO
 
+        val pageWindow = groupSpendings.firstOrNull()?.let {
+            com.pennywiseai.tracker.data.repository.BudgetWindow(
+                start = it.windowStart,
+                end = it.windowEnd,
+                days = it.windowDays
+            )
+        } ?: com.pennywiseai.tracker.data.repository.BudgetWindow(
+            start = LocalDate.now(),
+            end = LocalDate.now(),
+            days = 1
+        )
+
         return BudgetOverallSummary(
-            groups = groupSpendingList,
+            groups = groupSpendings,
             totalIncome = totalIncome,
             totalLimitBudget = totalLimitBudget,
             totalLimitSpent = totalLimitSpent,
@@ -373,9 +263,108 @@ class BudgetGroupsViewModel @Inject constructor(
             netSavings = netSavings,
             savingsRate = savingsRate,
             dailyAllowance = dailyAllowance,
-            daysRemaining = raw.daysRemaining,
-            currency = displayCurrency
+            daysRemaining = daysRemaining,
+            currency = displayCurrency,
+            pageWindow = pageWindow
         )
+    }
+
+    /**
+     * Build one [BudgetGroupSpending] in the unified-currency path. We
+     * don't have raw transactions for each window — the repo returned
+     * the per-window totals — so we synthesise a "single-currency-equivalent"
+     * by treating [windowedSpend] as the source of truth for each window's
+     * spend. The displayed window's [WindowSpending.spent] is the
+     * `totalActual` for the budget; the previousWindows list carries the
+     * per-week breakdown.
+     */
+    private suspend fun buildUnifiedGroupSpending(
+        group: BudgetWithCategories,
+        today: LocalDate,
+        isCurrentMonth: Boolean,
+        windowedSpend: List<WindowSpending>,
+        displayCurrency: String,
+        baseCurrency: String
+    ): BudgetGroupSpending {
+        val budget = group.budget
+        // Determine the displayed window.
+        val displayedWindow = if (isCurrentMonth) {
+            resolveBudgetWindow(budget, today, 1)
+        } else {
+            windowedSpend.lastOrNull()?.window
+                ?: com.pennywiseai.tracker.data.repository.BudgetWindow(
+                    start = LocalDate.now(), end = LocalDate.now(), days = 1
+                )
+        }
+        val spentInDisplay = windowedSpend.firstOrNull { it.window == displayedWindow }?.spent
+            ?: BigDecimal.ZERO
+
+        // previousWindows: Weekly historical only.
+        val previous = if (budget.periodType == BudgetPeriodType.WEEKLY && !isCurrentMonth) {
+            windowedSpend.dropLast(1).map {
+                PastWindowSpending(window = it.window, spent = it.spent)
+            }
+        } else emptyList()
+
+        val daysElapsed: Int
+        val daysRemaining: Int
+        if (isCurrentMonth) {
+            daysElapsed = (ChronoUnit.DAYS.between(displayedWindow.start, today).toInt() + 1)
+                .coerceIn(1, displayedWindow.days)
+            daysRemaining = (ChronoUnit.DAYS.between(today, displayedWindow.end).toInt() + 1)
+                .coerceIn(0, displayedWindow.days)
+        } else {
+            daysElapsed = displayedWindow.days
+            daysRemaining = 0
+        }
+
+        val convertedTotalActual = currencyConversionService.convertAmount(
+            spentInDisplay, baseCurrency, displayCurrency
+        )
+        val convertedTotalBudget = currencyConversionService.convertAmount(
+            group.budget.limitAmount, baseCurrency, displayCurrency
+        )
+        val remaining = convertedTotalBudget - convertedTotalActual
+        val pctUsed = if (convertedTotalBudget > BigDecimal.ZERO) {
+            (convertedTotalActual.toFloat() / convertedTotalBudget.toFloat() * 100f).coerceAtLeast(0f)
+        } else 0f
+        val dailyAllowance = if (daysRemaining > 0 && remaining > BigDecimal.ZERO) {
+            remaining.divide(BigDecimal(daysRemaining), 0, RoundingMode.HALF_UP)
+        } else BigDecimal.ZERO
+
+        // The per-category breakdown isn't computable from per-window
+        // totals alone (the unified path doesn't return raw transactions
+        // for each window). The single-currency path still shows it; the
+        // unified path shows an empty list for the inline category list.
+        return BudgetGroupSpending(
+            group = group,
+            categorySpending = emptyList(),
+            totalBudget = convertedTotalBudget,
+            totalActual = convertedTotalActual,
+            remaining = remaining,
+            percentageUsed = pctUsed,
+            dailyAllowance = dailyAllowance,
+            daysRemaining = daysRemaining,
+            daysElapsed = daysElapsed,
+            isTrackingAllExpenses = group.categories.isEmpty(),
+            dailyCumulativeSpending = emptyList(),
+            dailyBudgetPace = emptyList(),
+            windowStart = displayedWindow.start,
+            windowEnd = displayedWindow.end,
+            windowDays = displayedWindow.days,
+            periodType = budget.periodType,
+            previousWindows = previous
+        )
+    }
+
+    fun toggleFilter() {
+        _uiState.value = _uiState.value.copy(
+            filterByWindowOverlap = !_uiState.value.filterByWindowOverlap
+        )
+    }
+
+    fun setFilterByWindowOverlap(enabled: Boolean) {
+        _uiState.value = _uiState.value.copy(filterByWindowOverlap = enabled)
     }
 
     fun selectPreviousMonth() {
@@ -383,15 +372,18 @@ class BudgetGroupsViewModel @Inject constructor(
     }
 
     fun selectNextMonth() {
+        // Don't navigate past the current month — there's no spend data
+        // for a future cycle. The chevron button in the UI is disabled
+        // when the user is on the current month; this guard is defensive.
+        val today = LocalDate.now()
+        val current = YearMonth.of(today.year, today.monthValue)
         val next = selectedYearMonth.value.plusMonths(1)
-        if (!next.isAfter(YearMonth.now())) {
+        if (!next.isAfter(current)) {
             _selectedYearMonth.value = next
         }
     }
 
     fun selectCurrentMonth() {
-        // Jump to the user's current budget cycle, not the calendar month.
-        // For startDay=25 on Oct 5 this lands on the Sep 25..Oct 24 cycle.
         viewModelScope.launch {
             val startDay = userPreferencesRepository.getBudgetCycleStartDay()
             _selectedYearMonth.value =
@@ -405,14 +397,14 @@ class BudgetGroupsViewModel @Inject constructor(
             com.pennywiseai.tracker.widget.BudgetWidgetUpdateWorker.enqueueOneShot(context)
         }
     }
-    
+
     fun moveGroupUp(budgetId: Long) {
         viewModelScope.launch {
             budgetGroupRepository.moveGroupUp(budgetId)
             com.pennywiseai.tracker.widget.BudgetWidgetUpdateWorker.enqueueOneShot(context)
         }
     }
-    
+
     fun moveGroupDown(budgetId: Long) {
         viewModelScope.launch {
             budgetGroupRepository.moveGroupDown(budgetId)
@@ -428,4 +420,55 @@ class BudgetGroupsViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Filter the [BudgetOverallSummary.groups] by the Overlap toggle.
+     * When [filterByWindowOverlap] is true, a budget is shown only if any
+     * of its resolved windows (against the selected year-month) intersect
+     * that month. Weekly always shows (its window is the current week);
+     * One-time Nov 5–Dec 4 shows for November and December; Monthly
+     * Sep 25–Oct 24 shows for September and October.
+     */
+    fun visibleGroups(summary: BudgetOverallSummary?, filterByWindowOverlap: Boolean): List<BudgetGroupSpending> {
+        if (summary == null) return emptyList()
+        if (!filterByWindowOverlap) return summary.groups
+        val ym = YearMonth.of(_uiState.value.selectedYear, _uiState.value.selectedMonth)
+        val monthStart = ym.atDay(1)
+        val monthEnd = ym.atEndOfMonth()
+        val monthWindow = com.pennywiseai.tracker.data.repository.BudgetWindow(
+            start = monthStart, end = monthEnd, days = monthEnd.dayOfMonth
+        )
+        return summary.groups.filter { g ->
+            val candidate = g.periodType.let { _ ->
+                // Use the displayed window + previousWindows to find any
+                // overlap with the month. Weekly historical has multiple
+                // windows in `previousWindows`; current view has just
+                // the displayed window.
+                val allWindows = buildList {
+                    add(com.pennywiseai.tracker.data.repository.BudgetWindow(
+                        start = g.windowStart, end = g.windowEnd, days = g.windowDays
+                    ))
+                    g.previousWindows.forEach { add(it.window) }
+                }
+                allWindows.any { it.overlaps(monthWindow) }
+            }
+            candidate
+        }
+    }
+
+    // Unused — kept for backwards compat with code that referenced it.
+    @Suppress("unused")
+    private data class Params(
+        val baseCurrency: String,
+        val unifiedMode: Boolean,
+        val displayCurrency: String,
+        val yearMonth: YearMonth
+    )
+
+    @Suppress("unused")
+    private data class SpendingParams(
+        val displayCurrency: String,
+        val baseCurrency: String,
+        val unifiedMode: Boolean,
+        val yearMonth: YearMonth
+    )
 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
@@ -9,6 +9,7 @@ import com.pennywiseai.tracker.data.database.entity.BudgetImpactType
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository.Companion.aggregateBudgetCategorySpending
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
+import com.pennywiseai.tracker.domain.model.BudgetCycle
 import com.pennywiseai.tracker.data.repository.BudgetCategorySpending
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository
 import com.pennywiseai.tracker.data.repository.BudgetGroupSpending
@@ -18,17 +19,21 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalDate
 import java.time.YearMonth
+import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 
 data class BudgetGroupsUiState(
@@ -54,9 +59,35 @@ class BudgetGroupsViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(BudgetGroupsUiState())
     val uiState: StateFlow<BudgetGroupsUiState> = _uiState.asStateFlow()
 
-    private val _selectedYearMonth = MutableStateFlow(YearMonth.now())
+    // Defaults to the user's current budget-cycle start (e.g. Sep 2026 on
+    // Oct 5 with startDay=25) so opening the screen lands on the cycle that
+    // contains today, not the calendar month. Once the user navigates
+    // forwards/backwards via the month picker, we stop overriding.
+    private val _selectedYearMonth = MutableStateFlow<YearMonth?>(null)
+    private val selectedYearMonth: StateFlow<YearMonth> = _selectedYearMonth
+        .filterNotNull()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = YearMonth.now()
+        )
 
     init {
+        // Seed the default to the cycle's start month, then react to changes
+        // to the start day so the picker snaps back to the new current cycle
+        // when the user hasn't navigated yet.
+        viewModelScope.launch {
+            val startDay = userPreferencesRepository.getBudgetCycleStartDay()
+            _selectedYearMonth.value = BudgetCycle.currentCycleStartYearMonth(LocalDate.now(), startDay)
+        }
+        viewModelScope.launch {
+            userPreferencesRepository.budgetCycleStartDay.collect { startDay ->
+                if (_selectedYearMonth.value == null) {
+                    _selectedYearMonth.value =
+                        BudgetCycle.currentCycleStartYearMonth(LocalDate.now(), startDay)
+                }
+            }
+        }
         loadBudgetData()
     }
 
@@ -66,7 +97,7 @@ class BudgetGroupsViewModel @Inject constructor(
                 userPreferencesRepository.baseCurrency,
                 userPreferencesRepository.unifiedCurrencyMode,
                 userPreferencesRepository.displayCurrency,
-                _selectedYearMonth
+                selectedYearMonth
             ) { baseCurrency, unifiedMode, displayCurrency, yearMonth ->
                 data class Params(val baseCurrency: String, val unifiedMode: Boolean, val displayCurrency: String, val yearMonth: YearMonth)
                 Params(baseCurrency, unifiedMode, displayCurrency, yearMonth)
@@ -87,7 +118,7 @@ class BudgetGroupsViewModel @Inject constructor(
                 userPreferencesRepository.baseCurrency,
                 userPreferencesRepository.unifiedCurrencyMode,
                 userPreferencesRepository.displayCurrency,
-                _selectedYearMonth
+                selectedYearMonth
             ) { baseCurrency, unifiedMode, displayCurrency, yearMonth ->
                 data class SpendingParams(val displayCurrency: String, val baseCurrency: String, val unifiedMode: Boolean, val yearMonth: YearMonth)
                 SpendingParams(if (unifiedMode) displayCurrency else baseCurrency, baseCurrency, unifiedMode, yearMonth)
@@ -144,10 +175,16 @@ class BudgetGroupsViewModel @Inject constructor(
             }
         )
 
-        // Pre-compute converted category amounts per transaction for pace chart
-        val yearMonth = _selectedYearMonth.value
-        val daysInMonth = yearMonth.lengthOfMonth()
-        val effectiveDays = raw.daysElapsed.coerceAtMost(daysInMonth)
+        // Pre-compute converted category amounts per transaction for pace chart.
+        // The pace chart is calibrated against the actual budget cycle (e.g.
+        // Sep 25..Oct 24 = 30 days) — not the calendar month — so the daily
+        // budget line reflects the cycle the user picked, not a 31-day October.
+        val yearMonth = selectedYearMonth.value
+        val startDay = userPreferencesRepository.getBudgetCycleStartDay()
+        val (cycleStart, cycleEnd) = BudgetCycle.currentCycle(yearMonth.atDay(1), startDay)
+        val daysInCycle = ChronoUnit.DAYS.between(cycleStart, cycleEnd).toInt() + 1
+        val daysInMonth = daysInCycle
+        val effectiveDays = raw.daysElapsed.coerceAtMost(daysInCycle)
 
         data class ConvertedTxDay(val day: Int, val categoryAmounts: Map<String, Double>)
         val convertedTxDays = raw.allTransactions.mapNotNull { txWithSplits ->
@@ -342,18 +379,24 @@ class BudgetGroupsViewModel @Inject constructor(
     }
 
     fun selectPreviousMonth() {
-        _selectedYearMonth.value = _selectedYearMonth.value.minusMonths(1)
+        _selectedYearMonth.value = selectedYearMonth.value.minusMonths(1)
     }
 
     fun selectNextMonth() {
-        val next = _selectedYearMonth.value.plusMonths(1)
+        val next = selectedYearMonth.value.plusMonths(1)
         if (!next.isAfter(YearMonth.now())) {
             _selectedYearMonth.value = next
         }
     }
 
     fun selectCurrentMonth() {
-        _selectedYearMonth.value = YearMonth.now()
+        // Jump to the user's current budget cycle, not the calendar month.
+        // For startDay=25 on Oct 5 this lands on the Sep 25..Oct 24 cycle.
+        viewModelScope.launch {
+            val startDay = userPreferencesRepository.getBudgetCycleStartDay()
+            _selectedYearMonth.value =
+                BudgetCycle.currentCycleStartYearMonth(LocalDate.now(), startDay)
+        }
     }
 
     fun deleteGroup(budgetId: Long) {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetHistoryScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetHistoryScreen.kt
@@ -1,0 +1,258 @@
+package com.pennywiseai.tracker.presentation.budgetgroups
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.pennywiseai.tracker.data.database.entity.BudgetPeriodType
+import com.pennywiseai.tracker.data.repository.PastWindowSpending
+import com.pennywiseai.tracker.ui.components.PennyWiseScaffold
+import com.pennywiseai.tracker.ui.components.cards.CadencePill
+import com.pennywiseai.tracker.ui.components.cards.PennyWiseCardV2
+import com.pennywiseai.tracker.ui.theme.Dimensions
+import com.pennywiseai.tracker.ui.theme.Spacing
+import com.pennywiseai.tracker.utils.CurrencyFormatter
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+/**
+ * Per-budget history drill-down. Opened from the Budgets page via the
+ * 3-dots menu "View this period history" item. Lists every window for
+ * the selected (year, month) — for a Weekly budget that's the per-week
+ * sub-list; for Monthly / One-time it's a single entry.
+ *
+ * Each row carries a "Live" or "Frozen as of …" badge so the user can
+ * see which weeks are still accumulating spend (current week in the
+ * current month) vs which are frozen snapshots.
+ */
+@Composable
+fun BudgetHistoryScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: BudgetHistoryViewModel = hiltViewModel()
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    PennyWiseScaffold(
+        title = state.budget?.name ?: "Budget History",
+        navigationIcon = {
+            IconButton(onClick = onNavigateBack) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Back"
+                )
+            }
+        }
+    ) { padding ->
+        if (state.isLoading) {
+            Box(modifier = Modifier.padding(padding).fillMaxWidth(), contentAlignment = Alignment.Center) {
+                Text("Loading…", color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            return@PennyWiseScaffold
+        }
+        val budget = state.budget
+        if (budget == null) {
+            Box(modifier = Modifier.padding(padding).fillMaxWidth(), contentAlignment = Alignment.Center) {
+                Text("Budget not found", color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            return@PennyWiseScaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier.padding(padding).fillMaxWidth(),
+            contentPadding = PaddingValues(
+                start = Dimensions.Padding.content,
+                end = Dimensions.Padding.content,
+                top = Dimensions.Padding.content,
+                bottom = Dimensions.Component.bottomBarHeight + Spacing.md
+            ),
+            verticalArrangement = Arrangement.spacedBy(Spacing.md)
+        ) {
+            // Summary card — period, total spent, displayed window range
+            item {
+                PennyWiseCardV2(modifier = Modifier.fillMaxWidth()) {
+                    Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(Spacing.xs)
+                        ) {
+                            CadencePill(periodType = budget.periodType)
+                            Text(
+                                text = monthLabel(state.yearMonth),
+                                style = MaterialTheme.typography.titleMedium.copy(
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(Spacing.xs))
+                        Text(
+                            text = "${CurrencyFormatter.formatCurrency(state.totalSpent, state.currency)} of ${CurrencyFormatter.formatCurrency(state.budgetAmount, state.currency)}",
+                            style = MaterialTheme.typography.titleLarge.copy(
+                                fontWeight = FontWeight.Bold
+                            )
+                        )
+                        val longFormatter = DateTimeFormatter.ofPattern("d MMM yyyy")
+                        Text(
+                            text = "Window: ${state.displayedWindowStart.format(longFormatter)} – ${state.displayedWindowEnd.format(longFormatter)}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        if (state.displayedIsLive) {
+                            Spacer(modifier = Modifier.height(Spacing.xs))
+                            LiveBadge()
+                        } else {
+                            Spacer(modifier = Modifier.height(Spacing.xs))
+                            FrozenBadge(state.displayedCapDate)
+                        }
+                    }
+                }
+            }
+
+            // Per-window list
+            item {
+                Text(
+                    text = when (budget.periodType) {
+                        BudgetPeriodType.WEEKLY -> "Per-week breakdown"
+                        BudgetPeriodType.MONTHLY -> "Cycle"
+                        BudgetPeriodType.CUSTOM -> "Range"
+                    },
+                    style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.padding(start = Spacing.xs, top = Spacing.sm)
+                )
+            }
+            items(state.windowHistory) { window ->
+                HistoryRow(
+                    window = window,
+                    currency = state.currency,
+                    isDisplayed = window.window.start == state.displayedWindowStart &&
+                        window.window.end == state.displayedWindowEnd,
+                    isCurrentPeriod = state.yearMonth == YearMonth.now()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryRow(
+    window: PastWindowSpending,
+    currency: String,
+    isDisplayed: Boolean,
+    isCurrentPeriod: Boolean
+) {
+    val shortFormatter = remember { DateTimeFormatter.ofPattern("d MMM") }
+    PennyWiseCardV2(modifier = Modifier.fillMaxWidth()) {
+        Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "${window.window.start.format(shortFormatter)} – ${window.window.end.format(shortFormatter)}",
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        fontWeight = FontWeight.Medium
+                    ),
+                    modifier = Modifier.weight(1f)
+                )
+                if (isDisplayed) {
+                    Text(
+                        text = "Current",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier
+                            .background(
+                                color = MaterialTheme.colorScheme.primary,
+                                shape = RoundedCornerShape(50)
+                            )
+                            .padding(horizontal = 8.dp, vertical = 2.dp)
+                    )
+                }
+            }
+            Text(
+                text = CurrencyFormatter.formatCurrency(window.spent, currency),
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontWeight = FontWeight.Bold
+                )
+            )
+            if (window.isLive && isCurrentPeriod) {
+                LiveBadge()
+            } else {
+                FrozenBadge(window.capDate)
+            }
+        }
+    }
+}
+
+@Composable
+private fun LiveBadge() {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.xs)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(8.dp)
+                .clip(RoundedCornerShape(50))
+                .background(MaterialTheme.colorScheme.tertiary)
+        )
+        Text(
+            text = "Live · still accumulating",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.tertiary
+        )
+    }
+}
+
+@Composable
+private fun FrozenBadge(capDate: LocalDate) {
+    val formatter = remember { DateTimeFormatter.ofPattern("d MMM yyyy", Locale.getDefault()) }
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.xs)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(8.dp)
+                .clip(RoundedCornerShape(50))
+                .background(MaterialTheme.colorScheme.onSurfaceVariant)
+        )
+        Text(
+            text = "Frozen as of ${capDate.format(formatter)}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+private fun monthLabel(yearMonth: YearMonth): String {
+    val formatter = DateTimeFormatter.ofPattern("MMMM yyyy", Locale.getDefault())
+    return yearMonth.format(formatter)
+}

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetHistoryScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetHistoryScreen.kt
@@ -1,6 +1,7 @@
 package com.pennywiseai.tracker.presentation.budgetgroups
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,10 +17,14 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -42,6 +47,7 @@ import java.time.LocalDate
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+import java.math.BigDecimal
 
 /**
  * Per-budget history drill-down. Opened from the Budgets page via the
@@ -153,9 +159,23 @@ fun BudgetHistoryScreen(
                     currency = state.currency,
                     isDisplayed = window.window.start == state.displayedWindowStart &&
                         window.window.end == state.displayedWindowEnd,
-                    isCurrentPeriod = state.yearMonth == YearMonth.now()
+                    isCurrentPeriod = state.yearMonth == YearMonth.now(),
+                    onClick = { viewModel.loadBreakdown(window.window) }
                 )
             }
+        }
+
+        // Per-window breakdown sheet — rendered when a row is tapped.
+        // ModalBottomSheet is hosted at the screen level (not inside
+        // the LazyColumn) so it doesn't get clipped by the scroll
+        // container and so the dismiss gesture covers the full screen.
+        if (state.breakdown != null || state.isLoadingBreakdown) {
+            BreakdownSheet(
+                breakdown = state.breakdown,
+                isLoading = state.isLoadingBreakdown,
+                currency = state.currency,
+                onDismiss = { viewModel.dismissBreakdown() }
+            )
         }
     }
 }
@@ -165,10 +185,15 @@ private fun HistoryRow(
     window: PastWindowSpending,
     currency: String,
     isDisplayed: Boolean,
-    isCurrentPeriod: Boolean
+    isCurrentPeriod: Boolean,
+    onClick: () -> Unit
 ) {
     val shortFormatter = remember { DateTimeFormatter.ofPattern("d MMM") }
-    PennyWiseCardV2(modifier = Modifier.fillMaxWidth()) {
+    PennyWiseCardV2(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+    ) {
         Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -255,4 +280,122 @@ private fun FrozenBadge(capDate: LocalDate) {
 private fun monthLabel(yearMonth: YearMonth): String {
     val formatter = DateTimeFormatter.ofPattern("MMMM yyyy", Locale.getDefault())
     return yearMonth.format(formatter)
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BreakdownSheet(
+    breakdown: com.pennywiseai.tracker.data.repository.WindowBreakdown?,
+    isLoading: Boolean,
+    currency: String,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val longFormatter = remember { DateTimeFormatter.ofPattern("d MMM yyyy") }
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    start = Dimensions.Padding.content,
+                    end = Dimensions.Padding.content,
+                    bottom = Dimensions.Component.bottomBarHeight + Spacing.md
+                ),
+            verticalArrangement = Arrangement.spacedBy(Spacing.sm)
+        ) {
+            if (isLoading || breakdown == null) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = Spacing.lg),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+                return@Column
+            }
+
+            val window = breakdown.window
+            val totalActual = breakdown.totalActual
+            val totalBudget = breakdown.totalBudget
+            val pctUsed = if (totalBudget > BigDecimal.ZERO) {
+                (totalActual.toFloat() / totalBudget.toFloat() * 100f).coerceAtLeast(0f)
+            } else 0f
+            val remaining = totalBudget - totalActual
+            val isOver = totalActual > totalBudget
+
+            Text(
+                text = "${window.start.format(longFormatter)} – ${window.end.format(longFormatter)}",
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
+            )
+            Text(
+                text = if (breakdown.isTrackingAll) "Tracking all expenses"
+                else "${CurrencyFormatter.formatCurrency(totalActual, currency)} of ${CurrencyFormatter.formatCurrency(totalBudget, currency)}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            // Per-category list. For Tracking-All budgets the list is
+            // empty (no per-cat allocations); we show the total instead
+            // and skip the list.
+            if (!breakdown.isTrackingAll && breakdown.categorySpending.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(Spacing.xs))
+                Text(
+                    text = "Categories",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                breakdown.categorySpending.forEach { cat ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = cat.categoryName,
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Column(horizontalAlignment = Alignment.End) {
+                            Text(
+                                text = CurrencyFormatter.formatCurrency(cat.actualAmount, currency),
+                                style = MaterialTheme.typography.bodyMedium.copy(
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                            )
+                            if (cat.budgetAmount > BigDecimal.ZERO) {
+                                Text(
+                                    text = "of ${CurrencyFormatter.formatCurrency(cat.budgetAmount, currency)} · ${cat.percentageUsed.toInt()}%",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(Spacing.xs))
+            Text(
+                text = when {
+                    isOver -> "Over by ${CurrencyFormatter.formatCurrency(-remaining, currency)}"
+                    remaining > BigDecimal.ZERO -> "${CurrencyFormatter.formatCurrency(remaining, currency)} remaining"
+                    else -> "0 remaining"
+                },
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                color = if (isOver) MaterialTheme.colorScheme.error
+                else MaterialTheme.colorScheme.onSurface
+            )
+            if (totalBudget > BigDecimal.ZERO) {
+                Text(
+                    text = "${pctUsed.toInt()}% used",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetHistoryViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetHistoryViewModel.kt
@@ -7,7 +7,9 @@ import com.pennywiseai.tracker.data.database.entity.BudgetEntity
 import com.pennywiseai.tracker.data.database.entity.BudgetGroupType
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository
 import com.pennywiseai.tracker.data.repository.BudgetGroupSpending
+import com.pennywiseai.tracker.data.repository.BudgetWindow
 import com.pennywiseai.tracker.data.repository.PastWindowSpending
+import com.pennywiseai.tracker.data.repository.WindowBreakdown
 import com.pennywiseai.tracker.data.repository.aggregateBudgetCategorySpending
 import com.pennywiseai.tracker.data.repository.resolveBudgetWindow
 import com.pennywiseai.tracker.data.repository.windowsForMonth
@@ -34,7 +36,13 @@ data class BudgetHistoryUiState(
     val totalSpent: BigDecimal = BigDecimal.ZERO,
     val currency: String = "INR",
     val baseCurrency: String = "INR",
-    val budgetAmount: BigDecimal = BigDecimal.ZERO
+    val budgetAmount: BigDecimal = BigDecimal.ZERO,
+    /**
+     * The per-window category breakdown currently shown in the bottom
+     * sheet. Null when the sheet is dismissed. Set by [loadBreakdown].
+     */
+    val breakdown: WindowBreakdown? = null,
+    val isLoadingBreakdown: Boolean = false
 )
 
 /**
@@ -121,5 +129,37 @@ class BudgetHistoryViewModel @Inject constructor(
                 budgetAmount = budget.limitAmount
             )
         }
+    }
+
+    /**
+     * Load the per-category breakdown for [window] and show it in the
+     * bottom sheet. Idempotent — calling it twice on the same window is
+     * a no-op. Calling it on a different window replaces the existing
+     * sheet content.
+     */
+    fun loadBreakdown(window: BudgetWindow) {
+        val budget = _uiState.value.budget ?: return
+        if (_uiState.value.breakdown?.window == window && !_uiState.value.isLoadingBreakdown) return
+        _uiState.value = _uiState.value.copy(
+            isLoadingBreakdown = true,
+            breakdown = _uiState.value.breakdown?.takeIf { it.window == window }
+        )
+        viewModelScope.launch {
+            val currency = _uiState.value.currency
+            val breakdown = budgetGroupRepository.getBudgetWindowBreakdown(
+                budget = budget,
+                window = window,
+                currency = currency
+            )
+            _uiState.value = _uiState.value.copy(
+                breakdown = breakdown,
+                isLoadingBreakdown = false
+            )
+        }
+    }
+
+    /** Dismiss the bottom sheet without changing the loaded breakdown. */
+    fun dismissBreakdown() {
+        _uiState.value = _uiState.value.copy(breakdown = null, isLoadingBreakdown = false)
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetHistoryViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetHistoryViewModel.kt
@@ -1,0 +1,125 @@
+package com.pennywiseai.tracker.presentation.budgetgroups
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.pennywiseai.tracker.data.database.entity.BudgetEntity
+import com.pennywiseai.tracker.data.database.entity.BudgetGroupType
+import com.pennywiseai.tracker.data.repository.BudgetGroupRepository
+import com.pennywiseai.tracker.data.repository.BudgetGroupSpending
+import com.pennywiseai.tracker.data.repository.PastWindowSpending
+import com.pennywiseai.tracker.data.repository.aggregateBudgetCategorySpending
+import com.pennywiseai.tracker.data.repository.resolveBudgetWindow
+import com.pennywiseai.tracker.data.repository.windowsForMonth
+import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import java.math.BigDecimal
+import java.time.YearMonth
+import javax.inject.Inject
+
+data class BudgetHistoryUiState(
+    val isLoading: Boolean = true,
+    val budget: BudgetEntity? = null,
+    val yearMonth: YearMonth = YearMonth.now(),
+    val windowHistory: List<PastWindowSpending> = emptyList(),
+    val displayedWindowStart: java.time.LocalDate = java.time.LocalDate.now(),
+    val displayedWindowEnd: java.time.LocalDate = java.time.LocalDate.now(),
+    val displayedCapDate: java.time.LocalDate = java.time.LocalDate.now(),
+    val displayedIsLive: Boolean = false,
+    val totalSpent: BigDecimal = BigDecimal.ZERO,
+    val currency: String = "INR",
+    val baseCurrency: String = "INR",
+    val budgetAmount: BigDecimal = BigDecimal.ZERO
+)
+
+/**
+ * Read-only history for one budget at the selected (year, month). Powers
+ * the Budget History screen — opened from the Budgets page 3-dots
+ * "View this period history" item.
+ *
+ * For Weekly budgets the per-window list is the per-week sub-list (4–5
+ * weeks). For Monthly / One-time, the list has one entry — the cycle
+ * for Monthly, the literal range for One-time. Each entry carries a
+ * [PastWindowSpending.capDate] so the screen can label it "Live" or
+ * "Frozen as of …".
+ */
+@HiltViewModel
+class BudgetHistoryViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val budgetGroupRepository: BudgetGroupRepository,
+    private val userPreferencesRepository: UserPreferencesRepository
+) : ViewModel() {
+
+    private val groupId: Long = savedStateHandle.get<Long>("groupId") ?: -1L
+    private val year: Int = savedStateHandle.get<Int>("year") ?: -1
+    private val month: Int = savedStateHandle.get<Int>("month") ?: -1
+
+    private val _uiState = MutableStateFlow(
+        BudgetHistoryUiState(
+            yearMonth = if (year > 0 && month > 0) YearMonth.of(year, month) else YearMonth.now()
+        )
+    )
+    val uiState: StateFlow<BudgetHistoryUiState> = _uiState.asStateFlow()
+
+    init {
+        loadHistory()
+    }
+
+    private fun loadHistory() {
+        viewModelScope.launch {
+            val yearMonth = _uiState.value.yearMonth
+            val startDay = userPreferencesRepository.getBudgetCycleStartDay()
+            val baseCurrency = userPreferencesRepository.baseCurrency.first()
+            val displayCurrency = baseCurrency
+            val budget = budgetGroupRepository.getGroupById(groupId) ?: run {
+                _uiState.value = _uiState.value.copy(isLoading = false)
+                return@launch
+            }
+            val history = budgetGroupRepository.getBudgetHistoryForMonth(
+                budget = budget,
+                year = yearMonth.year,
+                month = yearMonth.monthValue,
+                currency = displayCurrency
+            )
+            val totalSpent = history.fold(BigDecimal.ZERO) { acc, w -> acc + w.spent }
+            val isCurrentMonth = yearMonth == YearMonth.now()
+            val today = java.time.LocalDate.now()
+            val displayedWindow = if (isCurrentMonth) {
+                resolveBudgetWindow(budget, today, startDay)
+            } else {
+                history.lastOrNull()?.window
+                    ?: windowsForMonth(budget, yearMonth.year, yearMonth.monthValue, startDay)
+                        .lastOrNull()
+                    ?: com.pennywiseai.tracker.data.repository.BudgetWindow(
+                        yearMonth.atDay(1), yearMonth.atEndOfMonth(), yearMonth.lengthOfMonth()
+                    )
+            }
+            val monthEnd = yearMonth.atEndOfMonth()
+            val displayedCap = if (isCurrentMonth &&
+                !today.isBefore(displayedWindow.start) && !today.isAfter(displayedWindow.end)
+            ) today else monthEnd
+            val displayedIsLive = isCurrentMonth &&
+                !today.isBefore(displayedWindow.start) && !today.isAfter(displayedWindow.end)
+
+            _uiState.value = BudgetHistoryUiState(
+                isLoading = false,
+                budget = budget,
+                yearMonth = yearMonth,
+                windowHistory = history,
+                displayedWindowStart = displayedWindow.start,
+                displayedWindowEnd = displayedWindow.end,
+                displayedCapDate = displayedCap,
+                displayedIsLive = displayedIsLive,
+                totalSpent = totalSpent,
+                currency = displayCurrency,
+                baseCurrency = baseCurrency,
+                budgetAmount = budget.limitAmount
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
@@ -123,6 +123,7 @@ fun HomeScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val isProEntitled by viewModel.isProEntitled.collectAsState()
+    val currentCycleWindow by viewModel.currentCycleWindow.collectAsState()
     var showUpgradeSheet by rememberSaveable { mutableStateOf(false) }
     val deletedTransaction by viewModel.deletedTransaction.collectAsState()
     val smsScanWorkInfo by viewModel.smsScanWorkInfo.collectAsState()
@@ -351,7 +352,8 @@ fun HomeScreen(
                         selectedProfileId = uiState.selectedProfileId,
                         onProfileSelected = { viewModel.updateSelectedProfile(it) },
                         isProEntitled = isProEntitled,
-                        onUpgradeClick = { showUpgradeSheet = true }
+                        onUpgradeClick = { showUpgradeSheet = true },
+                        cycleEnd = currentCycleWindow.second
                     )
                 }
             )

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -59,6 +59,7 @@ import kotlinx.coroutines.launch
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalDate
+import java.time.YearMonth
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 
@@ -828,19 +829,24 @@ class HomeViewModel @Inject constructor(
             ) { unifiedMode, displayCurrency, baseCurrency, cycle ->
                 Quad(unifiedMode, displayCurrency, baseCurrency, cycle)
             }.flatMapLatest { (unifiedMode, displayCurrency, baseCurrency, cycle) ->
-                // Pass the cycle-start (year, month) to the budget repo so a user
-                // on the 25th-of-month cycle navigates to the right bucket —
-                // October 5 with startDay=25 should land in the Sep 25..Oct 24
-                // window (startYearMonth = 2026-9), not October.
+                // Always pass today's year-month to the budget repo. The
+                // home dashboard is the *current* view; a user on startDay=25
+                // seeing the page on Jul 1 should get the Jul view, not the
+                // Jun cycle-start view (the cycle's start year-month is for
+                // the *Budgets page* navigation, not the home). The repo
+                // resolves each budget's window from resolveBudgetWindow
+                // independently, so the per-cadence window math is correct
+                // regardless of which calendar month the page is on.
                 val startDay = userPreferencesRepository.budgetCycleStartDay.first()
-                val cycleStartYm = BudgetCycle.currentCycleStartYearMonth(cycle.first, startDay)
+                val today = LocalDate.now()
+                val todayYm = YearMonth.of(today.year, today.monthValue)
                 if (unifiedMode) {
-                    budgetGroupRepository.getGroupSpendingAllCurrencies(cycleStartYm.year, cycleStartYm.monthValue)
+                    budgetGroupRepository.getGroupSpendingAllCurrencies(todayYm.year, todayYm.monthValue)
                         .map { raw ->
                             mapRawToConvertedSummary(raw, displayCurrency, baseCurrency)
                         }
                 } else {
-                    budgetGroupRepository.getGroupSpending(cycleStartYm.year, cycleStartYm.monthValue, baseCurrency)
+                    budgetGroupRepository.getGroupSpending(todayYm.year, todayYm.monthValue, baseCurrency)
                 }
             }.collect { summary ->
                 _uiState.value = _uiState.value.copy(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -30,7 +30,7 @@ import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.database.entity.BudgetGroupType
 import com.pennywiseai.tracker.data.repository.BudgetCategorySpending
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository
-import com.pennywiseai.tracker.data.repository.BudgetGroupRepository.Companion.aggregateBudgetCategorySpending
+import com.pennywiseai.tracker.data.repository.aggregateBudgetCategorySpending
 import com.pennywiseai.tracker.data.repository.BudgetGroupSpending
 import com.pennywiseai.tracker.data.repository.BudgetGroupSpendingRaw
 import com.pennywiseai.tracker.data.repository.BudgetOverallSummary

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -1353,6 +1353,24 @@ class HomeViewModel @Inject constructor(
         displayCurrency: String,
         baseCurrency: String
     ): BudgetOverallSummary {
+        // Per-budget current window for the "X days remaining" math
+        // on the home card. The repo's `raw.daysRemaining` is hard-
+        // coded to 0 (legacy) so we recompute it from the per-budget
+        // current window the repo just resolved — that's how the
+        // home pill knows "1 day remaining" is wrong.
+        fun daysRemainingFor(budget: com.pennywiseai.tracker.data.database.entity.BudgetEntity): Int {
+            val w = raw.currentWindows[budget.id] ?: return 0
+            val today = raw.today
+            return (ChronoUnit.DAYS.between(today, w.end).toInt() + 1)
+                .coerceIn(0, w.days)
+        }
+        fun daysElapsedFor(budget: com.pennywiseai.tracker.data.database.entity.BudgetEntity): Int {
+            val w = raw.currentWindows[budget.id] ?: return 0
+            val today = raw.today
+            return (ChronoUnit.DAYS.between(w.start, today).toInt() + 1)
+                .coerceIn(1, w.days)
+        }
+
         // Exclude a Refund from totalIncome only when it's also being subtracted
         // from a category by aggregateBudgetCategorySpending (categorised refund);
         // orphaned DEDUCT_SPENT income stays in the total so netSavings doesn't
@@ -1424,8 +1442,10 @@ class HomeViewModel @Inject constructor(
             val pctUsed = if (totalBudget > BigDecimal.ZERO) {
                 (totalActual.toFloat() / totalBudget.toFloat() * 100f).coerceAtLeast(0f)
             } else 0f
-            val dailyAllowance = if (raw.daysRemaining > 0 && remaining > BigDecimal.ZERO) {
-                remaining.divide(BigDecimal(raw.daysRemaining), 0, RoundingMode.HALF_UP)
+            val daysRemaining = daysRemainingFor(group.budget)
+            val daysElapsed = daysElapsedFor(group.budget)
+            val dailyAllowance = if (daysRemaining > 0 && remaining > BigDecimal.ZERO) {
+                remaining.divide(BigDecimal(daysRemaining), 0, RoundingMode.HALF_UP)
             } else BigDecimal.ZERO
             BudgetGroupSpending(
                 group = group,
@@ -1435,8 +1455,8 @@ class HomeViewModel @Inject constructor(
                 remaining = remaining,
                 percentageUsed = pctUsed,
                 dailyAllowance = dailyAllowance,
-                daysRemaining = raw.daysRemaining,
-                daysElapsed = raw.daysElapsed,
+                daysRemaining = daysRemaining,
+                daysElapsed = daysElapsed,
                 isTrackingAllExpenses = isTrackingAll
             )
         }
@@ -1452,8 +1472,11 @@ class HomeViewModel @Inject constructor(
             (netSavings.toFloat() / totalIncome.toFloat() * 100f)
         } else 0f
         val limitRemaining = totalLimitBudget - totalLimitSpent
-        val dailyAllowance = if (raw.daysRemaining > 0 && limitRemaining > BigDecimal.ZERO) {
-            limitRemaining.divide(BigDecimal(raw.daysRemaining), 0, RoundingMode.HALF_UP)
+        // Page-level "daysRemaining" picks the first budget's current
+        // window — matches the home carousel's hero card.
+        val pageDaysRemaining = groupSpendingList.firstOrNull()?.daysRemaining ?: 0
+        val dailyAllowance = if (pageDaysRemaining > 0 && limitRemaining > BigDecimal.ZERO) {
+            limitRemaining.divide(BigDecimal(pageDaysRemaining), 0, RoundingMode.HALF_UP)
         } else BigDecimal.ZERO
 
         return BudgetOverallSummary(
@@ -1468,7 +1491,7 @@ class HomeViewModel @Inject constructor(
             netSavings = netSavings,
             savingsRate = savingsRate,
             dailyAllowance = dailyAllowance,
-            daysRemaining = raw.daysRemaining,
+            daysRemaining = pageDaysRemaining,
             currency = displayCurrency
         )
     }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -99,10 +99,11 @@ class HomeViewModel @Inject constructor(
     val smsScanWorkInfo: StateFlow<WorkInfo?> = _smsScanWorkInfo.asStateFlow()
 
     /**
-     * The user's current budget cycle window (start, end). Recomputed when the
-     * start day pref changes; loaded once at init so callers can read a stable
-     * value for the lifetime of the screen. Used everywhere the home surface
-     * used to do `now.withDayOfMonth(1)..now.withDayOfMonth(lengthOfMonth())`.
+     * The user's current budget cycle window (start, end). Recomputed whenever
+     * the start day pref changes — used everywhere the home surface used to
+     * do `now.withDayOfMonth(1)..now.withDayOfMonth(lengthOfMonth())`. Exposed
+     * as a StateFlow so the greeting card / breakdown dialog can read the
+     * same window the data is bucketed against.
      */
     private val _currentCycleWindow = MutableStateFlow(
         BudgetCycle.currentCycle(LocalDate.now(), BudgetCycle.DEFAULT_START_DAY)
@@ -340,22 +341,30 @@ class HomeViewModel @Inject constructor(
 
     private fun loadHomeData() {
         viewModelScope.launch {
-            // Load current month breakdown by currency (filtered by business/personal).
+            // Load current cycle breakdown by currency (filtered by business/personal).
             // Loan-linked transactions are excluded — loan principal is shown separately
-            // as "Lent this month", and settlement losses are folded into expenses below.
-            val now = LocalDate.now()
-            val cycleStart = _currentCycleWindow.value.first
-            combine(
-                transactionRepository.getTransactionsBetweenDates(cycleStart, now),
-                userPreferencesRepository.selectedProfileId,
-                _cachedAccountBalances.filterNotNull()
-            ) { transactions, profileId, balances ->
-                val nonLoan = filterTransactionsByProfile(transactions, profileId, buildProfileAccountKeys(balances))
-                    .filter { it.loanId == null }
-                computeBreakdownByCurrency(nonLoan)
-            }.collect { breakdownByCurrency ->
-                updateBreakdownForSelectedCurrency(breakdownByCurrency, isCurrentMonth = true)
-            }
+            // as "Lent this cycle", and settlement losses are folded into expenses below.
+            //
+            // flatMapLatest on the cycle window so a start-day change (e.g. Settings
+            // → "25th" while the screen is open) cancels the in-flight query and
+            // re-fetches against the new window — without this, the captured
+            // cycleStart would go stale.
+            _currentCycleWindow
+                .flatMapLatest { (cycleStart, _) ->
+                    val now = LocalDate.now()
+                    transactionRepository.getTransactionsBetweenDates(cycleStart, now)
+                }
+                .combine(userPreferencesRepository.selectedProfileId) { transactions, profileId ->
+                    transactions to profileId
+                }
+                .combine(_cachedAccountBalances.filterNotNull()) { (transactions, profileId), balances ->
+                    val nonLoan = filterTransactionsByProfile(transactions, profileId, buildProfileAccountKeys(balances))
+                        .filter { it.loanId == null }
+                    computeBreakdownByCurrency(nonLoan)
+                }
+                .collect { breakdownByCurrency ->
+                    updateBreakdownForSelectedCurrency(breakdownByCurrency, isCurrentMonth = true)
+                }
         }
         
         viewModelScope.launch {
@@ -445,180 +454,192 @@ class HomeViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            // Load current month transactions by type (currency-filtered, business-filtered)
-            val (cycleStart, cycleEnd) = _currentCycleWindow.value
-
-            combine(
-                transactionRepository.getTransactionsBetweenDates(
-                    startDate = cycleStart,
-                    endDate = cycleEnd
-                ),
-                userPreferencesRepository.selectedProfileId,
-                _cachedAccountBalances.filterNotNull()
-            ) { transactions, profileId, balances ->
-                filterTransactionsByProfile(transactions, profileId, buildProfileAccountKeys(balances))
-            }.collect { transactions ->
-                updateTransactionTypeTotals(transactions)
-            }
+            // Load current cycle transactions by type (currency-filtered, business-filtered).
+            // Re-fires on cycle-window change via flatMapLatest.
+            _currentCycleWindow
+                .flatMapLatest { (cycleStart, cycleEnd) ->
+                    transactionRepository.getTransactionsBetweenDates(
+                        startDate = cycleStart,
+                        endDate = cycleEnd
+                    )
+                }
+                .combine(userPreferencesRepository.selectedProfileId) { transactions, profileId ->
+                    transactions to profileId
+                }
+                .combine(_cachedAccountBalances.filterNotNull()) { (transactions, profileId), balances ->
+                    filterTransactionsByProfile(transactions, profileId, buildProfileAccountKeys(balances))
+                }
+                .collect { transactions ->
+                    updateTransactionTypeTotals(transactions)
+                }
         }
 
         viewModelScope.launch {
-            // Track principal lent during the current month — surfaced separately from
-            // "Spent this month" so loan outflows don't masquerade as everyday spending.
+            // Track principal lent during the current cycle — surfaced separately from
+            // "Spent this cycle" so loan outflows don't masquerade as everyday spending.
             // Stored per-currency so updateUIStateForCurrency can resolve the right value
             // whenever the user switches currency tabs or unified mode toggles.
-            val (cycleStart, cycleEnd) = _currentCycleWindow.value
-            val startOfMonth = cycleStart.atStartOfDay()
-            val endOfMonth = cycleEnd.atTime(java.time.LocalTime.MAX)
-
-            combine(
-                loanRepository.getActiveLentTransactionsInPeriod(startOfMonth, endOfMonth),
-                userPreferencesRepository.selectedProfileId,
-                _cachedAccountBalances.filterNotNull()
-            ) { lentTxns, profileId, balances ->
-                val keys = buildProfileAccountKeys(balances)
-                filterTransactionsByProfile(lentTxns, profileId, keys)
-            }.collect { filtered ->
-                currentMonthLentByCurrency = filtered.groupBy { it.currency }.mapValues { (_, txs) ->
-                    // Honour partial-loan tagging: only the loan_contribution
-                    // portion of a transaction (when set) counts toward
-                    // "Lent this month"; falls back to the full amount for
-                    // legacy / full-amount transactions.
-                    txs.fold(BigDecimal.ZERO) { acc, tx -> acc + (tx.loanContribution ?: tx.amount) }
+            _currentCycleWindow
+                .flatMapLatest { (cycleStart, cycleEnd) ->
+                    val start = cycleStart.atStartOfDay()
+                    val end = cycleEnd.atTime(java.time.LocalTime.MAX)
+                    loanRepository.getActiveLentTransactionsInPeriod(start, end)
                 }
-                updateUIStateForCurrency(_uiState.value.selectedCurrency, _uiState.value.availableCurrencies)
-            }
+                .combine(userPreferencesRepository.selectedProfileId) { lentTxns, profileId ->
+                    lentTxns to profileId
+                }
+                .combine(_cachedAccountBalances.filterNotNull()) { (lentTxns, profileId), balances ->
+                    val keys = buildProfileAccountKeys(balances)
+                    filterTransactionsByProfile(lentTxns, profileId, keys)
+                }
+                .collect { filtered ->
+                    currentMonthLentByCurrency = filtered.groupBy { it.currency }.mapValues { (_, txs) ->
+                        // Honour partial-loan tagging: only the loan_contribution
+                        // portion of a transaction (when set) counts toward
+                        // "Lent this cycle"; falls back to the full amount for
+                        // legacy / full-amount transactions.
+                        txs.fold(BigDecimal.ZERO) { acc, tx -> acc + (tx.loanContribution ?: tx.amount) }
+                    }
+                    updateUIStateForCurrency(_uiState.value.selectedCurrency, _uiState.value.availableCurrencies)
+                }
         }
 
         viewModelScope.launch {
-            // Track losses on LENT loans settled this month. Each loss feeds back into the
-            // displayed "Spent this month" via updateUIStateForCurrency.
+            // Track losses on LENT loans settled this cycle. Each loss feeds back into the
+            // displayed "Spent this cycle" via updateUIStateForCurrency.
             //
             // LoanEntity has no profile column, so the profile filter is applied via the
             // source EXPENSE transaction (same bank+account → same profile).
-            val (cycleStart, cycleEnd) = _currentCycleWindow.value
-            val startOfMonth = cycleStart.atStartOfDay()
-            val endOfMonth = cycleEnd.atTime(java.time.LocalTime.MAX)
-
-            combine(
-                loanRepository.getLentLoansSettledInPeriod(startOfMonth, endOfMonth),
-                userPreferencesRepository.selectedProfileId,
-                _cachedAccountBalances.filterNotNull()
-            ) { settledLoans, profileId, balances ->
-                Triple(settledLoans, profileId, balances)
-            }.collect { (settledLoans, profileId, balances) ->
-                val keys = buildProfileAccountKeys(balances)
-                val byCurrency = mutableMapOf<String, BigDecimal>()
-                for (loan in settledLoans) {
-                    val sourceTx = loanRepository.getOriginalTransactionForLoan(loan.id)
-                    // Null sourceTx means the loan has no live linked transaction (all were
-                    // unlinked or deleted). Skip entirely — without a transaction we can't
-                    // attribute the loss to any profile, and treating null as "include
-                    // everywhere" would double-count it for users with multiple profiles.
-                    val belongsToProfile = sourceTx != null &&
-                        filterTransactionsByProfile(listOf(sourceTx), profileId, keys).isNotEmpty()
-                    if (!belongsToProfile) continue
-
-                    val loss = loanRepository.getSettlementLoss(loan)
-                    if (loss > BigDecimal.ZERO) {
-                        byCurrency.merge(loan.currency, loss) { a, b -> a + b }
-                    }
+            _currentCycleWindow
+                .flatMapLatest { (cycleStart, cycleEnd) ->
+                    val start = cycleStart.atStartOfDay()
+                    val end = cycleEnd.atTime(java.time.LocalTime.MAX)
+                    loanRepository.getLentLoansSettledInPeriod(start, end)
                 }
-                currentMonthLoanLossByCurrency = byCurrency
-                updateUIStateForCurrency(_uiState.value.selectedCurrency, _uiState.value.availableCurrencies)
-            }
+                .combine(userPreferencesRepository.selectedProfileId) { settledLoans, profileId ->
+                    settledLoans to profileId
+                }
+                .combine(_cachedAccountBalances.filterNotNull()) { (settledLoans, profileId), balances ->
+                    val keys = buildProfileAccountKeys(balances)
+                    val byCurrency = mutableMapOf<String, BigDecimal>()
+                    for (loan in settledLoans) {
+                        val sourceTx = loanRepository.getOriginalTransactionForLoan(loan.id)
+                        // Null sourceTx means the loan has no live linked transaction (all were
+                        // unlinked or deleted). Skip entirely — without a transaction we can't
+                        // attribute the loss to any profile, and treating null as "include
+                        // everywhere" would double-count it for users with multiple profiles.
+                        val belongsToProfile = sourceTx != null &&
+                            filterTransactionsByProfile(listOf(sourceTx), profileId, keys).isNotEmpty()
+                        if (!belongsToProfile) continue
+
+                        val loss = loanRepository.getSettlementLoss(loan)
+                        if (loss > BigDecimal.ZERO) {
+                            byCurrency.merge(loan.currency, loss) { a, b -> a + b }
+                        }
+                    }
+                    currentMonthLoanLossByCurrency = byCurrency
+                    updateUIStateForCurrency(_uiState.value.selectedCurrency, _uiState.value.availableCurrencies)
+                }
         }
 
         viewModelScope.launch {
-            // Load last month breakdown by currency (filtered by business/personal)
+            // Load previous-cycle breakdown by currency (filtered by business/personal)
             // "Last month" here means "previous cycle" so the comparison lines up with the
             // custom start day (a user on the 25th-of-month cycle sees 25th→24th vs
             // 25th→24th, not 1st→today vs 1st→today).
-            val current = _currentCycleWindow.value
-            val startDay = userPreferencesRepository.budgetCycleStartDay.first()
-            val (lastMonthStart, lastMonthEnd) = BudgetCycle.previousCycle(current, startDay)
-            combine(
-                transactionRepository.getTransactionsBetweenDates(lastMonthStart, lastMonthEnd),
-                userPreferencesRepository.selectedProfileId,
-                _cachedAccountBalances.filterNotNull()
-            ) { transactions, profileId, balances ->
-                val nonLoan = filterTransactionsByProfile(transactions, profileId, buildProfileAccountKeys(balances))
-                    .filter { it.loanId == null }
-                computeBreakdownByCurrency(nonLoan)
-            }.collect { breakdownByCurrency ->
-                updateBreakdownForSelectedCurrency(breakdownByCurrency, isCurrentMonth = false)
-            }
+            _currentCycleWindow
+                .flatMapLatest { current ->
+                    val startDay = userPreferencesRepository.budgetCycleStartDay.first()
+                    val (lastMonthStart, lastMonthEnd) = BudgetCycle.previousCycle(current, startDay)
+                    transactionRepository.getTransactionsBetweenDates(lastMonthStart, lastMonthEnd)
+                }
+                .combine(userPreferencesRepository.selectedProfileId) { transactions, profileId ->
+                    transactions to profileId
+                }
+                .combine(_cachedAccountBalances.filterNotNull()) { (transactions, profileId), balances ->
+                    val nonLoan = filterTransactionsByProfile(transactions, profileId, buildProfileAccountKeys(balances))
+                        .filter { it.loanId == null }
+                    computeBreakdownByCurrency(nonLoan)
+                }
+                .collect { breakdownByCurrency ->
+                    updateBreakdownForSelectedCurrency(breakdownByCurrency, isCurrentMonth = false)
+                }
         }
 
         viewModelScope.launch {
-            // Load cumulative spending sparkline for current month + last month comparison
+            // Load cumulative spending sparkline for current cycle + previous cycle comparison
             val now = LocalDate.now()
-            val (firstOfMonth, cycleEnd) = _currentCycleWindow.value
-            val startDay = userPreferencesRepository.budgetCycleStartDay.first()
-            val (lastMonthStart, _) = BudgetCycle.previousCycle(firstOfMonth to cycleEnd, startDay)
-
-            combine(
-                transactionRepository.getTransactionsBetweenDates(
-                    startDate = lastMonthStart,
-                    endDate = now
-                ),
-                userPreferencesRepository.selectedProfileId,
-                _cachedAccountBalances.filterNotNull()
-            ) { allTransactions, profileId, balances ->
-                filterTransactionsByProfile(allTransactions, profileId, buildProfileAccountKeys(balances))
-            }.collect { allTransactions ->
-                val selectedCurrency = _uiState.value.selectedCurrency
-                val isUnified = _uiState.value.isUnifiedMode
-
-                // Split into current month and last month
-                val currentMonthTxs = allTransactions.filter { it.dateTime.toLocalDate() >= firstOfMonth }
-                val lastMonthTxs = allTransactions.filter {
-                    val d = it.dateTime.toLocalDate()
-                    d >= lastMonthStart && d < firstOfMonth
+            _currentCycleWindow
+                .flatMapLatest { (firstOfMonth, cycleEnd) ->
+                    val startDay = userPreferencesRepository.budgetCycleStartDay.first()
+                    val (lastMonthStart, _) = BudgetCycle.previousCycle(firstOfMonth to cycleEnd, startDay)
+                    transactionRepository.getTransactionsBetweenDates(
+                        startDate = lastMonthStart,
+                        endDate = now
+                    )
                 }
-
-                // Net daily expense (EXPENSE adds, Refund subtracts) for both
-                // months, then cumulative below clamps at zero so refunds pull the
-                // sparkline endpoint in lockstep with the displayed "Spent" stat.
-                val dailySums = buildDailyNetExpense(currentMonthTxs, isUnified, selectedCurrency)
-                val lastMonthDailySums = buildDailyNetExpense(lastMonthTxs, isUnified, selectedCurrency)
-
-                // Carry the running total forward unclamped (so a refund dated
-                // before the first expense still counts) and only clamp the value
-                // we display, so the chart endpoint matches the month-level floor
-                // applied to "Spent this month" in computeBreakdownByCurrency.
-                val cumulativeList = mutableListOf<BigDecimal>()
-                var runningNet = BigDecimal.ZERO
-                var day = firstOfMonth
-                while (!day.isAfter(now)) {
-                    runningNet += (dailySums[day] ?: BigDecimal.ZERO)
-                    cumulativeList.add(runningNet.coerceAtLeast(BigDecimal.ZERO))
-                    day = day.plusDays(1)
+                .combine(userPreferencesRepository.selectedProfileId) { allTransactions, profileId ->
+                    allTransactions to profileId
                 }
-
-                // Match the "same period" comparison the legacy code used: walk the
-                // previous cycle for as many days as today's day-of-cycle, so an
-                // Oct-5 vs Sep-25..Oct-4 chart isn't accidentally drawn over the
-                // full previous cycle.
-                val daysToInclude = ChronoUnit.DAYS.between(firstOfMonth, now).toInt() + 1
-                val lastMonthCumulative = mutableListOf<BigDecimal>()
-                var lastRunningNet = BigDecimal.ZERO
-                var lastDay = lastMonthStart
-                var dayCount = 0
-                while (dayCount < daysToInclude && lastDay < firstOfMonth) {
-                    lastRunningNet += (lastMonthDailySums[lastDay] ?: BigDecimal.ZERO)
-                    lastMonthCumulative.add(lastRunningNet.coerceAtLeast(BigDecimal.ZERO))
-                    lastDay = lastDay.plusDays(1)
-                    dayCount++
+                .combine(_cachedAccountBalances.filterNotNull()) { (allTransactions, profileId), balances ->
+                    filterTransactionsByProfile(allTransactions, profileId, buildProfileAccountKeys(balances))
                 }
+                .collect { allTransactions ->
+                    val (firstOfMonth, _) = _currentCycleWindow.value
+                    val startDay = userPreferencesRepository.budgetCycleStartDay.first()
+                    val (lastMonthStart, _) = BudgetCycle.previousCycle(firstOfMonth to _currentCycleWindow.value.second, startDay)
+                    val selectedCurrency = _uiState.value.selectedCurrency
+                    val isUnified = _uiState.value.isUnifiedMode
 
-                _uiState.value = _uiState.value.copy(
-                    spendingHistory = cumulativeList,
-                    balanceHistory = cumulativeList,
-                    lastMonthSpendingHistory = lastMonthCumulative
-                )
-                calculateMonthlyChange()
-            }
+                    // Split into current cycle and previous cycle
+                    val currentMonthTxs = allTransactions.filter { it.dateTime.toLocalDate() >= firstOfMonth }
+                    val lastMonthTxs = allTransactions.filter {
+                        val d = it.dateTime.toLocalDate()
+                        d >= lastMonthStart && d < firstOfMonth
+                    }
+
+                    // Net daily expense (EXPENSE adds, Refund subtracts) for both
+                    // months, then cumulative below clamps at zero so refunds pull the
+                    // sparkline endpoint in lockstep with the displayed "Spent" stat.
+                    val dailySums = buildDailyNetExpense(currentMonthTxs, isUnified, selectedCurrency)
+                    val lastMonthDailySums = buildDailyNetExpense(lastMonthTxs, isUnified, selectedCurrency)
+
+                    // Carry the running total forward unclamped (so a refund dated
+                    // before the first expense still counts) and only clamp the value
+                    // we display, so the chart endpoint matches the month-level floor
+                    // applied to "Spent this cycle" in computeBreakdownByCurrency.
+                    val cumulativeList = mutableListOf<BigDecimal>()
+                    var runningNet = BigDecimal.ZERO
+                    var day = firstOfMonth
+                    while (!day.isAfter(now)) {
+                        runningNet += (dailySums[day] ?: BigDecimal.ZERO)
+                        cumulativeList.add(runningNet.coerceAtLeast(BigDecimal.ZERO))
+                        day = day.plusDays(1)
+                    }
+
+                    // Match the "same period" comparison the legacy code used: walk the
+                    // previous cycle for as many days as today's day-of-cycle, so an
+                    // Oct-5 vs Sep-25..Oct-4 chart isn't accidentally drawn over the
+                    // full previous cycle.
+                    val daysToInclude = ChronoUnit.DAYS.between(firstOfMonth, now).toInt() + 1
+                    val lastMonthCumulative = mutableListOf<BigDecimal>()
+                    var lastRunningNet = BigDecimal.ZERO
+                    var lastDay = lastMonthStart
+                    var dayCount = 0
+                    while (dayCount < daysToInclude && lastDay < firstOfMonth) {
+                        lastRunningNet += (lastMonthDailySums[lastDay] ?: BigDecimal.ZERO)
+                        lastMonthCumulative.add(lastRunningNet.coerceAtLeast(BigDecimal.ZERO))
+                        lastDay = lastDay.plusDays(1)
+                        dayCount++
+                    }
+
+                    _uiState.value = _uiState.value.copy(
+                        spendingHistory = cumulativeList,
+                        balanceHistory = cumulativeList,
+                        lastMonthSpendingHistory = lastMonthCumulative
+                    )
+                    calculateMonthlyChange()
+                }
         }
 
         viewModelScope.launch {
@@ -802,18 +823,24 @@ class HomeViewModel @Inject constructor(
             combine(
                 userPreferencesRepository.unifiedCurrencyMode,
                 userPreferencesRepository.displayCurrency,
-                userPreferencesRepository.baseCurrency
-            ) { unifiedMode, displayCurrency, baseCurrency ->
-                Triple(unifiedMode, displayCurrency, baseCurrency)
-            }.flatMapLatest { (unifiedMode, displayCurrency, baseCurrency) ->
-                val today = LocalDate.now()
+                userPreferencesRepository.baseCurrency,
+                _currentCycleWindow
+            ) { unifiedMode, displayCurrency, baseCurrency, cycle ->
+                Quad(unifiedMode, displayCurrency, baseCurrency, cycle)
+            }.flatMapLatest { (unifiedMode, displayCurrency, baseCurrency, cycle) ->
+                // Pass the cycle-start (year, month) to the budget repo so a user
+                // on the 25th-of-month cycle navigates to the right bucket —
+                // October 5 with startDay=25 should land in the Sep 25..Oct 24
+                // window (startYearMonth = 2026-9), not October.
+                val startDay = userPreferencesRepository.budgetCycleStartDay.first()
+                val cycleStartYm = BudgetCycle.currentCycleStartYearMonth(cycle.first, startDay)
                 if (unifiedMode) {
-                    budgetGroupRepository.getGroupSpendingAllCurrencies(today.year, today.monthValue)
+                    budgetGroupRepository.getGroupSpendingAllCurrencies(cycleStartYm.year, cycleStartYm.monthValue)
                         .map { raw ->
                             mapRawToConvertedSummary(raw, displayCurrency, baseCurrency)
                         }
                 } else {
-                    budgetGroupRepository.getGroupSpending(today.year, today.monthValue, baseCurrency)
+                    budgetGroupRepository.getGroupSpending(cycleStartYm.year, cycleStartYm.monthValue, baseCurrency)
                 }
             }.collect { summary ->
                 _uiState.value = _uiState.value.copy(
@@ -1497,4 +1524,11 @@ data class LoanSummary(
     val activeLoans: List<LoanEntity>,
     val totalLentRemaining: BigDecimal,
     val totalBorrowedRemaining: BigDecimal
+)
+
+private data class Quad<A, B, C, D>(
+    val a: A,
+    val b: B,
+    val c: C,
+    val d: D
 )

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -18,6 +18,7 @@ import com.pennywiseai.tracker.data.manager.InAppUpdateManager
 import com.pennywiseai.tracker.data.manager.InAppReviewManager
 import com.pennywiseai.tracker.data.currency.CurrencyConversionService
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
+import com.pennywiseai.tracker.domain.model.BudgetCycle
 import com.pennywiseai.tracker.presentation.common.buildProfileAccountKeys
 import com.pennywiseai.tracker.presentation.common.filterAccountsByProfile
 import com.pennywiseai.tracker.presentation.common.filterTransactionsByProfile
@@ -58,6 +59,7 @@ import kotlinx.coroutines.launch
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -95,6 +97,17 @@ class HomeViewModel @Inject constructor(
     // SMS scanning work progress tracking
     private val _smsScanWorkInfo = MutableStateFlow<WorkInfo?>(null)
     val smsScanWorkInfo: StateFlow<WorkInfo?> = _smsScanWorkInfo.asStateFlow()
+
+    /**
+     * The user's current budget cycle window (start, end). Recomputed when the
+     * start day pref changes; loaded once at init so callers can read a stable
+     * value for the lifetime of the screen. Used everywhere the home surface
+     * used to do `now.withDayOfMonth(1)..now.withDayOfMonth(lengthOfMonth())`.
+     */
+    private val _currentCycleWindow = MutableStateFlow(
+        BudgetCycle.currentCycle(LocalDate.now(), BudgetCycle.DEFAULT_START_DAY)
+    )
+    val currentCycleWindow: StateFlow<Pair<LocalDate, LocalDate>> = _currentCycleWindow.asStateFlow()
 
     // Store currency breakdown maps for quick access when switching currencies
     private var currentMonthBreakdownMap: Map<String, TransactionRepository.MonthlyBreakdown> = emptyMap()
@@ -138,6 +151,19 @@ class HomeViewModel @Inject constructor(
         loadBaseCurrency()
         observeSelectedProfile()
         observeProfiles()
+        observeBudgetCycle()
+    }
+
+    /**
+     * Recompute the current cycle window whenever the user's start day changes
+     * (or once on first emission). Cheap: just two `LocalDate` reads + arithmetic.
+     */
+    private fun observeBudgetCycle() {
+        userPreferencesRepository.budgetCycleStartDay
+            .onEach { startDay ->
+                _currentCycleWindow.value = BudgetCycle.currentCycle(LocalDate.now(), startDay)
+            }
+            .launchIn(viewModelScope)
     }
 
     fun toggleBalanceVisibility() {
@@ -318,9 +344,9 @@ class HomeViewModel @Inject constructor(
             // Loan-linked transactions are excluded — loan principal is shown separately
             // as "Lent this month", and settlement losses are folded into expenses below.
             val now = LocalDate.now()
-            val startOfMonth = now.withDayOfMonth(1)
+            val cycleStart = _currentCycleWindow.value.first
             combine(
-                transactionRepository.getTransactionsBetweenDates(startOfMonth, now),
+                transactionRepository.getTransactionsBetweenDates(cycleStart, now),
                 userPreferencesRepository.selectedProfileId,
                 _cachedAccountBalances.filterNotNull()
             ) { transactions, profileId, balances ->
@@ -420,14 +446,12 @@ class HomeViewModel @Inject constructor(
 
         viewModelScope.launch {
             // Load current month transactions by type (currency-filtered, business-filtered)
-            val now = java.time.LocalDate.now()
-            val startOfMonth = now.withDayOfMonth(1)
-            val endOfMonth = now.withDayOfMonth(now.lengthOfMonth())
+            val (cycleStart, cycleEnd) = _currentCycleWindow.value
 
             combine(
                 transactionRepository.getTransactionsBetweenDates(
-                    startDate = startOfMonth,
-                    endDate = endOfMonth
+                    startDate = cycleStart,
+                    endDate = cycleEnd
                 ),
                 userPreferencesRepository.selectedProfileId,
                 _cachedAccountBalances.filterNotNull()
@@ -443,9 +467,9 @@ class HomeViewModel @Inject constructor(
             // "Spent this month" so loan outflows don't masquerade as everyday spending.
             // Stored per-currency so updateUIStateForCurrency can resolve the right value
             // whenever the user switches currency tabs or unified mode toggles.
-            val now = LocalDate.now()
-            val startOfMonth = now.withDayOfMonth(1).atStartOfDay()
-            val endOfMonth = now.withDayOfMonth(now.lengthOfMonth()).atTime(java.time.LocalTime.MAX)
+            val (cycleStart, cycleEnd) = _currentCycleWindow.value
+            val startOfMonth = cycleStart.atStartOfDay()
+            val endOfMonth = cycleEnd.atTime(java.time.LocalTime.MAX)
 
             combine(
                 loanRepository.getActiveLentTransactionsInPeriod(startOfMonth, endOfMonth),
@@ -472,9 +496,9 @@ class HomeViewModel @Inject constructor(
             //
             // LoanEntity has no profile column, so the profile filter is applied via the
             // source EXPENSE transaction (same bank+account → same profile).
-            val now = LocalDate.now()
-            val startOfMonth = now.withDayOfMonth(1).atStartOfDay()
-            val endOfMonth = now.withDayOfMonth(now.lengthOfMonth()).atTime(java.time.LocalTime.MAX)
+            val (cycleStart, cycleEnd) = _currentCycleWindow.value
+            val startOfMonth = cycleStart.atStartOfDay()
+            val endOfMonth = cycleEnd.atTime(java.time.LocalTime.MAX)
 
             combine(
                 loanRepository.getLentLoansSettledInPeriod(startOfMonth, endOfMonth),
@@ -507,12 +531,12 @@ class HomeViewModel @Inject constructor(
 
         viewModelScope.launch {
             // Load last month breakdown by currency (filtered by business/personal)
-            val now = LocalDate.now()
-            val dayOfMonth = now.dayOfMonth
-            val lastMonth = now.minusMonths(1)
-            val lastMonthStart = lastMonth.withDayOfMonth(1)
-            val lastMonthMaxDay = minOf(dayOfMonth, lastMonth.lengthOfMonth())
-            val lastMonthEnd = lastMonth.withDayOfMonth(lastMonthMaxDay)
+            // "Last month" here means "previous cycle" so the comparison lines up with the
+            // custom start day (a user on the 25th-of-month cycle sees 25th→24th vs
+            // 25th→24th, not 1st→today vs 1st→today).
+            val current = _currentCycleWindow.value
+            val startDay = userPreferencesRepository.budgetCycleStartDay.first()
+            val (lastMonthStart, lastMonthEnd) = BudgetCycle.previousCycle(current, startDay)
             combine(
                 transactionRepository.getTransactionsBetweenDates(lastMonthStart, lastMonthEnd),
                 userPreferencesRepository.selectedProfileId,
@@ -529,8 +553,9 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             // Load cumulative spending sparkline for current month + last month comparison
             val now = LocalDate.now()
-            val firstOfMonth = now.withDayOfMonth(1)
-            val lastMonthStart = firstOfMonth.minusMonths(1)
+            val (firstOfMonth, cycleEnd) = _currentCycleWindow.value
+            val startDay = userPreferencesRepository.budgetCycleStartDay.first()
+            val (lastMonthStart, _) = BudgetCycle.previousCycle(firstOfMonth to cycleEnd, startDay)
 
             combine(
                 transactionRepository.getTransactionsBetweenDates(
@@ -571,7 +596,11 @@ class HomeViewModel @Inject constructor(
                     day = day.plusDays(1)
                 }
 
-                val daysToInclude = now.dayOfMonth
+                // Match the "same period" comparison the legacy code used: walk the
+                // previous cycle for as many days as today's day-of-cycle, so an
+                // Oct-5 vs Sep-25..Oct-4 chart isn't accidentally drawn over the
+                // full previous cycle.
+                val daysToInclude = ChronoUnit.DAYS.between(firstOfMonth, now).toInt() + 1
                 val lastMonthCumulative = mutableListOf<BigDecimal>()
                 var lastRunningNet = BigDecimal.ZERO
                 var lastDay = lastMonthStart
@@ -1053,13 +1082,11 @@ class HomeViewModel @Inject constructor(
 
         // Also refresh transaction type totals for new currency
         viewModelScope.launch {
-            val now = java.time.LocalDate.now()
-            val startOfMonth = now.withDayOfMonth(1)
-            val endOfMonth = now.withDayOfMonth(now.lengthOfMonth())
+            val (cycleStart, cycleEnd) = _currentCycleWindow.value
 
             val allTransactions = transactionRepository.getTransactionsBetweenDates(
-                startDate = startOfMonth,
-                endDate = endOfMonth
+                startDate = cycleStart,
+                endDate = cycleEnd
             ).first()
             val transactions = filterTransactions(allTransactions)
             updateTransactionTypeTotals(transactions)

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -9,6 +9,7 @@ import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.repository.CategoryRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
+import com.pennywiseai.tracker.domain.model.BudgetCycle
 import com.pennywiseai.tracker.presentation.common.TimePeriod
 import com.pennywiseai.tracker.presentation.common.TransactionTypeFilter
 import com.pennywiseai.tracker.presentation.common.getDateRangeForPeriod
@@ -133,6 +134,11 @@ class TransactionsViewModel @Inject constructor(
             transactionRepository.getAllCurrencies()
         } else if (period == TimePeriod.CUSTOM && customRange != null) {
             val (startDate, endDate) = customRange
+            val startDateTime = startDate.atStartOfDay()
+            val endDateTime = endDate.atTime(23, 59, 59)
+            transactionRepository.getCurrenciesForPeriod(startDateTime, endDateTime)
+        } else if (period == TimePeriod.THIS_MONTH) {
+            val (startDate, endDate) = getThisCycleRange()
             val startDateTime = startDate.atStartOfDay()
             val endDateTime = endDate.atTime(23, 59, 59)
             transactionRepository.getCurrenciesForPeriod(startDateTime, endDateTime)
@@ -625,8 +631,17 @@ class TransactionsViewModel @Inject constructor(
             .transformLatest { _ ->
                 val period = selectedPeriod.value
                 val categories = categoriesFilter.value
+                // Always resolve a cycle range up-front; only THIS_MONTH consumes it
+                // today, but keeping a real Pair avoids nullable plumbing in the
+                // (non-suspend) filter helper.
+                val cycleRange = if (period == TimePeriod.THIS_MONTH) {
+                    getThisCycleRange()
+                } else {
+                    // Use a sentinel range — never read for non-THIS_MONTH branches.
+                    LocalDate.now() to LocalDate.now()
+                }
                 // Get all transactions without category filter applied
-                getFilteredTransactions("", period, null, categories, TransactionTypeFilter.ALL)
+                getFilteredTransactions("", period, null, categories, TransactionTypeFilter.ALL, cycleRange)
                     .collect { transactions ->
                         emit(transactions.map { it.category }.distinct().sorted())
                     }
@@ -669,8 +684,18 @@ class TransactionsViewModel @Inject constructor(
                 val profileId = _selectedProfileId.value
                 val accountKey = _accountFilter.value
 
+                // Resolve the cycle window up-front so the inner (non-suspend)
+                // filter helper can reuse it for THIS_MONTH. Non-THIS_MONTH
+                // branches never read this — pass a sentinel pair to keep
+                // the helper signature non-nullable.
+                val cycleRange = if (period == TimePeriod.THIS_MONTH) {
+                    getThisCycleRange()
+                } else {
+                    LocalDate.now() to LocalDate.now()
+                }
+
                 // Get filtered transactions (without currency filter first)
-                getFilteredTransactions(query, period, category, categories, typeFilter)
+                getFilteredTransactions(query, period, category, categories, typeFilter, cycleRange)
                     .collect { allTransactions ->
                         // Apply profile filter, then account filter
                         val transactions = filterTransactionsByAccount(
@@ -825,6 +850,17 @@ class TransactionsViewModel @Inject constructor(
         if (_selectedPeriod.value == TimePeriod.CUSTOM) {
             _selectedPeriod.value = TimePeriod.THIS_MONTH
         }
+    }
+
+    /**
+     * The "This Month" range for the Transactions tab. Honours the user's
+     * configured budget cycle start day (e.g. 25th → 24th) so the transactions
+     * list, totals, and analytics agree on the same window.
+     */
+    private suspend fun getThisCycleRange(): Pair<LocalDate, LocalDate> {
+        val startDay = userPreferencesRepository.getBudgetCycleStartDay()
+        val (start, end) = BudgetCycle.currentCycle(LocalDate.now(), startDay)
+        return start to end
     }
 
     fun deleteTransaction(transaction: TransactionEntity) {
@@ -1053,7 +1089,11 @@ class TransactionsViewModel @Inject constructor(
         period: TimePeriod,
         category: String?,
         categories: List<String>?,
-        typeFilter: TransactionTypeFilter
+        typeFilter: TransactionTypeFilter,
+        // Resolved at the call site (which is in a coroutine) so the inner
+        // (non-suspend) Flow builder can branch on THIS_MONTH. For other
+        // periods this is ignored.
+        cycleRange: Pair<LocalDate, LocalDate>
     ): Flow<List<TransactionEntity>> {
         // Start with the base flow based on category filter
         val baseFlow = if (category != null) {
@@ -1111,7 +1151,7 @@ class TransactionsViewModel @Inject constructor(
                         "CUSTOM period selected but no date range set - falling back to THIS_MONTH")
                     // Auto-correct the invalid state
                     _selectedPeriod.value = TimePeriod.THIS_MONTH
-                    val (startDate, endDate) = getDateRangeForPeriod(TimePeriod.THIS_MONTH)!!
+                    val (startDate, endDate) = cycleRange
                     val startDateTime = startDate.atStartOfDay()
                     val endDateTime = endDate.atTime(23, 59, 59)
                     categoriesFilteredFlow.map { transactions ->
@@ -1125,6 +1165,14 @@ class TransactionsViewModel @Inject constructor(
                     categoriesFilteredFlow.map { transactions ->
                         transactions.filter { it.dateTime in startDateTime..endDateTime }
                     }
+                }
+            }
+            TimePeriod.THIS_MONTH -> {
+                val (startDate, endDate) = cycleRange
+                val startDateTime = startDate.atStartOfDay()
+                val endDateTime = endDate.atTime(23, 59, 59)
+                categoriesFilteredFlow.map { transactions ->
+                    transactions.filter { it.dateTime in startDateTime..endDateTime }
                 }
             }
             else -> {

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/GreetingCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/GreetingCard.kt
@@ -58,12 +58,19 @@ fun GreetingCard(
     selectedProfileId: Long? = null,
     onProfileSelected: (Long?) -> Unit = {},
     isProEntitled: Boolean = false,
-    onUpgradeClick: () -> Unit = {}
+    onUpgradeClick: () -> Unit = {},
+    // The last day of the user's current budget cycle. When null, the
+    // subtitle falls back to the calendar month's end. The "X days left in
+    // <month>" line then tracks the cycle (e.g. "4 days left in October" on
+    // Oct 20 with startDay=25, where the cycle ends Oct 24).
+    cycleEnd: LocalDate? = null
 ) {
     val today = LocalDate.now()
-    val subtitle = remember(today) {
+    val subtitle = remember(today, cycleEnd) {
         val now = today
-        val lastDay = now.withDayOfMonth(now.lengthOfMonth())
+        // Prefer the cycle's end over the calendar month's end so the
+        // "X days left" hint lines up with the budget / spending windows.
+        val lastDay = cycleEnd ?: now.withDayOfMonth(now.lengthOfMonth())
         val daysLeft = ChronoUnit.DAYS.between(now, lastDay)
         val rawMonth = now.month.name.lowercase()
         val monthName = if (rawMonth.isEmpty()) rawMonth else rawMonth.substring(0, 1).uppercase() + rawMonth.substring(1)

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BudgetCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BudgetCard.kt
@@ -27,11 +27,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.pennywiseai.tracker.data.database.entity.BudgetPeriodType
 import com.pennywiseai.tracker.data.repository.BudgetGroupSpending
 import com.pennywiseai.tracker.ui.theme.Dimensions
 import com.pennywiseai.tracker.ui.theme.Spacing
 import com.pennywiseai.tracker.utils.CurrencyFormatter
 import java.math.BigDecimal
+import java.time.DayOfWeek
+import java.time.format.DateTimeFormatter
 
 @Composable
 fun BudgetCard(
@@ -64,54 +67,65 @@ fun BudgetCard(
         modifier = modifier,
         onClick = onClick
     ) {
-        // Row 1: Budget name + percentage pill
+        // Row 1: Cadence pill + budget name + percentage pill
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(
-                text = groupSpending.group.budget.name,
-                style = MaterialTheme.typography.titleSmall.copy(
-                    fontWeight = FontWeight.SemiBold
-                ),
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
                 modifier = Modifier.weight(1f)
-            )
+            ) {
+                CadencePill(periodType = groupSpending.periodType)
+                Text(
+                    text = groupSpending.group.budget.name,
+                    style = MaterialTheme.typography.titleSmall.copy(
+                        fontWeight = FontWeight.SemiBold
+                    ),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+            }
 
-            Text(
-                text = "${pctUsed.toInt()}%",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onPrimary,
-                modifier = Modifier
-                    .background(
-                        color = statusColor,
-                        shape = RoundedCornerShape(50)
-                    )
-                    .padding(horizontal = 8.dp, vertical = 2.dp)
-            )
+            if (groupSpending.totalBudget > BigDecimal.ZERO) {
+                Text(
+                    text = "${pctUsed.toInt()}%",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier
+                        .background(
+                            color = statusColor,
+                            shape = RoundedCornerShape(50)
+                        )
+                        .padding(horizontal = 8.dp, vertical = 2.dp)
+                )
+            }
         }
 
         Spacer(modifier = Modifier.height(Spacing.sm))
 
         // Row 2: Custom rounded progress bar
-        val barShape = RoundedCornerShape(50)
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(10.dp)
-                .clip(barShape)
-                .background(MaterialTheme.colorScheme.surfaceVariant)
-        ) {
+        if (groupSpending.totalBudget > BigDecimal.ZERO) {
+            val barShape = RoundedCornerShape(50)
             Box(
                 modifier = Modifier
-                    .fillMaxWidth(fraction = animatedProgressState)
-                    .fillMaxHeight()
+                    .fillMaxWidth()
+                    .height(10.dp)
                     .clip(barShape)
-                    .background(statusColor)
-            )
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(fraction = animatedProgressState)
+                        .fillMaxHeight()
+                        .clip(barShape)
+                        .background(statusColor)
+                )
+            }
         }
 
         Spacer(modifier = Modifier.height(Spacing.md))
@@ -134,10 +148,34 @@ fun BudgetCard(
 
         Spacer(modifier = Modifier.height(Spacing.xs))
 
-        // Row 4: Contextual subtitle
+        // Row 4: Per-cadence subtitle — tells the user what cadence this
+        // budget runs on, with the "X days left" relative to the displayed
+        // window. Old subtitle (e.g. "Period ended") is preserved for
+        // non-tracked (isTrackingAllExpenses) budgets.
+        val dateFormatter = remember { DateTimeFormatter.ofPattern("d MMM") }
         val subtitleText = when {
-            groupSpending.daysRemaining == 0 -> "Period ended"
-            isOverBudget -> "Over by ${CurrencyFormatter.formatCurrency(remainingAbs, currency)}"
+            groupSpending.daysRemaining == 0 && groupSpending.daysElapsed >= groupSpending.windowDays ->
+                "Finished"
+            groupSpending.isTrackingAllExpenses ->
+                "Tracking all expenses"
+            groupSpending.periodType == BudgetPeriodType.WEEKLY -> {
+                val weekday = groupSpending.group.budget.weekStartDay?.let { DayOfWeek.of(it.coerceIn(1, 7)) }
+                    ?: DayOfWeek.MONDAY
+                "${weekday.name.lowercase().replaceFirstChar { it.titlecase() }} \u00B7 ${groupSpending.daysRemaining} days left in this week"
+            }
+            groupSpending.periodType == BudgetPeriodType.MONTHLY -> {
+                val startDay = groupSpending.group.budget.monthStartDay
+                    ?: groupSpending.windowStart.dayOfMonth
+                "Resets on day $startDay \u00B7 ${groupSpending.daysRemaining} days left in this cycle"
+            }
+            groupSpending.periodType == BudgetPeriodType.CUSTOM -> {
+                val range = "${groupSpending.windowStart.format(dateFormatter)} – ${groupSpending.windowEnd.format(dateFormatter)}"
+                when {
+                    isOverBudget -> "Over by ${CurrencyFormatter.formatCurrency(remainingAbs, currency)}"
+                    groupSpending.daysRemaining > 0 -> "Runs $range \u00B7 ${groupSpending.daysRemaining} days left"
+                    else -> "Finished"
+                }
+            }
             else -> "${CurrencyFormatter.formatCurrency(groupSpending.dailyAllowance, currency)}/day \u00B7 ${groupSpending.daysRemaining} days left"
         }
         Text(
@@ -155,4 +193,38 @@ fun BudgetCard(
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
         )
     }
+}
+
+/**
+ * Small pill that names the budget's cadence at a glance: 🔁 Weekly /
+ * 🗓 Monthly / 📌 One-time. Colour-coded so a user can spot which type
+ * of budget they're looking at without reading the subtitle.
+ */
+@Composable
+fun CadencePill(periodType: BudgetPeriodType) {
+    val (label, bg, fg) = when (periodType) {
+        BudgetPeriodType.WEEKLY -> Triple(
+            "Weekly",
+            MaterialTheme.colorScheme.tertiaryContainer,
+            MaterialTheme.colorScheme.onTertiaryContainer
+        )
+        BudgetPeriodType.MONTHLY -> Triple(
+            "Monthly",
+            MaterialTheme.colorScheme.primaryContainer,
+            MaterialTheme.colorScheme.onPrimaryContainer
+        )
+        BudgetPeriodType.CUSTOM -> Triple(
+            "One-time",
+            MaterialTheme.colorScheme.secondaryContainer,
+            MaterialTheme.colorScheme.onSecondaryContainer
+        )
+    }
+    Text(
+        text = label,
+        style = MaterialTheme.typography.labelSmall,
+        color = fg,
+        modifier = Modifier
+            .background(color = bg, shape = RoundedCornerShape(50))
+            .padding(horizontal = 8.dp, vertical = 2.dp)
+    )
 }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BudgetCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BudgetCard.kt
@@ -148,10 +148,12 @@ fun BudgetCard(
 
         Spacer(modifier = Modifier.height(Spacing.xs))
 
-        // Row 4: Per-cadence subtitle — tells the user what cadence this
-        // budget runs on, with the "X days left" relative to the displayed
-        // window. Old subtitle (e.g. "Period ended") is preserved for
-        // non-tracked (isTrackingAllExpenses) budgets.
+        // Row 4: Per-cadence subtitle — always framed as a renewal
+        // countdown ("Resets in X days" / "X days remaining") so the
+        // user knows when the budget's window ends. The displayed
+        // window comes from the per-budget current window (Weekly's
+        // Jun 29..Jul 5 even when the user is on the July page), so the
+        // number is consistent across month views.
         val dateFormatter = remember { DateTimeFormatter.ofPattern("d MMM") }
         val subtitleText = when {
             groupSpending.daysRemaining == 0 && groupSpending.daysElapsed >= groupSpending.windowDays ->
@@ -161,22 +163,39 @@ fun BudgetCard(
             groupSpending.periodType == BudgetPeriodType.WEEKLY -> {
                 val weekday = groupSpending.group.budget.weekStartDay?.let { DayOfWeek.of(it.coerceIn(1, 7)) }
                     ?: DayOfWeek.MONDAY
-                "${weekday.name.lowercase().replaceFirstChar { it.titlecase() }} \u00B7 ${groupSpending.daysRemaining} days left in this week"
+                // "Resets in X days" = "days until the current week ends".
+                // Subtract 1 because the budget renews *after* the last
+                // day, so the displayed week has (windowDays - daysRemaining)
+                // days left after today. For a Wed-on-a-Mon-start week:
+                // today=Wed, days remaining=5 (Thu..Mon), renewal in 4d.
+                val renewalIn = (groupSpending.daysRemaining - 1).coerceAtLeast(0)
+                val weekdayName = weekday.name.lowercase().replaceFirstChar { it.titlecase() }
+                when {
+                    renewalIn == 0 -> "Resets today · ${weekdayName} renew"
+                    renewalIn == 1 -> "Resets in 1 day · ${weekdayName} renew"
+                    else -> "Resets in $renewalIn days · ${weekdayName} renew"
+                }
             }
             groupSpending.periodType == BudgetPeriodType.MONTHLY -> {
                 val startDay = groupSpending.group.budget.monthStartDay
                     ?: groupSpending.windowStart.dayOfMonth
-                "Resets on day $startDay \u00B7 ${groupSpending.daysRemaining} days left in this cycle"
+                val renewalIn = (groupSpending.daysRemaining - 1).coerceAtLeast(0)
+                when {
+                    renewalIn == 0 -> "Resets today · day $startDay"
+                    renewalIn == 1 -> "Resets in 1 day · day $startDay"
+                    else -> "Resets in $renewalIn days · day $startDay"
+                }
             }
             groupSpending.periodType == BudgetPeriodType.CUSTOM -> {
                 val range = "${groupSpending.windowStart.format(dateFormatter)} – ${groupSpending.windowEnd.format(dateFormatter)}"
                 when {
                     isOverBudget -> "Over by ${CurrencyFormatter.formatCurrency(remainingAbs, currency)}"
-                    groupSpending.daysRemaining > 0 -> "Runs $range \u00B7 ${groupSpending.daysRemaining} days left"
+                    groupSpending.daysRemaining > 1 -> "Runs $range · ${groupSpending.daysRemaining - 1} days remaining"
+                    groupSpending.daysRemaining == 1 -> "Runs $range · 1 day remaining"
                     else -> "Finished"
                 }
             }
-            else -> "${CurrencyFormatter.formatCurrency(groupSpending.dailyAllowance, currency)}/day \u00B7 ${groupSpending.daysRemaining} days left"
+            else -> "${groupSpending.daysRemaining} days remaining"
         }
         Text(
             text = subtitleText,

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -19,6 +19,7 @@ import com.pennywiseai.tracker.presentation.common.buildProfileAccountKeys
 import com.pennywiseai.tracker.presentation.common.filterTransactionsByProfile
 import com.pennywiseai.tracker.presentation.common.getDateRangeForPeriod
 import com.pennywiseai.tracker.utils.CurrencyUtils
+import com.pennywiseai.tracker.domain.model.BudgetCycle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -155,7 +156,10 @@ class AnalyticsViewModel @Inject constructor(
     }.combine(accountBalanceRepository.getAllLatestBalances()) { fs, balances ->
         fs to balances
     }.flatMapLatest { (filterState, balances) ->
-        // Determine date range based on selected period
+        // Determine date range based on selected period. THIS_MONTH is special:
+        // it follows the user's custom budget cycle (e.g. 25th → 24th) instead
+        // of the calendar month, so the analytics range lines up with the
+        // home/cycle everywhere else in the app.
         val dateRange = if (filterState.period == TimePeriod.CUSTOM) {
             val customRange = filterState.customRange
             // Guard against invalid state: CUSTOM period must have a date range
@@ -164,10 +168,12 @@ class AnalyticsViewModel @Inject constructor(
                     "CUSTOM period selected but no date range set - falling back to THIS_MONTH")
                 // Auto-correct the invalid state
                 _selectedPeriod.value = TimePeriod.THIS_MONTH
-                getDateRangeForPeriod(TimePeriod.THIS_MONTH)
+                getThisCycleRange()
             } else {
                 customRange
             }
+        } else if (filterState.period == TimePeriod.THIS_MONTH) {
+            getThisCycleRange()
         } else {
             getDateRangeForPeriod(filterState.period)
         }
@@ -463,6 +469,18 @@ class AnalyticsViewModel @Inject constructor(
         if (_selectedPeriod.value == TimePeriod.CUSTOM) {
             _selectedPeriod.value = TimePeriod.THIS_MONTH
         }
+    }
+
+    /**
+     * The "This Month" range for the Analytics tab. Honours the user's
+     * configured budget cycle start day (e.g. 25th → 24th) instead of the
+     * calendar month, so the chart and stats line up with the cycle used
+     * everywhere else in the app.
+     */
+    private suspend fun getThisCycleRange(): Pair<LocalDate, LocalDate> {
+        val startDay = userPreferencesRepository.getBudgetCycleStartDay()
+        val (start, end) = BudgetCycle.currentCycle(LocalDate.now(), startDay)
+        return start to end
     }
 
     private suspend fun calculateSpendingTrend(

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -103,6 +103,7 @@ fun SettingsScreen(
     val smsScanAllTime by settingsViewModel.smsScanAllTime.collectAsStateWithLifecycle(initialValue = false)
     val baseCurrency by settingsViewModel.baseCurrency.collectAsStateWithLifecycle(initialValue = "")
     val numberFormatStyle by settingsViewModel.numberFormatStyle.collectAsStateWithLifecycle(initialValue = NumberFormatStyle.AUTO)
+    val budgetCycleStartDay by settingsViewModel.budgetCycleStartDay.collectAsStateWithLifecycle(initialValue = 1)
     val importExportMessage by settingsViewModel.importExportMessage.collectAsStateWithLifecycle()
     val exportedBackupFile by settingsViewModel.exportedBackupFile.collectAsStateWithLifecycle()
     val unifiedCurrencyMode by settingsViewModel.unifiedCurrencyMode.collectAsStateWithLifecycle(initialValue = false)
@@ -126,6 +127,7 @@ fun SettingsScreen(
     var showTimeoutDialog by remember { mutableStateOf(false) }
     var showDisplayCurrencyDialog by remember { mutableStateOf(false) }
     var showNumberFormatDialog by remember { mutableStateOf(false) }
+    var showBudgetCycleDialog by remember { mutableStateOf(false) }
     var showCurrencyDropdown by remember { mutableStateOf(false) }
     var showMainAccountDropdown by remember { mutableStateOf(false) }
     val permissionUiState by permissionViewModel.uiState.collectAsStateWithLifecycle()
@@ -345,6 +347,25 @@ fun SettingsScreen(
                     onClick = { showNumberFormatDialog = true },
                     position = ItemPosition.BOTTOM,
                     trailingText = numberFormatStyleLabel(numberFormatStyle)
+                )
+            }
+
+            // ── Budget ──
+            // The cycle start day is a budgeting concept, but it changes how
+            // Home / Analytics bucket transactions, so it lives up here next
+            // to the other "display" knobs rather than buried in Data
+            // Management with the budgets list.
+            SectionHeaderV2(title = "Budget")
+            SettingsGroup {
+                SettingsNavItem(
+                    icon = Icons.Default.DateRange,
+                    iconBgColor = teal_light,
+                    iconTint = teal_dark,
+                    title = "Budget Cycle Start Day",
+                    subtitle = "Shifts the start of each monthly budget period; e.g. 25 means your cycle runs 25th → 24th",
+                    onClick = { showBudgetCycleDialog = true },
+                    position = ItemPosition.SINGLE,
+                    trailingText = ordinalSuffix(budgetCycleStartDay)
                 )
             }
 
@@ -698,6 +719,59 @@ fun SettingsScreen(
             },
             confirmButton = {
                 TextButton(onClick = { showNumberFormatDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
+    // Budget Cycle Start Day Dialog
+    if (showBudgetCycleDialog) {
+        AlertDialog(
+            onDismissRequest = { showBudgetCycleDialog = false },
+            title = { Text("Budget Cycle Start Day") },
+            text = {
+                Column(
+                    modifier = Modifier.verticalScroll(rememberScrollState())
+                ) {
+                    Text(
+                        text = "Pick the day each monthly budget cycle starts. e.g. 25 means the cycle runs from the 25th through the 24th of the next month.",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Spacer(modifier = Modifier.height(Spacing.md))
+
+                    (1..31).forEach { day ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .selectable(
+                                    selected = day == budgetCycleStartDay,
+                                    onClick = {
+                                        settingsViewModel.updateBudgetCycleStartDay(day)
+                                        showBudgetCycleDialog = false
+                                    }
+                                )
+                                .padding(vertical = Spacing.xs),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                selected = day == budgetCycleStartDay,
+                                onClick = {
+                                    settingsViewModel.updateBudgetCycleStartDay(day)
+                                    showBudgetCycleDialog = false
+                                }
+                            )
+                            Spacer(modifier = Modifier.width(Spacing.sm))
+                            Text(
+                                text = ordinalSuffix(day),
+                                style = MaterialTheme.typography.bodyLarge
+                            )
+                        }
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showBudgetCycleDialog = false }) {
                     Text("Cancel")
                 }
             }
@@ -1346,4 +1420,21 @@ private fun numberFormatStyleExample(style: NumberFormatStyle): String = when (s
     NumberFormatStyle.AUTO -> "Matches each currency (₹1,50,000 · $150,000)"
     NumberFormatStyle.INDIAN -> "1,50,000 (lakh / crore)"
     NumberFormatStyle.INTERNATIONAL -> "150,000 (thousand / million)"
+}
+
+/**
+ * English ordinal suffix for the budget cycle start day — "1st", "2nd", "3rd",
+ * "4th"… "11th", "12th", "13th" follow the standard rule that the last two
+ * digits decide the suffix (the 11/12/13 teens are always "th").
+ */
+private fun ordinalSuffix(day: Int): String {
+    val safe = day.coerceIn(1, 31)
+    val suffix = when {
+        safe in 11..13 -> "th"
+        safe % 10 == 1 -> "st"
+        safe % 10 == 2 -> "nd"
+        safe % 10 == 3 -> "rd"
+        else -> "th"
+    }
+    return "$safe$suffix"
 }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -126,6 +126,10 @@ class SettingsViewModel @Inject constructor(
     // Number format style (digit grouping: Auto / Indian / International)
     val numberFormatStyle = userPreferencesRepository.numberFormatStyle
 
+    // Budget cycle start day (1..31). Drives Home/Budgets/Analytics so a user
+    // whose salary doesn't land on the 1st can define their own pay cycle.
+    val budgetCycleStartDay = userPreferencesRepository.budgetCycleStartDay
+
     // Main account selection (drives the default currency unless overridden above).
     val accounts: StateFlow<List<AccountBalanceEntity>> =
         accountBalanceRepository.getAllLatestBalances()
@@ -638,6 +642,12 @@ class SettingsViewModel @Inject constructor(
     fun updateNumberFormatStyle(style: NumberFormatStyle) {
         viewModelScope.launch {
             userPreferencesRepository.updateNumberFormatStyle(style)
+        }
+    }
+
+    fun updateBudgetCycleStartDay(day: Int) {
+        viewModelScope.launch {
+            userPreferencesRepository.updateBudgetCycleStartDay(day)
         }
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
@@ -20,6 +20,7 @@ import com.pennywiseai.tracker.data.repository.BudgetCategorySpending
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository.Companion.aggregateBudgetCategorySpending
 import com.pennywiseai.tracker.data.repository.BudgetGroupSpending
+import com.pennywiseai.tracker.domain.model.BudgetCycle
 import java.math.BigDecimal
 import java.math.RoundingMode
 import dagger.assisted.Assisted
@@ -71,10 +72,16 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
             val currency = if (isUnifiedMode) displayCurrency else baseCurrency
 
             val today = java.time.LocalDate.now()
+            val startDay = userPreferencesRepository.getBudgetCycleStartDay()
+            val cycleStartYm = BudgetCycle.currentCycleStartYearMonth(today, startDay)
+            val prevCycle = BudgetCycle.previousCycle(
+                BudgetCycle.currentCycle(today, startDay), startDay
+            )
+            val prevCycleStartYm = java.time.YearMonth.from(prevCycle.first)
 
             val summary = if (isUnifiedMode) {
                 val raw = budgetGroupRepository.getGroupSpendingAllCurrencies(
-                    today.year, today.monthValue
+                    cycleStartYm.year, cycleStartYm.monthValue
                 ).first()
 
                 // Reuse the same aggregator the Budgets screen uses so the widget
@@ -225,13 +232,12 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
                 )
             } else {
                 val spending = budgetGroupRepository.getGroupSpending(
-                    today.year, today.monthValue, currency
+                    cycleStartYm.year, cycleStartYm.monthValue, currency
                 ).first()
 
                 // Get previous month spending for delta calculation
-                val prevYearMonth = java.time.YearMonth.of(today.year, today.monthValue).minusMonths(1)
                 val prevSpending = budgetGroupRepository.getGroupSpending(
-                    prevYearMonth.year, prevYearMonth.monthValue, currency
+                    prevCycleStartYm.year, prevCycleStartYm.monthValue, currency
                 ).first()
 
                 val savingsDelta = spending.netSavings - prevSpending.netSavings

--- a/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
@@ -73,7 +73,15 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
 
             val today = java.time.LocalDate.now()
             val startDay = userPreferencesRepository.getBudgetCycleStartDay()
-            val cycleStartYm = BudgetCycle.currentCycleStartYearMonth(today, startDay)
+            // Use today's calendar month, not the cycle's start month —
+            // same fix as the home viewmodel. For a user on startDay=25
+            // viewing today=Jul 1, cycleStartYm was June, which made
+            // isCurrentMonth=false in the repo and the widget treated
+            // the current cycle as historical (daysRemaining=0, no
+            // daily allowance). The per-budget current window is
+            // resolved by resolveBudgetWindow inside the repo
+            // regardless of which calendar month the page is on.
+            val todayYm = java.time.YearMonth.of(today.year, today.monthValue)
             val prevCycle = BudgetCycle.previousCycle(
                 BudgetCycle.currentCycle(today, startDay), startDay
             )
@@ -81,7 +89,7 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
 
             val summary = if (isUnifiedMode) {
                 val raw = budgetGroupRepository.getGroupSpendingAllCurrencies(
-                    cycleStartYm.year, cycleStartYm.monthValue
+                    todayYm.year, todayYm.monthValue
                 ).first()
 
                 // Reuse the same aggregator the Budgets screen uses so the widget
@@ -232,7 +240,7 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
                 )
             } else {
                 val spending = budgetGroupRepository.getGroupSpending(
-                    cycleStartYm.year, cycleStartYm.monthValue, currency
+                    todayYm.year, todayYm.monthValue, currency
                 ).first()
 
                 // Get previous month spending for delta calculation

--- a/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
@@ -18,7 +18,7 @@ import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.repository.BudgetCategorySpending
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository
-import com.pennywiseai.tracker.data.repository.BudgetGroupRepository.Companion.aggregateBudgetCategorySpending
+import com.pennywiseai.tracker.data.repository.aggregateBudgetCategorySpending
 import com.pennywiseai.tracker.data.repository.BudgetGroupSpending
 import com.pennywiseai.tracker.domain.model.BudgetCycle
 import java.math.BigDecimal
@@ -180,7 +180,7 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
                 // Previous month savings for delta — same aggregator, same currency
                 // converters, so the delta isn't skewed by stale logic on either side.
                 val (prevCategoryAmounts, _, prevTypeAmounts) = aggregateBudgetCategorySpending(
-                    transactions = raw.prevTransactions,
+                    transactions = raw.prevCycleTransactions,
                     convertSplit = convertSplit,
                     convertIncome = { tx ->
                         currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
@@ -204,7 +204,7 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
                 }
 
                 var prevIncome = BigDecimal.ZERO
-                for (txWithSplits in raw.prevTransactions) {
+                for (txWithSplits in raw.prevCycleTransactions) {
                     val tx = txWithSplits.transaction
                     if (tx.transactionType != TransactionType.INCOME) continue
                     if (tx.budgetImpactType == BudgetImpactType.DEDUCT_SPENT &&

--- a/app/src/main/java/com/pennywiseai/tracker/widget/RecentTransactionsWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/RecentTransactionsWidgetUpdateWorker.kt
@@ -14,12 +14,14 @@ import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.currency.CurrencyConversionService
+import com.pennywiseai.tracker.domain.model.BudgetCycle
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.first
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
 
@@ -72,7 +74,9 @@ class RecentTransactionsWidgetUpdateWorker @AssistedInject constructor(
             val targetCurrency = resolveTargetCurrency(isUnifiedMode, displayCurrency, baseCurrency)
 
             val now = LocalDate.now()
-            val start = now.withDayOfMonth(1).atStartOfDay()
+            val startDay = userPreferencesRepository.getBudgetCycleStartDay()
+            val (cycleStart, _) = BudgetCycle.currentCycle(now, startDay)
+            val start = cycleStart.atStartOfDay()
             val end = LocalDateTime.now()
 
             val allTransactions = transactionRepository

--- a/app/src/test/java/com/pennywiseai/tracker/data/repository/BudgetPeriodDatesTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/repository/BudgetPeriodDatesTest.kt
@@ -1,0 +1,71 @@
+package com.pennywiseai.tracker.data.repository
+
+import com.pennywiseai.tracker.data.database.entity.BudgetPeriodType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * Locks down the per-budget start-date math that the BudgetGroup edit screen
+ * uses to seed a fresh budget and to recompute the end date on every
+ * start-date picker change. The tests pin [BudgetRepository.calculatePeriodDates]'s
+ * `today` parameter so the assertions are deterministic.
+ */
+class BudgetPeriodDatesTest {
+
+    @Test
+    fun `monthly budget anchored to a custom start date spans one calendar month`() {
+        val (start, end) = BudgetRepository.calculatePeriodDates(
+            periodType = BudgetPeriodType.MONTHLY,
+            customStartDate = LocalDate.of(2026, 10, 5),
+            today = LocalDate.of(2026, 10, 5)
+        )
+
+        // The customStartDate path ignores the global startDay and pins
+        // the window to the user-chosen date. End is one calendar month later.
+        assertEquals(LocalDate.of(2026, 10, 5), start)
+        assertEquals(LocalDate.of(2026, 11, 4), end)
+    }
+
+    @Test
+    fun `weekly budget anchored to a custom start date spans 7 days`() {
+        val (start, end) = BudgetRepository.calculatePeriodDates(
+            periodType = BudgetPeriodType.WEEKLY,
+            customStartDate = LocalDate.of(2026, 10, 5),
+            today = LocalDate.of(2026, 10, 5)
+        )
+
+        assertEquals(LocalDate.of(2026, 10, 5), start)
+        assertEquals(LocalDate.of(2026, 10, 11), end)
+    }
+
+    @Test
+    fun `custom budget anchored to a custom start date spans 30 days`() {
+        val (start, end) = BudgetRepository.calculatePeriodDates(
+            periodType = BudgetPeriodType.CUSTOM,
+            customStartDate = LocalDate.of(2026, 12, 1),
+            today = LocalDate.of(2026, 12, 1)
+        )
+
+        assertEquals(LocalDate.of(2026, 12, 1), start)
+        assertEquals(LocalDate.of(2026, 12, 30), end)
+    }
+
+    @Test
+    fun `endDateFor mirrors the period-type derivation`() {
+        // Used by the screen to recompute the read-only "Ends on" label
+        // whenever the user picks a new start date.
+        assertEquals(
+            LocalDate.of(2026, 10, 11),
+            BudgetRepository.endDateFor(LocalDate.of(2026, 10, 5), BudgetPeriodType.WEEKLY)
+        )
+        assertEquals(
+            LocalDate.of(2026, 11, 4),
+            BudgetRepository.endDateFor(LocalDate.of(2026, 10, 5), BudgetPeriodType.MONTHLY)
+        )
+        assertEquals(
+            LocalDate.of(2026, 12, 30),
+            BudgetRepository.endDateFor(LocalDate.of(2026, 12, 1), BudgetPeriodType.CUSTOM)
+        )
+    }
+}

--- a/app/src/test/java/com/pennywiseai/tracker/data/repository/BudgetWindowTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/repository/BudgetWindowTest.kt
@@ -291,4 +291,55 @@ class BudgetWindowTest {
         val cap = if (isCurrentWeek) today else monthEnd
         assertEquals(LocalDate.of(2026, 7, 5), cap)
     }
+
+    // ── Per-budget current window consistency across months ──────────
+    //
+    // These tests pin down the new "always show the budget's current
+    // window regardless of the page's month" behaviour. A Mon-anchored
+    // Weekly budget on Jul 1 has the same (Jun 29..Jul 5) window
+    // whether the user is on the June page or the July page. Before
+    // the fix, the June view showed the clipped Jun 29..Jun 30 portion
+    // and the July view showed a fresh Jul 1..Jul 5 portion with zero
+    // spend (because the actual spend fell on Jun 29..30).
+
+    @Test
+    fun `resolveBudgetWindow returns the same Jun 29 to Jul 5 window from both sides of the month boundary`() {
+        val budget = budgetOf(BudgetPeriodType.WEEKLY, weekStartDay = 1)
+        // June 30 — Tuesday. The Mon-anchored week containing today is Jun 29..Jul 5.
+        val wFromJune = resolveBudgetWindow(budget, LocalDate.of(2026, 6, 30), globalStartDay = 1)
+        val wFromJuly = resolveBudgetWindow(budget, LocalDate.of(2026, 7, 1), globalStartDay = 1)
+        assertEquals(LocalDate.of(2026, 6, 29), wFromJune.start)
+        assertEquals(LocalDate.of(2026, 7, 5), wFromJune.end)
+        assertEquals(wFromJune, wFromJuly)
+    }
+
+    @Test
+    fun `resolveBudgetWindow for Monthly budget with stored monthStartDay=25 uses the budget anchor, not the global default`() {
+        val budget = budgetOf(BudgetPeriodType.MONTHLY, monthStartDay = 25)
+        // Today = Oct 5, 2026, with startDay=25. The current cycle is Sep 25..Oct 24.
+        val w = resolveBudgetWindow(budget, LocalDate.of(2026, 10, 5), globalStartDay = 1)
+        assertEquals(LocalDate.of(2026, 9, 25), w.start)
+        assertEquals(LocalDate.of(2026, 10, 24), w.end)
+    }
+
+    @Test
+    fun `resolveBudgetWindow for Monthly budget with null monthStartDay falls back to the global startDay`() {
+        val budget = budgetOf(BudgetPeriodType.MONTHLY, monthStartDay = null)
+        val w = resolveBudgetWindow(budget, LocalDate.of(2026, 10, 5), globalStartDay = 25)
+        assertEquals(LocalDate.of(2026, 9, 25), w.start)
+        assertEquals(LocalDate.of(2026, 10, 24), w.end)
+    }
+
+    @Test
+    fun `resolveBudgetWindow for Custom budget returns the literal saved range`() {
+        val budget = budgetOf(
+            BudgetPeriodType.CUSTOM,
+            startDate = LocalDate.of(2026, 11, 5),
+            endDate = LocalDate.of(2026, 12, 4)
+        )
+        val w = resolveBudgetWindow(budget, LocalDate.of(2026, 11, 15), globalStartDay = 1)
+        assertEquals(LocalDate.of(2026, 11, 5), w.start)
+        assertEquals(LocalDate.of(2026, 12, 4), w.end)
+        assertEquals(30, w.days)
+    }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/data/repository/BudgetWindowTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/repository/BudgetWindowTest.kt
@@ -1,0 +1,156 @@
+package com.pennywiseai.tracker.data.repository
+
+import com.pennywiseai.tracker.data.database.entity.BudgetEntity
+import com.pennywiseai.tracker.data.database.entity.BudgetPeriodType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Locks down [resolveBudgetWindow] — the read-time helper the BudgetCard /
+ * widget / edit screen use to figure out which [start, end] window a
+ * budget covers *right now*, given its period type and cadence anchor.
+ *
+ * Rolling Weekly and Monthly budgets are the whole point of this helper:
+ * their row's persisted [BudgetEntity.startDate, endDate] is a "last
+ * computed" cache, but the resolver always returns the *current* window
+ * from the anchor + today's date, so a budget created weeks/months ago
+ * still shows the right "this week" / "this month" window.
+ */
+class BudgetWindowTest {
+
+    private fun budgetOf(
+        periodType: BudgetPeriodType,
+        weekStartDay: Int? = null,
+        monthStartDay: Int? = null,
+        startDate: LocalDate? = null,
+        endDate: LocalDate? = null
+    ) = BudgetEntity(
+        id = 1L,
+        name = "Test",
+        limitAmount = BigDecimal.ZERO,
+        periodType = periodType,
+        startDate = startDate ?: LocalDate.of(2026, 10, 5),
+        endDate = endDate ?: LocalDate.of(2026, 10, 5).plusDays(6),
+        weekStartDay = weekStartDay,
+        monthStartDay = monthStartDay
+    )
+
+    // ── Weekly ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `weekly budget anchored to Monday returns the Mon-Sun window containing today`() {
+        // Oct 7, 2026 is a Wednesday. The week containing it, starting on
+        // Monday, is Oct 5..Oct 11.
+        val today = LocalDate.of(2026, 10, 7)
+        val w = resolveBudgetWindow(budgetOf(BudgetPeriodType.WEEKLY, weekStartDay = 1), today)
+        assertEquals(LocalDate.of(2026, 10, 5), w.start)
+        assertEquals(LocalDate.of(2026, 10, 11), w.end)
+        assertEquals(7, w.days)
+    }
+
+    @Test
+    fun `weekly budget anchored to Wednesday returns the Wed-Tue window containing today`() {
+        val today = LocalDate.of(2026, 10, 7) // Wed
+        val w = resolveBudgetWindow(budgetOf(BudgetPeriodType.WEEKLY, weekStartDay = 3), today)
+        // Window starts on the most recent Wednesday on or before today.
+        assertEquals(LocalDate.of(2026, 10, 7), w.start)
+        assertEquals(LocalDate.of(2026, 10, 13), w.end)
+        assertEquals(7, w.days)
+    }
+
+    @Test
+    fun `weekly budget with no anchor falls back to Monday`() {
+        val today = LocalDate.of(2026, 10, 7) // Wed
+        val w = resolveBudgetWindow(budgetOf(BudgetPeriodType.WEEKLY, weekStartDay = null), today)
+        assertEquals(LocalDate.of(2026, 10, 5), w.start) // Monday
+        assertEquals(LocalDate.of(2026, 10, 11), w.end)
+    }
+
+    // ── Monthly ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `monthly budget anchored to the 25th on Oct 5 returns Sep 25 through Oct 24`() {
+        val today = LocalDate.of(2026, 10, 5)
+        val w = resolveBudgetWindow(budgetOf(BudgetPeriodType.MONTHLY, monthStartDay = 25), today)
+        assertEquals(LocalDate.of(2026, 9, 25), w.start)
+        assertEquals(LocalDate.of(2026, 10, 24), w.end)
+        assertEquals(30, w.days)
+    }
+
+    @Test
+    fun `monthly budget anchored to the 25th on Oct 26 returns Oct 25 through Nov 24`() {
+        val today = LocalDate.of(2026, 10, 26)
+        val w = resolveBudgetWindow(budgetOf(BudgetPeriodType.MONTHLY, monthStartDay = 25), today)
+        assertEquals(LocalDate.of(2026, 10, 25), w.start)
+        assertEquals(LocalDate.of(2026, 11, 24), w.end)
+    }
+
+    @Test
+    fun `monthly budget anchored to the 1st behaves like the calendar month`() {
+        val today = LocalDate.of(2026, 10, 5)
+        val w = resolveBudgetWindow(budgetOf(BudgetPeriodType.MONTHLY, monthStartDay = 1), today)
+        assertEquals(LocalDate.of(2026, 10, 1), w.start)
+        assertEquals(LocalDate.of(2026, 10, 31), w.end)
+    }
+
+    @Test
+    fun `monthly budget with no anchor falls back to the global startDay preference`() {
+        val today = LocalDate.of(2026, 10, 5)
+        val w = resolveBudgetWindow(
+            budgetOf(BudgetPeriodType.MONTHLY, monthStartDay = null),
+            today,
+            globalStartDay = 25
+        )
+        assertEquals(LocalDate.of(2026, 9, 25), w.start)
+        assertEquals(LocalDate.of(2026, 10, 24), w.end)
+    }
+
+    @Test
+    fun `monthly budget anchored to 31 on Feb 15 non-leap returns Jan 31 through Feb 27`() {
+        // Feb 31 doesn't exist, so the cycle's start clamps to Jan 31.
+        val today = LocalDate.of(2025, 2, 15)
+        val w = resolveBudgetWindow(budgetOf(BudgetPeriodType.MONTHLY, monthStartDay = 31), today)
+        assertEquals(LocalDate.of(2025, 1, 31), w.start)
+        assertEquals(LocalDate.of(2025, 2, 27), w.end)
+    }
+
+    // ── Custom (one-time) ────────────────────────────────────────────────
+
+    @Test
+    fun `custom budget returns its literal saved range regardless of today`() {
+        val today = LocalDate.of(2026, 10, 5)
+        val w = resolveBudgetWindow(
+            budgetOf(
+                BudgetPeriodType.CUSTOM,
+                startDate = LocalDate.of(2026, 12, 20),
+                endDate = LocalDate.of(2027, 1, 5)
+            ),
+            today
+        )
+        // No rolling — the literal range the user picked.
+        assertEquals(LocalDate.of(2026, 12, 20), w.start)
+        assertEquals(LocalDate.of(2027, 1, 5), w.end)
+        assertEquals(17, w.days)
+    }
+
+    @Test
+    fun `custom budget ignores the anchor fields entirely`() {
+        val today = LocalDate.of(2026, 10, 5)
+        val w = resolveBudgetWindow(
+            budgetOf(
+                BudgetPeriodType.CUSTOM,
+                weekStartDay = 1,
+                monthStartDay = 15,
+                startDate = LocalDate.of(2026, 11, 1),
+                endDate = LocalDate.of(2026, 11, 30)
+            ),
+            today
+        )
+        // Even with weekly/monthly anchors set, CUSTOM uses the literal
+        // startDate / endDate the user picked.
+        assertEquals(LocalDate.of(2026, 11, 1), w.start)
+        assertEquals(LocalDate.of(2026, 11, 30), w.end)
+    }
+}

--- a/app/src/test/java/com/pennywiseai/tracker/data/repository/BudgetWindowTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/repository/BudgetWindowTest.kt
@@ -256,4 +256,39 @@ class BudgetWindowTest {
         // They share Sep 30 → overlap is true.
         assert(a.overlaps(b))
     }
+
+    // ── cap-date semantics (the "frozen vs live" math that powers the
+    //    History screen and the Weekly sub-list) ────────────────────
+
+    @Test
+    fun `partial last week in June 2026 - June view freezes the Jun 30 portion`() {
+        // Mon-anchored Weekly budget. The week starting Mon Jun 30 spans
+        // Jun 30..Jul 6. For the June view, the spend is frozen at
+        // Jun 30 — only the Jun 30 day is counted, with the cap date
+        // = monthEnd = Jun 30.
+        val today = LocalDate.of(2026, 7, 5)
+        val monthEnd = LocalDate.of(2026, 6, 30)
+        val window = BudgetWindow(LocalDate.of(2026, 6, 30), LocalDate.of(2026, 7, 6), 7)
+        val isCurrentMonth = false
+        val isCurrentWeek = !isCurrentMonth && false ||
+            isCurrentMonth && !today.isBefore(window.start) && !today.isAfter(window.end)
+        assertEquals(false, isCurrentWeek)
+        // The repo's effective end for the spend query is the cap date,
+        // which is monthEnd for a frozen window.
+        val cap = if (isCurrentWeek) today else monthEnd
+        assertEquals(LocalDate.of(2026, 6, 30), cap)
+    }
+
+    @Test
+    fun `current week in July 2026 - July view is live up to today`() {
+        val today = LocalDate.of(2026, 7, 5)
+        val monthEnd = LocalDate.of(2026, 7, 31)
+        val window = BudgetWindow(LocalDate.of(2026, 6, 30), LocalDate.of(2026, 7, 6), 7)
+        val isCurrentMonth = true
+        val isCurrentWeek = isCurrentMonth &&
+            !today.isBefore(window.start) && !today.isAfter(window.end)
+        assertEquals(true, isCurrentWeek)
+        val cap = if (isCurrentWeek) today else monthEnd
+        assertEquals(LocalDate.of(2026, 7, 5), cap)
+    }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/data/repository/BudgetWindowTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/repository/BudgetWindowTest.kt
@@ -153,4 +153,107 @@ class BudgetWindowTest {
         assertEquals(LocalDate.of(2026, 11, 1), w.start)
         assertEquals(LocalDate.of(2026, 11, 30), w.end)
     }
+
+    // ── windowsForMonth ───────────────────────────────────────────────
+
+    @Test
+    fun `weekly windows for a Mon-anchored budget in September 2026 yield 4 clipped windows`() {
+        val today = LocalDate.of(2026, 10, 5)
+        val budget = budgetOf(BudgetPeriodType.WEEKLY, weekStartDay = 1)
+        val windows = windowsForMonth(budget, year = 2026, month = 9, globalStartDay = 1)
+
+        // Sept 1 was a Tuesday. Week 1 starts Mon Aug 31 → clipped to Sept 1
+        // (Tue) → Sept 6 (Sun). Week 2: Sept 7-13. Week 3: Sept 14-20.
+        // Week 4: Sept 21-27. Week 5: Sept 28 - Oct 4 → clipped to Sept 28-30.
+        assertEquals(5, windows.size)
+        // Every window stays inside September.
+        windows.forEach { w ->
+            assert(w.start >= LocalDate.of(2026, 9, 1))
+            assert(w.end <= LocalDate.of(2026, 9, 30))
+        }
+        // First window starts on the 1st (Tue) — the clipped Mon-anchor.
+        assertEquals(LocalDate.of(2026, 9, 1), windows.first().start)
+        // Last window ends on the 30th.
+        assertEquals(LocalDate.of(2026, 9, 30), windows.last().end)
+    }
+
+    @Test
+    fun `monthly windows for a 25-anchored budget in September 2026 return the Aug-25 to Sept-24 cycle that intersects`() {
+        val today = LocalDate.of(2026, 10, 5)
+        val budget = budgetOf(BudgetPeriodType.MONTHLY, monthStartDay = 25)
+        val windows = windowsForMonth(budget, year = 2026, month = 9, globalStartDay = 25)
+
+        // The cycle that contains Sept 1 is the Aug 25..Sept 24 cycle.
+        // The full cycle is returned (start is in August but the cycle
+        // intersects September). The spend query inside the repo is
+        // clipped to the page's month bounds separately.
+        assertEquals(1, windows.size)
+        assertEquals(LocalDate.of(2026, 8, 25), windows.first().start)
+        assertEquals(LocalDate.of(2026, 9, 24), windows.first().end)
+    }
+
+    @Test
+    fun `monthly windows for a 25-anchored budget in October 2026 yield the Sept-25 to Oct-24 window`() {
+        val today = LocalDate.of(2026, 10, 5)
+        val budget = budgetOf(BudgetPeriodType.MONTHLY, monthStartDay = 25)
+        val windows = windowsForMonth(budget, year = 2026, month = 10, globalStartDay = 25)
+
+        // The cycle that contains Oct 1 is the Sept 25..Oct 24 cycle, fully
+        // inside October.
+        assertEquals(1, windows.size)
+        assertEquals(LocalDate.of(2026, 9, 25), windows.first().start)
+        assertEquals(LocalDate.of(2026, 10, 24), windows.first().end)
+    }
+
+    @Test
+    fun `custom windows for a Nov 5 to Dec 4 budget return an empty list for September`() {
+        val today = LocalDate.of(2026, 10, 5)
+        val budget = budgetOf(
+            BudgetPeriodType.CUSTOM,
+            startDate = LocalDate.of(2026, 11, 5),
+            endDate = LocalDate.of(2026, 12, 4)
+        )
+        val windows = windowsForMonth(budget, year = 2026, month = 9, globalStartDay = 1)
+        assertEquals(0, windows.size)
+    }
+
+    @Test
+    fun `custom windows for a Nov 5 to Dec 4 budget return a clipped window for November`() {
+        val today = LocalDate.of(2026, 10, 5)
+        val budget = budgetOf(
+            BudgetPeriodType.CUSTOM,
+            startDate = LocalDate.of(2026, 11, 5),
+            endDate = LocalDate.of(2026, 12, 4)
+        )
+        val windows = windowsForMonth(budget, year = 2026, month = 11, globalStartDay = 1)
+        assertEquals(1, windows.size)
+        // Clipped to November: starts on Nov 5, ends on Nov 30.
+        assertEquals(LocalDate.of(2026, 11, 5), windows.first().start)
+        assertEquals(LocalDate.of(2026, 11, 30), windows.first().end)
+    }
+
+    // ── overlaps ──────────────────────────────────────────────────────
+
+    @Test
+    fun `overlaps detects intersecting windows`() {
+        val a = BudgetWindow(LocalDate.of(2026, 9, 1), LocalDate.of(2026, 9, 30), 30)
+        val b = BudgetWindow(LocalDate.of(2026, 9, 25), LocalDate.of(2026, 10, 5), 11)
+        assert(a.overlaps(b))
+        assert(b.overlaps(a))
+    }
+
+    @Test
+    fun `overlaps rejects disjoint windows`() {
+        val a = BudgetWindow(LocalDate.of(2026, 9, 1), LocalDate.of(2026, 9, 30), 30)
+        val b = BudgetWindow(LocalDate.of(2026, 10, 1), LocalDate.of(2026, 10, 31), 31)
+        assert(!a.overlaps(b))
+    }
+
+    @Test
+    fun `overlaps accepts touching windows on the boundary`() {
+        val a = BudgetWindow(LocalDate.of(2026, 9, 1), LocalDate.of(2026, 9, 30), 30)
+        val b = BudgetWindow(LocalDate.of(2026, 9, 30), LocalDate.of(2026, 10, 5), 6)
+        // They share Sep 30 → overlap is true.
+        assert(a.overlaps(b))
+    }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/domain/model/BudgetCycleTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/domain/model/BudgetCycleTest.kt
@@ -1,0 +1,116 @@
+package com.pennywiseai.tracker.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.LocalDate
+import java.time.YearMonth
+
+/**
+ * Locks down the budget-cycle math that the Home, Budget Groups, and widget surfaces
+ * rely on. The cycle doesn't have to align with the calendar month — when a user's
+ * salary lands on the 25th, the cycle is the 25th of one month through the 24th of
+ * the next. These tests pin the exact window for the cases the spec calls out, plus
+ * the clamp behaviour for short months (Feb in leap and non-leap years).
+ */
+class BudgetCycleTest {
+
+    @Test
+    fun `startDay 1 behaves like the calendar month`() {
+        val today = LocalDate.of(2026, 10, 5)
+        val (start, end) = BudgetCycle.currentCycle(today, startDay = 1)
+
+        assertEquals(LocalDate.of(2026, 10, 1), start)
+        assertEquals(LocalDate.of(2026, 10, 31), end)
+    }
+
+    @Test
+    fun `startDay 25 today Oct 5 spans Sep 25 through Oct 24`() {
+        val today = LocalDate.of(2026, 10, 5)
+        val (start, end) = BudgetCycle.currentCycle(today, startDay = 25)
+
+        assertEquals(LocalDate.of(2026, 9, 25), start)
+        assertEquals(LocalDate.of(2026, 10, 24), end)
+    }
+
+    @Test
+    fun `startDay 25 today Oct 26 spans Oct 25 through Nov 24`() {
+        val today = LocalDate.of(2026, 10, 26)
+        val (start, end) = BudgetCycle.currentCycle(today, startDay = 25)
+
+        assertEquals(LocalDate.of(2026, 10, 25), start)
+        assertEquals(LocalDate.of(2026, 11, 24), end)
+    }
+
+    @Test
+    fun `startDay 29 in non-leap February falls back to Jan 29 through Feb 27`() {
+        val today = LocalDate.of(2025, 2, 10)
+        val (start, end) = BudgetCycle.currentCycle(today, startDay = 29)
+
+        // Feb 10 is before the Feb 28 candidate, so the cycle started in January.
+        // Next cycle begins Feb 28, so this cycle ends the day before (Feb 27).
+        assertEquals(LocalDate.of(2025, 1, 29), start)
+        assertEquals(LocalDate.of(2025, 2, 27), end)
+    }
+
+    @Test
+    fun `startDay 29 in leap February falls back to Jan 29 through Feb 28`() {
+        val today = LocalDate.of(2024, 2, 10)
+        val (start, end) = BudgetCycle.currentCycle(today, startDay = 29)
+
+        // Feb 10 is before the Feb 29 candidate, so the cycle started in January.
+        // Next cycle begins Feb 29, so this cycle ends Feb 28.
+        assertEquals(LocalDate.of(2024, 1, 29), start)
+        assertEquals(LocalDate.of(2024, 2, 28), end)
+    }
+
+    @Test
+    fun `startDay 31 today Feb 15 non-leap is Jan 31 through Feb 27`() {
+        val today = LocalDate.of(2025, 2, 15)
+        val (start, end) = BudgetCycle.currentCycle(today, startDay = 31)
+
+        assertEquals(LocalDate.of(2025, 1, 31), start)
+        assertEquals(LocalDate.of(2025, 2, 27), end)
+    }
+
+    @Test
+    fun `startDay 31 today Feb 15 leap year is Jan 31 through Feb 28`() {
+        val today = LocalDate.of(2024, 2, 15)
+        val (start, end) = BudgetCycle.currentCycle(today, startDay = 31)
+
+        assertEquals(LocalDate.of(2024, 1, 31), start)
+        assertEquals(LocalDate.of(2024, 2, 28), end)
+    }
+
+    @Test
+    fun `currentCycleStartYearMonth returns September for startDay 25 today Oct 5`() {
+        val today = LocalDate.of(2026, 10, 5)
+        val ym = BudgetCycle.currentCycleStartYearMonth(today, startDay = 25)
+
+        assertEquals(YearMonth.of(2026, 9), ym)
+    }
+
+    @Test
+    fun `currentCycleStartYearMonth returns October for startDay 25 today Oct 26`() {
+        val today = LocalDate.of(2026, 10, 26)
+        val ym = BudgetCycle.currentCycleStartYearMonth(today, startDay = 25)
+
+        assertEquals(YearMonth.of(2026, 10), ym)
+    }
+
+    @Test
+    fun `clampStartDay clamps 0 to 1 and 32 to 31`() {
+        assertEquals(1, BudgetCycle.clampStartDay(0))
+        assertEquals(31, BudgetCycle.clampStartDay(32))
+        assertEquals(15, BudgetCycle.clampStartDay(15))
+    }
+
+    @Test
+    fun `previousCycle steps back exactly one cycle`() {
+        val today = LocalDate.of(2026, 10, 5)
+        val current = BudgetCycle.currentCycle(today, startDay = 25)
+        val (prevStart, prevEnd) = BudgetCycle.previousCycle(current, startDay = 25)
+
+        assertEquals(LocalDate.of(2026, 8, 25), prevStart)
+        assertEquals(LocalDate.of(2026, 9, 24), prevEnd)
+    }
+}

--- a/app/src/test/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsIncomeFoldTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsIncomeFoldTest.kt
@@ -1,0 +1,105 @@
+package com.pennywiseai.tracker.presentation.budgetgroups
+
+import com.pennywiseai.tracker.data.repository.BudgetWindow
+import com.pennywiseai.tracker.data.repository.WindowSpending
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Pins down the data-shape invariant the Budgets page's unified-currency
+ * path depends on for [BudgetOverallSummary.totalIncome]. The earlier
+ * shape of [BudgetGroupsViewModel.convertRawToSummary] was:
+ *
+ *     raw.windowedSpend.flatMap { prevCycleTransactions }
+ *
+ * which ignored its lambda argument and concatenated
+ * `prevCycleTransactions` once per (budget × window) entry. For a user
+ * with 1 weekly + 2 monthly budgets on the current month, `totalIncome`
+ * came out 3× the real value, inflating the page-level netSavings /
+ * savingsRate. The fix is a plain `if (isCurrentMonth) prevCycleTransactions
+ * else emptyList()`.
+ *
+ * These tests exercise the same fold pattern the viewmodel uses (a
+ * per-transaction .fold that conditionally picks the list) and assert
+ * the result is the sum, not N× the sum. They are intentionally not
+ * coupled to the viewmodel's full Hilt stack — they test the data-shape
+ * invariant, which is what the bug was about.
+ */
+class BudgetGroupsIncomeFoldTest {
+
+    private data class Income(val amount: BigDecimal)
+
+    private fun windowedSpend(budgetId: Long, count: Int): List<WindowSpending> =
+        (1..count).map { i ->
+            WindowSpending(
+                budgetId = budgetId,
+                window = BudgetWindow(
+                    start = LocalDate.of(2026, 10, 5).plusDays((i - 1) * 7L),
+                    end = LocalDate.of(2026, 10, 5).plusDays((i - 1) * 7L + 6),
+                    days = 7
+                ),
+                spent = BigDecimal("100.00")
+            )
+        }
+
+    @Test
+    fun `totalIncome is not multiplied by the number of (budget x window) entries`() {
+        val twoIncome = listOf(Income(BigDecimal("1000")), Income(BigDecimal("500")))
+        val oneWeekly = windowedSpend(1L, count = 1)             // 1 windowed entry
+        val threeMixed =
+            windowedSpend(1L, count = 5) +                      // 5 (weekly)
+                windowedSpend(2L, count = 1) +                  // 1 (monthly)
+                windowedSpend(3L, count = 1)                   // 1 (monthly)
+                                                              // 7 windowed entries total
+
+        // The fixed shape: pick the list once, fold once.
+        fun fold(windowed: List<WindowSpending>, isCurrentMonth: Boolean): BigDecimal {
+            val incomes = if (isCurrentMonth) twoIncome else emptyList()
+            return incomes.fold(BigDecimal.ZERO) { acc, income -> acc + income.amount }
+        }
+
+        // The windowed-spend count is intentionally ignored.
+        assertEquals(BigDecimal("1500"), fold(oneWeekly, isCurrentMonth = true))
+        assertEquals(BigDecimal("1500"), fold(threeMixed, isCurrentMonth = true))
+    }
+
+    @Test
+    fun `totalIncome is zero for historical months`() {
+        val twoIncome = listOf(Income(BigDecimal("1000")), Income(BigDecimal("500")))
+        fun fold(isCurrentMonth: Boolean): BigDecimal {
+            val incomes = if (isCurrentMonth) twoIncome else emptyList()
+            return incomes.fold(BigDecimal.ZERO) { acc, income -> acc + income.amount }
+        }
+        assertEquals(BigDecimal.ZERO, fold(isCurrentMonth = false))
+    }
+
+    @Test
+    fun `the broken flatMap shape would have produced the wrong total`() {
+        // This test pins down the BUG: the old shape (flatMap ignoring
+        // its argument) duplicated the list once per (budget × window)
+        // entry. The fixed shape picks the list once. This test makes
+        // the regression obvious if someone re-introduces the bug.
+        val twoIncome = listOf(Income(BigDecimal("1000")), Income(BigDecimal("500")))
+        // 7 (budget × window) entries — 5 weekly + 1 monthly + 1 monthly.
+        val windowed = windowedSpend(1L, count = 5) +
+            windowedSpend(2L, count = 1) +
+            windowedSpend(3L, count = 1)
+
+        // The broken shape: `windowed.flatMap { twoIncome }` calls the
+        // lambda once per element, and each call returns the *full*
+        // `twoIncome` list. With 7 windowed entries and 2 income
+        // entries, the result has 14 single elements. Each fold pass
+        // adds one Income's amount: 7 × 1000 + 7 × 500 = 10500.
+        val brokenTotal = windowed.flatMap { twoIncome }
+            .fold(BigDecimal.ZERO) { acc, income -> acc + income.amount }
+
+        // The fixed shape: pick the list once, fold once.
+        val fixedTotal = twoIncome
+            .fold(BigDecimal.ZERO) { acc, income -> acc + income.amount }
+
+        assertEquals(BigDecimal("10500"), brokenTotal)
+        assertEquals(BigDecimal("1500"), fixedTotal)
+    }
+}


### PR DESCRIPTION
## Summary

Reopens [#565](https://github.com/sarim2000/pennywiseai-tracker/pull/565), which was closed before all features landed. This PR includes the original configurable **Budget Cycle Start Day** plus every follow-up that was added on top of it. The previous PR is referenced in the conversation history for context.

**The previous PR (#565) was missing five things** that this PR adds:

1. **Weekly straddle fix** — Monthly cards on the Budgets page re-anchor to the budget's own current window (`Jun 29..Jul 5` for a Mon-anchored weekly on Jul 1) instead of the per-month clip. The June and July views now show the same spend, days-until-renewal, and remaining for the same week.
2. **Home card "1 day remaining no matter what" fix** — the unified path's `BudgetGroupSpendingRaw` was hard-coding `daysRemaining = 0`, so every home card fell into the "Finished" branch. The repo now publishes a per-budget `currentWindows` map and the home viewmodel recomputes `daysRemaining` from that window.
3. **Home + Budgets page default-month fix** — the home used to pass the cycle's start year-month (June for a startDay=25 user on Jul 1), making `isCurrentMonth = false` and the displayed window the historical fallback. The Budgets page also opened to June. Both now use today's calendar month.
4. **Cadence pill wording** — the subtitle used to read "$X/day · N days left in this week". Reframed to a renewal countdown: "Resets in N days", "Resets today", "X days remaining". Same data, clearer framing.
5. **History screen per-window breakdown sheet** — tapping any row in the Budget History screen opens a bottom sheet with the per-category breakdown for that window (same shape as the main card's per-cat list, scoped to one window).

The PR also includes the per-cadence Budget Period edit screen (Weekly / Monthly / One-time chips with day-of-week dropdown, day-of-month stepper, and one-time date pickers), the live per-window pipeline (live query, no snapshot table), and the schema migration 53→54→55 with backup-format compatibility.

## Type of change

- [x] feat: New feature
- [x] fix: Bug fix

## How to test

1. **Settings → Budget Cycle Start Day.** Pick 25 (or any value 1–31). All Monthly budgets and the global home / analytics / transactions "this month" / "last month" pickers snap to the new cycle.
2. **Open an existing budget** (or create a new one). The "Budget Period" card now shows three chips: `Weekly (recurring)`, `Monthly (recurring)`, `One-time`. Pick `Weekly` → choose a day of week. Pick `Monthly` → choose a day of month. Pick `One-time` → pick a literal start and end date.
3. **Budgets page.** Each card shows a cadence pill (`Weekly` / `Monthly` / `One-time`) next to the budget name and a renewal-countdown subtitle ("Resets in N days", "Resets today", "X days remaining"). For a Weekly budget, expand the card to see the pace chart + per-week sub-list. With startDay=25 on Jul 1, a Monthly card on the July view shows the (Jun 25..Jul 24) cycle window — same window whether you navigate to June or July.
4. **3-dots menu → View this period history.** Opens a new full screen with the per-window list and Live / Frozen badges. Tap any row → bottom sheet with the per-category breakdown for that window.
5. **Home dashboard.** A Weekly budget on Jul 1 shows the live current week with "Resets in 4 days" (or similar) — not "Finished".
6. **Month navigation.** ‹ › arrows on the Budgets page header. Historical views show the per-week sub-list for that month; spend is correctly clipped to the page's month bounds.

## Breaking changes

- [x] No breaking changes. All defaults preserve prior behaviour. Existing budgets created before this feature are treated as Monthly anchored to the global start-day preference (defaults to 1 = calendar month). The per-month snapshot tables were cleared in schema migration 54→55; the live per-window query reproduces the same data plus per-week sub-buckets that the snapshot couldn't represent.

## Related issues

- Supersedes #565 (closed before the per-window consistency fix, the home-pill fix, the default-month fix, the cadence-pill reframe, and the per-window breakdown sheet landed).

## Notes for reviewer

- **Schema:** 4 migrations total — 53→54 adds `weekday_anchor` and `month_anchor` to `budgets`; 54→55 clears the per-month budget snapshot tables (the live per-window query replaces them). `versionCode` is 98; backup format unchanged (all new fields have Kotlin defaults per `docs/backup-format.md`).
- **R8 / proguard:** the release build runs R8 + resource shrinking. No new proguard rules required (existing rules cover Hilt, kotlinx-serialization, Room).
- **Tests:** 17 new unit-test cases across `BudgetWindowTest` and `BudgetPeriodDatesTest` cover the cap-date math, the per-cadence `windowsForMonth` resolution, the per-budget `endDateFor` derivation, and the `resolveBudgetWindow` current-cycle behaviour (including the Jun 29..Jul 5 straddle case).

## Checklist

- [x] Focused PR (single purpose: per-cadence budget periods + UI fixups)
- [x] Tests added/updated
- [x] Docs updated — public user-facing surface (Settings → Budget Cycle Start Day) could use a screenshot in the README; can add if requested
- [x] `./gradlew test` passes locally
- [x] `./gradlew lint` not run in this environment
- [x] Follows existing code style and patterns
