### PR TITLE
fix(txn): edit picker sets bankName so account balance updates (#566, #570)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailScreen.kt
@@ -1304,6 +1304,7 @@ private fun EditableExtractedInfoCard(
                 AccountNumberField(
                     accountNumber = transaction.accountNumber,
                     onAccountNumberChange = { viewModel.updateAccountNumber(it) },
+                    onBankNameChange = { viewModel.updateBankName(it) },
                     viewModel = viewModel
                 )
             }
@@ -1881,7 +1882,12 @@ private fun AccountNumberField(
     viewModel: TransactionDetailViewModel,
     label: String = "Account (Optional)",
     placeholder: String = "Select or enter account number",
-    excludeAccount: String? = null
+    excludeAccount: String? = null,
+    // Fired alongside onAccountNumberChange when a real account is picked from
+    // the dropdown, so the transaction's bankName follows the selected account
+    // (accounts are keyed by bankName+last4). Only the single-account field
+    // wires this; transfer From/To fields leave it null. See #566 / #570.
+    onBankNameChange: ((String?) -> Unit)? = null
 ) {
     val availableAccounts by viewModel.availableAccounts.collectAsStateWithLifecycle()
     val filteredAccounts = availableAccounts.filter { it.accountLast4 != excludeAccount }
@@ -1973,6 +1979,7 @@ private fun AccountNumberField(
                         onClick = {
                             selectedAccount = account.displayName
                             onAccountNumberChange(account.accountLast4)
+                            onBankNameChange?.invoke(account.bankName)
                             expanded = false
                         },
                         contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
@@ -429,6 +429,21 @@ class TransactionDetailViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Set the transaction's bank when the user picks an account from the
+     * dropdown. The account is keyed by (bankName, accountLast4), so selecting
+     * "HDFC ••1234" must update BOTH fields — otherwise a transaction that
+     * started on a different bank (e.g. a subscription-created row, or a
+     * "Manual Entry" row) keeps its stale bankName, saveChanges() looks up
+     * getLatestBalance(staleBank, newLast4), misses, and the account balance
+     * silently never updates (issues #566, #570).
+     */
+    fun updateBankName(bankName: String?) {
+        _editableTransaction.update { current ->
+            current?.copy(bankName = if (bankName.isNullOrEmpty()) null else bankName)
+        }
+    }
+
     fun updateFromAccount(account: String?) {
         _editableTransaction.update { current ->
             current?.copy(fromAccount = if (account.isNullOrEmpty()) null else account)

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
@@ -621,9 +621,25 @@ class TransactionDetailViewModel @Inject constructor(
                     newReceiptPath = receiptManager.saveReceipt(pendingUri)
                 }
 
+                // Reconcile the bank with the selected account so the balance
+                // lookup keys on the right (bankName, accountLast4) pair — even
+                // if the account number was hand-typed rather than picked from
+                // the dropdown (which already sets both). Only override when
+                // exactly one known account matches the last-4: don't guess when
+                // the same last-4 exists on multiple banks, or when it's a
+                // novel/unknown number. Clearing (accountNumber == null) keeps
+                // the existing bank untouched. Belt-and-braces with the picker's
+                // onBankNameChange so no edit path can desync (#566, #570).
+                val resolvedBankName = toSave.accountNumber
+                    ?.let { last4 -> availableAccounts.value.filter { it.accountLast4 == last4 } }
+                    ?.singleOrNull()
+                    ?.bankName
+                    ?: toSave.bankName
+
                 // Normalize merchant name before saving
                 val normalizedTransaction = toSave.copy(
                     merchantName = normalizeMerchantName(toSave.merchantName),
+                    bankName = resolvedBankName,
                     receiptPath = newReceiptPath
                 )
 


### PR DESCRIPTION
## Problem
Editing a transaction to assign an account **did not update that account's balance** — reported independently in **#566** and **#570** (a second reporter confirmed #566's exact repro).

## Root cause
The account picker in `TransactionDetailScreen.AccountNumberField` set only `accountNumber` (the last-4) on select, never `bankName`:

```kotlin
onClick = {
    selectedAccount = account.displayName
    onAccountNumberChange(account.accountLast4)   // ← only the last-4
}
```

Accounts are keyed by **(bankName, accountLast4)**. So a transaction that started on a *different* bank kept its stale `bankName`:
- a **subscription** mark-as-paid row (`bankName` = the subscription's), or
- a **"Manual Entry"** row (manual add without an account).

`saveChanges()` then called `getLatestBalance(staleBank, newLast4)`, missed, and silently skipped the balance update. The balance never moved.

## Fix
Propagate the selected account's `bankName` alongside its last-4:
- `TransactionDetailViewModel.updateBankName()` sets the transaction's bank.
- `AccountNumberField` gains an optional `onBankNameChange`, fired from the dropdown `onClick` next to `onAccountNumberChange`. **Only the single-account field wires it**; the transfer From/To fields (which key on `fromAccount`/`toAccount`) pass `null` and are unchanged.

The manual **add** flow was already correct — it passes a full `AccountBalanceEntity` (both `bankName` + `accountLast4`) to `AddTransactionUseCase`.

## Verification (emulator, ground-truth via DB)
1. Added a ₹100 expense with **no account** → `bank_name = "Manual Entry"`, `account_number = NULL`. Kotak ••7777 baseline = **₹2000**.
2. Edited it → assigned **Kotak ••7777** → Save.
3. Result: `bank_name = "Kotak Bank"`, `account_number = 7777`, and a new balance row **₹1900** (2000 − 100). ✅

Before the fix, `bank_name` stayed `"Manual Entry"`, the lookup missed, and the balance stayed ₹2000.

## Scope
- Resolves **#566** and the balance half of **#570**.
- Assigning a *default* account to a subscription so mark-as-paid auto-hits it (**#570 part 1**) remains a separate enhancement.

Closes #566