### PR TITLE
fix(budget): keep month nav on past months with no snapshot (#569)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsScreen.kt
@@ -114,11 +114,27 @@ fun BudgetGroupsScreen(
         }
 
         if (!uiState.hasGroups) {
-            EmptyBudgetState(
-                modifier = Modifier.hazeSource(hazeState).background(MaterialTheme.colorScheme.background).padding(paddingValues),
-                onSmartDefaults = { viewModel.runSmartDefaults() },
-                onCreateNew = { onNavigateToGroupEdit(-1L) }
-            )
+            val isCurrentMonth =
+                YearMonth.of(uiState.selectedYear, uiState.selectedMonth) == YearMonth.now()
+            if (isCurrentMonth) {
+                EmptyBudgetState(
+                    modifier = Modifier.hazeSource(hazeState).background(MaterialTheme.colorScheme.background).padding(paddingValues),
+                    onSmartDefaults = { viewModel.runSmartDefaults() },
+                    onCreateNew = { onNavigateToGroupEdit(-1L) }
+                )
+            } else {
+                // A past month with no snapshot has no groups to show, but the
+                // month navigator must stay on-screen so the user isn't trapped
+                // and can step back to the current month (#569).
+                EmptyPastMonthState(
+                    modifier = Modifier.hazeSource(hazeState).background(MaterialTheme.colorScheme.background),
+                    topPadding = paddingValues.calculateTopPadding(),
+                    year = uiState.selectedYear,
+                    month = uiState.selectedMonth,
+                    onPreviousMonth = { viewModel.selectPreviousMonth() },
+                    onNextMonth = { viewModel.selectNextMonth() }
+                )
+            }
         } else {
             BudgetGroupsContent(
                 modifier = Modifier.hazeSource(hazeState).background(MaterialTheme.colorScheme.background),
@@ -195,6 +211,62 @@ private fun EmptyBudgetState(
                 ) {
                     Text("Create Custom Budget")
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyPastMonthState(
+    modifier: Modifier = Modifier,
+    topPadding: Dp = 0.dp,
+    year: Int,
+    month: Int,
+    onPreviousMonth: () -> Unit,
+    onNextMonth: () -> Unit
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(
+                start = Dimensions.Padding.content,
+                end = Dimensions.Padding.content,
+                top = Dimensions.Padding.content + topPadding
+            )
+    ) {
+        MonthSelector(
+            year = year,
+            month = month,
+            isCurrentMonth = false,
+            onPrevious = onPreviousMonth,
+            onNext = onNextMonth
+        )
+
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(Spacing.md)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.AccountBalance,
+                    contentDescription = null,
+                    modifier = Modifier.size(64.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = "No budgets tracked this month",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    text = "There's no budget history for ${YearMonth.of(year, month).format(DateTimeFormatter.ofPattern("MMMM yyyy"))}.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center
+                )
             }
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsScreen.kt
@@ -129,6 +129,7 @@ fun BudgetGroupsScreen(
                 EmptyPastMonthState(
                     modifier = Modifier.hazeSource(hazeState).background(MaterialTheme.colorScheme.background),
                     topPadding = paddingValues.calculateTopPadding(),
+                    bottomPadding = paddingValues.calculateBottomPadding(),
                     year = uiState.selectedYear,
                     month = uiState.selectedMonth,
                     onPreviousMonth = { viewModel.selectPreviousMonth() },
@@ -220,6 +221,7 @@ private fun EmptyBudgetState(
 private fun EmptyPastMonthState(
     modifier: Modifier = Modifier,
     topPadding: Dp = 0.dp,
+    bottomPadding: Dp = 0.dp,
     year: Int,
     month: Int,
     onPreviousMonth: () -> Unit,
@@ -231,7 +233,8 @@ private fun EmptyPastMonthState(
             .padding(
                 start = Dimensions.Padding.content,
                 end = Dimensions.Padding.content,
-                top = Dimensions.Padding.content + topPadding
+                top = Dimensions.Padding.content + topPadding,
+                bottom = bottomPadding
             )
     ) {
         MonthSelector(


### PR DESCRIPTION
## Problem
Fixes #569. Tapping `<` to view a previous month with no budget snapshot showed the onboarding **"Set Up Your Budget"** empty state — which has **no month navigator**. The user was trapped with no way back to the current month, so past-month budgets looked "unavailable."

## Root cause
Past months load their groups from month-end snapshots (`snapshotDao.getGroupSnapshots`). A month that was never snapshotted (e.g. budgets were set up this month) returns no groups → `hasGroups = false` → the whole screen is replaced by `EmptyBudgetState`, whose `MonthSelector` only lives inside `BudgetGroupsContent`.

## Fix
Split the empty branch by whether the selected month is the current month:
- **Current month, no budgets** → unchanged onboarding CTA (Smart Defaults / Create Custom).
- **Past month, no history** → new `EmptyPastMonthState` that keeps the month navigator on screen plus a "No budgets tracked this month" message, so the user can always step back.

## Verification
- `./init.sh app` ✅ (CI parity)
- On-device (emulator): created budgets for the current month → tapped `<` to June (no snapshot) → month navigator stays visible with the new message → tapped `>` → returned to July with budgets intact. Current-month onboarding state confirmed unchanged.

| Before | After |
|---|---|
| Past month → full-screen setup CTA, no way back | Past month → month nav + "No budgets tracked this month" |