### PR TITLE
fix(onboarding): keep bottom bar above the system navigation bar (#563)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/onboarding/OnBoardingScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/onboarding/OnBoardingScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -798,7 +799,10 @@ private fun OnBoardingBottomBar(
     val isFirstStep = uiState.currentStep == OnBoardingStep.WELCOME
     val canGoBack = !isFirstStep && !uiState.isScanning
 
-    Column {
+    // Keep the controls above the system navigation bar under edge-to-edge (#563):
+    // the Scaffold's bottomBar slot doesn't apply navigation-bar insets on its own,
+    // so without this the gesture/3-button nav bar overlaps the Next button.
+    Column(modifier = Modifier.navigationBarsPadding()) {
         StepIndicator(
             currentStep = uiState.currentStep,
             modifier = Modifier


### PR DESCRIPTION
## Problem
On devices with a 3-button navigation bar, the onboarding **Next / Get Started** button was overlapped by the system nav bar and hard to tap (#563). The app draws edge-to-edge, but the Scaffold's `bottomBar` slot doesn't apply navigation-bar insets on its own.

## Fix
Add `Modifier.navigationBarsPadding()` to the onboarding bottom bar's root `Column`, lifting the whole controls row (Back · step dots · CTA) above the system nav bar.

## Verification
Emulator (3-button nav forced on):
- **Welcome** step — "Get Started" clears the nav bar.
- **Profile** step — full Back / step-dots / "Save & Continue" row clears the nav bar.

Single-file, low-risk change; behaves correctly under both gesture and 3-button nav.

Closes #563