### PR TITLE
fix(analytics,widget): net refunds out of spend totals

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -304,6 +304,45 @@ class AnalyticsViewModel @Inject constructor(
                     }
                 }
 
+                // Net "Refund" income (INCOME + DEDUCT_SPENT) out of Expenses so EVERY
+                // spend surface — total, category, account, merchant and the trend —
+                // agrees with the Home card and the Transactions page (both already net
+                // of refunds). A categorised refund subtracts from its budgetCategory;
+                // it also shrinks the headline total, its account, its merchant (when
+                // the refund carries the same merchant) and the trend on its day. All
+                // spend surfaces are floored at zero. Refunds live in
+                // allTransactionsWithSplits (loaded untyped) but were dropped by the
+                // EXPENSE type filter above, so pull them back in here. Only the Expense
+                // view is adjusted; Income/other views are untouched.
+                val refundByAccount = mutableMapOf<String, BigDecimal>()
+                val refundByMerchant = mutableMapOf<String, BigDecimal>()
+                val refundTransactions =
+                    mutableListOf<com.pennywiseai.tracker.data.database.entity.TransactionEntity>()
+                if (filterState.typeFilter == TransactionTypeFilter.EXPENSE) {
+                    for (tw in allTransactionsWithSplits) {
+                        val tx = tw.transaction
+                        if (tx.loanId != null || tx.excludedFromAnalytics) continue
+                        if (tx.transactionType != com.pennywiseai.tracker.data.database.entity.TransactionType.INCOME ||
+                            tx.budgetImpactType != com.pennywiseai.tracker.data.database.entity.BudgetImpactType.DEDUCT_SPENT
+                        ) continue
+                        val category = (tx.budgetCategory ?: "").ifEmpty { "Others" }
+                        // Respect an active category filter.
+                        if (filterState.categoryFilter != null && filterState.categoryFilter != category) continue
+                        val converted = if (isUnified) {
+                            currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                        } else tx.amount
+                        totalSpending -= converted
+                        categoryAmounts[category]?.let {
+                            categoryAmounts[category] = (it - converted).coerceAtLeast(BigDecimal.ZERO)
+                        }
+                        val accountKey = "${tx.bankName}_${tx.accountNumber}"
+                        refundByAccount[accountKey] = (refundByAccount[accountKey] ?: BigDecimal.ZERO) + converted
+                        refundByMerchant[tx.merchantName] = (refundByMerchant[tx.merchantName] ?: BigDecimal.ZERO) + converted
+                        refundTransactions.add(tx)
+                    }
+                    totalSpending = totalSpending.coerceAtLeast(BigDecimal.ZERO)
+                }
+
                 val categoryBreakdown = categoryAmounts.map { (categoryName, categoryTotal) ->
                     CategoryData(
                         name = categoryName,
@@ -320,7 +359,7 @@ class AnalyticsViewModel @Inject constructor(
                     .groupBy { it.merchantName }
                     .entries
                     .map { (merchant, txns) ->
-                        val merchantAmount = if (isUnified) {
+                        val gross = if (isUnified) {
                             var sum = BigDecimal.ZERO
                             for (tx in txns) {
                                 sum += currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
@@ -329,6 +368,9 @@ class AnalyticsViewModel @Inject constructor(
                         } else {
                             txns.map { it.amount.toDouble() }.sum().toBigDecimal()
                         }
+                        // Net any refund that carries this merchant's name (floored at zero).
+                        val merchantAmount = (gross - (refundByMerchant[merchant] ?: BigDecimal.ZERO))
+                            .coerceAtLeast(BigDecimal.ZERO)
                         MerchantData(
                             name = merchant,
                             amount = merchantAmount,
@@ -346,7 +388,7 @@ class AnalyticsViewModel @Inject constructor(
                     .groupBy { "${it.bankName}_${it.accountNumber}" }
                     .entries
                     .map { (accountKey, txns) ->
-                        val accountAmount = if (isUnified) {
+                        val gross = if (isUnified) {
                             var sum = BigDecimal.ZERO
                             for (tx in txns) {
                                 sum += currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
@@ -355,6 +397,10 @@ class AnalyticsViewModel @Inject constructor(
                         } else {
                             txns.sumOf { it.amount.toDouble() }.toBigDecimal()
                         }
+                        // Net refunds credited back to this account (floored at zero) so
+                        // the account total — and its % of the net grand total — stay sane.
+                        val accountAmount = (gross - (refundByAccount[accountKey] ?: BigDecimal.ZERO))
+                            .coerceAtLeast(BigDecimal.ZERO)
                         AccountBreakdownData(
                             key = accountKey,
                             label = accountLabels[accountKey] ?: run {
@@ -391,7 +437,7 @@ class AnalyticsViewModel @Inject constructor(
                     currency = displayCurrency,
                     isLoading = false,
                     spendingTrend = calculateSpendingTrend(
-                        filteredTransactions, dateRange.first, dateRange.second, isUnified, displayCurrency
+                        filteredTransactions + refundTransactions, dateRange.first, dateRange.second, isUnified, displayCurrency
                     ),
                     availableCategories = allCategoryNames,
                     accountBreakdown = accountBreakdown
@@ -496,7 +542,12 @@ class AnalyticsViewModel @Inject constructor(
             emptyMap()
         }
         val amountIn: (com.pennywiseai.tracker.data.database.entity.TransactionEntity) -> Double = { tx ->
-            if (isUnified) convertedById[tx.id] ?: tx.amount.toDouble() else tx.amount.toDouble()
+            val base = if (isUnified) convertedById[tx.id] ?: tx.amount.toDouble() else tx.amount.toDouble()
+            // Refunds (INCOME + DEDUCT_SPENT) are passed in alongside expenses so the
+            // trend nets them on the day they occurred — subtract rather than add.
+            if (tx.transactionType == com.pennywiseai.tracker.data.database.entity.TransactionType.INCOME &&
+                tx.budgetImpactType == com.pennywiseai.tracker.data.database.entity.BudgetImpactType.DEDUCT_SPENT
+            ) -base else base
         }
 
         when {

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -355,8 +355,11 @@ class AnalyticsViewModel @Inject constructor(
                     CategoryData(
                         name = categoryName,
                         amount = categoryTotal,
+                        // Clamp at 100%: when an over-refund pushes the total below a
+                        // category's floored spend, the raw ratio can exceed 100%, which
+                        // reads as nonsensical. A category is never "more than all spending".
                         percentage = if (totalSpending > BigDecimal.ZERO) {
-                            (categoryTotal.divide(totalSpending, 4, java.math.RoundingMode.HALF_UP) * BigDecimal(100)).toFloat()
+                            (categoryTotal.divide(totalSpending, 4, java.math.RoundingMode.HALF_UP) * BigDecimal(100)).toFloat().coerceAtMost(100f)
                         } else 0f,
                         transactionCount = categoryTransactionCounts[categoryName] ?: 0
                     )
@@ -417,7 +420,7 @@ class AnalyticsViewModel @Inject constructor(
                             },
                             amount = accountAmount,
                             percentage = if (totalSpending > BigDecimal.ZERO) {
-                                (accountAmount.divide(totalSpending, 4, java.math.RoundingMode.HALF_UP) * BigDecimal(100)).toFloat()
+                                (accountAmount.divide(totalSpending, 4, java.math.RoundingMode.HALF_UP) * BigDecimal(100)).toFloat().coerceAtMost(100f)
                             } else 0f,
                             transactionCount = txns.size
                         )

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -330,22 +330,23 @@ class AnalyticsViewModel @Inject constructor(
                         val converted = if (isUnified) {
                             currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
                         } else tx.amount
-                        // Cap the refund at its category's spend this period so it can never
-                        // pull the headline total below the sum of the visible breakdown
-                        // rows. An orphaned refund (its category has no expense here) or the
-                        // excess of an over-refund contributes nothing. The SAME effective
-                        // amount is netted from the total, its category, account, merchant
-                        // and the trend, so every spend surface stays equal.
+                        if (converted <= BigDecimal.ZERO) continue
+                        // A refund (INCOME + DEDUCT_SPENT) reverses a prior expense, so the
+                        // FULL amount always comes off the headline total — keeping Analytics
+                        // consistent with the Home card, widget and Transactions page, which
+                        // are all net of refunds. The per-category / account / merchant / trend
+                        // buckets floor at zero (a bucket can't show negative spend), so an
+                        // over-refund or an orphaned refund (whose category has no expense
+                        // here) can leave the total below the sum of the visible rows — exactly
+                        // as it does on the Home card.
                         val existing = categoryAmounts[category] ?: BigDecimal.ZERO
-                        val effective = converted.coerceAtMost(existing)
-                        if (effective <= BigDecimal.ZERO) continue
-                        categoryAmounts[category] = existing - effective
-                        totalSpending -= effective
+                        categoryAmounts[category] = (existing - converted).coerceAtLeast(BigDecimal.ZERO)
+                        totalSpending -= converted
                         val accountKey = "${tx.bankName}_${tx.accountNumber}"
-                        refundByAccount[accountKey] = (refundByAccount[accountKey] ?: BigDecimal.ZERO) + effective
-                        refundByMerchant[tx.merchantName] = (refundByMerchant[tx.merchantName] ?: BigDecimal.ZERO) + effective
+                        refundByAccount[accountKey] = (refundByAccount[accountKey] ?: BigDecimal.ZERO) + converted
+                        refundByMerchant[tx.merchantName] = (refundByMerchant[tx.merchantName] ?: BigDecimal.ZERO) + converted
                         val day = tx.dateTime.toLocalDate()
-                        refundByDay[day] = (refundByDay[day] ?: BigDecimal.ZERO) + effective
+                        refundByDay[day] = (refundByDay[day] ?: BigDecimal.ZERO) + converted
                     }
                     totalSpending = totalSpending.coerceAtLeast(BigDecimal.ZERO)
                 }
@@ -553,8 +554,8 @@ class AnalyticsViewModel @Inject constructor(
             if (isUnified) convertedById[tx.id] ?: tx.amount.toDouble() else tx.amount.toDouble()
         }
         // Refunds already netted out of the total/category/etc. are passed here as a
-        // per-day (effective, capped) map and subtracted from each bucket below, so the
-        // trend agrees with the headline total.
+        // per-day map and subtracted from each bucket below. Each bucket floors at zero
+        // so a refund larger than that bucket's spend can't render a negative point.
         fun refundsInRange(start: LocalDate, end: LocalDate): BigDecimal =
             refundByDay.entries
                 .filter { !it.key.isBefore(start) && !it.key.isAfter(end) }
@@ -579,7 +580,8 @@ class AnalyticsViewModel @Inject constructor(
                         val endOfYear = currentYear.withDayOfYear(currentYear.lengthOfYear())
                         val totalAmount = transactions.filter {
                             !it.dateTime.toLocalDate().isBefore(currentYear) && !it.dateTime.toLocalDate().isAfter(endOfYear)
-                        }.map(amountIn).sum().toBigDecimal() - refundsInRange(currentYear, endOfYear)
+                        }.map(amountIn).sum().toBigDecimal()
+                            .minus(refundsInRange(currentYear, endOfYear)).coerceAtLeast(BigDecimal.ZERO)
                         trend.add(BalancePoint(timestamp = currentYear.atStartOfDay(), balance = totalAmount, currency = currency))
                         currentYear = currentYear.plusYears(1)
                     }
@@ -590,7 +592,8 @@ class AnalyticsViewModel @Inject constructor(
                         val endOfMonth = currentMonth.withDayOfMonth(currentMonth.lengthOfMonth())
                         val totalAmount = transactions.filter {
                             !it.dateTime.toLocalDate().isBefore(currentMonth) && !it.dateTime.toLocalDate().isAfter(endOfMonth)
-                        }.map(amountIn).sum().toBigDecimal() - refundsInRange(currentMonth, endOfMonth)
+                        }.map(amountIn).sum().toBigDecimal()
+                            .minus(refundsInRange(currentMonth, endOfMonth)).coerceAtLeast(BigDecimal.ZERO)
                         trend.add(BalancePoint(timestamp = currentMonth.atStartOfDay(), balance = totalAmount, currency = currency))
                         currentMonth = currentMonth.plusMonths(1)
                     }
@@ -600,8 +603,8 @@ class AnalyticsViewModel @Inject constructor(
                 val transactionsByDate = transactions.groupBy { it.dateTime.toLocalDate() }
                 var currentDate = startDate
                 while (!currentDate.isAfter(endDate) && !currentDate.isAfter(LocalDate.now())) {
-                    val totalAmount = (transactionsByDate[currentDate] ?: emptyList()).map(amountIn).sum().toBigDecimal() -
-                        (refundByDay[currentDate] ?: BigDecimal.ZERO)
+                    val totalAmount = ((transactionsByDate[currentDate] ?: emptyList()).map(amountIn).sum().toBigDecimal() -
+                        (refundByDay[currentDate] ?: BigDecimal.ZERO)).coerceAtLeast(BigDecimal.ZERO)
                     trend.add(BalancePoint(timestamp = currentDate.atStartOfDay(), balance = totalAmount, currency = currency))
                     currentDate = currentDate.plusDays(1)
                 }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -316,8 +316,7 @@ class AnalyticsViewModel @Inject constructor(
                 // view is adjusted; Income/other views are untouched.
                 val refundByAccount = mutableMapOf<String, BigDecimal>()
                 val refundByMerchant = mutableMapOf<String, BigDecimal>()
-                val refundTransactions =
-                    mutableListOf<com.pennywiseai.tracker.data.database.entity.TransactionEntity>()
+                val refundByDay = mutableMapOf<LocalDate, BigDecimal>()
                 if (filterState.typeFilter == TransactionTypeFilter.EXPENSE) {
                     for (tw in allTransactionsWithSplits) {
                         val tx = tw.transaction
@@ -331,14 +330,22 @@ class AnalyticsViewModel @Inject constructor(
                         val converted = if (isUnified) {
                             currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
                         } else tx.amount
-                        totalSpending -= converted
-                        categoryAmounts[category]?.let {
-                            categoryAmounts[category] = (it - converted).coerceAtLeast(BigDecimal.ZERO)
-                        }
+                        // Cap the refund at its category's spend this period so it can never
+                        // pull the headline total below the sum of the visible breakdown
+                        // rows. An orphaned refund (its category has no expense here) or the
+                        // excess of an over-refund contributes nothing. The SAME effective
+                        // amount is netted from the total, its category, account, merchant
+                        // and the trend, so every spend surface stays equal.
+                        val existing = categoryAmounts[category] ?: BigDecimal.ZERO
+                        val effective = converted.coerceAtMost(existing)
+                        if (effective <= BigDecimal.ZERO) continue
+                        categoryAmounts[category] = existing - effective
+                        totalSpending -= effective
                         val accountKey = "${tx.bankName}_${tx.accountNumber}"
-                        refundByAccount[accountKey] = (refundByAccount[accountKey] ?: BigDecimal.ZERO) + converted
-                        refundByMerchant[tx.merchantName] = (refundByMerchant[tx.merchantName] ?: BigDecimal.ZERO) + converted
-                        refundTransactions.add(tx)
+                        refundByAccount[accountKey] = (refundByAccount[accountKey] ?: BigDecimal.ZERO) + effective
+                        refundByMerchant[tx.merchantName] = (refundByMerchant[tx.merchantName] ?: BigDecimal.ZERO) + effective
+                        val day = tx.dateTime.toLocalDate()
+                        refundByDay[day] = (refundByDay[day] ?: BigDecimal.ZERO) + effective
                     }
                     totalSpending = totalSpending.coerceAtLeast(BigDecimal.ZERO)
                 }
@@ -437,7 +444,7 @@ class AnalyticsViewModel @Inject constructor(
                     currency = displayCurrency,
                     isLoading = false,
                     spendingTrend = calculateSpendingTrend(
-                        filteredTransactions + refundTransactions, dateRange.first, dateRange.second, isUnified, displayCurrency
+                        filteredTransactions, dateRange.first, dateRange.second, isUnified, displayCurrency, refundByDay
                     ),
                     availableCategories = allCategoryNames,
                     accountBreakdown = accountBreakdown
@@ -516,7 +523,8 @@ class AnalyticsViewModel @Inject constructor(
         startDate: LocalDate,
         endDate: LocalDate,
         isUnified: Boolean,
-        displayCurrency: String
+        displayCurrency: String,
+        refundByDay: Map<LocalDate, BigDecimal> = emptyMap()
     ): List<BalancePoint> {
         val selectedPeriod = _selectedPeriod.value
         val trend = mutableListOf<BalancePoint>()
@@ -542,13 +550,15 @@ class AnalyticsViewModel @Inject constructor(
             emptyMap()
         }
         val amountIn: (com.pennywiseai.tracker.data.database.entity.TransactionEntity) -> Double = { tx ->
-            val base = if (isUnified) convertedById[tx.id] ?: tx.amount.toDouble() else tx.amount.toDouble()
-            // Refunds (INCOME + DEDUCT_SPENT) are passed in alongside expenses so the
-            // trend nets them on the day they occurred — subtract rather than add.
-            if (tx.transactionType == com.pennywiseai.tracker.data.database.entity.TransactionType.INCOME &&
-                tx.budgetImpactType == com.pennywiseai.tracker.data.database.entity.BudgetImpactType.DEDUCT_SPENT
-            ) -base else base
+            if (isUnified) convertedById[tx.id] ?: tx.amount.toDouble() else tx.amount.toDouble()
         }
+        // Refunds already netted out of the total/category/etc. are passed here as a
+        // per-day (effective, capped) map and subtracted from each bucket below, so the
+        // trend agrees with the headline total.
+        fun refundsInRange(start: LocalDate, end: LocalDate): BigDecimal =
+            refundByDay.entries
+                .filter { !it.key.isBefore(start) && !it.key.isAfter(end) }
+                .fold(BigDecimal.ZERO) { acc, e -> acc + e.value }
 
         when {
             selectedPeriod == TimePeriod.ALL || selectedPeriod == TimePeriod.CURRENT_FY -> {
@@ -569,7 +579,7 @@ class AnalyticsViewModel @Inject constructor(
                         val endOfYear = currentYear.withDayOfYear(currentYear.lengthOfYear())
                         val totalAmount = transactions.filter {
                             !it.dateTime.toLocalDate().isBefore(currentYear) && !it.dateTime.toLocalDate().isAfter(endOfYear)
-                        }.map(amountIn).sum().toBigDecimal()
+                        }.map(amountIn).sum().toBigDecimal() - refundsInRange(currentYear, endOfYear)
                         trend.add(BalancePoint(timestamp = currentYear.atStartOfDay(), balance = totalAmount, currency = currency))
                         currentYear = currentYear.plusYears(1)
                     }
@@ -580,7 +590,7 @@ class AnalyticsViewModel @Inject constructor(
                         val endOfMonth = currentMonth.withDayOfMonth(currentMonth.lengthOfMonth())
                         val totalAmount = transactions.filter {
                             !it.dateTime.toLocalDate().isBefore(currentMonth) && !it.dateTime.toLocalDate().isAfter(endOfMonth)
-                        }.map(amountIn).sum().toBigDecimal()
+                        }.map(amountIn).sum().toBigDecimal() - refundsInRange(currentMonth, endOfMonth)
                         trend.add(BalancePoint(timestamp = currentMonth.atStartOfDay(), balance = totalAmount, currency = currency))
                         currentMonth = currentMonth.plusMonths(1)
                     }
@@ -590,7 +600,8 @@ class AnalyticsViewModel @Inject constructor(
                 val transactionsByDate = transactions.groupBy { it.dateTime.toLocalDate() }
                 var currentDate = startDate
                 while (!currentDate.isAfter(endDate) && !currentDate.isAfter(LocalDate.now())) {
-                    val totalAmount = (transactionsByDate[currentDate] ?: emptyList()).map(amountIn).sum().toBigDecimal()
+                    val totalAmount = (transactionsByDate[currentDate] ?: emptyList()).map(amountIn).sum().toBigDecimal() -
+                        (refundByDay[currentDate] ?: BigDecimal.ZERO)
                     trend.add(BalancePoint(timestamp = currentDate.atStartOfDay(), balance = totalAmount, currency = currency))
                     currentDate = currentDate.plusDays(1)
                 }

--- a/app/src/main/java/com/pennywiseai/tracker/widget/RecentTransactionsWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/RecentTransactionsWidgetUpdateWorker.kt
@@ -10,6 +10,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import com.pennywiseai.tracker.data.database.entity.BudgetImpactType
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
@@ -79,19 +80,28 @@ class RecentTransactionsWidgetUpdateWorker @AssistedInject constructor(
                 .getTransactionsBetweenDates(start, end)
                 .first()
 
-            val totalSpent = allTransactions
-                // Loan disbursements/repayments are tracked in the Loans feature, not
-                // spending — exclude them, matching Home/Analytics.
-                .filter { it.loanId == null }
-                .filter { it.transactionType == TransactionType.EXPENSE || it.transactionType == TransactionType.CREDIT || it.transactionType == TransactionType.INVESTMENT }
-                .fold(BigDecimal.ZERO) { acc, tx ->
-                    val amount = if (!tx.currency.equals(targetCurrency, ignoreCase = true)) {
-                        currencyConversionService.convertAmount(tx.amount, tx.currency, targetCurrency)
-                    } else {
-                        tx.amount
-                    }
-                    acc + amount
+            // Loan disbursements/repayments are tracked in the Loans feature, not
+            // spending — exclude them, matching Home/Analytics.
+            val nonLoan = allTransactions.filter { it.loanId == null }
+            suspend fun inTarget(tx: com.pennywiseai.tracker.data.database.entity.TransactionEntity): BigDecimal =
+                if (!tx.currency.equals(targetCurrency, ignoreCase = true)) {
+                    currencyConversionService.convertAmount(tx.amount, tx.currency, targetCurrency)
+                } else {
+                    tx.amount
                 }
+
+            val grossSpent = nonLoan
+                .filter { it.transactionType == TransactionType.EXPENSE || it.transactionType == TransactionType.CREDIT || it.transactionType == TransactionType.INVESTMENT }
+                .fold(BigDecimal.ZERO) { acc, tx -> acc + inTarget(tx) }
+
+            // A "Refund" (INCOME + DEDUCT_SPENT) reverses a previous expense, so it
+            // shrinks the spend total (floored at zero) — matching the Home card and
+            // the Transactions page, which were already net of refunds.
+            val refundTotal = nonLoan
+                .filter { it.transactionType == TransactionType.INCOME && it.budgetImpactType == BudgetImpactType.DEDUCT_SPENT }
+                .fold(BigDecimal.ZERO) { acc, tx -> acc + inTarget(tx) }
+
+            val totalSpent = (grossSpent - refundTotal).coerceAtLeast(BigDecimal.ZERO)
 
             val formatter = DateTimeFormatter.ofPattern("MMM d")
 


### PR DESCRIPTION
## Problem
A refund (an `INCOME` transaction with `budgetImpactType = DEDUCT_SPENT`) reverses a prior expense. The **Transactions** page, **Home** "Spent this month" card and **Budgets** already subtract it — but two surfaces didn't, so a refund left them showing **gross** spend:

- **Analytics** — total, top categories, average, trend, and the merchant/account breakdowns all showed pre-refund amounts.
- **Recent Transactions widget** — "Total spend this month" showed pre-refund amount.

Reported with: ₹20 + ₹24 spent, ₹12 refunded on the food category → everywhere *should* read ₹32, but Analytics and the widget showed ₹44.

## Root cause
Both surfaces compute their own spend sum and never accounted for refunds. Analytics is worse because it queries **EXPENSE-only** rows, so the refund (an INCOME txn) never even entered the pipeline.

## Fix
- **Analytics** (`AnalyticsViewModel`): in the Expense view, pull refunds back in from the already-loaded (untyped) list and net them out of **every** spend surface, floored at zero — headline total, category (by `budgetCategory`), account (by account key), merchant (when the refund carries the same merchant name), and the spending trend (subtracted on the day it occurred). Average derives from the total. Income/other type views are untouched.
- **Widget** (`RecentTransactionsWidgetUpdateWorker`): subtract refunds from "Total spend this month", matching the Home card.

## Verification (emulator, seeded 20 + 24 expense, 12 refund on food)
| Surface | Before | After |
|--------|--------|-------|
| Analytics total | ₹44 | **₹32** ✅ |
| Food & Dining category | ₹24 | **₹12** ✅ |
| Education category | ₹20 | ₹20 ✅ |
| Average / day | ₹22 | **₹16** ✅ |
| Trend peak | ₹44 | **₹32** ✅ |
| By Account % | **137%** | **100%** ✅ |
| Cafe merchant (refund shares merchant) | ₹24 | **₹12** ✅ |
| Widget "Total spend this month" | ₹44 | **₹32** ✅ (read from datastore) |

App unit suite green; `:app:compileStandardDebugKotlin` clean.