### PR TITLE
fix(home): respect 'exclude from analytics' in main card income/spend

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -226,7 +226,14 @@ class HomeViewModel @Inject constructor(
     private fun computeBreakdownByCurrency(
         transactions: List<TransactionEntity>
     ): Map<String, TransactionRepository.MonthlyBreakdown> {
-        return transactions.groupBy { it.currency }.mapValues { (_, txs) ->
+        // "Exclude from analytics" transactions stay in history & account balances
+        // but must not count toward the home card's income/spend figures — same as
+        // the Analytics screen, budgets and AI summaries already do (#451). Without
+        // this, an excluded income still showed up as income on the main card even
+        // though the row is labelled "Excluded".
+        return transactions
+            .filter { !it.excludedFromAnalytics }
+            .groupBy { it.currency }.mapValues { (_, txs) ->
             // A "Refund" (INCOME + DEDUCT_SPENT) is the reversal of a previous
             // expense, so it should shrink "Spent this month" and not appear as
             // new income. "Extra budget" (ADD_TO_LIMIT) is real money in — leave
@@ -271,6 +278,7 @@ class HomeViewModel @Inject constructor(
         val daily = mutableMapOf<LocalDate, BigDecimal>()
         for (tx in transactions) {
             if (tx.loanId != null) continue
+            if (tx.excludedFromAnalytics) continue  // keep the trend line consistent with the income/spend figures (#451)
             if (!isUnified && tx.currency != selectedCurrency) continue
 
             val sign = when {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -1077,7 +1077,9 @@ class HomeViewModel @Inject constructor(
     private fun updateTransactionTypeTotals(transactions: List<TransactionEntity>) {
         val selectedCurrency = _uiState.value.selectedCurrency
         val isUnified = _uiState.value.isUnifiedMode
-        val nonLoanTransactions = transactions.filter { it.loanId == null }
+        // Drop excluded-from-analytics rows here too, so the home CREDIT/TRANSFER/
+        // INVESTMENT totals stay consistent with the income/spend breakdown (#451).
+        val nonLoanTransactions = transactions.filter { it.loanId == null && !it.excludedFromAnalytics }
 
         if (isUnified) {
             // Convert all transactions to display currency


### PR DESCRIPTION
## Bug (reported on Discord)
A user excluded some **income** transactions ("Exclude from analytics"). They correctly show as **"Income · Excluded"** in the list — but the home **"This month" card still counted them as income** (their excluded ₹5k showed up as the card's Income figure).

## Root cause
`excludedFromAnalytics` is honored **everywhere else** — Analytics screen, budgets, AI summaries, transaction lists — but **not** in the home card's own stat computation (`HomeViewModel.computeBreakdownByCurrency` + `buildDailyNetExpense`). Those summed income/expenses/trend over **all** transactions.

## Fix
- `computeBreakdownByCurrency` — filter out excluded rows before computing income / expenses / refund.
- `buildDailyNetExpense` — skip excluded rows so the trend line matches the figures.

Excluded transactions **still count toward account balances** (separate code path), matching the toggle's own promise: *"Kept in history & balance, ignored in spending stats."*

## Verification (emulator)
1. Added a ₹7,777 income → card showed **Income ₹7,777 / Saved ₹7,777**.
2. Toggled **Exclude from analytics** → card dropped to **Income ₹0 / Expenses ₹0 / Saved ₹0**.
3. The row stayed in Recent (labelled **Excluded**) and the account total (₹10,09,899) was unchanged. ✅