### PR TITLE
fix(subscriptions): don't drop the funding account on two edit/recurring edge paths (#570 follow-up)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
@@ -81,7 +81,11 @@ class AddTransactionUseCase @Inject constructor(
                 amount = amount,
                 nextPaymentDate = nextPaymentDate,
                 state = SubscriptionState.ACTIVE,
-                bankName = "Manual Entry",
+                // Carry the funding account onto the auto-created subscription so
+                // marking it paid later moves that account's balance — otherwise
+                // this whole class of subscriptions silently skips the #570 fix.
+                bankName = bankName ?: "Manual Entry",
+                accountLast4 = accountLast4,
                 category = category,
                 currency = currency,
                 createdAt = LocalDateTime.now(),

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
@@ -853,19 +853,26 @@ private fun EditSubscriptionDialog(
     var nextDate by remember { mutableStateOf(subscription.nextPaymentDate) }
     var showDatePicker by remember { mutableStateOf(false) }
     var showAccountMenu by remember { mutableStateOf(false) }
-    // Pre-select the subscription's current funding account by (bank, last4).
-    var selectedAccount by remember(subscription.id, accounts) {
-        mutableStateOf(
-            accounts.firstOrNull {
-                it.bankName == subscription.bankName &&
-                    it.accountLast4 == subscription.accountLast4
-            }
-        )
-    }
     // Whether the user actually changed the account. Guards against wiping a
     // stored account the picker can't represent (e.g. one not yet in the
     // balance list) when the user edits other fields and saves.
     var accountChanged by remember(subscription.id) { mutableStateOf(false) }
+    var selectedAccount by remember(subscription.id) {
+        mutableStateOf<AccountBalanceEntity?>(null)
+    }
+    // Pre-select the subscription's current funding account by (bank, last4).
+    // Runs when the async accounts list first resolves, but never once the user
+    // has touched the picker — otherwise an accounts tick mid-edit would revert
+    // a freshly-picked account while accountChanged stayed true, writing the
+    // stale value on save (keyed both on subscription.id keeps the two in sync).
+    LaunchedEffect(subscription.id, accounts) {
+        if (!accountChanged) {
+            selectedAccount = accounts.firstOrNull {
+                it.bankName == subscription.bankName &&
+                    it.accountLast4 == subscription.accountLast4
+            }
+        }
+    }
 
     val parsedAmount = remember(amountText) {
         amountText.trim().takeIf { it.isNotEmpty() }?.let {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
@@ -232,8 +232,8 @@ fun SubscriptionsScreen(
                             onTap = { markPaidTarget = subscription },
                             onHide = { viewModel.hideSubscription(subscription.id) },
                             onMarkAsEnded = { viewModel.markAsEnded(subscription.id) },
-                            onEdit = { merchantName, amount, nextDate, category, account ->
-                                viewModel.updateSubscription(subscription.id, merchantName, amount, nextDate, category, account)
+                            onEdit = { merchantName, amount, nextDate, category, account, accountChanged ->
+                                viewModel.updateSubscription(subscription.id, merchantName, amount, nextDate, category, account, accountChanged)
                             },
                             onDelete = { viewModel.deleteSubscription(subscription.id) }
                         )
@@ -466,7 +466,7 @@ private fun SwipeableSubscriptionItem(
     onTap: () -> Unit = {},
     onHide: () -> Unit,
     onMarkAsEnded: () -> Unit = {},
-    onEdit: (merchantName: String, amount: BigDecimal, nextDate: LocalDate?, category: String?, account: AccountBalanceEntity?) -> Unit = { _, _, _, _, _ -> },
+    onEdit: (merchantName: String, amount: BigDecimal, nextDate: LocalDate?, category: String?, account: AccountBalanceEntity?, accountChanged: Boolean) -> Unit = { _, _, _, _, _, _ -> },
     onDelete: () -> Unit = {}
 ) {
     var showSmsBody by remember { mutableStateOf(false) }
@@ -808,8 +808,8 @@ private fun SwipeableSubscriptionItem(
             subscription = subscription,
             accounts = accounts,
             onDismiss = { showEditDialog = false },
-            onSave = { merchantName, amount, nextDate, category, account ->
-                onEdit(merchantName, amount, nextDate, category, account)
+            onSave = { merchantName, amount, nextDate, category, account, accountChanged ->
+                onEdit(merchantName, amount, nextDate, category, account, accountChanged)
                 showEditDialog = false
             }
         )
@@ -845,7 +845,7 @@ private fun EditSubscriptionDialog(
     subscription: SubscriptionEntity,
     accounts: List<AccountBalanceEntity> = emptyList(),
     onDismiss: () -> Unit,
-    onSave: (merchantName: String, amount: BigDecimal, nextDate: LocalDate?, category: String?, account: AccountBalanceEntity?) -> Unit
+    onSave: (merchantName: String, amount: BigDecimal, nextDate: LocalDate?, category: String?, account: AccountBalanceEntity?, accountChanged: Boolean) -> Unit
 ) {
     var merchantName by remember { mutableStateOf(subscription.merchantName) }
     var amountText by remember { mutableStateOf(subscription.amount.toPlainString()) }
@@ -862,6 +862,10 @@ private fun EditSubscriptionDialog(
             }
         )
     }
+    // Whether the user actually changed the account. Guards against wiping a
+    // stored account the picker can't represent (e.g. one not yet in the
+    // balance list) when the user edits other fields and saves.
+    var accountChanged by remember(subscription.id) { mutableStateOf(false) }
 
     val parsedAmount = remember(amountText) {
         amountText.trim().takeIf { it.isNotEmpty() }?.let {
@@ -946,6 +950,7 @@ private fun EditSubscriptionDialog(
                             text = { Text("No account") },
                             onClick = {
                                 selectedAccount = null
+                                accountChanged = true
                                 showAccountMenu = false
                             },
                             leadingIcon = { Icon(Icons.Default.Block, contentDescription = null) }
@@ -965,6 +970,7 @@ private fun EditSubscriptionDialog(
                                 },
                                 onClick = {
                                     selectedAccount = account
+                                    accountChanged = true
                                     showAccountMenu = false
                                 },
                                 leadingIcon = {
@@ -993,7 +999,7 @@ private fun EditSubscriptionDialog(
                 enabled = isValid,
                 onClick = {
                     parsedAmount?.let { amt ->
-                        onSave(merchantName, amt, nextDate, category, selectedAccount)
+                        onSave(merchantName, amt, nextDate, category, selectedAccount, accountChanged)
                     }
                 }
             ) { Text("Save") }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
@@ -185,6 +185,7 @@ class SubscriptionsViewModel @Inject constructor(
         nextPaymentDate: java.time.LocalDate?,
         category: String?,
         account: AccountBalanceEntity?,
+        accountChanged: Boolean,
     ) {
         viewModelScope.launch {
             val existing = subscriptionRepository.getSubscriptionById(id) ?: return@launch
@@ -194,11 +195,14 @@ class SubscriptionsViewModel @Inject constructor(
                     amount = amount,
                     nextPaymentDate = nextPaymentDate,
                     category = category?.trim()?.takeIf { it.isNotEmpty() },
-                    // Re-key the funding account. Clearing it (null) reverts to the
-                    // unlinked "Manual Entry" placeholder so mark-as-paid stops
-                    // touching a balance. (#570)
-                    bankName = account?.bankName ?: "Manual Entry",
-                    accountLast4 = account?.accountLast4,
+                    // Only re-key the funding account when the user actually touched
+                    // the picker. Otherwise keep what's stored — the dialog can't
+                    // pre-select an account that isn't in the balance list yet (e.g.
+                    // one auto-captured from an SMS mandate), so blindly writing the
+                    // picker's null would wipe that assignment. Picking clears via
+                    // "No account" still work because that flips accountChanged. (#570)
+                    bankName = if (accountChanged) account?.bankName ?: "Manual Entry" else existing.bankName,
+                    accountLast4 = if (accountChanged) account?.accountLast4 else existing.accountLast4,
                     updatedAt = java.time.LocalDateTime.now()
                 )
             )


### PR DESCRIPTION
Follow-up to #598 (which fixed #570). Greptile rated #598 **3/5**, confirming the core balance logic is correct and atomic but flagging two adjacent paths that still drop the funding account. Both are addressed here.

## 1. Recurring manual transaction → subscription dropped the account
`AddTransactionUseCase` creates a `SubscriptionEntity` when a manual transaction is saved as recurring, but hard-coded `bankName = "Manual Entry"` and set no `accountLast4` — even though the selected account is right there in the params. Every subscription born that way silently skipped the balance move on mark-as-paid. Now it forwards `bankName`/`accountLast4`.

## 2. Editing a subscription could wipe a mandate-assigned account
The edit dialog pre-selects the funding account by matching `(bank, last4)` against the **balance list**. A subscription can reference an account that isn't in that list yet (e.g. auto-captured from an SMS mandate, before any balance row exists), so it showed as "No account" and saving other fields wrote the picker's `null`, wiping the assignment.

Fix: thread an `accountChanged` flag from the dialog. The stored account is only rewritten when the user actually touches the picker; otherwise it's preserved. Explicitly choosing "No account" still clears it (the flag flips).

## Verification
- `./init.sh app` green.
- On-device (emulator): created a sub funded by Kotak ••7777 → **edit name only → account preserved (7777)**; **change account in picker → updated (9999)**. Test data cleaned up.
- Fix #1's trigger (save-as-recurring) is only reachable via the prefill-from-recurring-source path, not a simple toggle, so it's covered by compile + unit tests + inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)