### PR TITLE
fix(analytics): render categories in their assigned color, not gray (#586)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/CategoryBreakdownCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/CategoryBreakdownCard.kt
@@ -78,10 +78,8 @@ private fun CategoryBar(
         label = "category_bar_${category.name}"
     )
 
-    // Get category-specific color
-    val categoryInfo = CategoryMapping.categories[category.name]
-        ?: CategoryMapping.categories["Others"]!!
-    val categoryColor = categoryInfo.color
+    // Category color: user's assigned color, else built-in palette, else gray (#586)
+    val categoryColor = CategoryMapping.colorFor(category.name, category.color)
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/pennywiseai/tracker/ui/icons/CategoryMapping.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/icons/CategoryMapping.kt
@@ -56,6 +56,19 @@ object CategoryMapping {
         val fallbackIcon: ImageVector = Icons.Default.Category
     )
 
+    /**
+     * Resolves the display color for a category. Prefers the user's assigned color
+     * ([overrideHex], e.g. "#4CAF50" from CategoryEntity), then the built-in palette,
+     * then gray — so user-created categories no longer render gray in Analytics (#586).
+     */
+    fun colorFor(name: String, overrideHex: String? = null): Color {
+        if (!overrideHex.isNullOrBlank()) {
+            runCatching { Color(android.graphics.Color.parseColor(overrideHex)) }
+                .getOrNull()?.let { return it }
+        }
+        return categories[name]?.color ?: Color.Gray
+    }
+
     val categories = mapOf(
         "Food & Dining" to CategoryInfo(
             displayName = "Food & Dining",

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -8,6 +8,7 @@ import com.pennywiseai.tracker.data.database.entity.ProfileEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionWithSplits
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
+import com.pennywiseai.tracker.data.repository.CategoryRepository
 import com.pennywiseai.tracker.data.repository.ProfileRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -41,8 +42,15 @@ class AnalyticsViewModel @Inject constructor(
     private val currencyConversionService: CurrencyConversionService,
     private val accountBalanceRepository: AccountBalanceRepository,
     private val profileRepository: ProfileRepository,
+    private val categoryRepository: CategoryRepository,
     private val savedStateHandle: androidx.lifecycle.SavedStateHandle
 ) : ViewModel() {
+
+    // name -> hex color for the user's categories (incl. recolored built-ins), so
+    // Analytics renders each category in its assigned color instead of gray (#586).
+    private val categoryColors: Flow<Map<String, String>> =
+        categoryRepository.getAllCategories()
+            .map { cats -> cats.associate { it.name to it.color } }
 
     // Profile filter — reuses the global Home profile selection so the two stay in sync.
     val selectedProfileId: StateFlow<Long?> = userPreferencesRepository.selectedProfileId
@@ -155,7 +163,9 @@ class AnalyticsViewModel @Inject constructor(
         )
     }.combine(accountBalanceRepository.getAllLatestBalances()) { fs, balances ->
         fs to balances
-    }.flatMapLatest { (filterState, balances) ->
+    }.combine(categoryColors) { (fs, balances), colors ->
+        Triple(fs, balances, colors)
+    }.flatMapLatest { (filterState, balances, categoryColorMap) ->
         // Determine date range based on selected period. THIS_MONTH is special:
         // it follows the user's custom budget cycle (e.g. 25th → 24th) instead
         // of the calendar month, so the analytics range lines up with the
@@ -367,7 +377,8 @@ class AnalyticsViewModel @Inject constructor(
                         percentage = if (totalSpending > BigDecimal.ZERO) {
                             (categoryTotal.divide(totalSpending, 4, java.math.RoundingMode.HALF_UP) * BigDecimal(100)).toFloat().coerceAtMost(100f)
                         } else 0f,
-                        transactionCount = categoryTransactionCounts[categoryName] ?: 0
+                        transactionCount = categoryTransactionCounts[categoryName] ?: 0,
+                        color = categoryColorMap[categoryName]
                     )
                 }.sortedByDescending { it.amount }
 
@@ -689,7 +700,10 @@ data class CategoryData(
     val name: String,
     val amount: BigDecimal,
     val percentage: Float,
-    val transactionCount: Int
+    val transactionCount: Int,
+    // Hex color (e.g. "#4CAF50") of the user's category, when known. Null falls
+    // back to the built-in CategoryMapping palette, then gray (#586).
+    val color: String? = null
 )
 
 data class MerchantData(

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/CategoryPieChart.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/CategoryPieChart.kt
@@ -48,9 +48,9 @@ fun CategoryPieChart(
             Pie(
                 label = category.name,
                 data = category.amount.toDouble(),
-                color = CategoryMapping.categories[category.name]?.color ?: Color.Gray,
-                selectedColor = (CategoryMapping.categories[category.name]?.color
-                    ?: Color.Gray).copy(alpha = 0.8f),
+                color = CategoryMapping.colorFor(category.name, category.color),
+                selectedColor = CategoryMapping.colorFor(category.name, category.color)
+                    .copy(alpha = 0.8f),
                 selected = false,
                 scaleAnimEnterSpec = tween(400),
                 colorAnimEnterSpec = tween(500)

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/CategoryPieChart.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/CategoryPieChart.kt
@@ -45,12 +45,12 @@ fun CategoryPieChart(
 
     val pieData = remember(categories) {
         categories.map { category ->
+            val sliceColor = CategoryMapping.colorFor(category.name, category.color)
             Pie(
                 label = category.name,
                 data = category.amount.toDouble(),
-                color = CategoryMapping.colorFor(category.name, category.color),
-                selectedColor = CategoryMapping.colorFor(category.name, category.color)
-                    .copy(alpha = 0.8f),
+                color = sliceColor,
+                selectedColor = sliceColor.copy(alpha = 0.8f),
                 selected = false,
                 scaleAnimEnterSpec = tween(400),
                 colorAnimEnterSpec = tween(500)


### PR DESCRIPTION
## Problem

Fixes #586. On the Analytics page, user-created categories (and any built-in category the user recolored) rendered **gray** in both the category pie chart and the "Spending by Category" breakdown. The color was resolved only from the static `CategoryMapping` palette keyed by name, so anything not in that hard-coded map fell through to `Color.Gray`.

## Fix

- **`AnalyticsViewModel`** now folds each category's stored hex color (`CategoryEntity.color`) into `CategoryData.color` via a small `categoryColors` flow combined into the existing filter pipeline.
- **`CategoryMapping.colorFor(name, overrideHex)`** — new helper that prefers the user's assigned hex color, then the built-in palette, then gray. Parses defensively (`runCatching`) so a malformed hex can't crash rendering.
- **`CategoryPieChart`** and **`CategoryBreakdownCard`** resolve their color through the helper.

## Verification

- `./init.sh app` green (CI parity).
- On-device (emulator): created a custom category **ZTest586** with a magenta color and assigned it to a transaction. Before this change it would render gray; after, the pie chart, the pie legend, and the breakdown bar all render magenta. Reverted the test data afterward.