### PR TITLE
fix(accounts): fix credit card refund balance calculation

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsTransactionProcessor.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsTransactionProcessor.kt
@@ -11,6 +11,7 @@ import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.mapper.toEntity
 import com.pennywiseai.tracker.data.mapper.toEntityType
+import com.pennywiseai.tracker.utils.BalanceCalculator
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.CardRepository
 import com.pennywiseai.tracker.data.repository.MerchantMappingRepository
@@ -270,42 +271,21 @@ class SmsTransactionProcessor @Inject constructor(
                 targetAccountLast4
             )
 
-            val newBalance = when {
-                parsedTransaction.balance != null -> parsedTransaction.balance!!
-                isCreditCard -> {
-                    val currentBalance = existingAccount?.balance ?: BigDecimal.ZERO
-                    currentBalance + parsedTransaction.amount
-                }
-                existingAccount?.isCreditCard == true && parsedTransaction.type.toEntityType() == TransactionType.INCOME -> {
-                    val currentBalance = existingAccount.balance ?: BigDecimal.ZERO
-                    (currentBalance - parsedTransaction.amount).max(BigDecimal.ZERO)
-                }
-                else -> {
-                    // SMS doesn't have explicit balance - calculate based on transaction type
-                    val currentBalance = existingAccount?.balance ?: BigDecimal.ZERO
-                    when (parsedTransaction.type.toEntityType()) {
-                        TransactionType.INCOME -> {
-                            // Money coming in - add to balance
-                            currentBalance + parsedTransaction.amount
-                        }
-                        TransactionType.EXPENSE, TransactionType.INVESTMENT -> {
-                            // Money going out - subtract from balance
-                            (currentBalance - parsedTransaction.amount).max(BigDecimal.ZERO)
-                        }
-                        TransactionType.CREDIT, TransactionType.TRANSFER -> {
-                            // Keep existing balance for transfers (complex logic needed)
-                            // Credit should be handled above, this is fallback
-                            currentBalance
-                        }
-                    }
-                }
-            }
+            val resolvedIsCreditCard = isCreditCard || (existingAccount?.isCreditCard ?: false)
+
+            val newBalance = BalanceCalculator.calculateNewBalance(
+                explicitBalance = parsedTransaction.balance,
+                isCreditCard = resolvedIsCreditCard,
+                transactionType = parsedTransaction.type.toEntityType(),
+                transactionAmount = parsedTransaction.amount,
+                currentBalance = existingAccount?.balance
+            )
 
             // Credit-card SMS report the AVAILABLE limit, not the total. The UI derives
             // available = creditLimit − balance, so store total = available + outstanding
             // (the post-transaction balance) to keep that math correct. Falls back to the
             // existing stored limit when the SMS carries no limit. (#486)
-            val resolvedCreditLimit = if (isCreditCard && parsedTransaction.creditLimit != null) {
+            val resolvedCreditLimit = if (resolvedIsCreditCard && parsedTransaction.creditLimit != null) {
                 parsedTransaction.creditLimit!! + newBalance
             } else {
                 existingAccount?.creditLimit
@@ -318,7 +298,7 @@ class SmsTransactionProcessor @Inject constructor(
                 timestamp = entity.dateTime,
                 transactionId = if (rowId != -1L) rowId else null,
                 creditLimit = resolvedCreditLimit,
-                isCreditCard = isCreditCard || (existingAccount?.isCreditCard ?: false),
+                isCreditCard = resolvedIsCreditCard,
                 smsSource = parsedTransaction.smsBody.take(500),
                 sourceType = "TRANSACTION",
                 currency = parsedTransaction.currency,

--- a/app/src/main/java/com/pennywiseai/tracker/utils/BalanceCalculator.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/utils/BalanceCalculator.kt
@@ -15,22 +15,34 @@ object BalanceCalculator {
         transactionAmount: BigDecimal,
         currentBalance: BigDecimal?
     ): BigDecimal {
+        val cur = currentBalance ?: BigDecimal.ZERO
         return when {
             explicitBalance != null -> explicitBalance
-            isCreditCard && transactionType == TransactionType.INCOME -> {
-                val cur = currentBalance ?: BigDecimal.ZERO
-                (cur - transactionAmount).max(BigDecimal.ZERO)
-            }
             isCreditCard -> {
-                val cur = currentBalance ?: BigDecimal.ZERO
-                cur + transactionAmount
+                when (transactionType) {
+                    TransactionType.INCOME -> {
+                        // Refunds or repayments reduce outstanding debt
+                        (cur - transactionAmount).max(BigDecimal.ZERO)
+                    }
+                    TransactionType.EXPENSE, TransactionType.INVESTMENT, TransactionType.CREDIT -> {
+                        // Purchases or cash withdrawals increase outstanding debt
+                        cur + transactionAmount
+                    }
+                    TransactionType.TRANSFER -> {
+                        // Transfers between own accounts keep outstanding debt unchanged
+                        // (Requires explicit balance or complex leg resolution to modify)
+                        cur
+                    }
+                }
             }
             else -> {
-                val cur = currentBalance ?: BigDecimal.ZERO
                 when (transactionType) {
                     TransactionType.INCOME -> cur + transactionAmount
                     TransactionType.EXPENSE, TransactionType.INVESTMENT -> (cur - transactionAmount).max(BigDecimal.ZERO)
-                    else -> cur
+                    TransactionType.TRANSFER, TransactionType.CREDIT -> {
+                        // Transfers/credits on debit accounts do not change standard balance directly
+                        cur
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/pennywiseai/tracker/utils/BalanceCalculator.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/utils/BalanceCalculator.kt
@@ -1,0 +1,38 @@
+package com.pennywiseai.tracker.utils
+
+import com.pennywiseai.tracker.data.database.entity.TransactionType
+import java.math.BigDecimal
+
+object BalanceCalculator {
+    /**
+     * Calculates the new account balance post-transaction.
+     * For credit cards, balance represents outstanding debt.
+     */
+    fun calculateNewBalance(
+        explicitBalance: BigDecimal?,
+        isCreditCard: Boolean,
+        transactionType: TransactionType,
+        transactionAmount: BigDecimal,
+        currentBalance: BigDecimal?
+    ): BigDecimal {
+        return when {
+            explicitBalance != null -> explicitBalance
+            isCreditCard && transactionType == TransactionType.INCOME -> {
+                val cur = currentBalance ?: BigDecimal.ZERO
+                (cur - transactionAmount).max(BigDecimal.ZERO)
+            }
+            isCreditCard -> {
+                val cur = currentBalance ?: BigDecimal.ZERO
+                cur + transactionAmount
+            }
+            else -> {
+                val cur = currentBalance ?: BigDecimal.ZERO
+                when (transactionType) {
+                    TransactionType.INCOME -> cur + transactionAmount
+                    TransactionType.EXPENSE, TransactionType.INVESTMENT -> (cur - transactionAmount).max(BigDecimal.ZERO)
+                    else -> cur
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
@@ -18,6 +18,7 @@ import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
 import com.pennywiseai.tracker.data.manager.TransactionDeduplication
 import com.pennywiseai.tracker.data.mapper.toEntity
 import com.pennywiseai.tracker.data.mapper.toEntityType
+import com.pennywiseai.tracker.utils.BalanceCalculator
 import com.pennywiseai.tracker.core.TimeConstants
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.repository.*
@@ -793,35 +794,21 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
 
         val existing = accountBalanceRepository.getLatestBalance(parsed.bankName, targetAccount)
 
-        // 1. Calculate the new balance
-        val newBalance = when {
-            // Explicit balance from SMS takes priority
-            parsed.balance != null -> parsed.balance!!
+        val resolvedIsCreditCard = isCreditCard || (existing?.isCreditCard ?: false)
 
-            // For Credit Cards: usually transaction amount adds to current outstanding balance
-            isCreditCard -> (existing?.balance ?: BigDecimal.ZERO) + parsed.amount
-
-            // For existing Credit Card accounts receiving a payment (INCOME)
-            existing?.isCreditCard == true && parsed.type.toEntityType() == TransactionType.INCOME -> {
-                (existing.balance - parsed.amount).max(BigDecimal.ZERO)
-            }
-
-            // Standard fallback calculation based on transaction type
-            else -> {
-                val cur = existing?.balance ?: BigDecimal.ZERO
-                when (parsed.type.toEntityType()) {
-                    TransactionType.INCOME -> cur + parsed.amount
-                    TransactionType.EXPENSE, TransactionType.INVESTMENT -> (cur - parsed.amount).max(BigDecimal.ZERO)
-                    else -> cur
-                }
-            }
-        }
+        val newBalance = BalanceCalculator.calculateNewBalance(
+            explicitBalance = parsed.balance,
+            isCreditCard = resolvedIsCreditCard,
+            transactionType = parsed.type.toEntityType(),
+            transactionAmount = parsed.amount,
+            currentBalance = existing?.balance
+        )
 
         // Credit-card SMS report the AVAILABLE limit, not the total. The UI derives
         // available = creditLimit − balance, so store total = available + outstanding
         // (the post-transaction balance). Falls back to the existing stored limit when
         // the SMS carries no limit. (#486)
-        val resolvedCreditLimit = if (isCreditCard && parsed.creditLimit != null) {
+        val resolvedCreditLimit = if (resolvedIsCreditCard && parsed.creditLimit != null) {
             parsed.creditLimit!! + newBalance
         } else {
             existing?.creditLimit
@@ -834,7 +821,7 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
             timestamp     = entity.dateTime,
             transactionId = if (rowId != -1L) rowId else null,
             creditLimit   = resolvedCreditLimit,
-            isCreditCard  = isCreditCard || (existing?.isCreditCard ?: false),
+            isCreditCard  = resolvedIsCreditCard,
             smsSource     = parsed.smsBody.take(500),
             sourceType    = "TRANSACTION",
             currency      = parsed.currency,

--- a/app/src/test/java/com/pennywiseai/tracker/utils/BalanceCalculatorTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/utils/BalanceCalculatorTest.kt
@@ -1,0 +1,105 @@
+package com.pennywiseai.tracker.utils
+
+import com.pennywiseai.tracker.data.database.entity.TransactionType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.math.BigDecimal
+
+class BalanceCalculatorTest {
+
+    @Test
+    fun `explicit balance takes priority over all logic`() {
+        val newBalance = BalanceCalculator.calculateNewBalance(
+            explicitBalance = BigDecimal("100.00"),
+            isCreditCard = false,
+            transactionType = TransactionType.INCOME,
+            transactionAmount = BigDecimal("50.00"),
+            currentBalance = BigDecimal("500.00")
+        )
+        assertEquals(BigDecimal("100.00"), newBalance)
+    }
+
+    @Test
+    fun `credit card income transaction subtracts from outstanding balance`() {
+        val newBalance = BalanceCalculator.calculateNewBalance(
+            explicitBalance = null,
+            isCreditCard = true,
+            transactionType = TransactionType.INCOME,
+            transactionAmount = BigDecimal("30.00"),
+            currentBalance = BigDecimal("100.00")
+        )
+        assertEquals(BigDecimal("70.00"), newBalance)
+    }
+
+    @Test
+    fun `credit card income transaction clamps outstanding balance to zero`() {
+        val newBalance = BalanceCalculator.calculateNewBalance(
+            explicitBalance = null,
+            isCreditCard = true,
+            transactionType = TransactionType.INCOME,
+            transactionAmount = BigDecimal("150.00"),
+            currentBalance = BigDecimal("100.00")
+        )
+        assertEquals(BigDecimal.ZERO, newBalance)
+    }
+
+    @Test
+    fun `credit card credit purchase adds to outstanding balance`() {
+        val newBalance = BalanceCalculator.calculateNewBalance(
+            explicitBalance = null,
+            isCreditCard = true,
+            transactionType = TransactionType.CREDIT,
+            transactionAmount = BigDecimal("50.00"),
+            currentBalance = BigDecimal("100.00")
+        )
+        assertEquals(BigDecimal("150.00"), newBalance)
+    }
+
+    @Test
+    fun `debit income adds to standard account balance`() {
+        val newBalance = BalanceCalculator.calculateNewBalance(
+            explicitBalance = null,
+            isCreditCard = false,
+            transactionType = TransactionType.INCOME,
+            transactionAmount = BigDecimal("50.00"),
+            currentBalance = BigDecimal("100.00")
+        )
+        assertEquals(BigDecimal("150.00"), newBalance)
+    }
+
+    @Test
+    fun `debit expense subtracts from standard account balance`() {
+        val newBalance = BalanceCalculator.calculateNewBalance(
+            explicitBalance = null,
+            isCreditCard = false,
+            transactionType = TransactionType.EXPENSE,
+            transactionAmount = BigDecimal("40.00"),
+            currentBalance = BigDecimal("100.00")
+        )
+        assertEquals(BigDecimal("60.00"), newBalance)
+    }
+
+    @Test
+    fun `debit investment subtracts from standard account balance`() {
+        val newBalance = BalanceCalculator.calculateNewBalance(
+            explicitBalance = null,
+            isCreditCard = false,
+            transactionType = TransactionType.INVESTMENT,
+            transactionAmount = BigDecimal("40.00"),
+            currentBalance = BigDecimal("100.00")
+        )
+        assertEquals(BigDecimal("60.00"), newBalance)
+    }
+
+    @Test
+    fun `debit transfer preserves standard account balance`() {
+        val newBalance = BalanceCalculator.calculateNewBalance(
+            explicitBalance = null,
+            isCreditCard = false,
+            transactionType = TransactionType.TRANSFER,
+            transactionAmount = BigDecimal("100.00"),
+            currentBalance = BigDecimal("500.00")
+        )
+        assertEquals(BigDecimal("500.00"), newBalance)
+    }
+}

--- a/app/src/test/java/com/pennywiseai/tracker/utils/BalanceCalculatorTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/utils/BalanceCalculatorTest.kt
@@ -102,4 +102,52 @@ class BalanceCalculatorTest {
         )
         assertEquals(BigDecimal("500.00"), newBalance)
     }
+
+    @Test
+    fun `credit card with null current balance defaults to zero`() {
+        val newBalance = BalanceCalculator.calculateNewBalance(
+            explicitBalance = null,
+            isCreditCard = true,
+            transactionType = TransactionType.CREDIT,
+            transactionAmount = BigDecimal("50.00"),
+            currentBalance = null
+        )
+        assertEquals(BigDecimal("50.00"), newBalance)
+    }
+
+    @Test
+    fun `credit card transfer preserves outstanding balance`() {
+        val newBalance = BalanceCalculator.calculateNewBalance(
+            explicitBalance = null,
+            isCreditCard = true,
+            transactionType = TransactionType.TRANSFER,
+            transactionAmount = BigDecimal("100.00"),
+            currentBalance = BigDecimal("500.00")
+        )
+        assertEquals(BigDecimal("500.00"), newBalance)
+    }
+
+    @Test
+    fun `credit card expense adds to outstanding balance`() {
+        val newBalance = BalanceCalculator.calculateNewBalance(
+            explicitBalance = null,
+            isCreditCard = true,
+            transactionType = TransactionType.EXPENSE,
+            transactionAmount = BigDecimal("75.00"),
+            currentBalance = BigDecimal("100.00")
+        )
+        assertEquals(BigDecimal("175.00"), newBalance)
+    }
+
+    @Test
+    fun `credit card investment adds to outstanding balance`() {
+        val newBalance = BalanceCalculator.calculateNewBalance(
+            explicitBalance = null,
+            isCreditCard = true,
+            transactionType = TransactionType.INVESTMENT,
+            transactionAmount = BigDecimal("150.00"),
+            currentBalance = BigDecimal("100.00")
+        )
+        assertEquals(BigDecimal("250.00"), newBalance)
+    }
 }


### PR DESCRIPTION
## Summary

Credit card refund balance calculation was incorrect. `INCOME` transactions on credit cards (like refunds or repayments) mistakenly increased the outstanding balance (debt) instead of decreasing it. This happened because the general `isCreditCard` check was evaluated before the type check.

Fixed by extracting and unifying all post-transaction account balance calculations into BalanceCalculator. Integrated the unified calculator in both SmsTransactionProcessor and OptimizedSmsReaderWorker. Added comprehensive unit tests in BalanceCalculatorTest.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Code improvement (no behavior change)
- [ ] perf: Performance improvement
- [ ] style: Formatting (no behavior change)
- [x] test: Add/update tests
- [ ] chore/ci: Build or CI changes

## Screenshots/Recordings (optional)

<!-- Add images or videos for UI changes. -->

## How to test

<!-- Steps for reviewers to verify the change locally. -->
1. Run the local unit tests specifically for [BalanceCalculatorTest](file:///home/rahul/projects/pennywiseai-tracker/app/src/test/java/com/pennywiseai/tracker/utils/BalanceCalculatorTest.kt):
   ```bash
   ./gradlew :app:testStandardDebugUnitTest --tests "com.pennywiseai.tracker.utils.BalanceCalculatorTest"
   ```
2. Verify all test cases pass successfully.

## Breaking changes

- [x] No breaking changes
- [ ] Yes (describe):

## Related issues

<!-- e.g., Closes #123, Fixes #456 -->

## Checklist

- [x] Focused PR (single purpose)
- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `./gradlew test` passes locally
- [x] `./gradlew lint` passes locally
- [x] Follows existing code style and patterns