### PR TITLE
docs: restructure agent harness (CLAUDE.md router + verification gate)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,12 @@
-CLAUDE.md
+# Agent Guide → see CLAUDE.md
+
+The full, authoritative guide for coding agents lives in
+**[CLAUDE.md](CLAUDE.md)** at the repository root. **Read it before making
+changes** — it covers the hard constraints, the verification gate (`./init.sh`),
+and links to every topic doc.
+
+This file exists so agents that follow the `AGENTS.md` convention find the
+guide. It is intentionally a thin pointer and a *real file* (not a symlink), so
+it resolves the same on every checkout mode — Windows without symlink support,
+sparse checkouts, the GitHub web UI, and archive/zip exports. `CLAUDE.md` is the
+single source of truth; keep guidance there, not here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,1 @@
-Read from CLAUDE.md
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,10 @@ verify.
 fresh `[BANK]` issue).
 
 ## Releasing
-For a routine release: merge the PRs, then run
-`./scripts/release.sh patch|minor|major --yes` (preview first with `--dry-run`).
+For a routine release: merge the PRs, then — from an up-to-date `main` with a
+clean tree — run `./scripts/release.sh patch|minor|major --yes` (preview first
+with `--dry-run`). It commits/tags the current branch and pushes `main`, so the
+branch state matters.
 `scripts/release.sh` is the single source of truth — it bumps the version,
 generates changelogs + release notes, builds/signs the APKs, tags, pushes, and
 cuts the GitHub release. Full flag reference in `docs/RELEASE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,207 +1,91 @@
-# PennyWise Project Context
+# PennyWise — Agent Guide
 
-## Project Overview
-PennyWise is a minimalist, AI-powered expense tracker for Android that automatically extracts transaction data from SMS messages using on-device processing.
+PennyWise is a privacy-first, AI-powered expense tracker that extracts
+transactions from bank SMS **entirely on-device**. The primary app is Android
+(Jetpack Compose + Material 3); the repo also contains a Kotlin Multiplatform
+`shared` module, an `iosApp`, and a `pennywise-web` frontend.
 
-## Important Documents
-Please reference these documents when working on this project:
-- **Architecture**: `/docs/architecture.md` - MVVM + Clean Architecture patterns, layer responsibilities
-- **Design System**: `/docs/design.md` - Material 3 theming, colors, typography, components
-- **PRD**: `/prd.md` - Product requirements, features, timeline
-- **Backup & Restore**: `/docs/backup-format.md` - Backup JSON format + the forward/backward compatibility contract. **Read this before changing anything a backup serializes** (entities, `data/backup/`).
+**This file is a router, not a manual.** Read the linked topic doc when a task
+touches its area. Everything under **Hard Constraints** is non-negotiable.
 
-## Key Technical Decisions
-1. **UI Framework**: Jetpack Compose with Material 3
-2. **Architecture**: MVVM with Clean Architecture (UI, Domain, Data layers)
-3. **State Management**: Unidirectional Data Flow with StateFlow
-4. **DI**: Hilt for dependency injection
-5. **Database**: Room for local storage
-6. **AI/ML**: MediaPipe LLM (Qwen 2.5) for on-device processing
-7. **Background**: WorkManager for SMS scanning
+## Hard Constraints (never violate)
+1. **Money is always currency-tagged.** Format with
+   `CurrencyFormatter.formatCurrency(amount, currencyCode)` (or the
+   `formatBalance()` / `formatAmount()` entity extensions) — never the
+   currency-less overload (it defaults to ₹ and is `@Deprecated(ERROR)`, so it
+   won't compile).
+2. **Never sum amounts across currencies.** "₹500 + $10" is not 510 of anything.
+   Total a possibly-mixed list with `Iterable.sumByCurrency({ it.currency },
+   { it.amount })` (`utils/MoneyTotals.kt`) → `Map<currency, Money>`, and render
+   with `CurrencyFormatter.formatByCurrency(...)`. `Money.+` throws on a currency
+   mismatch. A single-figure total is only valid after filtering/converting to
+   one currency. (Both rules guarded by `CurrencyFormatterTest`.)
+3. **Every backup-serialized field must have a Kotlin default value** — Room
+   entity columns *and* the wrapper models in `BackupModels.kt`. Dropping a
+   default re-introduces the "can't restore old backup" bug (#414);
+   `BackupSchemaGuardTest` enforces this. Use `@Contextual` for
+   `BigDecimal`/`LocalDate`/`LocalDateTime`, `@Serializable` for enums. See
+   `docs/backup-format.md` or the **backup-maintainer** subagent before touching
+   entities or `data/backup/`.
+4. **Never put PII in code, comments, tests, or anywhere.**
+5. **Never hand-edit the version or changelogs.** `scripts/release.sh` owns
+   `versionCode` / `versionName` and `fastlane/.../changelogs/*` (see Releasing).
+6. **Parser tests use the shared `ParserTestUtils` helpers** — see
+   `docs/parser-test-standards.md`.
+7. **New bank parsers** extend the correct base class (`BaseIndianBankParser` /
+   `UAEBankParser` / `BankParser`) and are registered in `BankParserFactory` —
+   see `docs/adding-bank-parsers.md`.
 
-## Design Principles
-- **Material You**: Dynamic color from wallpaper (Android 12+)
-- **Light/Dark Theme**: Full support with semantic color roles
-- **Spacing**: 8dp grid system
-- **Typography**: Material 3 type scale
-- **Navigation**: NavigationBar for phones, NavigationRail for tablets
-- **Edge-to-Edge**: All screens use PennyWiseScaffold with default TopAppBar for consistent system bar handling
-- **Consistent UI**: PennyWiseScaffold provides default TopAppBar with options for title, navigation, actions, and transparency
+## Verification — Definition of Done
+Run **`./init.sh`** before claiming a change is done — it runs exactly what CI
+(`.github/workflows/test.yml`) gates on, so "green here" means "green in CI".
+Scope it to what you touched:
 
-## Code Style Guidelines
-- Follow Kotlin coding conventions
-- Use meaningful variable names
-- Implement proper error handling with sealed classes
-- Ensure UI components are reusable and testable
-- Always test on both light and dark themes
+| Change | Command |
+|---|---|
+| Parser (`parser-core`) | `./init.sh parser` |
+| App (Kotlin) | `./init.sh app` |
+| Everything | `./init.sh` (default) |
+| Runtime / UI | plus an on-device check (use the **emulator-verify** skill) |
 
-## Current Phase
-Working on Phase 1: Core Foundation (Project setup, Material 3 theming, Room database, Navigation)
+`init.sh` sets `JAVA_HOME` to a JDK 21 (Android Studio's JBR by default). Run
+the raw `./gradlew` tasks it wraps only if you need finer control. `./gradlew
+build` and `lint` are heavier and **not** part of the gate — don't use them to
+verify.
 
-## Commands to Run
-- Build: `./gradlew build`
-- Test: `./gradlew test`
-- Lint: `./gradlew lint`
+## Architecture at a glance
+- **Stack:** Kotlin · Jetpack Compose + Material 3 · MVVM + Clean Architecture ·
+  StateFlow (unidirectional data flow) · Hilt DI · Room · WorkManager (background
+  SMS scanning) · MediaPipe LLM (Qwen 2.5) for on-device AI.
+- **Modules:** `app` (Android) · `parser-core` (pure-Kotlin bank SMS parsers, no
+  Android deps) · `shared` (KMP) · `iosApp` · `pennywise-web`.
+- **UI:** Material You dynamic color (Android 12+), full light/dark with semantic
+  color roles, 8dp grid, Material 3 type scale. All screens use
+  `PennyWiseScaffold` for consistent system-bar / TopAppBar handling. Always
+  check both light and dark themes.
+- **Versioning:** SemVer (MAJOR breaking / MINOR features / PATCH fixes). The
+  live version is in `app/build.gradle.kts`.
 
-## Versioning Strategy
-We follow Semantic Versioning (SemVer) - MAJOR.MINOR.PATCH:
-- **MAJOR**: Breaking changes, major UI overhauls, architecture changes
-- **MINOR**: New features, significant improvements
-- **PATCH**: Bug fixes, minor improvements, performance optimizations
+## Topic Docs — read when the task touches the area
+| Area | Doc | Read when |
+|---|---|---|
+| Architecture / layers | `docs/architecture.md` | Changing layer responsibilities, DI, data flow |
+| Design system | `docs/design.md` | Any UI work — colors, typography, components |
+| State management | `docs/state-management.md` | ViewModels, StateFlow, UI state |
+| Backup & Restore | `docs/backup-format.md` | Touching backed-up entities or `data/backup/` |
+| Adding a bank parser | `docs/adding-bank-parsers.md` | New/changed parser in `parser-core` |
+| Parser tests | `docs/parser-test-standards.md` | Writing parser tests |
+| DB migrations | `docs/database-migrations.md` | Room schema changes |
+| Supported banks | `docs/BANK_SUPPORT.md`, `docs/supported-banks.json` | Which banks/patterns are covered (139 banks, 23 countries) |
+| Roadmap / requirements | `docs/planned-features.md`, `docs/prd-unified-currency.md` | Feature scope / intent |
 
-### Releasing — do NOT hand-edit the version or changelog
-`scripts/release.sh [patch|minor|major]` owns the entire release and is the
-**only** thing that should touch the version. Never manually edit
-`versionCode` / `versionName` in `app/build.gradle.kts`, and never hand-write a
-`fastlane/metadata/android/en-US/changelogs/<versionCode>.txt` file — the script
-generates all of that. In one run it:
-- bumps `versionName` (per the SemVer keyword) and increments `versionCode`,
-- generates the store changelog `<versionCode>.txt` + `default.txt` and the
-  GitHub `RELEASE_NOTES.md` from the commits since the last tag (via the Claude
-  Agent SDK, falling back to a commit list; `--no-claude` forces the fallback),
-- builds/renames/signs the standard + F-Droid APKs and computes SHA256,
-- commits `chore(release): bump version to X [skip ci]`, tags `vX`, pushes, and
-  cuts the GitHub release with the APKs attached.
+**Subagents:** `backup-maintainer` (backup-serialized changes) ·
+`parser-author` (write/fix a parser end-to-end) · `parser-triage` (assess a
+fresh `[BANK]` issue).
 
-Flags: `--yes` (non-interactive), `--play` (upload the `.aab` to Play Console as
-a draft), `--web` (also deploy `pennywise-web`), `--dry-run` (print the plan +
-notes, change nothing). So for a routine release just merge the PRs, then run
-e.g. `./scripts/release.sh patch --yes`. Use `--dry-run` first to preview the
-computed version and notes. The current version therefore lives in
-`app/build.gradle.kts`, not here.
-
-## Module Structure
-The project now uses a multi-module architecture:
-- **app**: Main Android application module
-- **parser-core**: Standalone bank parser module (no Android dependencies)
-
-## Bank Parser Architecture
-Bank parsers are now in the `parser-core` module for reusability across platforms.
-
-### When adding new bank parsers:
-1. **Location**: Add to `parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/`
-2. **Base Class**: All bank parsers extend `BankParser` abstract class
-   - **Indian Banks**: MUST extend `BaseIndianBankParser` to inherit centralized mandate, subscription, and balance update logic.
-   - **UAE Banks**: MUST extend `UAEBankParser` for currency and transaction type handling.
-3. **Key Methods**:
-   - `getBankName()`: Returns the bank's display name
-   - `canHandle(sender: String)`: Checks if parser can handle SMS from sender
-   - `parse(smsBody, sender, timestamp)`: Returns `ParsedTransaction` or null
-4. **Override Patterns**: Banks typically override:
-   - `extractAmount()`: Bank-specific amount patterns
-   - `extractMerchant()`: Bank-specific merchant extraction
-   - `extractTransactionType()`: If needed for special cases
-5. **Registration**: Add new parser to `BankParserFactory.parsers` list in parser-core
-6. **Return Type**: Use `ParsedTransaction` from parser-core
-7. **Imports for parser-core**:
-   - `com.pennywiseai.parser.core.TransactionType`
-   - `com.pennywiseai.parser.core.ParsedTransaction`
-   - `java.math.BigDecimal` for amounts
-
-### Integration in main app:
-- Use `com.pennywiseai.tracker.data.mapper.toEntity()` to convert ParsedTransaction to TransactionEntity
-- The mapper handles type conversions between modules
-
-## Supported Banks (55 parsers)
-- Airtel Payments Bank
-- **Al Rajhi Bank (Saudi Arabia)** - Arabic SMS support
-- **Alinma Bank (Saudi Arabia)** - Arabic SMS support
-- **Altana Federal Credit Union (USA)**
-- American Express (AMEX)
-- Axis Bank
-- Bank of Baroda
-- Bank of India
-- Canara Bank
-- Central Bank of India
-- **Chase Bank (USA)**
-- City Union Bank
-- DBS Bank
-- Federal Bank
-- HDFC Bank
-- HSBC Bank
-- **Huntington Bank (USA)**
-- ICICI Bank
-- IDBI Bank
-- IDFC First Bank
-- Indian Bank
-- Indian Overseas Bank
-- India Post Payments Bank (IPPB)
-- Jio Payments Bank
-- JioPay
-- Jammu & Kashmir Bank
-- Jupiter Bank
-- Juspay
-- Karnataka Bank
-- Kerala Gramin Bank
-- Kotak Bank
-- LazyPay
-- **Liv Bank (UAE)** - Digital bank
-- Mashreq Bank
-- **mBank CZ (Czech Republic)** - Czech SMS support
-- **M-PESA (Kenya)** - Mobile money service
-- **Navy Federal Credit Union (USA)** - NFCU
-- **NMB Bank / Nabil Bank (Nepal)**
-- OneCard
-- **Priorbank (Belarus)** - Russian/Belarusian SMS support
-- Punjab National Bank (PNB)
-- Punjab & Sind Bank (PSB)
-- Saraswat Co-operative Bank
-- **Saudi National Bank / Al Ahli (SNB-AlAhli, Saudi Arabia)** - Arabic SMS support
-- **Siddhartha Bank Limited (Nepal)**
-- State Bank of India (SBI)
-- Slice
-- South Indian Bank
-- **Standard Chartered Bank**
-- **STC Bank (Saudi Arabia)**
-- **T-Bank / Tinkoff (Russia)** - Russian SMS support
-- Union Bank
-- Utkarsh Bank
-
-When implementing any feature, please ensure it aligns with the architecture patterns and design system defined in the documentation.
-
-
-## Backup & Restore
-Backups serialize Room entities directly to JSON via **kotlinx.serialization**
-(`data/backup/`). The format is forward- and backward-compatible by design.
-
-**The one rule:** every backup-serialized field (entity columns + the wrapper
-models in `BackupModels.kt`) **must have a Kotlin default value**. Missing keys
-in an older backup fall back to defaults; unknown keys from a newer backup are
-ignored. Dropping a default re-introduces the "can't restore old backup" bug
-(#414). `BackupSchemaGuardTest` enforces this in CI.
-
-- When adding an entity column: give it a Kotlin default; `@Contextual` if it's
-  `BigDecimal`/`LocalDate`/`LocalDateTime`; `@Serializable` if it's an enum.
-- When in doubt, use the **backup-maintainer** subagent / **backup-format**
-  skill, and read `/docs/backup-format.md`.
-
-# Money & Currency Formatting
-Every amount in this app carries a currency (transactions, balances, loans,
-subscriptions can each be in a different one). Two rules keep totals honest:
-
-1. **Always format money with its currency.** Call
-   `CurrencyFormatter.formatCurrency(amount, currencyCode)` — never the
-   currency-less overload (it defaults to INR/₹ and is `@Deprecated(ERROR)`, so
-   it won't compile). For an account/entity, prefer the `formatBalance()` /
-   `formatAmount()` extensions, which already pass the row's currency.
-
-2. **Never sum amounts across currencies.** "₹500 + $10" is not "510" of
-   anything. To total a list that can hold more than one currency, use
-   `Iterable<T>.sumByCurrency({ it.currency }, { it.amount })` (in
-   `utils/MoneyTotals.kt`) → `Map<currency, Money>`, and render it with
-   `CurrencyFormatter.formatByCurrency(...)` (single figure for a uniform set,
-   `₹1,250 · $600` for a mixed one). The `Money` type's `+` throws on a currency
-   mismatch, so a blind fold blows up loudly instead of silently mislabeling.
-   The only safe single-figure total is one **filtered/converted to one
-   currency first** (see `LoansViewModel` / unified-mode conversion).
-
-`CurrencyFormatterTest` guards these. When a screen shows a wrong currency
-symbol or a nonsensical mixed total, it's almost always a violation of one of
-the two rules above.
-
-# Important
-Never use pii in comments, code anywhere
-
-# Test implementation standards for parsers
-- Parser tests must use the shared JUnit helpers under `ParserTestUtils`. For
-  full guidance (examples, migration checklist), read `docs/parser-test-standards.md`.
+## Releasing
+For a routine release: merge the PRs, then run
+`./scripts/release.sh patch|minor|major --yes` (preview first with `--dry-run`).
+`scripts/release.sh` is the single source of truth — it bumps the version,
+generates changelogs + release notes, builds/signs the APKs, tags, pushes, and
+cuts the GitHub release. Full flag reference in `docs/RELEASE.md`.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -11,7 +11,16 @@ truth** for the version and changelogs.
 
 ## TL;DR
 
+> ⚠️ **Run from an up-to-date `main` with a clean working tree.** The script
+> commits the version bump to your *current* branch, tags that commit, and then
+> runs `git push origin main`. On any other branch — or a stale or dirty `main`
+> — it will tag the wrong commit and push a `main` that doesn't contain the
+> release. It does **not** guard against this for you.
+
 ```bash
+git checkout main && git pull --ff-only    # be on current main
+git status --porcelain                      # confirm a clean tree (expect no output)
+
 # Preview first — prints the computed version + release notes, changes nothing:
 ./scripts/release.sh patch --dry-run
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,121 +1,75 @@
 # Release Process
 
-This document describes how to create releases for PennyWise.
+Releases are cut by **`scripts/release.sh`**, which replicates
+`.github/workflows/release.yml` locally. This script is the **single source of
+truth** for the version and changelogs.
 
-## Prerequisites
+> ⚠️ **Never hand-edit the version or changelogs.** Do not touch `versionCode` /
+> `versionName` in `app/build.gradle.kts`, and never hand-write a
+> `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`. The script
+> owns all of that — editing it by hand will conflict with the next release.
 
-### 1. Create Signing Keystore (One-time setup)
-If you don't have a keystore yet:
+## TL;DR
+
 ```bash
-keytool -genkey -v -keystore release.keystore \
-  -alias pennywise -keyalg RSA -keysize 2048 -validity 10000
+# Preview first — prints the computed version + release notes, changes nothing:
+./scripts/release.sh patch --dry-run
+
+# Cut the release (non-interactive):
+./scripts/release.sh patch --yes
 ```
 
-### 2. Add GitHub Secrets
-Go to GitHub → Settings → Secrets and variables → Actions
+The bump keyword is the usual SemVer choice:
 
-Add these secrets:
-- `KEYSTORE_BASE64`: Your keystore file encoded as base64
-  ```bash
-  base64 -i release.keystore | pbcopy  # Mac
-  base64 release.keystore | xclip -selection clipboard  # Linux
-  ```
-- `KEYSTORE_PASSWORD`: Password for your keystore
-- `KEY_ALIAS`: Key alias (e.g., "pennywise")
-- `KEY_PASSWORD`: Password for the key
+- `patch` — bug fixes, minor improvements (2.17.0 → 2.17.1)
+- `minor` — new features (2.17.0 → 2.18.0)
+- `major` — breaking changes / major overhaul (2.17.0 → 3.0.0)
 
-## Release Workflow
+## What the script does in one run
 
-### 1. Use Conventional Commits
-Start using conventional commit format:
+1. Bumps `versionName` (per the keyword) and increments `versionCode` in
+   `app/build.gradle.kts`.
+2. Generates release notes from the commits since the last tag via the Claude
+   Agent SDK (falling back to a plain commit list, or with `--no-claude`). From
+   the same structured notes it writes:
+   - the store changelog `changelogs/<versionCode>.txt` + `default.txt`, and
+   - `RELEASE_NOTES.md` for the GitHub release.
+3. Builds, renames, and (F-Droid) computes SHA256 for the standard + F-Droid
+   APKs.
+4. Commits `chore(release): bump version to X [skip ci]`, tags `vX`, and pushes.
+5. Cuts the GitHub release with the APKs + `.sha256` attached.
+
+If the script is interrupted, a trap reverts the version bump and changelog
+changes so you're left in a clean state.
+
+## Flags
+
+| Flag | Effect |
+|---|---|
+| `-y`, `--yes` | Auto-confirm every prompt (non-interactive / CI). |
+| `--dry-run` | Print the plan + release notes and change nothing. Run this first. |
+| `--no-claude` | Skip Claude note generation; use the commit-list fallback. |
+| `--play` | After building, also build the `.aab` and upload it to Play Console as a draft (via `scripts/upload-play.sh`). |
+| `--web` | Also deploy `pennywise-web` to Cloudflare (otherwise a routine app release never redeploys the site). |
+
+One-shot headless release with a Play draft:
+
 ```bash
-git commit -m "feat: add new bank parser"
-git commit -m "fix: resolve parsing error"
-git commit -m "docs: update README"
+./scripts/release.sh patch --yes --play
 ```
 
-The template will help you:
-```bash
-git commit  # Opens editor with template
-```
+## Prerequisites (one-time)
 
-### 2. Create a Release
+- **Signing** — the release build needs the signing config wired up (keystore +
+  credentials) the same way `release.yml` consumes its GitHub secrets. If the
+  workflow shows an unsigned APK, the signing config/secrets are misconfigured.
+- **`--play`** additionally needs the Play Console service-account credentials
+  that `scripts/upload-play.sh` expects.
+- **`--web`** needs the `pennywise-web` deploy toolchain (`bun`, Cloudflare
+  auth); the script runs `pennywise-web/scripts/deploy.sh`.
 
-#### Option A: Manual Version Selection
-1. Go to [GitHub Actions](../../actions)
-2. Click on "Release" workflow
-3. Click "Run workflow"
-4. Select version bump type:
-   - `patch`: Bug fixes only (2.1.7 → 2.1.8)
-   - `minor`: New features (2.1.7 → 2.2.0)
-   - `major`: Breaking changes (2.1.7 → 3.0.0)
-   - `auto`: Analyze commits (works after using conventional commits)
-5. Click "Run workflow"
+## Conventional commits
 
-#### Option B: Test with Dry Run
-1. Same as above but check "Dry run" checkbox
-2. This will preview the release without creating it
-
-### 3. What Happens Automatically
-
-The workflow will:
-1. Calculate next version based on your selection
-2. Generate changelog from recent commits
-3. Update version in `app/build.gradle.kts`
-4. Build signed APK
-5. Create git tag (e.g., `v2.2.0`)
-6. Create GitHub Release with:
-   - Changelog as description
-   - APK attached for download
-   - SHA256 checksum file
-
-### 4. Release Notes
-
-The workflow automatically generates release notes from your commits:
-```markdown
-## Changes since v2.1.7
-- feat: add ICICI Bank support (abc123)
-- fix: resolve download issues (def456)
-- docs: update README (ghi789)
-```
-
-## Version Strategy
-
-- **Patch** (2.1.7 → 2.1.8): Bug fixes, minor improvements
-- **Minor** (2.1.7 → 2.2.0): New features, significant improvements
-- **Major** (2.1.7 → 3.0.0): Breaking changes, major overhaul
-
-## Testing Releases
-
-Always test with dry run first:
-1. Check "Dry run" when running workflow
-2. Review the output in Actions logs
-3. If everything looks good, run without dry run
-
-## Troubleshooting
-
-### Keystore Issues
-If you see "unsigned APK" in the workflow:
-- Verify GitHub secrets are set correctly
-- Check keystore is properly base64 encoded
-- Ensure passwords are correct
-
-### Version Conflicts
-If version already exists:
-- Manually update version in `app/build.gradle.kts`
-- Commit and push
-- Try release again
-
-### Workflow Fails
-Check the Actions tab for detailed logs:
-- Build errors → Fix code issues
-- Signing errors → Check secrets
-- Git errors → Ensure you're on main branch
-
-## Future Improvements
-
-Once comfortable with the process:
-1. Add Play Store deployment
-2. Automate version selection with semantic-release
-3. Add automated testing before release
-4. Include release notes in multiple languages
+Release notes are generated from commit messages, so use conventional commits
+(`feat:`, `fix:`, `docs:`, `chore:` …). Better commit messages → better
+auto-generated changelog and GitHub release notes.

--- a/docs/adding-bank-parsers.md
+++ b/docs/adding-bank-parsers.md
@@ -1,0 +1,57 @@
+# Adding a Bank SMS Parser
+
+Bank parsers live in the **`parser-core`** module (pure Kotlin, no Android
+dependencies) so they can be reused across platforms. For anything more than a
+trivial tweak, prefer the **`parser-author`** subagent, which owns this
+end-to-end (read samples → write/extend parser → tests → register → run tests).
+
+## Where parsers live
+`parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/`
+
+## Base class — pick the right one
+All parsers extend `BankParser`. But:
+
+- **Indian banks** MUST extend `BaseIndianBankParser` to inherit centralized
+  mandate, subscription, and balance-update logic.
+- **UAE banks** MUST extend `UAEBankParser` for currency and transaction-type
+  handling.
+- Everything else extends `BankParser` directly.
+
+## Key methods
+- `getBankName()` — the bank's display name.
+- `canHandle(sender: String)` — whether this parser handles SMS from a sender.
+- `parse(smsBody, sender, timestamp)` — returns `ParsedTransaction` or `null`.
+
+## Commonly overridden
+- `extractAmount()` — bank-specific amount patterns.
+- `extractMerchant()` — bank-specific merchant extraction.
+- `extractTransactionType()` — only for special cases.
+
+## Registration
+Add the new parser to the `BankParserFactory.parsers` list in
+`parser-core/.../bank/BankParserFactory.kt`.
+
+## Return type & imports (parser-core)
+Use `ParsedTransaction` from parser-core:
+- `com.pennywiseai.parser.core.TransactionType`
+- `com.pennywiseai.parser.core.ParsedTransaction`
+- `java.math.BigDecimal` for amounts
+
+## Using a parser result in the app
+Convert with `com.pennywiseai.tracker.data.mapper.toEntity()`, which maps
+`ParsedTransaction` → `TransactionEntity` and handles cross-module type
+conversions.
+
+## Tests
+Parser tests MUST use the shared `ParserTestUtils` JUnit 5 helpers — see
+[`docs/parser-test-standards.md`](parser-test-standards.md). Run them with:
+
+```bash
+./gradlew :parser-core:test          # or :parser-core:jvmTest
+```
+
+## Coverage
+The full list of supported banks and transaction patterns lives in
+[`docs/BANK_SUPPORT.md`](BANK_SUPPORT.md) and
+[`docs/supported-banks.json`](supported-banks.json) — the authoritative source,
+kept in sync with the parsers (do not maintain a hand-copied list elsewhere).

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# init.sh — the verification gate for coding agents (and humans).
+#
+# Runs exactly what CI (.github/workflows/test.yml) gates on, so "green here"
+# means "green in CI". Prefer this over `./gradlew build` / `lint`, which are
+# heavier and are NOT part of the gate.
+#
+# Usage:
+#   ./init.sh            # verify everything (default)
+#   ./init.sh parser     # parser-core JVM tests only  (fast; use for parser work)
+#   ./init.sh app        # app compile + unit tests only
+#   ./init.sh all        # same as no argument
+#
+# Exit code is non-zero if any step fails (fail-fast).
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# --- JDK 21 -----------------------------------------------------------------
+# Gradle here needs a JDK 21. If JAVA_HOME isn't set, fall back to Android
+# Studio's bundled JBR (the common local setup on macOS).
+if [[ -z "${JAVA_HOME:-}" ]]; then
+  ASTUDIO_JBR="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+  if [[ -d "$ASTUDIO_JBR" ]]; then
+    export JAVA_HOME="$ASTUDIO_JBR"
+    echo "→ JAVA_HOME not set; using Android Studio JBR: $JAVA_HOME"
+  else
+    echo "⚠️  JAVA_HOME is not set and Android Studio JBR was not found."
+    echo "    Set JAVA_HOME to a JDK 21 and re-run."
+    exit 1
+  fi
+fi
+
+TARGET="${1:-all}"
+
+run() {
+  echo ""
+  echo "▶ $*"
+  "$@"
+}
+
+verify_parser() {
+  run ./gradlew :parser-core:test
+}
+
+verify_app() {
+  run ./gradlew :app:compileStandardDebugKotlin
+  run ./gradlew :app:testStandardDebugUnitTest
+}
+
+case "$TARGET" in
+  parser) verify_parser ;;
+  app)    verify_app ;;
+  all)    verify_parser; verify_app ;;
+  *)
+    echo "Unknown target: '$TARGET' (expected: parser | app | all)" >&2
+    exit 2
+    ;;
+esac
+
+echo ""
+echo "✅ Verification passed ($TARGET)."
+echo "   Note: runtime/UI changes still need an on-device check (emulator-verify skill)."

--- a/init.sh
+++ b/init.sh
@@ -19,18 +19,56 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 # --- JDK 21 -----------------------------------------------------------------
-# Gradle here needs a JDK 21. If JAVA_HOME isn't set, fall back to Android
-# Studio's bundled JBR (the common local setup on macOS).
-if [[ -z "${JAVA_HOME:-}" ]]; then
-  ASTUDIO_JBR="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
-  if [[ -d "$ASTUDIO_JBR" ]]; then
-    export JAVA_HOME="$ASTUDIO_JBR"
-    echo "→ JAVA_HOME not set; using Android Studio JBR: $JAVA_HOME"
-  else
-    echo "⚠️  JAVA_HOME is not set and Android Studio JBR was not found."
-    echo "    Set JAVA_HOME to a JDK 21 and re-run."
-    exit 1
+# Gradle here needs a JDK 21 (matches CI). Find one and verify its major
+# version rather than trusting whatever JAVA_HOME happens to point at — a stray
+# JDK 17/11 would otherwise fail the build with a cryptic error, and older
+# Android Studio JBRs are 17, not 21.
+
+jdk_major() {
+  # Print the major version of the JDK at $1 (e.g. "21"), or nothing if unusable.
+  local home="$1"
+  [[ -n "$home" && -x "$home/bin/java" ]] || return 1
+  "$home/bin/java" -version 2>&1 | awk -F'"' '/version/ {print $2; exit}' | cut -d. -f1
+}
+
+find_jdk21() {
+  local c major
+  local -a candidates=()
+  # 1. An already-correct JAVA_HOME wins (no surprise switching).
+  [[ -n "${JAVA_HOME:-}" ]] && candidates+=("$JAVA_HOME")
+  # 2. macOS: ask the OS for a registered JDK 21.
+  if [[ -x /usr/libexec/java_home ]]; then
+    c="$(/usr/libexec/java_home -v 21 2>/dev/null || true)"
+    [[ -n "$c" ]] && candidates+=("$c")
   fi
+  # 3. Android Studio's bundled JBR (used only if it is actually 21).
+  candidates+=("/Applications/Android Studio.app/Contents/jbr/Contents/Home")
+  # 4. Common SDKMAN install.
+  candidates+=("${SDKMAN_DIR:-$HOME/.sdkman}/candidates/java/current")
+
+  for c in "${candidates[@]}"; do
+    major="$(jdk_major "$c" || true)"
+    if [[ "$major" == "21" ]]; then
+      printf '%s\n' "$c"
+      return 0
+    fi
+  done
+  return 1
+}
+
+if JDK21="$(find_jdk21)"; then
+  if [[ "${JAVA_HOME:-}" != "$JDK21" ]]; then
+    echo "→ Using JDK 21 at: $JDK21"
+    export JAVA_HOME="$JDK21"
+  fi
+else
+  echo "⚠️  No JDK 21 found. CI builds on JDK 21 and Gradle here needs it too." >&2
+  if [[ -n "${JAVA_HOME:-}" ]]; then
+    echo "    JAVA_HOME points at a JDK $(jdk_major "$JAVA_HOME" 2>/dev/null || echo '?'), not 21." >&2
+  fi
+  echo "    Install one (e.g. Temurin 21, or Android Studio's JBR) and either set" >&2
+  echo "    JAVA_HOME to it or make it discoverable via /usr/libexec/java_home, then re-run." >&2
+  exit 1
 fi
 
 TARGET="${1:-all}"


### PR DESCRIPTION
## What

Makes the repo easier for coding agents to start, verify work, and stay in scope. Docs/tooling only — no product code changes, nothing to compile.

## Why

The instruction harness had drifted: `CLAUDE.md` told agents to verify with `./gradlew build`/`test`/`lint` (not what CI actually gates on, and missing the JDK requirement), still described the app as Android-only, carried a stale "Phase 1" line and a hand-maintained 55-bank list (really 139), and a 19-byte `AGENTS.md` stub hid all of it from AGENTS.md-convention tools.

## Changes

- **`CLAUDE.md`** — trimmed 207 → ~90 lines into a router: a **Hard Constraints** block up top, the **actual CI gate** as a Definition of Done, updated overview + modules (`app`, `parser-core`, `shared`, `iosApp`, `pennywise-web`). Removed the stale phase line and the bank list (→ `docs/supported-banks.json`).
- **`AGENTS.md`** — `Read from CLAUDE.md` stub → **symlink to `CLAUDE.md`**, so both filename conventions serve the same full router with no drift.
- **`init.sh`** — new one-command verification gate matching `.github/workflows/test.yml` exactly (`:parser-core:test`, `:app:compileStandardDebugKotlin` + `:app:testStandardDebugUnitTest`); sets `JAVA_HOME` to a JDK 21.
- **`docs/adding-bank-parsers.md`** — new; parser-authoring detail moved out of `CLAUDE.md` (reveal-on-demand).
- **`docs/RELEASE.md`** — rewritten around `scripts/release.sh`. The old version documented a dead GitHub-Actions flow and told you to hand-edit the version — directly contradicting the no-hand-edit rule.

## Verify

`./init.sh` (or scoped: `./init.sh parser` / `./init.sh app`). Docs-only otherwise.