### PR TITLE
feat(subscriptions): assign a funding account so mark-as-paid moves its balance (#570)

### DIFF
--- a/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/57.json
+++ b/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/57.json
@@ -1,0 +1,1815 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 57,
+    "identityHash": "ea1e750d537f3280049a03c28c80ec69",
+    "entities": [
+      {
+        "tableName": "transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` TEXT NOT NULL, `merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `transaction_type` TEXT NOT NULL, `date_time` TEXT NOT NULL, `description` TEXT, `sms_body` TEXT, `bank_name` TEXT, `sms_sender` TEXT, `account_number` TEXT, `balance_after` TEXT, `transaction_hash` TEXT NOT NULL DEFAULT '', `is_recurring` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `excluded_from_analytics` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `from_account` TEXT, `to_account` TEXT, `reference` TEXT, `loan_id` INTEGER DEFAULT NULL, `loan_contribution` TEXT DEFAULT NULL, `receipt_path` TEXT DEFAULT NULL, `budget_category` TEXT DEFAULT NULL, `budget_impact_type` TEXT DEFAULT NULL, `group_id` INTEGER DEFAULT NULL, `profile_id` INTEGER DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionType",
+            "columnName": "transaction_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateTime",
+            "columnName": "date_time",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsSender",
+            "columnName": "sms_sender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountNumber",
+            "columnName": "account_number",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "balanceAfter",
+            "columnName": "balance_after",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "transactionHash",
+            "columnName": "transaction_hash",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isRecurring",
+            "columnName": "is_recurring",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "excludedFromAnalytics",
+            "columnName": "excluded_from_analytics",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "fromAccount",
+            "columnName": "from_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toAccount",
+            "columnName": "to_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "loanId",
+            "columnName": "loan_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "loanContribution",
+            "columnName": "loan_contribution",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "receiptPath",
+            "columnName": "receipt_path",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetCategory",
+            "columnName": "budget_category",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetImpactType",
+            "columnName": "budget_impact_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "group_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transactions_transaction_hash",
+            "unique": true,
+            "columnNames": [
+              "transaction_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_transactions_transaction_hash` ON `${TABLE_NAME}` (`transaction_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `merchant_name` TEXT NOT NULL, `amount` TEXT NOT NULL, `next_payment_date` TEXT, `state` TEXT NOT NULL, `bank_name` TEXT, `account_last4` TEXT, `umn` TEXT, `category` TEXT, `sms_body` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `direction` TEXT NOT NULL DEFAULT 'EXPENSE', `billing_cycle` TEXT NOT NULL DEFAULT 'Monthly', `last_paid_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextPaymentDate",
+            "columnName": "next_payment_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umn",
+            "columnName": "umn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'EXPENSE'"
+          },
+          {
+            "fieldPath": "billingCycle",
+            "columnName": "billing_cycle",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Monthly'"
+          },
+          {
+            "fieldPath": "lastPaidAt",
+            "columnName": "last_paid_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `message` TEXT NOT NULL, `isUser` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `isSystemPrompt` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUser",
+            "columnName": "isUser",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemPrompt",
+            "columnName": "isSystemPrompt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "merchant_mappings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`merchant_name`))",
+        "fields": [
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "merchant_name"
+          ]
+        }
+      },
+      {
+        "tableName": "merchant_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`merchant_name` TEXT NOT NULL, `alias` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`merchant_name`))",
+        "fields": [
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "merchant_name"
+          ]
+        }
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `color` TEXT NOT NULL, `is_system` INTEGER NOT NULL, `is_income` INTEGER NOT NULL, `display_order` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIncome",
+            "columnName": "is_income",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_categories_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_categories_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "account_balances",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT NOT NULL, `balance` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `transaction_id` INTEGER, `credit_limit` TEXT, `is_credit_card` INTEGER NOT NULL DEFAULT 0, `sms_source` TEXT, `source_type` TEXT, `account_type` TEXT, `created_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `statement_day` INTEGER DEFAULT NULL, `profile_id` INTEGER NOT NULL DEFAULT 1, `alias` TEXT, `lowBalanceThreshold` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "creditLimit",
+            "columnName": "credit_limit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isCreditCard",
+            "columnName": "is_credit_card",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "smsSource",
+            "columnName": "sms_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "source_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountType",
+            "columnName": "account_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "statementDay",
+            "columnName": "statement_day",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lowBalanceThreshold",
+            "columnName": "lowBalanceThreshold",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_account_balances_bank_name_account_last4_timestamp",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "account_last4",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4_timestamp` ON `${TABLE_NAME}` (`bank_name`, `account_last4`, `timestamp`)"
+          },
+          {
+            "name": "index_account_balances_bank_name_account_last4",
+            "unique": false,
+            "columnNames": [
+              "bank_name",
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4` ON `${TABLE_NAME}` (`bank_name`, `account_last4`)"
+          },
+          {
+            "name": "index_account_balances_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "unrecognized_sms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sender` TEXT NOT NULL, `sms_body` TEXT NOT NULL, `received_at` TEXT NOT NULL, `reported` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receivedAt",
+            "columnName": "received_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reported",
+            "columnName": "reported",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_unrecognized_sms_sender_sms_body",
+            "unique": true,
+            "columnNames": [
+              "sender",
+              "sms_body"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_unrecognized_sms_sender_sms_body` ON `${TABLE_NAME}` (`sender`, `sms_body`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `card_last4` TEXT NOT NULL, `card_type` TEXT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT, `nickname` TEXT, `is_active` INTEGER NOT NULL DEFAULT 1, `last_balance` TEXT, `last_balance_source` TEXT, `last_balance_date` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardLast4",
+            "columnName": "card_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardType",
+            "columnName": "card_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastBalance",
+            "columnName": "last_balance",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceSource",
+            "columnName": "last_balance_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceDate",
+            "columnName": "last_balance_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cards_bank_name_card_last4",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cards_bank_name_card_last4` ON `${TABLE_NAME}` (`bank_name`, `card_last4`)"
+          },
+          {
+            "name": "index_cards_card_last4",
+            "unique": false,
+            "columnNames": [
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_card_last4` ON `${TABLE_NAME}` (`card_last4`)"
+          },
+          {
+            "name": "index_cards_account_last4",
+            "unique": false,
+            "columnNames": [
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_account_last4` ON `${TABLE_NAME}` (`account_last4`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `conditions` TEXT NOT NULL, `actions` TEXT NOT NULL, `is_active` INTEGER NOT NULL, `is_system_template` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conditions",
+            "columnName": "conditions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actions",
+            "columnName": "actions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemTemplate",
+            "columnName": "is_system_template",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_rules_priority_is_active",
+            "unique": false,
+            "columnNames": [
+              "priority",
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_priority_is_active` ON `${TABLE_NAME}` (`priority`, `is_active`)"
+          },
+          {
+            "name": "index_transaction_rules_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "rule_applications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `rule_id` TEXT NOT NULL, `rule_name` TEXT NOT NULL, `transaction_id` TEXT NOT NULL, `fields_modified` TEXT NOT NULL, `applied_at` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`rule_id`) REFERENCES `transaction_rules`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "rule_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleName",
+            "columnName": "rule_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fieldsModified",
+            "columnName": "fields_modified",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedAt",
+            "columnName": "applied_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rule_applications_rule_id",
+            "unique": false,
+            "columnNames": [
+              "rule_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_rule_id` ON `${TABLE_NAME}` (`rule_id`)"
+          },
+          {
+            "name": "index_rule_applications_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          },
+          {
+            "name": "index_rule_applications_applied_at",
+            "unique": false,
+            "columnNames": [
+              "applied_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_applied_at` ON `${TABLE_NAME}` (`applied_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transaction_rules",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "rule_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "exchange_rates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `from_currency` TEXT NOT NULL, `to_currency` TEXT NOT NULL, `rate` TEXT NOT NULL, `provider` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `updated_at_unix` INTEGER NOT NULL DEFAULT 0, `expires_at` TEXT NOT NULL, `expires_at_unix` INTEGER NOT NULL DEFAULT 0, `is_custom_rate` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCurrency",
+            "columnName": "from_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCurrency",
+            "columnName": "to_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtUnix",
+            "columnName": "updated_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expires_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAtUnix",
+            "columnName": "expires_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isCustomRate",
+            "columnName": "is_custom_rate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_exchange_rates_from_currency_to_currency",
+            "unique": true,
+            "columnNames": [
+              "from_currency",
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_exchange_rates_from_currency_to_currency` ON `${TABLE_NAME}` (`from_currency`, `to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_from_currency",
+            "unique": false,
+            "columnNames": [
+              "from_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_from_currency` ON `${TABLE_NAME}` (`from_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_to_currency",
+            "unique": false,
+            "columnNames": [
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_to_currency` ON `${TABLE_NAME}` (`to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          },
+          {
+            "name": "index_exchange_rates_expires_at_unix",
+            "unique": false,
+            "columnNames": [
+              "expires_at_unix"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_expires_at_unix` ON `${TABLE_NAME}` (`expires_at_unix`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `period_type` TEXT NOT NULL, `start_date` TEXT NOT NULL, `end_date` TEXT NOT NULL, `weekday_anchor` INTEGER, `month_anchor` INTEGER, `currency` TEXT NOT NULL DEFAULT 'INR', `is_active` INTEGER NOT NULL DEFAULT 1, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "periodType",
+            "columnName": "period_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weekStartDay",
+            "columnName": "weekday_anchor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "monthStartDay",
+            "columnName": "month_anchor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budgets_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_budgets_is_active",
+            "unique": false,
+            "columnNames": [
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_is_active` ON `${TABLE_NAME}` (`is_active`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budget_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL DEFAULT '0', `match_type` TEXT DEFAULT NULL, FOREIGN KEY(`budget_id`) REFERENCES `budgets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          },
+          {
+            "fieldPath": "matchType",
+            "columnName": "match_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budget_categories_budget_id",
+            "unique": false,
+            "columnNames": [
+              "budget_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budget_categories_budget_id` ON `${TABLE_NAME}` (`budget_id`)"
+          },
+          {
+            "name": "index_budget_categories_budget_id_category_name",
+            "unique": true,
+            "columnNames": [
+              "budget_id",
+              "category_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_budget_categories_budget_id_category_name` ON `${TABLE_NAME}` (`budget_id`, `category_name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "budgets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "budget_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "budget_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `budget_name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetName",
+            "columnName": "budget_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "budget_category_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL, `match_type` TEXT DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchType",
+            "columnName": "match_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "transaction_splits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `transaction_id` INTEGER NOT NULL, `category` TEXT NOT NULL, `amount` TEXT NOT NULL, `created_at` TEXT NOT NULL, FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_splits_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_splits_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bank_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `package_name` TEXT NOT NULL, `sender_alias` TEXT NOT NULL, `message_body` TEXT NOT NULL, `message_hash` TEXT NOT NULL, `posted_at` TEXT NOT NULL, `processed` INTEGER NOT NULL, `transaction_id` INTEGER, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderAlias",
+            "columnName": "sender_alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageBody",
+            "columnName": "message_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageHash",
+            "columnName": "message_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postedAt",
+            "columnName": "posted_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "processed",
+            "columnName": "processed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bank_notifications_package_name_message_hash",
+            "unique": true,
+            "columnNames": [
+              "package_name",
+              "message_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_bank_notifications_package_name_message_hash` ON `${TABLE_NAME}` (`package_name`, `message_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "loans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `person_name` TEXT NOT NULL, `direction` TEXT NOT NULL, `original_amount` TEXT NOT NULL, `remaining_amount` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `status` TEXT NOT NULL DEFAULT 'ACTIVE', `note` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `settled_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personName",
+            "columnName": "person_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalAmount",
+            "columnName": "original_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remainingAmount",
+            "columnName": "remaining_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'ACTIVE'"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settledAt",
+            "columnName": "settled_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_loans_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_loans_person_name",
+            "unique": false,
+            "columnNames": [
+              "person_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_person_name` ON `${TABLE_NAME}` (`person_name`)"
+          },
+          {
+            "name": "index_loans_created_at",
+            "unique": false,
+            "columnNames": [
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_created_at` ON `${TABLE_NAME}` (`created_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `note` TEXT DEFAULT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_groups_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_groups_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `color_hex` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorHex",
+            "columnName": "color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ea1e750d537f3280049a03c28c80ec69')"
+    ]
+  }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
@@ -59,7 +59,7 @@ import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
  * that needs to record the version it was exported against. Bump this in lock-
  * step with any schema change.
  */
-const val SCHEMA_VERSION = 56
+const val SCHEMA_VERSION = 57
 
 /**
  * The PennyWise Room database.
@@ -121,7 +121,10 @@ const val SCHEMA_VERSION = 56
         // 47→55 are manual migrations registered in DatabaseModule.
         // 55→56 adds the merchant_aliases table — a pure additive change, so
         // Room generates the CREATE TABLE automatically.
-        AutoMigration(from = 55, to = 56)
+        AutoMigration(from = 55, to = 56),
+        // 56→57 adds a nullable account_last4 column to subscriptions — a pure
+        // additive change, so Room generates the ALTER TABLE automatically (#570).
+        AutoMigration(from = 56, to = 57)
     ]
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/SubscriptionEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/SubscriptionEntity.kt
@@ -32,7 +32,16 @@ data class SubscriptionEntity(
     
     @ColumnInfo(name = "bank_name")
     val bankName: String? = null,
-    
+
+    /**
+     * Last 4 digits of the specific account this subscription is paid from.
+     * Accounts are keyed by (bank_name + account_last4), so this pairs with
+     * [bankName] to identify the exact funding account (#570). Null when the
+     * source account isn't known (older rows, or SMS without an account tail).
+     */
+    @ColumnInfo(name = "account_last4")
+    val accountLast4: String? = null,
+
     @ColumnInfo(name = "umn")
     val umn: String? = null, // Unique Mandate Number for E-Mandates
     

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
@@ -241,6 +241,52 @@ class AccountBalanceRepository @Inject constructor(
         }
     }
 
+    /**
+     * Reflects a newly-inserted transaction ([transactionId], dated [date]) on
+     * its account's running balance. Manual/cash accounts are recomputed from
+     * their transactions (so back-dated or later-edited rows stay correct); an
+     * SMS-tracked account gets a signed "TRANSACTION" delta snapshot off its
+     * latest row. No-op when the account has no balance row yet (an SMS account
+     * we've never seen a balance for) — there's no anchor to move.
+     *
+     * The transaction MUST already be persisted before calling this. Callers
+     * that support manual accounts must also call [ensureManualOpening] BEFORE
+     * inserting the transaction, so the opening anchor is derived from the
+     * pre-insert balance. Shared by manual add (AddTransactionUseCase),
+     * subscription mark-as-paid and income-autopay (#570) so all three obey one
+     * balance rule.
+     */
+    suspend fun applyTransactionToBalance(
+        bankName: String,
+        accountLast4: String,
+        amount: BigDecimal,
+        type: TransactionType,
+        date: LocalDateTime,
+        transactionId: Long
+    ) {
+        if (isManualAccount(bankName, accountLast4)) {
+            recomputeManualBalance(bankName, accountLast4)
+            return
+        }
+        val currentAccount = getLatestBalance(bankName, accountLast4) ?: return
+        val newBalance = when (type) {
+            TransactionType.INCOME -> currentAccount.balance + amount
+            TransactionType.EXPENSE, TransactionType.CREDIT -> currentAccount.balance - amount
+            TransactionType.TRANSFER -> currentAccount.balance - amount
+            TransactionType.INVESTMENT -> currentAccount.balance - amount
+        }
+        insertBalance(
+            currentAccount.copy(
+                id = 0,
+                balance = newBalance,
+                timestamp = date,
+                transactionId = transactionId,
+                sourceType = "TRANSACTION",
+                smsSource = null
+            )
+        )
+    }
+
     private suspend fun insertBalanceDeltaByLast4(
         accountLast4: String,
         delta: BigDecimal,

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
@@ -287,6 +287,37 @@ class AccountBalanceRepository @Inject constructor(
         )
     }
 
+    /**
+     * Atomically insert [transaction] and reflect it on its account's balance,
+     * so a crash can't leave the transaction persisted (its dedup hash then
+     * blocking any retry) while the balance was never moved — a gap that would
+     * permanently short a hash-guarded autopay/mark-paid cycle. Wraps the
+     * opening-anchor pin, the insert, and [applyTransactionToBalance] in one
+     * Room transaction. Returns the new row id (-1 on a dedup-conflict insert).
+     * Pass a null account to insert with no balance side effect.
+     */
+    suspend fun insertTransactionWithBalance(
+        transaction: TransactionEntity,
+        bankName: String?,
+        accountLast4: String?
+    ): Long = database.withTransaction {
+        if (bankName != null && accountLast4 != null) {
+            ensureManualOpening(bankName, accountLast4)
+        }
+        val rowId = transactionDao.insertTransaction(transaction)
+        if (rowId != -1L && bankName != null && accountLast4 != null) {
+            applyTransactionToBalance(
+                bankName = bankName,
+                accountLast4 = accountLast4,
+                amount = transaction.amount,
+                type = transaction.transactionType,
+                date = transaction.dateTime,
+                transactionId = rowId
+            )
+        }
+        rowId
+    }
+
     private suspend fun insertBalanceDeltaByLast4(
         accountLast4: String,
         delta: BigDecimal,

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/SubscriptionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/SubscriptionRepository.kt
@@ -268,6 +268,9 @@ class SubscriptionRepository @Inject constructor(
                 nextPaymentDate = nextPaymentDate,
                 merchantName = mandateInfo.merchant,
                 umn = mandateInfo.umn ?: existing.umn, // Update UMN if provided
+                // Capture the debiting account from the mandate SMS when present,
+                // but never clobber an account the user assigned manually (#570).
+                accountLast4 = mandateInfo.accountLast4 ?: existing.accountLast4,
                 state = if (shouldReactivate) SubscriptionState.ACTIVE else existing.state,
                 smsBody = smsBody ?: existing.smsBody, // Update SMS body if provided
                 updatedAt = java.time.LocalDateTime.now()
@@ -282,6 +285,7 @@ class SubscriptionRepository @Inject constructor(
                 nextPaymentDate = nextPaymentDate,
                 state = SubscriptionState.ACTIVE,
                 bankName = bankName,
+                accountLast4 = mandateInfo.accountLast4,
                 umn = mandateInfo.umn,
                 category = determineCategory(mandateInfo.merchant),
                 smsBody = smsBody

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddSubscriptionUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddSubscriptionUseCase.kt
@@ -23,7 +23,9 @@ class AddSubscriptionUseCase @Inject constructor(
         paymentReminder: Boolean = true,
         notes: String? = null,
         currency: String = "INR",
-        direction: SubscriptionDirection = SubscriptionDirection.EXPENSE
+        direction: SubscriptionDirection = SubscriptionDirection.EXPENSE,
+        bankName: String? = null,
+        accountLast4: String? = null
     ): Long {
         Log.d("AddSubscriptionUseCase", "Creating subscription entity...")
 
@@ -32,7 +34,11 @@ class AddSubscriptionUseCase @Inject constructor(
             amount = amount,
             nextPaymentDate = nextPaymentDate,
             state = SubscriptionState.ACTIVE, // Always active for manually added subscriptions
-            bankName = "Manual Entry",
+            // When the user picks a funding account, key the subscription to it
+            // (bank + last4) so mark-as-paid can move that account's balance.
+            // Otherwise fall back to the unlinked "Manual Entry" placeholder.
+            bankName = bankName ?: "Manual Entry",
+            accountLast4 = accountLast4,
             category = category,
             currency = currency,
             smsBody = notes, // Store user notes in smsBody field

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
@@ -77,7 +77,7 @@ class AddTransactionUseCase @Inject constructor(
 
         // Update account balance if account was selected
         if (transactionId != -1L && bankName != null && accountLast4 != null) {
-            updateAccountBalance(
+            accountBalanceRepository.applyTransactionToBalance(
                 bankName = bankName,
                 accountLast4 = accountLast4,
                 amount = amount,
@@ -107,50 +107,6 @@ class AddTransactionUseCase @Inject constructor(
         }
     }
     
-    private suspend fun updateAccountBalance(
-        bankName: String,
-        accountLast4: String,
-        amount: BigDecimal,
-        type: TransactionType,
-        date: LocalDateTime,
-        transactionId: Long
-    ) {
-        // Manual/cash accounts derive their balance from their transactions, so a
-        // back-dated (or later edited) transaction must be reflected — recompute rather
-        // than writing a per-transaction delta snapshot stamped at the txn date (which a
-        // back-dated row hides from "latest"). The transaction is already persisted here,
-        // so the recompute sum includes it. (#469)
-        if (accountBalanceRepository.isManualAccount(bankName, accountLast4)) {
-            accountBalanceRepository.recomputeManualBalance(bankName, accountLast4)
-            return
-        }
-
-        // Get current account balance
-        val currentAccount = accountBalanceRepository.getLatestBalance(bankName, accountLast4)
-
-        if (currentAccount != null) {
-            // Calculate new balance based on transaction type
-            val newBalance = when (type) {
-                TransactionType.INCOME -> currentAccount.balance + amount
-                TransactionType.EXPENSE, TransactionType.CREDIT -> currentAccount.balance - amount
-                TransactionType.TRANSFER -> currentAccount.balance - amount  // Simplified - from account
-                TransactionType.INVESTMENT -> currentAccount.balance - amount
-            }
-
-            // Insert new balance record
-            accountBalanceRepository.insertBalance(
-                currentAccount.copy(
-                    id = 0,  // Auto-generate new ID
-                    balance = newBalance,
-                    timestamp = date,
-                    transactionId = transactionId,
-                    sourceType = "TRANSACTION",
-                    smsSource = null
-                )
-            )
-        }
-    }
-
     private fun generateManualTransactionHash(
         amount: BigDecimal,
         merchant: String,

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
@@ -8,14 +8,12 @@ import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.SubscriptionRepository
-import com.pennywiseai.tracker.data.repository.TransactionRepository
 import java.math.BigDecimal
 import java.security.MessageDigest
 import java.time.LocalDateTime
 import javax.inject.Inject
 
 class AddTransactionUseCase @Inject constructor(
-    private val transactionRepository: TransactionRepository,
     private val subscriptionRepository: SubscriptionRepository,
     private val accountBalanceRepository: AccountBalanceRepository
 ) {
@@ -64,28 +62,15 @@ class AddTransactionUseCase @Inject constructor(
             budgetImpactType = budgetImpactType
         )
 
-        // For manual/cash accounts, pin the opening anchor from the PRE-insert snapshot
-        // (balance − Σtxns) so the post-insert recompute reflects this new transaction.
-        // Establishing it after the insert would fold the new txn into the opening and
-        // the add would silently not move the balance. No-op for SMS accounts.
-        if (bankName != null && accountLast4 != null) {
-            accountBalanceRepository.ensureManualOpening(bankName, accountLast4)
-        }
-
-        // Insert the transaction
-        val transactionId = transactionRepository.insertTransaction(transaction)
-
-        // Update account balance if account was selected
-        if (transactionId != -1L && bankName != null && accountLast4 != null) {
-            accountBalanceRepository.applyTransactionToBalance(
-                bankName = bankName,
-                accountLast4 = accountLast4,
-                amount = amount,
-                type = type,
-                date = date,
-                transactionId = transactionId
-            )
-        }
+        // Insert the transaction and reflect it on the selected account's balance
+        // atomically. For manual/cash accounts the helper pins the opening anchor
+        // from the PRE-insert snapshot before inserting, so the recompute includes
+        // this new transaction. No-op balance side for SMS / no-account adds.
+        val transactionId = accountBalanceRepository.insertTransactionWithBalance(
+            transaction = transaction,
+            bankName = bankName,
+            accountLast4 = accountLast4
+        )
         
         // If marked as recurring, create a subscription
         if (isRecurring && transactionId != -1L) {

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/GenerateIncomeAutopayUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/GenerateIncomeAutopayUseCase.kt
@@ -46,13 +46,12 @@ class GenerateIncomeAutopayUseCase @Inject constructor(
             while (!scheduled.isAfter(today)) {
                 val hash = "autopay-${sub.id}-$scheduled"
                 if (transactionRepository.getTransactionByHash(hash) == null) {
-                    val phantomDate = scheduled.atStartOfDay()
                     val phantom = TransactionEntity(
                         amount = sub.amount,
                         merchantName = sub.merchantName,
                         category = sub.category ?: "Income",
                         transactionType = TransactionType.INCOME,
-                        dateTime = phantomDate,
+                        dateTime = scheduled.atStartOfDay(),
                         description = "Scheduled income (autopay)",
                         bankName = sub.bankName,
                         accountNumber = accountLast4,
@@ -62,28 +61,16 @@ class GenerateIncomeAutopayUseCase @Inject constructor(
                         createdAt = LocalDateTime.now(),
                         updatedAt = LocalDateTime.now()
                     )
-                    // Pin the manual opening anchor before insert so the recompute
-                    // reflects this phantom (see AddTransactionUseCase). No-op for
-                    // SMS accounts / when the subscription has no funding account.
-                    if (bankName != null && accountLast4 != null) {
-                        accountBalanceRepository.ensureManualOpening(bankName, accountLast4)
-                    }
-                    val rowId = transactionRepository.insertTransaction(phantom)
-                    if (rowId != -1L) {
-                        inserted++
-                        // Credit the funding account with this scheduled income so
-                        // the balance tracks phantom income too (#570).
-                        if (bankName != null && accountLast4 != null) {
-                            accountBalanceRepository.applyTransactionToBalance(
-                                bankName = bankName,
-                                accountLast4 = accountLast4,
-                                amount = sub.amount,
-                                type = TransactionType.INCOME,
-                                date = phantomDate,
-                                transactionId = rowId,
-                            )
-                        }
-                    }
+                    // Insert the phantom and credit the funding account atomically
+                    // so a crash between the two can't leave the row present (its
+                    // hash then blocking every retry) with the balance un-credited
+                    // (#570). No-op balance side for SMS / unlinked subscriptions.
+                    val rowId = accountBalanceRepository.insertTransactionWithBalance(
+                        transaction = phantom,
+                        bankName = bankName,
+                        accountLast4 = accountLast4,
+                    )
+                    if (rowId != -1L) inserted++
                 }
                 scheduled = subscriptionRepository.advance(scheduled, sub.billingCycle)
             }

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/GenerateIncomeAutopayUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/GenerateIncomeAutopayUseCase.kt
@@ -3,6 +3,7 @@ package com.pennywiseai.tracker.domain.usecase
 import android.util.Log
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
+import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.SubscriptionRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import java.time.LocalDate
@@ -25,7 +26,8 @@ import javax.inject.Inject
  */
 class GenerateIncomeAutopayUseCase @Inject constructor(
     private val subscriptionRepository: SubscriptionRepository,
-    private val transactionRepository: TransactionRepository
+    private val transactionRepository: TransactionRepository,
+    private val accountBalanceRepository: AccountBalanceRepository
 ) {
 
     /** Returns the count of phantom transactions inserted. */
@@ -39,25 +41,49 @@ class GenerateIncomeAutopayUseCase @Inject constructor(
             // Materialise every missed cycle up to today, not just one — a
             // user who didn't open the app for two months should see both
             // months' phantom income, not just the most recent.
+            val bankName = sub.bankName
+            val accountLast4 = sub.accountLast4
             while (!scheduled.isAfter(today)) {
                 val hash = "autopay-${sub.id}-$scheduled"
                 if (transactionRepository.getTransactionByHash(hash) == null) {
+                    val phantomDate = scheduled.atStartOfDay()
                     val phantom = TransactionEntity(
                         amount = sub.amount,
                         merchantName = sub.merchantName,
                         category = sub.category ?: "Income",
                         transactionType = TransactionType.INCOME,
-                        dateTime = scheduled.atStartOfDay(),
+                        dateTime = phantomDate,
                         description = "Scheduled income (autopay)",
                         bankName = sub.bankName,
+                        accountNumber = accountLast4,
                         currency = sub.currency,
                         transactionHash = hash,
                         isRecurring = true,
                         createdAt = LocalDateTime.now(),
                         updatedAt = LocalDateTime.now()
                     )
+                    // Pin the manual opening anchor before insert so the recompute
+                    // reflects this phantom (see AddTransactionUseCase). No-op for
+                    // SMS accounts / when the subscription has no funding account.
+                    if (bankName != null && accountLast4 != null) {
+                        accountBalanceRepository.ensureManualOpening(bankName, accountLast4)
+                    }
                     val rowId = transactionRepository.insertTransaction(phantom)
-                    if (rowId != -1L) inserted++
+                    if (rowId != -1L) {
+                        inserted++
+                        // Credit the funding account with this scheduled income so
+                        // the balance tracks phantom income too (#570).
+                        if (bankName != null && accountLast4 != null) {
+                            accountBalanceRepository.applyTransactionToBalance(
+                                bankName = bankName,
+                                accountLast4 = accountLast4,
+                                amount = sub.amount,
+                                type = TransactionType.INCOME,
+                                date = phantomDate,
+                                transactionId = rowId,
+                            )
+                        }
+                    }
                 }
                 scheduled = subscriptionRepository.advance(scheduled, sub.billingCycle)
             }

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/MarkSubscriptionPaidUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/MarkSubscriptionPaidUseCase.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.pennywiseai.tracker.data.database.entity.SubscriptionDirection
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
+import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.SubscriptionRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import java.time.LocalDate
@@ -44,6 +45,7 @@ import javax.inject.Inject
 class MarkSubscriptionPaidUseCase @Inject constructor(
     private val subscriptionRepository: SubscriptionRepository,
     private val transactionRepository: TransactionRepository,
+    private val accountBalanceRepository: AccountBalanceRepository,
 ) {
 
     sealed class Result {
@@ -100,21 +102,49 @@ class MarkSubscriptionPaidUseCase @Inject constructor(
             return Result.AlreadyMarked(nextDate)
         }
 
+        val txnType = if (isIncome) TransactionType.INCOME else TransactionType.EXPENSE
+        val txnDate = paymentDate.atStartOfDay()
         val transaction = TransactionEntity(
             amount = sub.amount,
             merchantName = sub.merchantName,
             category = sub.category ?: if (isIncome) "Income" else "Subscriptions",
-            transactionType = if (isIncome) TransactionType.INCOME else TransactionType.EXPENSE,
-            dateTime = paymentDate.atStartOfDay(),
+            transactionType = txnType,
+            dateTime = txnDate,
             description = if (isIncome) "Marked received" else "Marked paid",
             bankName = sub.bankName,
+            accountNumber = sub.accountLast4,
             currency = sub.currency,
             transactionHash = hash,
             isRecurring = true,
             createdAt = LocalDateTime.now(),
             updatedAt = LocalDateTime.now(),
         )
+
+        // Pin the manual/cash opening anchor from the PRE-insert snapshot so the
+        // post-insert recompute reflects this payment (see AddTransactionUseCase).
+        // No-op for SMS accounts and when the subscription has no funding account.
+        val bankName = sub.bankName
+        val accountLast4 = sub.accountLast4
+        if (bankName != null && accountLast4 != null) {
+            accountBalanceRepository.ensureManualOpening(bankName, accountLast4)
+        }
+
         val rowId = transactionRepository.insertTransaction(transaction)
+
+        // Move the funding account's balance by this payment, mirroring a manual
+        // add. Previously the transaction was inserted raw with no account and no
+        // balance update, so marking a subscription paid never touched the
+        // account it was paid from (#570).
+        if (rowId != -1L && bankName != null && accountLast4 != null) {
+            accountBalanceRepository.applyTransactionToBalance(
+                bankName = bankName,
+                accountLast4 = accountLast4,
+                amount = sub.amount,
+                type = txnType,
+                date = txnDate,
+                transactionId = rowId,
+            )
+        }
 
         val nextDate = subscriptionRepository.advance(scheduled, sub.billingCycle)
         subscriptionRepository.markPaid(sub.id, paymentDate, nextDate)

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/MarkSubscriptionPaidUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/MarkSubscriptionPaidUseCase.kt
@@ -120,31 +120,16 @@ class MarkSubscriptionPaidUseCase @Inject constructor(
             updatedAt = LocalDateTime.now(),
         )
 
-        // Pin the manual/cash opening anchor from the PRE-insert snapshot so the
-        // post-insert recompute reflects this payment (see AddTransactionUseCase).
-        // No-op for SMS accounts and when the subscription has no funding account.
-        val bankName = sub.bankName
-        val accountLast4 = sub.accountLast4
-        if (bankName != null && accountLast4 != null) {
-            accountBalanceRepository.ensureManualOpening(bankName, accountLast4)
-        }
-
-        val rowId = transactionRepository.insertTransaction(transaction)
-
-        // Move the funding account's balance by this payment, mirroring a manual
-        // add. Previously the transaction was inserted raw with no account and no
+        // Insert the payment and move the funding account's balance atomically.
+        // Previously the transaction was inserted raw with no account and no
         // balance update, so marking a subscription paid never touched the
-        // account it was paid from (#570).
-        if (rowId != -1L && bankName != null && accountLast4 != null) {
-            accountBalanceRepository.applyTransactionToBalance(
-                bankName = bankName,
-                accountLast4 = accountLast4,
-                amount = sub.amount,
-                type = txnType,
-                date = txnDate,
-                transactionId = rowId,
-            )
-        }
+        // account it was paid from (#570). No-op balance side for SMS accounts
+        // and when the subscription has no funding account.
+        val rowId = accountBalanceRepository.insertTransactionWithBalance(
+            transaction = transaction,
+            bankName = sub.bankName,
+            accountLast4 = sub.accountLast4,
+        )
 
         val nextDate = subscriptionRepository.advance(scheduled, sub.billingCycle)
         subscriptionRepository.markPaid(sub.id, paymentDate, nextDate)

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
@@ -380,6 +380,17 @@ class AddViewModel @Inject constructor(
             currentState.copy(currency = currency)
         }
     }
+
+    fun updateSubscriptionAccount(account: AccountBalanceEntity?) {
+        _subscriptionUiState.update { currentState ->
+            // Keep the subscription currency aligned with the chosen account so
+            // the two figures the user sees can't silently disagree.
+            currentState.copy(
+                selectedAccount = account,
+                currency = account?.currency ?: currentState.currency
+            )
+        }
+    }
     
     fun saveSubscription(onSuccess: () -> Unit) {
         val state = _subscriptionUiState.value
@@ -424,7 +435,9 @@ class AddViewModel @Inject constructor(
                     paymentReminder = false, // Not implemented yet
                     notes = state.notes.takeIf { it.isNotBlank() },
                     currency = state.currency,
-                    direction = state.direction
+                    direction = state.direction,
+                    bankName = state.selectedAccount?.bankName,
+                    accountLast4 = state.selectedAccount?.accountLast4
                 )
                 
                 Log.d("AddViewModel", "Subscription saved successfully with ID: $subscriptionId")
@@ -527,7 +540,13 @@ data class SubscriptionUiState(
      * incoming bank-debit SMS as today.
      */
     val direction: com.pennywiseai.tracker.data.database.entity.SubscriptionDirection =
-        com.pennywiseai.tracker.data.database.entity.SubscriptionDirection.EXPENSE
+        com.pennywiseai.tracker.data.database.entity.SubscriptionDirection.EXPENSE,
+    /**
+     * Optional funding account (#570). When set, mark-as-paid / scheduled
+     * income moves this account's balance; null keeps the subscription
+     * unlinked ("Manual Entry", no balance tracking).
+     */
+    val selectedAccount: AccountBalanceEntity? = null
 ) {
     val isValid: Boolean
         get() = serviceName.isNotBlank() &&

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/SubscriptionTabContent.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/SubscriptionTabContent.kt
@@ -22,6 +22,10 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
+import com.pennywiseai.tracker.domain.model.displayName
+import com.pennywiseai.tracker.domain.model.getAccountType
+import com.pennywiseai.tracker.presentation.accounts.AccountType
 import com.pennywiseai.tracker.ui.components.cards.PennyWiseCardV2
 import com.pennywiseai.tracker.ui.theme.*
 import com.pennywiseai.tracker.utils.CurrencyFormatter
@@ -56,11 +60,13 @@ fun SubscriptionTabContent(
 ) {
     val uiState by viewModel.subscriptionUiState.collectAsState()
     val categories by viewModel.categories.collectAsState()
+    val accounts by viewModel.accounts.collectAsState()
 
     var showDatePicker by remember { mutableStateOf(false) }
     var showCategoryMenu by remember { mutableStateOf(false) }
     var showBillingCycleMenu by remember { mutableStateOf(false) }
     var showCurrencyMenu by remember { mutableStateOf(false) }
+    var showAccountMenu by remember { mutableStateOf(false) }
 
     val billingCycles = listOf("Monthly", "Quarterly", "Semi-Annual", "Annual", "Weekly")
 
@@ -361,6 +367,147 @@ fun SubscriptionTabContent(
                     leadingIcon = { Icon(Icons.Default.Description, contentDescription = null) },
                     colors = subFilledColors()
                 )
+            }
+
+            // ── Funding account (optional) ──
+            // When set, marking this subscription paid (or an auto-created
+            // scheduled income) moves the chosen account's balance. Leaving it
+            // unset keeps the subscription unlinked, exactly like before. (#570)
+            Card(
+                onClick = { showAccountMenu = true },
+                modifier = Modifier.fillMaxWidth(),
+                shape = subFullShape,
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+                ),
+                border = null
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp, vertical = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Icon(
+                        when (uiState.selectedAccount?.getAccountType()) {
+                            AccountType.CASH -> Icons.Default.Money
+                            AccountType.CREDIT -> Icons.Default.CreditCard
+                            AccountType.SAVINGS, AccountType.CURRENT -> Icons.Default.AccountBalance
+                            null -> Icons.Default.AccountBalance
+                        },
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = uiState.selectedAccount?.bankName ?: "Paid from (optional)",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = if (uiState.selectedAccount != null)
+                                MaterialTheme.colorScheme.onSurface
+                            else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        if (uiState.selectedAccount != null &&
+                            uiState.selectedAccount?.accountLast4 != AccountBalanceEntity.WALLET_ACCOUNT_MARKER) {
+                            Text(
+                                text = "••${uiState.selectedAccount?.accountLast4}",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                    if (uiState.selectedAccount != null) {
+                        IconButton(
+                            onClick = { viewModel.updateSubscriptionAccount(null) },
+                            modifier = Modifier.size(24.dp)
+                        ) {
+                            Icon(
+                                Icons.Default.Clear,
+                                contentDescription = "Clear",
+                                modifier = Modifier.size(16.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                    Icon(
+                        Icons.Rounded.KeyboardArrowDown,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            // Account selection dropdown menu
+            DropdownMenu(
+                expanded = showAccountMenu,
+                onDismissRequest = { showAccountMenu = false }
+            ) {
+                DropdownMenuItem(
+                    text = {
+                        Column {
+                            Text("No account")
+                            Text(
+                                "Won't affect any balance",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    },
+                    onClick = {
+                        viewModel.updateSubscriptionAccount(null)
+                        showAccountMenu = false
+                    },
+                    leadingIcon = { Icon(Icons.Default.Block, contentDescription = null) }
+                )
+                HorizontalDivider()
+                val groupedAccounts = accounts.groupBy { it.getAccountType() }
+                groupedAccounts.forEach { (accountType, accountList) ->
+                    DropdownMenuItem(
+                        text = {
+                            Text(
+                                text = accountType.displayName(),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                fontWeight = FontWeight.Bold
+                            )
+                        },
+                        onClick = {},
+                        enabled = false
+                    )
+                    accountList.forEach { account ->
+                        DropdownMenuItem(
+                            text = {
+                                Column {
+                                    Text(AccountBalanceEntity.accountLabel(account.bankName, account.accountLast4))
+                                    Text(
+                                        CurrencyFormatter.formatCurrency(account.balance, account.currency),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.primary
+                                    )
+                                }
+                            },
+                            onClick = {
+                                viewModel.updateSubscriptionAccount(account)
+                                showAccountMenu = false
+                            },
+                            leadingIcon = {
+                                Icon(
+                                    when (accountType) {
+                                        AccountType.CASH -> Icons.Default.Money
+                                        AccountType.CREDIT -> Icons.Default.CreditCard
+                                        else -> Icons.Default.AccountBalance
+                                    },
+                                    contentDescription = null
+                                )
+                            },
+                            trailingIcon = {
+                                if (uiState.selectedAccount?.id == account.id) {
+                                    Icon(Icons.Default.Check, "Selected", tint = MaterialTheme.colorScheme.primary)
+                                }
+                            }
+                        )
+                    }
+                }
             }
 
             // Bottom padding for save button overlay

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
@@ -35,8 +35,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.pennywiseai.tracker.ui.theme.Dimensions
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.data.database.entity.SubscriptionEntity
 import com.pennywiseai.tracker.data.database.entity.SubscriptionState
+import com.pennywiseai.tracker.domain.model.getAccountType
+import com.pennywiseai.tracker.presentation.accounts.AccountType
 import com.pennywiseai.tracker.ui.components.*
 import com.pennywiseai.tracker.ui.components.cards.SectionHeaderV2
 import com.pennywiseai.tracker.ui.components.cards.SummaryCardV2
@@ -62,6 +65,7 @@ fun SubscriptionsScreen(
     onAddSubscriptionClick: () -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val accounts by viewModel.accounts.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     // Subscription currently being marked-as-paid. Null = sheet closed.
     var markPaidTarget by remember { mutableStateOf<SubscriptionEntity?>(null) }
@@ -221,14 +225,15 @@ fun SubscriptionsScreen(
                     ) {
                         SwipeableSubscriptionItem(
                             subscription = subscription,
+                            accounts = accounts,
                             isPaidThisCycle = subscription.id in uiState.paidThisCycleIds,
                             convertedAmount = uiState.convertedAmounts[subscription.id],
                             displayCurrency = uiState.displayCurrency,
                             onTap = { markPaidTarget = subscription },
                             onHide = { viewModel.hideSubscription(subscription.id) },
                             onMarkAsEnded = { viewModel.markAsEnded(subscription.id) },
-                            onEdit = { merchantName, amount, nextDate, category ->
-                                viewModel.updateSubscription(subscription.id, merchantName, amount, nextDate, category)
+                            onEdit = { merchantName, amount, nextDate, category, account ->
+                                viewModel.updateSubscription(subscription.id, merchantName, amount, nextDate, category, account)
                             },
                             onDelete = { viewModel.deleteSubscription(subscription.id) }
                         )
@@ -454,13 +459,14 @@ private fun TotalSubscriptionsSummary(
 @Composable
 private fun SwipeableSubscriptionItem(
     subscription: SubscriptionEntity,
+    accounts: List<AccountBalanceEntity> = emptyList(),
     isPaidThisCycle: Boolean = false,
     convertedAmount: BigDecimal? = null,
     displayCurrency: String? = null,
     onTap: () -> Unit = {},
     onHide: () -> Unit,
     onMarkAsEnded: () -> Unit = {},
-    onEdit: (merchantName: String, amount: BigDecimal, nextDate: LocalDate?, category: String?) -> Unit = { _, _, _, _ -> },
+    onEdit: (merchantName: String, amount: BigDecimal, nextDate: LocalDate?, category: String?, account: AccountBalanceEntity?) -> Unit = { _, _, _, _, _ -> },
     onDelete: () -> Unit = {}
 ) {
     var showSmsBody by remember { mutableStateOf(false) }
@@ -800,9 +806,10 @@ private fun SwipeableSubscriptionItem(
     if (showEditDialog) {
         EditSubscriptionDialog(
             subscription = subscription,
+            accounts = accounts,
             onDismiss = { showEditDialog = false },
-            onSave = { merchantName, amount, nextDate, category ->
-                onEdit(merchantName, amount, nextDate, category)
+            onSave = { merchantName, amount, nextDate, category, account ->
+                onEdit(merchantName, amount, nextDate, category, account)
                 showEditDialog = false
             }
         )
@@ -836,14 +843,25 @@ private fun SwipeableSubscriptionItem(
 @Composable
 private fun EditSubscriptionDialog(
     subscription: SubscriptionEntity,
+    accounts: List<AccountBalanceEntity> = emptyList(),
     onDismiss: () -> Unit,
-    onSave: (merchantName: String, amount: BigDecimal, nextDate: LocalDate?, category: String?) -> Unit
+    onSave: (merchantName: String, amount: BigDecimal, nextDate: LocalDate?, category: String?, account: AccountBalanceEntity?) -> Unit
 ) {
     var merchantName by remember { mutableStateOf(subscription.merchantName) }
     var amountText by remember { mutableStateOf(subscription.amount.toPlainString()) }
     var category by remember { mutableStateOf(subscription.category.orEmpty()) }
     var nextDate by remember { mutableStateOf(subscription.nextPaymentDate) }
     var showDatePicker by remember { mutableStateOf(false) }
+    var showAccountMenu by remember { mutableStateOf(false) }
+    // Pre-select the subscription's current funding account by (bank, last4).
+    var selectedAccount by remember(subscription.id, accounts) {
+        mutableStateOf(
+            accounts.firstOrNull {
+                it.bankName == subscription.bankName &&
+                    it.accountLast4 == subscription.accountLast4
+            }
+        )
+    }
 
     val parsedAmount = remember(amountText) {
         amountText.trim().takeIf { it.isNotEmpty() }?.let {
@@ -899,6 +917,75 @@ private fun EditSubscriptionDialog(
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth()
                 )
+
+                // Funding account (#570). Marking this subscription paid moves
+                // the chosen account's balance; "No account" keeps it unlinked.
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    OutlinedTextField(
+                        value = selectedAccount?.let {
+                            AccountBalanceEntity.accountLabel(it.bankName, it.accountLast4)
+                        } ?: "No account",
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text("Paid from") },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { showAccountMenu = true },
+                        enabled = false,
+                        trailingIcon = {
+                            IconButton(onClick = { showAccountMenu = true }) {
+                                Icon(Icons.Default.AccountBalance, contentDescription = "Pick account")
+                            }
+                        }
+                    )
+                    DropdownMenu(
+                        expanded = showAccountMenu,
+                        onDismissRequest = { showAccountMenu = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("No account") },
+                            onClick = {
+                                selectedAccount = null
+                                showAccountMenu = false
+                            },
+                            leadingIcon = { Icon(Icons.Default.Block, contentDescription = null) }
+                        )
+                        HorizontalDivider()
+                        accounts.forEach { account ->
+                            DropdownMenuItem(
+                                text = {
+                                    Column {
+                                        Text(AccountBalanceEntity.accountLabel(account.bankName, account.accountLast4))
+                                        Text(
+                                            CurrencyFormatter.formatCurrency(account.balance, account.currency),
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.primary
+                                        )
+                                    }
+                                },
+                                onClick = {
+                                    selectedAccount = account
+                                    showAccountMenu = false
+                                },
+                                leadingIcon = {
+                                    Icon(
+                                        when (account.getAccountType()) {
+                                            AccountType.CASH -> Icons.Default.Money
+                                            AccountType.CREDIT -> Icons.Default.CreditCard
+                                            else -> Icons.Default.AccountBalance
+                                        },
+                                        contentDescription = null
+                                    )
+                                },
+                                trailingIcon = {
+                                    if (selectedAccount?.id == account.id) {
+                                        Icon(Icons.Default.Check, "Selected", tint = MaterialTheme.colorScheme.primary)
+                                    }
+                                }
+                            )
+                        }
+                    }
+                }
             }
         },
         confirmButton = {
@@ -906,7 +993,7 @@ private fun EditSubscriptionDialog(
                 enabled = isValid,
                 onClick = {
                     parsedAmount?.let { amt ->
-                        onSave(merchantName, amt, nextDate, category)
+                        onSave(merchantName, amt, nextDate, category, selectedAccount)
                     }
                 }
             ) { Text("Save") }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
@@ -3,18 +3,22 @@ package com.pennywiseai.tracker.presentation.subscriptions
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.data.currency.CurrencyConversionService
+import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.data.database.entity.SubscriptionEntity
 import com.pennywiseai.tracker.data.database.entity.SubscriptionState
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
+import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.SubscriptionRepository
 import com.pennywiseai.tracker.domain.usecase.MarkSubscriptionPaidUseCase
 import com.pennywiseai.tracker.utils.Money
 import com.pennywiseai.tracker.utils.sumByCurrency
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
 import javax.inject.Inject
@@ -26,10 +30,16 @@ class SubscriptionsViewModel @Inject constructor(
     private val currencyConversionService: CurrencyConversionService,
     private val markSubscriptionPaidUseCase: MarkSubscriptionPaidUseCase,
     private val transactionRepository: com.pennywiseai.tracker.data.repository.TransactionRepository,
+    accountBalanceRepository: AccountBalanceRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SubscriptionsUiState())
     val uiState: StateFlow<SubscriptionsUiState> = _uiState.asStateFlow()
+
+    /** Accounts offered as the funding source in the edit dialog (#570). */
+    val accounts: StateFlow<List<AccountBalanceEntity>> =
+        accountBalanceRepository.getAllLatestBalances()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     init {
         loadSubscriptions()
@@ -173,7 +183,8 @@ class SubscriptionsViewModel @Inject constructor(
         merchantName: String,
         amount: BigDecimal,
         nextPaymentDate: java.time.LocalDate?,
-        category: String?
+        category: String?,
+        account: AccountBalanceEntity?,
     ) {
         viewModelScope.launch {
             val existing = subscriptionRepository.getSubscriptionById(id) ?: return@launch
@@ -183,6 +194,11 @@ class SubscriptionsViewModel @Inject constructor(
                     amount = amount,
                     nextPaymentDate = nextPaymentDate,
                     category = category?.trim()?.takeIf { it.isNotEmpty() },
+                    // Re-key the funding account. Clearing it (null) reverts to the
+                    // unlinked "Manual Entry" placeholder so mark-as-paid stops
+                    // touching a balance. (#570)
+                    bankName = account?.bankName ?: "Manual Entry",
+                    accountLast4 = account?.accountLast4,
                     updatedAt = java.time.LocalDateTime.now()
                 )
             )

--- a/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupModelsTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupModelsTest.kt
@@ -490,6 +490,52 @@ class BackupModelsTest {
     }
 
     /**
+     * #570 regression. An older backup's subscription predates the
+     * `account_last4` column (which pairs with `bank_name` to identify the
+     * funding account), so the key is simply absent. It must default to null,
+     * not crash the restore. A second row that *does* carry the key must
+     * round-trip its value.
+     */
+    @Test
+    fun oldBackupMissingAccountLast4_defaultsToNull() {
+        val json = """
+        {
+          "database": {
+            "subscriptions": [
+              {
+                "id": 9,
+                "merchantName": "Netflix",
+                "amount": "499.00",
+                "nextPaymentDate": "2023-06-01",
+                "bankName": "HDFC"
+              },
+              {
+                "id": 10,
+                "merchantName": "Spotify",
+                "amount": "119.00",
+                "nextPaymentDate": "2023-06-05",
+                "bankName": "HDFC",
+                "accountLast4": "4321"
+              }
+            ]
+          }
+        }
+        """.trimIndent()
+
+        val subs = backupJson.decodeFromString<PennyWiseBackup>(json)
+            .database.subscriptions
+
+        // Older row: account_last4 key absent → default null, no crash.
+        val netflix = subs.single { it.merchantName == "Netflix" }
+        assertNull(netflix.accountLast4)
+        assertEquals("HDFC", netflix.bankName)
+
+        // Newer row: value round-trips.
+        val spotify = subs.single { it.merchantName == "Spotify" }
+        assertEquals("4321", spotify.accountLast4)
+    }
+
+    /**
      * #509 regression. An older backup's account_balances row predates the
      * per-account `lowBalanceThreshold` column, so the key is simply absent.
      * It must default to null (alert off), not crash the restore. A second row

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/MandateInfo.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/MandateInfo.kt
@@ -36,4 +36,11 @@ interface MandateInfo {
      */
     val dateFormat: String
         get() = "dd/MM/yy"
+
+    /**
+     * Last 4 digits of the account the mandate debits, if the SMS states it.
+     * Null when unknown.
+     */
+    val accountLast4: String?
+        get() = null
 }

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BaseIndianBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/BaseIndianBankParser.kt
@@ -110,12 +110,17 @@ abstract class BaseIndianBankParser : BankParser() {
         val umnPattern = Regex("""UMN[:\s]+([^.\s]+)""", RegexOption.IGNORE_CASE)
         val umn = umnPattern.find(message)?.groupValues?.get(1)
 
+        // 5. Extract the debiting account's last 4 digits, if the SMS states it
+        // (e.g. "from A/c XX1234"). Reuses the bank's own account helper.
+        val accountLast4 = extractAccountLast4(message)
+
         return object : MandateInfo {
             override val amount = amount
             override val nextDeductionDate = dateStr
             override val merchant = merchant
             override val umn = umn
             override val dateFormat = "dd-MMM-yy" // Default fallback
+            override val accountLast4 = accountLast4
         }
     }
 

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/HDFCBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/HDFCBankParser.kt
@@ -600,7 +600,8 @@ class HDFCBankParser : BaseIndianBankParser() {
             amount = amount!!,
             nextDeductionDate = nextDeductionDate,
             merchant = merchant,
-            umn = umn
+            umn = umn,
+            accountLast4 = extractAccountLast4(message)
         )
     }
 
@@ -670,7 +671,8 @@ class HDFCBankParser : BaseIndianBankParser() {
             amount = amount!!,
             nextDeductionDate = nextDeductionDate,
             merchant = merchant,
-            umn = null
+            umn = null,
+            accountLast4 = extractAccountLast4(message)
         )
     }
 
@@ -681,7 +683,8 @@ class HDFCBankParser : BaseIndianBankParser() {
         override val amount: BigDecimal,
         override val nextDeductionDate: String?,
         override val merchant: String,
-        override val umn: String?
+        override val umn: String?,
+        override val accountLast4: String? = null
     ) : MandateInfo {
         override val dateFormat = "dd/MM/yy"
     }

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/IndianBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/IndianBankParser.kt
@@ -268,7 +268,8 @@ class IndianBankParser : BaseIndianBankParser() {
             amount = baseInfo.amount,
             nextDeductionDate = baseInfo.nextDeductionDate,
             merchant = baseInfo.merchant,
-            umn = baseInfo.umn
+            umn = baseInfo.umn,
+            accountLast4 = baseInfo.accountLast4
         )
     }
 
@@ -279,7 +280,8 @@ class IndianBankParser : BaseIndianBankParser() {
         override val amount: BigDecimal,
         override val nextDeductionDate: String?,
         override val merchant: String,
-        override val umn: String?
+        override val umn: String?,
+        override val accountLast4: String? = null
     ) : MandateInfo {
         override val dateFormat = "dd-MMM-yy"
     }

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/PNBBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/PNBBankParser.kt
@@ -164,7 +164,8 @@ class PNBBankParser : BaseIndianBankParser() {
             amount = amount,
             nextDeductionDate = null,
             merchant = merchant,
-            umn = umn
+            umn = umn,
+            accountLast4 = extractAccountLast4(message)
         )
     }
 
@@ -345,7 +346,8 @@ class PNBBankParser : BaseIndianBankParser() {
         override val amount: BigDecimal,
         override val nextDeductionDate: String?,
         override val merchant: String,
-        override val umn: String?
+        override val umn: String?,
+        override val accountLast4: String? = null
     ) : MandateInfo {
         override val dateFormat = "dd-MMM-yy"
     }

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SBIBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/SBIBankParser.kt
@@ -674,7 +674,8 @@ class SBIBankParser : BaseIndianBankParser() {
             amount = amount!!,
             nextDeductionDate = nextDeductionDate,
             merchant = merchant,
-            umn = umn
+            umn = umn,
+            accountLast4 = extractAccountLast4(message)
         )
     }
 
@@ -685,7 +686,8 @@ class SBIBankParser : BaseIndianBankParser() {
         override val amount: BigDecimal,
         override val nextDeductionDate: String?,
         override val merchant: String,
-        override val umn: String?
+        override val umn: String?,
+        override val accountLast4: String? = null
     ) : MandateInfo {
         override val dateFormat = "dd-MMM-yy"
     }

--- a/parser-core/src/test/kotlin/PNBBankParserTest.kt
+++ b/parser-core/src/test/kotlin/PNBBankParserTest.kt
@@ -180,6 +180,7 @@ class PNBBankParserTest {
                 assertEquals(BigDecimal("1500.00"), mandate?.amount)
                 assertEquals("Google", mandate?.merchant)
                 assertEquals("1d478c77808c410281f435rer5qwerty6@ybl-PNB", mandate?.umn)
+                assertEquals("4356", mandate?.accountLast4)
             }
         )
     }

--- a/parser-core/src/test/kotlin/TestHDFCMandateParsing.kt
+++ b/parser-core/src/test/kotlin/TestHDFCMandateParsing.kt
@@ -50,6 +50,7 @@ UMN ref456@ybl
                 assertNotNull(info, "Should parse e-mandate notification")
                 assertEquals(BigDecimal("599.00"), info!!.amount, "Amount mismatch")
                 assertEquals("CloudStorage", info.merchant, "Merchant should be 'CloudStorage'")
+                assertEquals("1234", info.accountLast4, "accountLast4 should be extracted from 'A/c XX1234'")
             },
 
             dynamicTest("E-Mandate notification is not parsed as transaction") {
@@ -108,6 +109,7 @@ for MusicApp ID: sub789
                 assertNotNull(info, "Should parse future debit notification")
                 assertEquals(BigDecimal("500.00"), info!!.amount, "Amount mismatch")
                 assertEquals("FitnessApp", info.merchant, "Merchant should be 'FitnessApp'")
+                assertEquals("5678", info.accountLast4, "accountLast4 should be extracted from 'A/c XX5678'")
             },
 
             dynamicTest("parseFutureDebit extracts merchant from 'for X will be'") {


### PR DESCRIPTION
Fixes #570.

## Problem
A subscription didn't record *which* account it was paid from, so marking one paid (or an auto-created scheduled income) inserted a transaction with no account and **never moved any account balance**. Users reported their balance staying flat after marking subscriptions paid.

## Fix
Subscriptions can now name a funding account (`bank_name` + new `account_last4`), and paying one moves that account's balance exactly like a manual transaction add.

### Data / schema
- `SubscriptionEntity`: new nullable `account_last4` (defaulted → backup-compatible, #414 rule). Schema **56 → 57** via `AutoMigration`; exported `57.json`; backup regression test decoding an older subscription JSON.

### Balance logic
- Extracted the add-transaction balance rule into a shared `AccountBalanceRepository.applyTransactionToBalance(...)` (manual/cash → recompute; SMS account → signed `TRANSACTION` delta). `AddTransactionUseCase` now calls it instead of a private copy.
- `MarkSubscriptionPaidUseCase` and `GenerateIncomeAutopayUseCase`: set `accountNumber = sub.accountLast4` on the created transaction, `ensureManualOpening` before insert, and apply the balance change after.

### UI
- **Add** form (`SubscriptionTabContent`): a new "Paid from (optional)" account picker, grouped by type with balances.
- **Edit** dialog (`SubscriptionsScreen`): a "Paid from" picker, pre-selected by `(bank, last4)`.

### SMS mandates (auto-capture)
- `MandateInfo` gains an optional `accountLast4` (default `null`), populated by the mandate parsers whose SMS carry the debiting account (HDFC / SBI / PNB / IndianBank + `BaseIndianBankParser`), each via its existing `extractAccountLast4` helper.
- `SubscriptionRepository.createOrUpdateFromMandate` persists it — without clobbering an account the user assigned manually.

## Verification
- `./init.sh app` and `./init.sh parser` green.
- On-device (emulator): created an EXPENSE subscription (₹500) funded by **Kotak ••7777 (₹2000)** → **Mark paid** → the transaction is tagged `account_number=7777` and the account balance moves to **₹1500**; `next_payment_date` advances one cycle; the edit dialog shows the account pre-selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)