### PR TITLE
feat(rules): clearer transaction-type labels + reset operator on field change (#515)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/RuleRepositoryImpl.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/RuleRepositoryImpl.kt
@@ -39,62 +39,17 @@ class RuleRepositoryImpl @Inject constructor(
         val allActiveRules = ruleDao.getActiveRules()
         return allActiveRules
             .map { entity -> entityToRule(entity) }
-            .filter { rule ->
-                // Check if rule has no TYPE condition (applies to all) or matches the type
-                val hasTypeCondition = rule.conditions.any { it.field == TransactionField.TYPE }
-                if (!hasTypeCondition) {
-                    true // Rule applies to all transaction types
-                } else {
-                    // Check if any TYPE condition matches
-                    rule.conditions.any { condition ->
-                        condition.field == TransactionField.TYPE &&
-                        when (condition.operator) {
-                            ConditionOperator.EQUALS -> condition.value.equals(type.name, ignoreCase = true)
-                            ConditionOperator.IN -> condition.value.split(",")
-                                .map { it.trim() }
-                                .any { it.equals(type.name, ignoreCase = true) }
-                            ConditionOperator.NOT_EQUALS -> !condition.value.equals(type.name, ignoreCase = true)
-                            ConditionOperator.NOT_IN -> !condition.value.split(",")
-                                .map { it.trim() }
-                                .any { it.equals(type.name, ignoreCase = true) }
-                            else -> false
-                        }
-                    }
-                }
-            }
+            .filter { rule -> isRuleApplicableToTransactionType(rule, type) }
     }
 
     override suspend fun getActiveRulesByTypes(types: List<TransactionType>): List<TransactionRule> {
         // Get all active rules and filter in memory based on conditions
         val allActiveRules = ruleDao.getActiveRules()
-        val typeNames = types.map { it.name }
 
         return allActiveRules
             .map { entity -> entityToRule(entity) }
             .filter { rule ->
-                // Check if rule has no TYPE condition (applies to all) or matches any of the types
-                val hasTypeCondition = rule.conditions.any { it.field == TransactionField.TYPE }
-                if (!hasTypeCondition) {
-                    true // Rule applies to all transaction types
-                } else {
-                    // Check if any TYPE condition matches any of the requested types
-                    rule.conditions.any { condition ->
-                        condition.field == TransactionField.TYPE &&
-                        when (condition.operator) {
-                            ConditionOperator.EQUALS -> typeNames.any { it.equals(condition.value, ignoreCase = true) }
-                            ConditionOperator.IN -> {
-                                val conditionTypes = condition.value.split(",").map { it.trim() }
-                                typeNames.any { type -> conditionTypes.any { it.equals(type, ignoreCase = true) } }
-                            }
-                            ConditionOperator.NOT_EQUALS -> typeNames.all { !it.equals(condition.value, ignoreCase = true) }
-                            ConditionOperator.NOT_IN -> {
-                                val conditionTypes = condition.value.split(",").map { it.trim() }
-                                typeNames.any { type -> conditionTypes.none { it.equals(type, ignoreCase = true) } }
-                            }
-                            else -> false
-                        }
-                    }
-                }
+                types.any { type -> isRuleApplicableToTransactionType(rule, type) }
             }
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/domain/model/rule/RuleCondition.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/model/rule/RuleCondition.kt
@@ -1,6 +1,59 @@
 package com.pennywiseai.tracker.domain.model.rule
 
+import com.pennywiseai.tracker.data.database.entity.TransactionType
 import kotlinx.serialization.Serializable
+
+/**
+ * Parses a stored [TransactionField.TYPE] value (an enum name like "EXPENSE") into a
+ * [TransactionType], or null if it doesn't map to a known type. Case/whitespace tolerant
+ * so older or hand-edited values still resolve.
+ */
+fun parseRuleTransactionType(value: String): TransactionType? =
+    runCatching { TransactionType.valueOf(value.trim().uppercase()) }.getOrNull()
+
+/**
+ * Operators for a [TransactionField.TYPE] condition that we can evaluate purely from the
+ * transaction's type, without running the full rule. Anything outside this set is passed
+ * through for full evaluation (see [isRuleApplicableToTransactionType]).
+ */
+private val TYPE_PRE_FILTER_OPERATORS = setOf(
+    ConditionOperator.EQUALS,
+    ConditionOperator.IN,
+    ConditionOperator.NOT_EQUALS,
+    ConditionOperator.NOT_IN
+)
+
+/** Whether a single TYPE condition matches [typeName] (an enum name), for the pre-filter operators. */
+fun matchesTransactionTypeCondition(condition: RuleCondition, typeName: String): Boolean =
+    when (condition.operator) {
+        ConditionOperator.EQUALS -> condition.value.equals(typeName, ignoreCase = true)
+        ConditionOperator.IN -> condition.value.split(",")
+            .map { it.trim() }
+            .any { it.equals(typeName, ignoreCase = true) }
+        ConditionOperator.NOT_EQUALS -> !condition.value.equals(typeName, ignoreCase = true)
+        ConditionOperator.NOT_IN -> !condition.value.split(",")
+            .map { it.trim() }
+            .any { it.equals(typeName, ignoreCase = true) }
+        else -> false
+    }
+
+/**
+ * Pre-filter for rules scoped by transaction type. Returns true when the rule *could* match a
+ * transaction of [type], so callers can cheaply narrow rules before full evaluation.
+ *
+ * Conservatively passes a rule through (returns true) when it has no TYPE condition, mixes in
+ * any OR logic (a failing TYPE condition can still match via an OR'd sibling), or uses a TYPE
+ * operator we can't evaluate here — those are decided by the full [RuleEngine] evaluation.
+ */
+fun isRuleApplicableToTransactionType(rule: TransactionRule, type: TransactionType): Boolean {
+    val typeConditions = rule.conditions.filter { it.field == TransactionField.TYPE }
+    val hasOrLogic = rule.conditions.any { it.logicalOperator == LogicalOperator.OR }
+    if (typeConditions.isEmpty() || hasOrLogic) return true
+
+    if (typeConditions.any { it.operator !in TYPE_PRE_FILTER_OPERATORS }) return true
+
+    return typeConditions.any { matchesTransactionTypeCondition(it, type.name) }
+}
 
 @Serializable
 data class RuleCondition(
@@ -45,6 +98,7 @@ data class RuleCondition(
                 val parts = value.split("||")
                 parts.size == 2 && parts[0].isNotBlank() && parts[1].isNotBlank()
             }
+            TransactionField.TYPE -> parseRuleTransactionType(value) != null
             else -> true
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/domain/model/rule/RuleCondition.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/model/rule/RuleCondition.kt
@@ -107,7 +107,7 @@ data class RuleCondition(
 @Serializable
 enum class TransactionField {
     AMOUNT,                  // Transaction amount
-    TYPE,                    // INCOME, EXPENSE, or TRANSFER
+    TYPE,                    // A TransactionType name: INCOME, EXPENSE, CREDIT, TRANSFER, or INVESTMENT
     CATEGORY,                // Transaction category
     MERCHANT,                // Merchant/vendor name
     NARRATION,               // Description/notes

--- a/app/src/main/java/com/pennywiseai/tracker/domain/service/RuleEngine.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/service/RuleEngine.kt
@@ -65,30 +65,10 @@ class RuleEngine @Inject constructor() {
         type: TransactionType
     ): Pair<TransactionEntity, List<RuleApplication>> {
         // Pre-filter rules that apply to this transaction type. This is an optimization
-        // for the common AND-only case; rules that mix in any OR logic are passed through
-        // since a TYPE condition that fails on its own can still let the rule match via
-        // an OR'd sibling.
+        // for the common AND-only case; the shared helper conservatively passes through
+        // rules with OR logic or non-pre-filterable TYPE operators for full evaluation.
         val applicableRules = rules.filter { rule ->
-            val hasTypeCondition = rule.conditions.any { it.field == TransactionField.TYPE }
-            val hasOrLogic = rule.conditions.any { it.logicalOperator == LogicalOperator.OR }
-            if (!hasTypeCondition || hasOrLogic) {
-                true
-            } else {
-                rule.conditions.any { condition ->
-                    condition.field == TransactionField.TYPE &&
-                    when (condition.operator) {
-                        ConditionOperator.EQUALS -> condition.value.equals(type.name, ignoreCase = true)
-                        ConditionOperator.IN -> condition.value.split(",")
-                            .map { it.trim() }
-                            .any { it.equals(type.name, ignoreCase = true) }
-                        ConditionOperator.NOT_EQUALS -> !condition.value.equals(type.name, ignoreCase = true)
-                        ConditionOperator.NOT_IN -> !condition.value.split(",")
-                            .map { it.trim() }
-                            .any { it.equals(type.name, ignoreCase = true) }
-                        else -> false
-                    }
-                }
-            }
+            isRuleApplicableToTransactionType(rule, type)
         }
 
         return evaluateRules(transaction, smsText, applicableRules)
@@ -285,14 +265,8 @@ class RuleEngine @Inject constructor() {
             }
             TransactionField.TYPE -> {
                 val newType = when (action.actionType) {
-                    ActionType.SET -> {
-                        // Convert string value to TransactionType enum
-                        try {
-                            TransactionType.valueOf(action.value.uppercase())
-                        } catch (e: Exception) {
-                            transaction.transactionType
-                        }
-                    }
+                    // Fall back to the existing type if the stored value isn't a known TransactionType.
+                    ActionType.SET -> parseRuleTransactionType(action.value) ?: transaction.transactionType
                     else -> transaction.transactionType
                 }
                 transaction.copy(transactionType = newType) to newType.name

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
@@ -33,7 +33,7 @@ import java.util.UUID
  * Labels mirror the [com.pennywiseai.tracker.data.database.entity.TransactionType] names (e.g.
  * EXPENSE → "Expense") so what the user picks matches what the rule stores and applies.
  */
-val RULE_TRANSACTION_TYPE_OPTIONS: List<Pair<String, String>> = listOf(
+internal val RULE_TRANSACTION_TYPE_OPTIONS: List<Pair<String, String>> = listOf(
     "INCOME" to "Income",
     "EXPENSE" to "Expense",
     "CREDIT" to "Credit",
@@ -42,7 +42,7 @@ val RULE_TRANSACTION_TYPE_OPTIONS: List<Pair<String, String>> = listOf(
 )
 
 /** User-facing label for a stored transaction-type value, falling back to the raw value. */
-fun ruleTransactionTypeLabel(value: String): String =
+internal fun ruleTransactionTypeLabel(value: String): String =
     RULE_TRANSACTION_TYPE_OPTIONS.firstOrNull { it.first.equals(value, ignoreCase = true) }?.second
         ?: value
 

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
@@ -28,6 +28,92 @@ import dev.chrisbanes.haze.hazeSource
 import com.pennywiseai.tracker.ui.theme.Spacing
 import java.util.UUID
 
+/**
+ * Transaction-type options for rule condition/action pickers: stored enum name → display label.
+ * Labels mirror the [com.pennywiseai.tracker.data.database.entity.TransactionType] names (e.g.
+ * EXPENSE → "Expense") so what the user picks matches what the rule stores and applies.
+ */
+val RULE_TRANSACTION_TYPE_OPTIONS: List<Pair<String, String>> = listOf(
+    "INCOME" to "Income",
+    "EXPENSE" to "Expense",
+    "CREDIT" to "Credit",
+    "TRANSFER" to "Transfer",
+    "INVESTMENT" to "Investment"
+)
+
+/** User-facing label for a stored transaction-type value, falling back to the raw value. */
+fun ruleTransactionTypeLabel(value: String): String =
+    RULE_TRANSACTION_TYPE_OPTIONS.firstOrNull { it.first.equals(value, ignoreCase = true) }?.second
+        ?: value
+
+/** The operator a field should reset to when it becomes the condition's field. */
+private fun TransactionField.defaultConditionOperator(): ConditionOperator = when (this) {
+    TransactionField.AMOUNT -> ConditionOperator.LESS_THAN
+    TransactionField.TRANSACTION_TIME -> ConditionOperator.LESS_THAN
+    TransactionField.TRANSACTION_HOUR -> ConditionOperator.EQUALS
+    TransactionField.TRANSACTION_DAY_OF_WEEK -> ConditionOperator.EQUALS
+    TransactionField.TRANSACTION_DAY_OF_MONTH -> ConditionOperator.EQUALS
+    TransactionField.TRANSACTION_DATE -> ConditionOperator.EQUALS
+    TransactionField.ACCOUNT -> ConditionOperator.EQUALS
+    TransactionField.TYPE -> ConditionOperator.EQUALS
+    else -> ConditionOperator.CONTAINS
+}
+
+/**
+ * Operators offered for a condition field, paired with their display label. The first entry is
+ * the field's default (see [defaultConditionOperator]); every default must appear in its list.
+ */
+private fun conditionOperatorsForField(
+    field: TransactionField
+): List<Pair<ConditionOperator, String>> = when (field) {
+    TransactionField.AMOUNT -> listOf(
+        ConditionOperator.LESS_THAN to "<",
+        ConditionOperator.GREATER_THAN to ">",
+        ConditionOperator.EQUALS to "="
+    )
+    TransactionField.TYPE -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.NOT_EQUALS to "is not"
+    )
+    TransactionField.TRANSACTION_TIME -> listOf(
+        ConditionOperator.LESS_THAN to "before",
+        ConditionOperator.GREATER_THAN to "after",
+        ConditionOperator.GREATER_THAN_OR_EQUAL to "at or after",
+        ConditionOperator.LESS_THAN_OR_EQUAL to "at or before",
+        ConditionOperator.EQUALS to "exactly at"
+    )
+    TransactionField.TRANSACTION_HOUR -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.LESS_THAN to "before",
+        ConditionOperator.GREATER_THAN to "after"
+    )
+    TransactionField.TRANSACTION_DAY_OF_WEEK -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.IN to "is any of",
+        ConditionOperator.NOT_EQUALS to "is not"
+    )
+    TransactionField.TRANSACTION_DAY_OF_MONTH -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.IN to "is any of",
+        ConditionOperator.LESS_THAN to "before",
+        ConditionOperator.GREATER_THAN to "after"
+    )
+    TransactionField.TRANSACTION_DATE -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.LESS_THAN to "before",
+        ConditionOperator.GREATER_THAN to "after"
+    )
+    TransactionField.ACCOUNT -> listOf(
+        ConditionOperator.EQUALS to "is",
+        ConditionOperator.NOT_EQUALS to "is not"
+    )
+    else -> listOf(
+        ConditionOperator.CONTAINS to "contains",
+        ConditionOperator.EQUALS to "equals",
+        ConditionOperator.STARTS_WITH to "starts with"
+    )
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreateRuleScreen(
@@ -155,7 +241,7 @@ fun CreateRuleScreen(
                 RuleAction(
                     field = TransactionField.TYPE,
                     actionType = ActionType.SET,
-                    value = "income"
+                    value = "INCOME"
                 )
             )
         },
@@ -577,14 +663,7 @@ fun CreateRuleScreen(
                                     )
                                     when {
                                         condition.field == TransactionField.TYPE -> {
-                                            append(when(condition.value) {
-                                                "INCOME" -> "Incoming"
-                                                "EXPENSE" -> "Outgoing"
-                                                "CREDIT" -> "Credit Card"
-                                                "TRANSFER" -> "Transfer"
-                                                "INVESTMENT" -> "Investment"
-                                                else -> condition.value
-                                            })
+                                            append(ruleTransactionTypeLabel(condition.value))
                                         }
                                         condition.field == TransactionField.TRANSACTION_DAY_OF_WEEK -> {
                                             append(condition.value.split(",").joinToString(", ") { dayNames[it.trim()] ?: it })
@@ -615,14 +694,7 @@ fun CreateRuleScreen(
                                         })
                                         // Show user-friendly labels for transaction types in actions too
                                         if (action.field == TransactionField.TYPE) {
-                                            append(when(action.value) {
-                                                "INCOME" -> "Incoming"
-                                                "EXPENSE" -> "Outgoing"
-                                                "CREDIT" -> "Credit Card"
-                                                "TRANSFER" -> "Transfer"
-                                                "INVESTMENT" -> "Investment"
-                                                else -> action.value
-                                            })
+                                            append(ruleTransactionTypeLabel(action.value))
                                         } else {
                                             append(action.value)
                                         }
@@ -707,7 +779,16 @@ private fun ConditionFieldSelector(
                 DropdownMenuItem(
                     text = { Text(label) },
                     onClick = {
-                        onConditionChange(condition.copy(field = field, value = ""))
+                        // Reset value AND operator: the previous operator may be invalid for the
+                        // new field (e.g. keeping "<" from Amount when switching to Transaction
+                        // Type, which only supports is / is not).
+                        onConditionChange(
+                            condition.copy(
+                                field = field,
+                                value = "",
+                                operator = field.defaultConditionOperator()
+                            )
+                        )
                         fieldDropdownExpanded = false
                     }
                 )
@@ -718,50 +799,7 @@ private fun ConditionFieldSelector(
     Spacer(modifier = Modifier.height(Spacing.sm))
 
     // Operator selector
-    val operators = when(condition.field) {
-        TransactionField.AMOUNT -> listOf(
-            ConditionOperator.LESS_THAN to "<",
-            ConditionOperator.GREATER_THAN to ">",
-            ConditionOperator.EQUALS to "="
-        )
-        TransactionField.TRANSACTION_TIME -> listOf(
-            ConditionOperator.LESS_THAN to "before",
-            ConditionOperator.GREATER_THAN to "after",
-            ConditionOperator.GREATER_THAN_OR_EQUAL to "at or after",
-            ConditionOperator.LESS_THAN_OR_EQUAL to "at or before",
-            ConditionOperator.EQUALS to "exactly at"
-        )
-        TransactionField.TRANSACTION_HOUR -> listOf(
-            ConditionOperator.EQUALS to "is",
-            ConditionOperator.LESS_THAN to "before",
-            ConditionOperator.GREATER_THAN to "after"
-        )
-        TransactionField.TRANSACTION_DAY_OF_WEEK -> listOf(
-            ConditionOperator.EQUALS to "is",
-            ConditionOperator.IN to "is any of",
-            ConditionOperator.NOT_EQUALS to "is not"
-        )
-        TransactionField.TRANSACTION_DAY_OF_MONTH -> listOf(
-            ConditionOperator.EQUALS to "is",
-            ConditionOperator.IN to "is any of",
-            ConditionOperator.LESS_THAN to "before",
-            ConditionOperator.GREATER_THAN to "after"
-        )
-        TransactionField.TRANSACTION_DATE -> listOf(
-            ConditionOperator.EQUALS to "is",
-            ConditionOperator.LESS_THAN to "before",
-            ConditionOperator.GREATER_THAN to "after"
-        )
-        TransactionField.ACCOUNT -> listOf(
-            ConditionOperator.EQUALS to "is",
-            ConditionOperator.NOT_EQUALS to "is not"
-        )
-        else -> listOf(
-            ConditionOperator.CONTAINS to "contains",
-            ConditionOperator.EQUALS to "equals",
-            ConditionOperator.STARTS_WITH to "starts with"
-        )
-    }
+    val operators = conditionOperatorsForField(condition.field)
 
     FlowRow(
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
@@ -790,15 +828,9 @@ private fun ConditionFieldSelector(
                 verticalArrangement = Arrangement.spacedBy(Spacing.xs),
                 modifier = Modifier.fillMaxWidth()
             ) {
-                listOf(
-                    "INCOME" to "Incoming",
-                    "EXPENSE" to "Outgoing",
-                    "CREDIT" to "Credit Card",
-                    "TRANSFER" to "Transfer",
-                    "INVESTMENT" to "Investment"
-                ).forEach { (type, displayLabel) ->
+                RULE_TRANSACTION_TYPE_OPTIONS.forEach { (type, displayLabel) ->
                     FilterChip(
-                        selected = condition.value == type,
+                        selected = condition.value.equals(type, ignoreCase = true),
                         onClick = { onConditionChange(condition.copy(value = type)) },
                         label = {
                             Text(displayLabel, style = MaterialTheme.typography.bodySmall)
@@ -1231,15 +1263,9 @@ private fun ActionEditor(
                         verticalArrangement = Arrangement.spacedBy(Spacing.xs),
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        listOf(
-                            "INCOME" to "Incoming",
-                            "EXPENSE" to "Outgoing",
-                            "CREDIT" to "Credit Card",
-                            "TRANSFER" to "Transfer",
-                            "INVESTMENT" to "Investment"
-                        ).forEach { (type, displayLabel) ->
+                        RULE_TRANSACTION_TYPE_OPTIONS.forEach { (type, displayLabel) ->
                             FilterChip(
-                                selected = action.value == type,
+                                selected = action.value.equals(type, ignoreCase = true),
                                 onClick = { onActionChange(action.copy(value = type)) },
                                 label = {
                                     Text(

--- a/app/src/test/java/com/pennywiseai/tracker/domain/model/rule/RuleConditionTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/domain/model/rule/RuleConditionTest.kt
@@ -1,6 +1,9 @@
 package com.pennywiseai.tracker.domain.model.rule
 
+import com.pennywiseai.tracker.data.database.entity.TransactionType
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -138,5 +141,120 @@ class RuleConditionTest {
             value = "32"
         )
         assertFalse(condition.validate())
+    }
+
+    // --- TYPE field validation ---
+
+    @Test
+    fun `TYPE with EXPENSE value returns true`() {
+        val condition = RuleCondition(
+            field = TransactionField.TYPE,
+            operator = ConditionOperator.EQUALS,
+            value = "EXPENSE"
+        )
+        assertTrue(condition.validate())
+    }
+
+    @Test
+    fun `TYPE with lowercase value returns true`() {
+        val condition = RuleCondition(
+            field = TransactionField.TYPE,
+            operator = ConditionOperator.EQUALS,
+            value = "income"
+        )
+        assertTrue(condition.validate())
+    }
+
+    @Test
+    fun `TYPE with unknown value returns false`() {
+        // A stale display label must not validate as a stored type value.
+        val condition = RuleCondition(
+            field = TransactionField.TYPE,
+            operator = ConditionOperator.EQUALS,
+            value = "Outgoing"
+        )
+        assertFalse(condition.validate())
+    }
+
+    // --- parseRuleTransactionType ---
+
+    @Test
+    fun `parseRuleTransactionType maps known names case- and whitespace-insensitively`() {
+        assertEquals(TransactionType.EXPENSE, parseRuleTransactionType("EXPENSE"))
+        assertEquals(TransactionType.INCOME, parseRuleTransactionType(" income "))
+        assertNull(parseRuleTransactionType("Outgoing"))
+    }
+
+    // --- isRuleApplicableToTransactionType ---
+
+    private fun typeRule(
+        operator: ConditionOperator,
+        value: String
+    ) = TransactionRule(
+        name = "Type rule",
+        conditions = listOf(
+            RuleCondition(field = TransactionField.TYPE, operator = operator, value = value)
+        ),
+        actions = listOf(
+            RuleAction(field = TransactionField.CATEGORY, actionType = ActionType.SET, value = "Food")
+        )
+    )
+
+    @Test
+    fun `isRuleApplicableToTransactionType matches EXPENSE only for expense transactions`() {
+        val rule = typeRule(ConditionOperator.EQUALS, "EXPENSE")
+        assertTrue(isRuleApplicableToTransactionType(rule, TransactionType.EXPENSE))
+        assertFalse(isRuleApplicableToTransactionType(rule, TransactionType.INCOME))
+    }
+
+    @Test
+    fun `isRuleApplicableToTransactionType with NOT_EQUALS excludes only that type`() {
+        val rule = typeRule(ConditionOperator.NOT_EQUALS, "EXPENSE")
+        assertFalse(isRuleApplicableToTransactionType(rule, TransactionType.EXPENSE))
+        assertTrue(isRuleApplicableToTransactionType(rule, TransactionType.INCOME))
+    }
+
+    @Test
+    fun `isRuleApplicableToTransactionType passes through rules with no TYPE condition`() {
+        val rule = TransactionRule(
+            name = "Merchant rule",
+            conditions = listOf(
+                RuleCondition(
+                    field = TransactionField.MERCHANT,
+                    operator = ConditionOperator.CONTAINS,
+                    value = "Amazon"
+                )
+            ),
+            actions = listOf(
+                RuleAction(field = TransactionField.CATEGORY, actionType = ActionType.SET, value = "Shopping")
+            )
+        )
+        assertTrue(isRuleApplicableToTransactionType(rule, TransactionType.EXPENSE))
+        assertTrue(isRuleApplicableToTransactionType(rule, TransactionType.INCOME))
+    }
+
+    @Test
+    fun `isRuleApplicableToTransactionType passes through when any OR logic is present`() {
+        // An OR'd sibling can still match, so a failing TYPE condition must not exclude the rule.
+        val rule = TransactionRule(
+            name = "Type OR merchant",
+            conditions = listOf(
+                RuleCondition(
+                    field = TransactionField.TYPE,
+                    operator = ConditionOperator.EQUALS,
+                    value = "EXPENSE"
+                ),
+                RuleCondition(
+                    field = TransactionField.MERCHANT,
+                    operator = ConditionOperator.CONTAINS,
+                    value = "Amazon",
+                    logicalOperator = LogicalOperator.OR
+                )
+            ),
+            actions = listOf(
+                RuleAction(field = TransactionField.CATEGORY, actionType = ActionType.SET, value = "Shopping")
+            )
+        )
+        assertTrue(isRuleApplicableToTransactionType(rule, TransactionType.INCOME))
     }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/domain/service/RuleEngineTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/domain/service/RuleEngineTest.kt
@@ -356,6 +356,97 @@ class RuleEngineTest {
         assertNotNull("Expected blocking rule to match", result)
     }
 
+    // --- TYPE action / condition tests (#515) ---
+
+    @Test
+    fun `SET TYPE action can set transaction type to EXPENSE`() {
+        val txn = transaction(
+            merchantName = "Amazon",
+            transactionType = TransactionType.CREDIT
+        )
+        val rule = TransactionRule(
+            name = "Mark card spend as expense",
+            conditions = listOf(
+                RuleCondition(TransactionField.MERCHANT, ConditionOperator.CONTAINS, "Amazon")
+            ),
+            actions = listOf(
+                RuleAction(TransactionField.TYPE, ActionType.SET, "EXPENSE")
+            )
+        )
+
+        val (result, applications) = engine.evaluateRules(txn, null, listOf(rule))
+
+        assertEquals(TransactionType.EXPENSE, result.transactionType)
+        assertTrue(applications.isNotEmpty())
+    }
+
+    @Test
+    fun `SET TYPE action with unknown value keeps the original type`() {
+        val txn = transaction(
+            merchantName = "Amazon",
+            transactionType = TransactionType.CREDIT
+        )
+        val rule = TransactionRule(
+            name = "Bad type value",
+            conditions = listOf(
+                RuleCondition(TransactionField.MERCHANT, ConditionOperator.CONTAINS, "Amazon")
+            ),
+            actions = listOf(
+                RuleAction(TransactionField.TYPE, ActionType.SET, "Outgoing")
+            )
+        )
+
+        val (result, _) = engine.evaluateRules(txn, null, listOf(rule))
+
+        assertEquals(TransactionType.CREDIT, result.transactionType)
+    }
+
+    @Test
+    fun `evaluateRulesForType applies a TYPE EXPENSE rule to expense transactions`() {
+        val txn = transaction(transactionType = TransactionType.EXPENSE)
+        val rule = TransactionRule(
+            name = "Expense-only rule",
+            conditions = listOf(
+                RuleCondition(TransactionField.TYPE, ConditionOperator.EQUALS, "EXPENSE")
+            ),
+            actions = listOf(
+                RuleAction(TransactionField.CATEGORY, ActionType.SET, "General")
+            )
+        )
+
+        val (_, applications) = engine.evaluateRulesForType(
+            txn,
+            smsText = null,
+            rules = listOf(rule),
+            type = TransactionType.EXPENSE
+        )
+
+        assertTrue(applications.isNotEmpty())
+    }
+
+    @Test
+    fun `evaluateRulesForType filters out a TYPE EXPENSE rule for income transactions`() {
+        val txn = transaction(transactionType = TransactionType.INCOME)
+        val rule = TransactionRule(
+            name = "Expense-only rule",
+            conditions = listOf(
+                RuleCondition(TransactionField.TYPE, ConditionOperator.EQUALS, "EXPENSE")
+            ),
+            actions = listOf(
+                RuleAction(TransactionField.CATEGORY, ActionType.SET, "General")
+            )
+        )
+
+        val (_, applications) = engine.evaluateRulesForType(
+            txn,
+            smsText = null,
+            rules = listOf(rule),
+            type = TransactionType.INCOME
+        )
+
+        assertTrue(applications.isEmpty())
+    }
+
     // --- factory helpers (shared) ---
 
     private fun transaction(


### PR DESCRIPTION
## What & why

Reimplements the intent of the stale/closed **#515** cleanly against current `main` (the Create Rule screen has since been refactored from single-action to a multi-action `ActionEditor`, so the original diff no longer applied).

Smart Rules could *already* store a `TYPE = EXPENSE` condition/action, but the editor made it confusing and error-prone:

- It labeled `EXPENSE` as **"Outgoing"** and `INCOME` as **"Incoming"** — users looking for "Expense" couldn't find it.
- Switching a condition's **field** kept the previous **operator**, so e.g. `<` (from Amount) stayed selected after switching to Transaction Type, which only supports *is / is not*.
- `TYPE` conditions fell through to the generic `contains / equals / starts with` operators instead of *is / is not*.
- The transaction-type pre-filter logic was duplicated across `RuleEngine` and `RuleRepositoryImpl` (three near-identical inline blocks).

## Changes

- **Relabel** type chips to match the `TransactionType` enum: **Income, Expense, Credit, Transfer, Investment** — in condition chips, action chips, and the rule preview.
- **Reset the operator to the field's default whenever the condition field changes** (all fields, not just TYPE) — a stale/incompatible operator can never linger. This also covers the Greptile P2 raised on the original PR (reset was scoped to TYPE only).
- Give `TYPE` conditions proper **is / is not** operators.
- **Validate** a `TYPE` condition's value is a known `TransactionType`.
- **Centralize** the type helpers (`parseRuleTransactionType`, `matchesTransactionTypeCondition`, `isRuleApplicableToTransactionType`) in `RuleCondition.kt` and reuse them from `RuleEngine` + `RuleRepositoryImpl`, deleting the duplicated inline blocks. (Unifying also gives the repository the engine's safer OR-logic / unknown-operator pass-through.)
- Tests: TYPE parse/validate, pre-filter matching (EQUALS/NOT_EQUALS/no-TYPE/OR pass-through), and `SET TYPE = EXPENSE`.

## Verification

- `./init.sh app` — green (build + unit tests).
- **Emulator** (Pixel_10_Pro): Settings → Smart Rules → Create Rule.
  - Field Amount (`<`) → switch to **Transaction Type**: operator chips become **is / is not** and auto-select **is** (no leftover `<`).
  - Condition preview: **"When type is Expense, set category to Food & Dining"**.
  - Action **Set Transaction Type = Expense** → preview **"…set type to Expense"**.
  - Rule saves, persists in the list (serialization round-trip), and the test rule was deleted afterward to leave data clean.

Closes #515.