### PR TITLE
feat: show eMola & M-Pesa Mozambique wallets as accounts in total balance

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/AccountBalanceEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/AccountBalanceEntity.kt
@@ -79,4 +79,12 @@ data class AccountBalanceEntity(
     @ColumnInfo(name = "lowBalanceThreshold")
     @Contextual
     val lowBalanceThreshold: BigDecimal? = null
-)
+) {
+    companion object {
+        // Sentinel account_last4 for mobile-money wallets (eMola, M-Pesa
+        // Mozambique) whose SMS has a running balance but no per-account number —
+        // the whole wallet is one account, keyed on bank_name. The UI renders
+        // this as the plain service name (no "••1234" suffix).
+        const val WALLET_ACCOUNT_MARKER = "WALLET"
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/AccountBalanceEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/AccountBalanceEntity.kt
@@ -86,5 +86,18 @@ data class AccountBalanceEntity(
         // the whole wallet is one account, keyed on bank_name. The UI renders
         // this as the plain service name (no "••1234" suffix).
         const val WALLET_ACCOUNT_MARKER = "WALLET"
+
+        /**
+         * Human-readable label for an account. Mobile-money wallets have no
+         * account number (and a blank last4 is meaningless), so show just the
+         * name; otherwise "Name ••1234". Use this everywhere an account is
+         * labelled so the [WALLET_ACCOUNT_MARKER] never leaks into the UI.
+         */
+        fun accountLabel(name: String, accountLast4: String?): String =
+            if (accountLast4.isNullOrBlank() || accountLast4 == WALLET_ACCOUNT_MARKER) {
+                name
+            } else {
+                "$name ••$accountLast4"
+            }
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsTransactionProcessor.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsTransactionProcessor.kt
@@ -202,7 +202,16 @@ class SmsTransactionProcessor @Inject constructor(
         entity: TransactionEntity,
         rowId: Long
     ) {
-        if (parsedTransaction.accountLast4 == null) return
+        if (parsedTransaction.accountLast4 == null) {
+            // Mobile-money wallets (eMola, M-Pesa Mozambique) have no per-account
+            // number — the whole wallet is one account. Derive a single service-level
+            // account row from the running balance the SMS carries, so the wallet shows
+            // up as an account and counts toward the total balance.
+            if (parsedTransaction.isMobileWallet && parsedTransaction.balance != null) {
+                upsertWalletBalance(parsedTransaction, entity, rowId)
+            }
+            return
+        }
 
         val isFromCard = parsedTransaction.isFromCard
 
@@ -321,5 +330,43 @@ class SmsTransactionProcessor @Inject constructor(
             accountBalanceRepository.insertBalance(balanceEntity)
             Log.d(TAG, "Saved balance update for ${parsedTransaction.bankName} **$targetAccountLast4")
         }
+    }
+
+    /**
+     * Derives a single service-level account row for a mobile-money wallet
+     * (eMola, M-Pesa Mozambique). These SMS carry the running balance but no
+     * per-account number, so the account is keyed on bankName with the
+     * [AccountBalanceEntity.WALLET_ACCOUNT_MARKER] sentinel and the balance is
+     * taken straight from the SMS (never a card, never credit).
+     */
+    private suspend fun upsertWalletBalance(
+        parsedTransaction: ParsedTransaction,
+        entity: TransactionEntity,
+        rowId: Long
+    ) {
+        val balance = parsedTransaction.balance ?: return
+        val existingAccount = accountBalanceRepository.getLatestBalance(
+            parsedTransaction.bankName,
+            AccountBalanceEntity.WALLET_ACCOUNT_MARKER
+        )
+
+        val balanceEntity = AccountBalanceEntity(
+            bankName = parsedTransaction.bankName,
+            accountLast4 = AccountBalanceEntity.WALLET_ACCOUNT_MARKER,
+            balance = balance,
+            timestamp = entity.dateTime,
+            transactionId = if (rowId != -1L) rowId else null,
+            creditLimit = null,
+            isCreditCard = false,
+            smsSource = parsedTransaction.smsBody.take(500),
+            sourceType = "TRANSACTION",
+            currency = parsedTransaction.currency,
+            profileId = existingAccount?.profileId ?: ProfileEntity.PERSONAL_ID,
+            alias = existingAccount?.alias,
+            lowBalanceThreshold = existingAccount?.lowBalanceThreshold
+        )
+
+        accountBalanceRepository.insertBalance(balanceEntity)
+        Log.d(TAG, "Saved wallet balance for ${parsedTransaction.bankName}")
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/AccountDetailScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/AccountDetailScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.ui.components.*
@@ -65,7 +66,7 @@ fun AccountDetailScreen(
             CustomTitleTopAppBar(
                 scrollBehaviorSmall = scrollBehaviorSmall,
                 scrollBehaviorLarge = scrollBehaviorLarge,
-                title = "${uiState.bankName} ••${uiState.accountLast4}",
+                title = AccountBalanceEntity.accountLabel(uiState.bankName, uiState.accountLast4),
                 hasBackButton = true,
                 hasActionButton = true,
                 navigationContent = {
@@ -366,7 +367,7 @@ private fun CurrentBalanceCard(
                     tint = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Text(
-                    text = "$bankName ••$accountLast4",
+                    text = AccountBalanceEntity.accountLabel(bankName, accountLast4),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/BalanceHistoryScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/BalanceHistoryScreen.kt
@@ -83,7 +83,7 @@ fun BalanceHistoryScreen(
                 .padding(horizontal = Dimensions.Padding.content)
         ) {
                 Text(
-                    text = "$bankName ••$accountLast4",
+                    text = AccountBalanceEntity.accountLabel(bankName, accountLast4),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
 import java.math.BigDecimal
+import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.data.database.entity.ProfileEntity
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -1020,9 +1021,9 @@ private fun AccountItem(
                         // stack; this keeps it as a clean second line. (#465)
                         Text(
                             text = if (alias != null) {
-                                "${account.bankName} ••${account.accountLast4}"
+                                AccountBalanceEntity.accountLabel(account.bankName, account.accountLast4)
                             } else {
-                                "••${account.accountLast4}"
+                                AccountBalanceEntity.accountLabel("", account.accountLast4).trim()
                             },
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -1277,7 +1278,7 @@ private fun AccountItem(
     if (showAliasDialog) {
         AccountAliasDialog(
             currentAlias = account.alias,
-            accountLabel = "${account.bankName} ••${account.accountLast4}",
+            accountLabel = AccountBalanceEntity.accountLabel(account.bankName, account.accountLast4),
             onDismiss = { showAliasDialog = false },
             onConfirm = { newAlias ->
                 onSetAlias(newAlias)
@@ -1289,7 +1290,7 @@ private fun AccountItem(
     if (showThresholdDialog) {
         LowBalanceThresholdDialog(
             currentThreshold = account.lowBalanceThreshold,
-            accountLabel = "${account.bankName} ••${account.accountLast4}",
+            accountLabel = AccountBalanceEntity.accountLabel(account.bankName, account.accountLast4),
             currency = CurrencyFormatter.resolveAccountCurrency(
                 account.sourceType, account.currency, account.bankName
             ),
@@ -1424,7 +1425,7 @@ private fun UpdateBalanceDialog(
             Column {
                 Text("Update Balance")
                 Text(
-                    text = "$bankName ••$accountLast4",
+                    text = AccountBalanceEntity.accountLabel(bankName, accountLast4),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -1502,7 +1503,7 @@ private fun UpdateCreditCardDialog(
             Column {
                 Text("Update Credit Card")
                 Text(
-                    text = "$bankName ••$accountLast4",
+                    text = AccountBalanceEntity.accountLabel(bankName, accountLast4),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -1929,11 +1930,13 @@ private fun LinkCardDialog(
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
                                 Column {
-                                    Text(
-                                        text = "••${account.accountLast4}",
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        fontWeight = FontWeight.Medium
-                                    )
+                                    if (account.accountLast4 != AccountBalanceEntity.WALLET_ACCOUNT_MARKER) {
+                                        Text(
+                                            text = "••${account.accountLast4}",
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            fontWeight = FontWeight.Medium
+                                        )
+                                    }
                                     Text(
                                         text = CurrencyFormatter.formatCurrency(account.balance, account.currency),
                                         style = MaterialTheme.typography.bodySmall,
@@ -2119,7 +2122,7 @@ private fun EditAccountDialog(
 
                 // Account Number (Read-only)
                 TextField(
-                    value = "••${account.accountLast4}",
+                    value = AccountBalanceEntity.accountLabel("", account.accountLast4).trim(),
                     onValueChange = {},
                     label = { Text("Account Number") },
                     enabled = false,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
@@ -648,7 +648,7 @@ class ManageAccountsViewModel @Inject constructor(
 
                 _uiState.update {
                     it.copy(
-                        successMessage = "Merged $moved transactions into ${target.bankName} ••${target.accountLast4}"
+                        successMessage = "Merged $moved transactions into ${AccountBalanceEntity.accountLabel(target.bankName, target.accountLast4)}"
                     )
                 }
                 delay(3000)

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/MergeAccountsSheet.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/MergeAccountsSheet.kt
@@ -126,7 +126,7 @@ fun MergeAccountsSheet(
                             tint = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                         Text(
-                            text = "${src.bankName} ••${src.accountLast4}",
+                            text = AccountBalanceEntity.accountLabel(src.bankName, src.accountLast4),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
@@ -153,9 +153,9 @@ fun MergeAccountsSheet(
                 val n = sourceTxnCount
                 Text(
                     if (n != null)
-                        "Move $n transactions from ${s.bankName} ••${s.accountLast4} into ${t.bankName} ••${t.accountLast4}. The source account is removed after the move. This can't be undone."
+                        "Move $n transactions from ${AccountBalanceEntity.accountLabel(s.bankName, s.accountLast4)} into ${AccountBalanceEntity.accountLabel(t.bankName, t.accountLast4)}. The source account is removed after the move. This can't be undone."
                     else
-                        "Move all transactions from ${s.bankName} ••${s.accountLast4} into ${t.bankName} ••${t.accountLast4}. The source account is removed after the move. This can't be undone."
+                        "Move all transactions from ${AccountBalanceEntity.accountLabel(s.bankName, s.accountLast4)} into ${AccountBalanceEntity.accountLabel(t.bankName, t.accountLast4)}. The source account is removed after the move. This can't be undone."
                 )
             },
             confirmButton = {
@@ -216,9 +216,11 @@ private fun AccountPicker(
                         )
                         Text(
                             text = buildString {
-                                append("••")
-                                append(acct.accountLast4)
-                                append(" · ")
+                                if (acct.accountLast4 != AccountBalanceEntity.WALLET_ACCOUNT_MARKER) {
+                                    append("••")
+                                    append(acct.accountLast4)
+                                    append(" · ")
+                                }
                                 append(acct.currency)
                                 if (acct.isCreditCard) append(" · Credit")
                             },

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/TransactionTabContent.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/TransactionTabContent.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.data.database.entity.BudgetImpactType
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.domain.model.displayName
@@ -368,7 +369,8 @@ fun TransactionTabContent(
                                     MaterialTheme.colorScheme.onSurface
                                 else MaterialTheme.colorScheme.onSurfaceVariant
                             )
-                            if (uiState.selectedAccount != null) {
+                            if (uiState.selectedAccount != null &&
+                                uiState.selectedAccount?.accountLast4 != AccountBalanceEntity.WALLET_ACCOUNT_MARKER) {
                                 Text(
                                     text = "••${uiState.selectedAccount?.accountLast4}",
                                     style = MaterialTheme.typography.bodySmall,
@@ -482,7 +484,7 @@ fun TransactionTabContent(
                         DropdownMenuItem(
                             text = {
                                 Column {
-                                    Text("${account.bankName} ••${account.accountLast4}")
+                                    Text(AccountBalanceEntity.accountLabel(account.bankName, account.accountLast4))
                                     Text(
                                         CurrencyFormatter.formatCurrency(account.balance, account.currency),
                                         style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/common/Filters.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/common/Filters.kt
@@ -136,7 +136,7 @@ fun accountOptions(accounts: List<AccountBalanceEntity>): List<AccountOption> {
         .map { account ->
             val key = "${account.bankName}_${account.accountLast4}"
             val alias = account.alias?.takeIf { it.isNotBlank() }
-            val label = alias ?: "${account.bankName} ••${account.accountLast4}"
+            val label = alias ?: AccountBalanceEntity.accountLabel(account.bankName, account.accountLast4)
             AccountOption(key = key, label = label)
         }
         .distinctBy { it.key }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import android.net.Uri
 import androidx.core.net.toUri
 import com.pennywiseai.tracker.data.currency.CurrencyConversionService
+import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.data.database.entity.BudgetImpactType
 import com.pennywiseai.tracker.data.database.entity.CategoryEntity
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
@@ -214,7 +215,7 @@ class TransactionDetailViewModel @Inject constructor(
                     AccountInfo(
                         bankName = balance.bankName,
                         accountLast4 = balance.accountLast4,
-                        displayName = "${balance.bankName} ••••${balance.accountLast4}",
+                        displayName = AccountBalanceEntity.accountLabel(balance.bankName, balance.accountLast4),
                         isCreditCard = balance.isCreditCard
                     )
                 }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/FinancialAccountRow.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/FinancialAccountRow.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
+import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.ui.theme.Spacing
 
 @Composable
@@ -31,11 +32,14 @@ fun FinancialAccountIdentity(
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f, fill = false)
         )
-        Spacer(modifier = Modifier.width(Spacing.xs))
-        Text(
-            text = "••$accountLast4",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
+        // Mobile-money wallets have no account number — show just the service name.
+        if (accountLast4 != AccountBalanceEntity.WALLET_ACCOUNT_MARKER) {
+            Spacer(modifier = Modifier.width(Spacing.xs))
+            Text(
+                text = "••$accountLast4",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/UnifiedAccountsCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/UnifiedAccountsCard.kt
@@ -237,13 +237,16 @@ private fun CompactAccountItem(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
-            Text(
-                text = "••$accountLast4",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            // Mobile-money wallets have no account number — show just the service name.
+            if (accountLast4 != AccountBalanceEntity.WALLET_ACCOUNT_MARKER) {
+                Text(
+                    text = "••$accountLast4",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
-        
+
         Column(
             horizontalAlignment = Alignment.End
         ) {

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/AccountCarousel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/AccountCarousel.kt
@@ -170,12 +170,15 @@ private fun AccountCarouselCard(
                 modifier = Modifier.weight(1f, fill = false)
             )
 
-            Text(
-                text = "••${account.accountLast4}",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
-                maxLines = 1
-            )
+            // Mobile-money wallets have no account number — show just the service name.
+            if (account.accountLast4 != AccountBalanceEntity.WALLET_ACCOUNT_MARKER) {
+                Text(
+                    text = "••${account.accountLast4}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                    maxLines = 1
+                )
+            }
 
             // Account type chip
             Surface(

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceCard.kt
@@ -369,7 +369,13 @@ fun BalanceCard(
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
                                     Text(
-                                        text = "${account.bankName} •• ${account.accountLast4}",
+                                        // Mobile-money wallets have no account number — show
+                                        // just the service name (no "•• 1234" suffix).
+                                        text = if (account.accountLast4 == AccountBalanceEntity.WALLET_ACCOUNT_MARKER) {
+                                            account.bankName
+                                        } else {
+                                            "${account.bankName} •• ${account.accountLast4}"
+                                        },
                                         style = MaterialTheme.typography.bodySmall,
                                         color = MaterialTheme.colorScheme.onSurface
                                     )

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -416,7 +416,8 @@ class AnalyticsViewModel @Inject constructor(
                             key = accountKey,
                             label = accountLabels[accountKey] ?: run {
                                 val first = txns.first()
-                                "${first.bankName ?: "Unknown"} ••${first.accountNumber ?: "----"}"
+                                com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
+                                    .accountLabel(first.bankName ?: "Unknown", first.accountNumber ?: "----")
                             },
                             amount = accountAmount,
                             percentage = if (totalSpending > BigDecimal.ZERO) {

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/onboarding/OnBoardingScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/onboarding/OnBoardingScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import com.pennywiseai.tracker.ui.effects.overScrollVertical
+import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
@@ -729,11 +730,14 @@ private fun AccountSetupStep(
                                 style = MaterialTheme.typography.titleSmall,
                                 fontWeight = FontWeight.Bold
                             )
-                            Text(
-                                text = "****${account.accountLast4}",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
+                            // Mobile-money wallets have no account number.
+                            if (account.accountLast4 != AccountBalanceEntity.WALLET_ACCOUNT_MARKER) {
+                                Text(
+                                    text = "****${account.accountLast4}",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
                         }
                         Column(horizontalAlignment = Alignment.End) {
                             Text(

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import com.pennywiseai.tracker.ui.effects.overScrollVertical
+import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
@@ -591,7 +592,7 @@ fun CreateRuleScreen(
                                         condition.field == TransactionField.ACCOUNT -> {
                                             val parts = condition.value.split("||")
                                             if (parts.size == 2) {
-                                                append("${parts[0]} ••${parts[1]}")
+                                                append(AccountBalanceEntity.accountLabel(parts[0], parts[1]))
                                             } else {
                                                 append(condition.value)
                                             }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import com.pennywiseai.tracker.ui.effects.overScrollVertical
+import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Help
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
@@ -304,7 +305,7 @@ fun SettingsScreen(
                         subtitle = "Sets your default currency",
                         currentValue = mainAccount?.let { acc ->
                             val name = acc.alias?.takeIf { it.isNotBlank() } ?: acc.bankName
-                            if (acc.accountLast4.isNotBlank()) "$name ••${acc.accountLast4}" else name
+                            AccountBalanceEntity.accountLabel(name, acc.accountLast4)
                         } ?: "Not set",
                         expanded = showMainAccountDropdown,
                         onExpandedChange = { showMainAccountDropdown = it },
@@ -312,9 +313,7 @@ fun SettingsScreen(
                     ) {
                         accounts.forEach { account ->
                             val name = account.alias?.takeIf { it.isNotBlank() } ?: account.bankName
-                            val label = if (account.accountLast4.isNotBlank()) {
-                                "$name ••${account.accountLast4}"
-                            } else name
+                            val label = AccountBalanceEntity.accountLabel(name, account.accountLast4)
                             val key = "${account.bankName}_${account.accountLast4}"
                             DropdownMenuItem(
                                 text = { Text(label) },

--- a/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/RulesViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/RulesViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.billing.EntitlementGate
+import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.billing.FreeTierLimits
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.domain.model.rule.TransactionRule
@@ -86,7 +87,7 @@ class RulesViewModel @Inject constructor(
                     AccountInfo(
                         bankName = balance.bankName,
                         accountLast4 = balance.accountLast4,
-                        displayName = "${balance.bankName} ••${balance.accountLast4}",
+                        displayName = AccountBalanceEntity.accountLabel(balance.bankName, balance.accountLast4),
                         isCreditCard = balance.isCreditCard,
                         accountType = balance.accountType
                     )

--- a/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
@@ -751,7 +751,16 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
         entity: com.pennywiseai.tracker.data.database.entity.TransactionEntity,
         rowId: Long
     ) {
-        val accountLast4 = parsed.accountLast4 ?: return
+        val accountLast4 = parsed.accountLast4 ?: run {
+            // Mobile-money wallets (eMola, M-Pesa Mozambique) have no per-account
+            // number — the whole wallet is one account. Derive a service-level row
+            // from the running balance so a full re-scan also creates it, matching
+            // SmsTransactionProcessor.
+            if (parsed.isMobileWallet && parsed.balance != null) {
+                upsertWalletBalance(parsed, entity, rowId)
+            }
+            return
+        }
 
         val card = if (parsed.isFromCard) {
             (cardRepository.getCard(parsed.bankName, accountLast4)
@@ -842,6 +851,41 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
             "Saved balance (${CurrencyFormatter.formatCurrency(newBalance, parsed.currency)})"
         }
         Log.i(TAG, logMsg)
+    }
+
+    /**
+     * Derives a single service-level account row for a mobile-money wallet
+     * (eMola, M-Pesa Mozambique). No per-account number, never a card/credit —
+     * keyed on bankName + [AccountBalanceEntity.WALLET_ACCOUNT_MARKER], balance
+     * taken straight from the SMS. Mirrors SmsTransactionProcessor.upsertWalletBalance.
+     */
+    private suspend fun upsertWalletBalance(
+        parsed: ParsedTransaction,
+        entity: com.pennywiseai.tracker.data.database.entity.TransactionEntity,
+        rowId: Long
+    ) {
+        val balance = parsed.balance ?: return
+        val existing = accountBalanceRepository.getLatestBalance(
+            parsed.bankName,
+            AccountBalanceEntity.WALLET_ACCOUNT_MARKER
+        )
+        val balanceEntity = AccountBalanceEntity(
+            bankName      = parsed.bankName,
+            accountLast4  = AccountBalanceEntity.WALLET_ACCOUNT_MARKER,
+            balance       = balance,
+            timestamp     = entity.dateTime,
+            transactionId = if (rowId != -1L) rowId else null,
+            creditLimit   = null,
+            isCreditCard  = false,
+            smsSource     = parsed.smsBody.take(500),
+            sourceType    = "TRANSACTION",
+            currency      = parsed.currency,
+            profileId     = existing?.profileId ?: ProfileEntity.PERSONAL_ID,
+            alias         = existing?.alias,
+            lowBalanceThreshold = existing?.lowBalanceThreshold
+        )
+        accountBalanceRepository.insertBalance(balanceEntity)
+        Log.i(TAG, "Saved wallet balance for ${parsed.bankName}")
     }
 
     // ─── Unrecognized SMS batch ────────────────────────────────────────────────

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/ParsedTransaction.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/ParsedTransaction.kt
@@ -18,7 +18,12 @@ data class ParsedTransaction(
     val isFromCard: Boolean = false,
     val currency: String = "INR",
     val fromAccount: String? = null,
-    val toAccount: String? = null
+    val toAccount: String? = null,
+    // Mobile-money wallet (e.g. eMola, M-Pesa Mozambique): the SMS carries a
+    // running balance but no per-account number, because the whole wallet IS the
+    // account. When true, the app derives a single service-level account row from
+    // the balance instead of requiring an accountLast4.
+    val isMobileWallet: Boolean = false
 ) {
     fun generateTransactionId(): String {
         val normalizedAmount = amount.setScale(2, java.math.RoundingMode.HALF_UP)

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BankParser.kt
@@ -72,9 +72,18 @@ abstract class BankParser {
             timestamp = timestamp,
             bankName = getBankName(),
             isFromCard = detectIsCard(smsBody),
-            currency = getCurrency()
+            currency = getCurrency(),
+            isMobileWallet = isMobileWallet()
         )
     }
+
+    /**
+     * Whether this parser represents a mobile-money wallet whose SMS carries a
+     * running balance but no per-account number (e.g. eMola, M-Pesa Mozambique).
+     * When true, the app derives a single service-level account row from the
+     * balance instead of requiring an accountLast4. Defaults to false.
+     */
+    open fun isMobileWallet(): Boolean = false
 
     /**
      * Checks if the message is a transaction message (not OTP, promotional, etc.)

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/EMolaParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/EMolaParser.kt
@@ -26,6 +26,10 @@ class EMolaParser : BankParser() {
 
     override fun getCurrency() = "MZN"
 
+    // Mobile-money wallet: SMS carries a running balance but no per-account
+    // number (the whole wallet is the account). See ParsedTransaction.isMobileWallet.
+    override fun isMobileWallet() = true
+
     override fun canHandle(sender: String): Boolean {
         return sender.equals("eMola", ignoreCase = true)
     }

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MPesaMozambiqueParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/MPesaMozambiqueParser.kt
@@ -30,6 +30,10 @@ class MPesaMozambiqueParser : BankParser() {
 
     override fun getCurrency() = "MZN"
 
+    // Mobile-money wallet: SMS carries a running balance but no per-account
+    // number (the whole wallet is the account). See ParsedTransaction.isMobileWallet.
+    override fun isMobileWallet() = true
+
     override fun canHandle(sender: String): Boolean {
         val normalizedSender = sender.uppercase()
         // M-Pesa Mozambique uses the same sender ID; differentiation is by content.

--- a/parser-core/src/test/kotlin/TestEMolaParser.kt
+++ b/parser-core/src/test/kotlin/TestEMolaParser.kt
@@ -72,4 +72,20 @@ class EMolaParserTest {
             "eMola should route to EMolaParser"
         )
     }
+
+    @Test
+    fun `eMola is flagged as a mobile-money wallet`() {
+        Assertions.assertTrue(
+            EMolaParser().isMobileWallet(),
+            "eMola has a running balance but no account number, so it must be a wallet"
+        )
+        // The flag must reach the parsed result so the app can derive a wallet account.
+        val parsed = EMolaParser().parse(
+            "Transaction ID PP260530.0934.w91238. You transfered 100.00MT to 871234566, name: John Doe at 09:34:45 on 30/05/2026. Fee: 0.00MT. Your account balance is 3,123.45MT.",
+            "eMola",
+            0L
+        )
+        Assertions.assertNotNull(parsed)
+        Assertions.assertTrue(parsed!!.isMobileWallet, "parsed eMola transaction must carry isMobileWallet=true")
+    }
 }

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/MPesaMozambiqueParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/MPesaMozambiqueParserTest.kt
@@ -6,7 +6,9 @@ import com.pennywiseai.parser.core.test.ParserTestCase
 import com.pennywiseai.parser.core.test.ParserTestUtils
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import java.math.BigDecimal
 
 /**
@@ -127,5 +129,27 @@ class MPesaMozambiqueParserTest {
         assertNotNull(ke, "Kenya message should parse")
         assertEquals("M-PESA", ke!!.bankName)
         assertEquals("KES", ke.currency)
+    }
+
+    @Test
+    fun `only Mozambique M-Pesa is flagged as a mobile-money wallet`() {
+        val now = System.currentTimeMillis()
+
+        // Mozambique M-Pesa -> wallet (derives a service-level account row in the app).
+        val mozMsg = "Confirmado DET0KAIXP5E. Recebeste  12,345.67MT de 123456 - SIMO aos 29/5/26  as 6:22 PM o novo saldo  M-Pesa e de 1,234.56MT."
+        val moz = BankParserFactory.parse(mozMsg, "M-Pesa", now)
+        assertNotNull(moz)
+        assertTrue(moz!!.isMobileWallet, "Mozambique M-Pesa must be flagged as a wallet")
+
+        // Scope guard: Tanzania & Kenya M-Pesa are NOT touched by this change.
+        val tzMsg = "SGR1234567 Confirmed. You have received TZS 50,000.00 from JOHN DOE (255754XXXXXX) on 2025-05-12 at 10:30 AM. New M-Pesa balance is TZS 150,000.00."
+        val tz = BankParserFactory.parse(tzMsg, "M-PESA", now)
+        assertNotNull(tz)
+        assertFalse(tz!!.isMobileWallet, "Tanzania M-Pesa must NOT be flagged (out of scope)")
+
+        val keMsg = "TJK6H7T3GA Confirmed. Ksh70.00 paid to person 1. on 20/10/24 at 4:21 PM.New M-PESA balance is Ksh123.12. Transaction cost, Ksh0.00. Amount you can transact within the day is 499,895.00."
+        val ke = BankParserFactory.parse(keMsg, "M-PESA", now)
+        assertNotNull(ke)
+        assertFalse(ke!!.isMobileWallet, "Kenya M-PESA must NOT be flagged (out of scope)")
     }
 }


### PR DESCRIPTION
Closes the Discord report (Alberto Godinho): M-Pesa & eMola (Mozambique) transactions show in the timeline, but the wallet **doesn't appear as an account and doesn't add to total balance**.

## Root cause
Mobile-money wallets carry a running balance in every SMS (`Your account balance is 3,123.45MT`) but **no per-account number** — every digit string in the message is a counterparty (recipient / sender / agent), never the user's own wallet. So `extractAccountLast4()` correctly returns null. But the app only ever derives account rows from a **non-null** `accountLast4` (`SmsTransactionProcessor` bailed with `if (accountLast4 == null) return`), and `AccountBalanceEntity.accountLast4` is a required column — so these wallets never became accounts. It was never an extraction bug; it's a model assumption (account = bank + 4 digits) that mobile money doesn't fit.

## Fix (scoped to eMola & M-Pesa Mozambique only)
- **parser-core**: add `ParsedTransaction.isMobileWallet` (default `false`); override `isMobileWallet() = true` on **only** `EMolaParser` and `MPesaMozambiqueParser`. Kenya/Tanzania M-Pesa are explicitly left out (test asserts they stay `false`).
- **app**: `SmsTransactionProcessor` derives one service-level account row for a wallet, keyed on `bankName` + `AccountBalanceEntity.WALLET_ACCOUNT_MARKER` ("WALLET"), using the SMS's running balance. **No DB migration** (reuses the existing non-null column); **no backup change** (`isMobileWallet` is transient, not persisted).
- **UI**: `BalanceCard` / `UnifiedAccountsCard` / `AccountCarousel` / `FinancialAccountRow` render a wallet as just the service name (no "•• 1234" suffix).

## Verification
- Unit: `isMobileWallet` true for eMola + M-Pesa MZ, false for Kenya/Tanzania M-Pesa; flag reaches the parsed result. Full `:parser-core:jvmTest` + app unit suite green.
- Emulator: injected an eMola SMS → new account **"eMola — MZN1,500"** appears in the accounts breakdown (clean name, no fake last-4) and is summed into the **Total**.

Note: MZN has no exchange rate configured, so the wallet balance shows in native currency with the existing "some balances could not be converted" note — expected.