### PR TITLE
fix(parser): extract account/card last-4 digits for NSB & NTB (Sri Lanka)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NationalSavingsBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NationalSavingsBankParser.kt
@@ -90,7 +90,7 @@ class NationalSavingsBankParser : BankParser() {
 
     override fun extractAccountLast4(message: String): String? {
         // "A/c XXXXXXXX6146 on ..." — last 4 digits after the X-masked prefix.
-        val pattern = Regex("""A/c\s+X+(\d{4})""", RegexOption.IGNORE_CASE)
+        val pattern = Regex("""A/c\s+X+(\d{4})(?!\d)""", RegexOption.IGNORE_CASE)
         return pattern.find(message)?.groupValues?.get(1)
     }
 }

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NationalSavingsBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NationalSavingsBankParser.kt
@@ -10,16 +10,18 @@ import java.math.BigDecimal
  *
  * Supported formats:
  * - Credit (INCOME):
- *   "Dear MR <NAME>,LKR 10,000.00 Credited to your A/c XXXXXXXXXXXX on DD/MM/YYYY at HH:mm.
+ *   "Dear MR <NAME>,LKR 10,000.00 Credited to your A/c XXXXXXXX1234 on DD/MM/YYYY at HH:mm.
  *    AvlBal LKR 12,653.61.Transaction CEFT Inward Transfer Deposit.Thank you for banking with us.Call Centre 1972."
  * - POS debit (EXPENSE):
- *   "Dear MR <NAME>,LKR 3,216.00 Debited from your A/c XXXXXXXXXXXX on DD/MM/YYYY at HH:mm.
+ *   "Dear MR <NAME>,LKR 3,216.00 Debited from your A/c XXXXXXXX1234 on DD/MM/YYYY at HH:mm.
  *    AvlBal LKR 9,437.61. @ Wetara Pharamcy & Groc Polgasowita. ATM POS Transaction.Thank you for banking with us.Call Centre 1972."
  * - ATM / Internet-Mobile withdrawal (EXPENSE):
- *   "Dear MR <NAME>,LKR 2,800.00 Debited from your A/c XXXXXXXXXXXX on DD/MM/YYYY at HH:mm.
+ *   "Dear MR <NAME>,LKR 2,800.00 Debited from your A/c XXXXXXXX1234 on DD/MM/YYYY at HH:mm.
  *    AvlBal LKR 24,037.61.Internet-Mobile Withdrawal.Thank you for banking with us.Call Centre 1972."
  *
- * The account number is fully masked ("XXXXXXXXXXXX") so no last 4 digits are available.
+ * The account number is masked with X's but exposes the last 4 digits ("XXXXXXXX1234");
+ * the last 4 are extracted. (Digits and names shown here are synthetic — real account
+ * numbers and customer names are PII and must never be committed.)
  */
 class NationalSavingsBankParser : BankParser() {
 
@@ -86,6 +88,9 @@ class NationalSavingsBankParser : BankParser() {
         return null
     }
 
-    // Account number is fully masked; no usable last 4 digits.
-    override fun extractAccountLast4(message: String): String? = null
+    override fun extractAccountLast4(message: String): String? {
+        // "A/c XXXXXXXX6146 on ..." — last 4 digits after the X-masked prefix.
+        val pattern = Regex("""A/c\s+X+(\d{4})""", RegexOption.IGNORE_CASE)
+        return pattern.find(message)?.groupValues?.get(1)
+    }
 }

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NationsTrustBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NationsTrustBankParser.kt
@@ -10,17 +10,17 @@ import java.math.BigDecimal
  *
  * Supported formats:
  * - Credit-card purchase (CREDIT):
- *   "Transaction Approved on your Card **************** for LKR 500.00 at BILL PAYMENT VIA NATIONS
+ *   "Transaction Approved on your Card 123456******1234 for LKR 500.00 at BILL PAYMENT VIA NATIONS
  *    Available Bal LKR 12345.73  Call 0114315315 for any inquiry."
  *
  * Not treated as a transaction:
- * - Credit-card bill settlement ("...payment of LKR 57,018.67 made to Card # **************** on ..."):
+ * - Credit-card bill settlement ("...payment of LKR 57,018.67 made to Card # 123456*****1234 on ..."):
  *   money paid TO the card to reduce the outstanding balance. There is no clean transaction
  *   type for it and it must not be misclassified as a spend, so we skip it — consistent with
  *   how ICICIBankParser skips credit-card bill payments.
  *
- * The card number is fully masked ("****************") so no usable last 4 digits are available;
- * accountLast4 is always null.
+ * Cards expose the last 4 digits with a masked middle ("123456******1234"); the last 4 are
+ * extracted. (Digits shown here are synthetic — real card numbers are PII, never committed.)
  */
 class NationsTrustBankParser : BankParser() {
 
@@ -78,6 +78,9 @@ class NationsTrustBankParser : BankParser() {
         return null
     }
 
-    // Card number is fully masked; no usable last 4 digits.
-    override fun extractAccountLast4(message: String): String? = null
+    override fun extractAccountLast4(message: String): String? {
+        // "Card 123456******1234 for LKR ..." — last 4 digits after the masked middle.
+        val pattern = Regex("""Card\s+\d{4,6}\*+(\d{4})""", RegexOption.IGNORE_CASE)
+        return pattern.find(message)?.groupValues?.get(1)
+    }
 }

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NationsTrustBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/NationsTrustBankParser.kt
@@ -80,7 +80,7 @@ class NationsTrustBankParser : BankParser() {
 
     override fun extractAccountLast4(message: String): String? {
         // "Card 123456******1234 for LKR ..." — last 4 digits after the masked middle.
-        val pattern = Regex("""Card\s+\d{4,6}\*+(\d{4})""", RegexOption.IGNORE_CASE)
+        val pattern = Regex("""Card\s+\d+\*+(\d{4})(?!\d)""", RegexOption.IGNORE_CASE)
         return pattern.find(message)?.groupValues?.get(1)
     }
 }

--- a/parser-core/src/test/kotlin/TestNationalSavingsBankParser.kt
+++ b/parser-core/src/test/kotlin/TestNationalSavingsBankParser.kt
@@ -12,40 +12,46 @@ class NationalSavingsBankParserTest {
     fun `national savings bank parser handles credit debit and withdrawals`(): List<DynamicTest> {
         val parser = NationalSavingsBankParser()
 
+        // Names and account digits below are synthetic (masked name, X-prefix + dummy last-4)
+        // — real customer names and account numbers are PII and must never be committed.
+        // Format matches real NSB SMS (X-masked account exposing the last 4 digits).
         val testCases = listOf(
             ParserTestCase(
                 name = "CEFT inward credit",
-                message = "Dear MR MASKED NAME,LKR 10,000.00 Credited to your A/c XXXXXXXXXXXX on DD/MM/YYYY at HH:mm.AvlBal LKR 12,653.61.Transaction CEFT Inward Transfer Deposit.Thank you for banking with us.Call Centre 1972.",
+                message = "Dear MR MASKED NAME,LKR 10,000.00 Credited to your A/c XXXXXXXX1234 on DD/MM/YYYY at HH:mm.AvlBal LKR 12,653.61.Transaction CEFT Inward Transfer Deposit.Thank you for banking with us.Call Centre 1972.",
                 sender = "NSB",
                 expected = ExpectedTransaction(
                     amount = BigDecimal("10000.00"),
                     currency = "LKR",
                     type = TransactionType.INCOME,
                     merchant = "CEFT Inward Transfer Deposit",
+                    accountLast4 = "1234",
                     balance = BigDecimal("12653.61")
                 )
             ),
             ParserTestCase(
                 name = "POS debit",
-                message = "Dear MR MASKED NAME,LKR 3,216.00 Debited from your A/c XXXXXXXXXXXX on DD/MM/YYYY at HH:mm.AvlBal LKR 9,437.61. @ Wetara Pharamcy & Groc Polgasowita. ATM POS Transaction.Thank you for banking with us.Call Centre 1972.",
+                message = "Dear MR MASKED NAME,LKR 3,216.00 Debited from your A/c XXXXXXXX5678 on DD/MM/YYYY at HH:mm.AvlBal LKR 9,437.61. @ Wetara Pharamcy & Groc Polgasowita. ATM POS Transaction.Thank you for banking with us.Call Centre 1972.",
                 sender = "NSB",
                 expected = ExpectedTransaction(
                     amount = BigDecimal("3216.00"),
                     currency = "LKR",
                     type = TransactionType.EXPENSE,
                     merchant = "Wetara Pharamcy & Groc Polgasowita",
+                    accountLast4 = "5678",
                     balance = BigDecimal("9437.61")
                 )
             ),
             ParserTestCase(
                 name = "Internet-Mobile withdrawal",
-                message = "Dear MR MASKED NAME,LKR 2,800.00 Debited from your A/c XXXXXXXXXXXX on DD/MM/YYYY at HH:mm.AvlBal LKR 24,037.61.Internet-Mobile Withdrawal.Thank you for banking with us.Call Centre 1972.",
+                message = "Dear MR MASKED NAME,LKR 2,800.00 Debited from your A/c XXXXXXXX9012 on DD/MM/YYYY at HH:mm.AvlBal LKR 24,037.61.Internet-Mobile Withdrawal.Thank you for banking with us.Call Centre 1972.",
                 sender = "NSB",
                 expected = ExpectedTransaction(
                     amount = BigDecimal("2800.00"),
                     currency = "LKR",
                     type = TransactionType.EXPENSE,
                     merchant = "Internet-Mobile Withdrawal",
+                    accountLast4 = "9012",
                     balance = BigDecimal("24037.61")
                 )
             )

--- a/parser-core/src/test/kotlin/TestNationsTrustBankParser.kt
+++ b/parser-core/src/test/kotlin/TestNationsTrustBankParser.kt
@@ -13,33 +13,37 @@ class NationsTrustBankParserTest {
         val parser = NationsTrustBankParser()
 
         val testCases = listOf(
+            // Card numbers below are synthetic (fake BIN 123456, dummy last-4) — real card
+            // numbers are PII and must never be committed. Format matches real NTB SMS.
             ParserTestCase(
                 name = "Card purchase - bill payment",
-                message = "Transaction Approved on your Card **************** for LKR 500.00 at BILL PAYMENT VIA NATIONS Available Bal LKR 12345.73  Call 0114315315 for any inquiry.",
+                message = "Transaction Approved on your Card 123456******1234 for LKR 500.00 at BILL PAYMENT VIA NATIONS Available Bal LKR 12345.73  Call 0114315315 for any inquiry.",
                 sender = "NationsSMS",
                 expected = ExpectedTransaction(
                     amount = BigDecimal("500.00"),
                     currency = "LKR",
                     type = TransactionType.CREDIT,
                     merchant = "BILL PAYMENT VIA NATIONS",
+                    accountLast4 = "1234",
                     balance = BigDecimal("12345.73")
                 )
             ),
             ParserTestCase(
                 name = "Card purchase - ride",
-                message = "Transaction Approved on your Card **************** for LKR 771.51 at PICKME RIDE Available Bal LKR 16730.45  Call 0114315315 for any inquiry.",
+                message = "Transaction Approved on your Card 123456******5678 for LKR 771.51 at PICKME RIDE Available Bal LKR 16730.45  Call 0114315315 for any inquiry.",
                 sender = "NationsSMS",
                 expected = ExpectedTransaction(
                     amount = BigDecimal("771.51"),
                     currency = "LKR",
                     type = TransactionType.CREDIT,
                     merchant = "PICKME RIDE",
+                    accountLast4 = "5678",
                     balance = BigDecimal("16730.45")
                 )
             ),
             ParserTestCase(
                 name = "Card bill settlement is skipped (not a spend)",
-                message = "Thank you for your payment of LKR 57,018.67 made to Card # **************** on 27-06-2026.",
+                message = "Thank you for your payment of LKR 57,018.67 made to Card # 123456*****1234 on 27-06-2026.",
                 sender = "NationsSMS",
                 shouldParse = false
             )


### PR DESCRIPTION
## Summary

My earlier parsers for these two Sri Lankan banks hand-masked the account/card number and returned `accountLast4 = null`. That was wrong - the real SMS expose the last 4 digits. This corrects both parsers, plus docs and tests (real format, synthetic digits - no PII).

- National Savings Bank: `A/c XXXXXXXX1234` → last 4 (Refs #573)
- Nations Trust Bank: `Card 123456******1234` → last 4 (Refs #574)

## Type of change

- [x] fix: Bug fix
- [x] test: Add/update tests

## How to test
1. Run `./init.sh parser` (or `./gradlew :parser-core:test`).
2. Confirm `NationsTrustBankParserTest` and `NationalSavingsBankParserTest` pass - each now asserts `accountLast4` from the masked-with-last-4 formats (`Card 123456******1234`, `A/c XXXXXXXX1234`).
3. Optional: feed a real NTB/NSB SMS through the app and verify the transaction shows the correct last-4 account.

## Breaking changes

- [x] No breaking changes

## Related issues

Addresses a gap in #573 and #574 issues.

## Checklist

- [x] Focused PR (single purpose)
- [x] Tests added/updated (if applicable)
- [x] Follows existing code style and patterns


