### PR TITLE
feat(tags): multi-tag support with analytics and transaction filtering (#514)

### DIFF
--- a/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/58.json
+++ b/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/58.json
@@ -1,0 +1,1925 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 58,
+    "identityHash": "9f6d8287abfad753d6b69656f3dd2683",
+    "entities": [
+      {
+        "tableName": "transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` TEXT NOT NULL, `merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `transaction_type` TEXT NOT NULL, `date_time` TEXT NOT NULL, `description` TEXT, `sms_body` TEXT, `bank_name` TEXT, `sms_sender` TEXT, `account_number` TEXT, `balance_after` TEXT, `transaction_hash` TEXT NOT NULL DEFAULT '', `is_recurring` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `excluded_from_analytics` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `from_account` TEXT, `to_account` TEXT, `reference` TEXT, `loan_id` INTEGER DEFAULT NULL, `loan_contribution` TEXT DEFAULT NULL, `receipt_path` TEXT DEFAULT NULL, `budget_category` TEXT DEFAULT NULL, `budget_impact_type` TEXT DEFAULT NULL, `group_id` INTEGER DEFAULT NULL, `profile_id` INTEGER DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionType",
+            "columnName": "transaction_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateTime",
+            "columnName": "date_time",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsSender",
+            "columnName": "sms_sender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountNumber",
+            "columnName": "account_number",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "balanceAfter",
+            "columnName": "balance_after",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "transactionHash",
+            "columnName": "transaction_hash",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isRecurring",
+            "columnName": "is_recurring",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "excludedFromAnalytics",
+            "columnName": "excluded_from_analytics",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "fromAccount",
+            "columnName": "from_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toAccount",
+            "columnName": "to_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "loanId",
+            "columnName": "loan_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "loanContribution",
+            "columnName": "loan_contribution",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "receiptPath",
+            "columnName": "receipt_path",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetCategory",
+            "columnName": "budget_category",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetImpactType",
+            "columnName": "budget_impact_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "group_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transactions_transaction_hash",
+            "unique": true,
+            "columnNames": [
+              "transaction_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_transactions_transaction_hash` ON `${TABLE_NAME}` (`transaction_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `merchant_name` TEXT NOT NULL, `amount` TEXT NOT NULL, `next_payment_date` TEXT, `state` TEXT NOT NULL, `bank_name` TEXT, `account_last4` TEXT, `umn` TEXT, `category` TEXT, `sms_body` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `direction` TEXT NOT NULL DEFAULT 'EXPENSE', `billing_cycle` TEXT NOT NULL DEFAULT 'Monthly', `last_paid_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextPaymentDate",
+            "columnName": "next_payment_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umn",
+            "columnName": "umn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'EXPENSE'"
+          },
+          {
+            "fieldPath": "billingCycle",
+            "columnName": "billing_cycle",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Monthly'"
+          },
+          {
+            "fieldPath": "lastPaidAt",
+            "columnName": "last_paid_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `message` TEXT NOT NULL, `isUser` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `isSystemPrompt` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUser",
+            "columnName": "isUser",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemPrompt",
+            "columnName": "isSystemPrompt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "merchant_mappings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`merchant_name`))",
+        "fields": [
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "merchant_name"
+          ]
+        }
+      },
+      {
+        "tableName": "merchant_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`merchant_name` TEXT NOT NULL, `alias` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`merchant_name`))",
+        "fields": [
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "merchant_name"
+          ]
+        }
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `color` TEXT NOT NULL, `is_system` INTEGER NOT NULL, `is_income` INTEGER NOT NULL, `display_order` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIncome",
+            "columnName": "is_income",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_categories_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_categories_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "account_balances",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT NOT NULL, `balance` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `transaction_id` INTEGER, `credit_limit` TEXT, `is_credit_card` INTEGER NOT NULL DEFAULT 0, `sms_source` TEXT, `source_type` TEXT, `account_type` TEXT, `created_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `statement_day` INTEGER DEFAULT NULL, `profile_id` INTEGER NOT NULL DEFAULT 1, `alias` TEXT, `lowBalanceThreshold` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "creditLimit",
+            "columnName": "credit_limit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isCreditCard",
+            "columnName": "is_credit_card",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "smsSource",
+            "columnName": "sms_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "source_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountType",
+            "columnName": "account_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "statementDay",
+            "columnName": "statement_day",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lowBalanceThreshold",
+            "columnName": "lowBalanceThreshold",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_account_balances_bank_name_account_last4_timestamp",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "account_last4",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4_timestamp` ON `${TABLE_NAME}` (`bank_name`, `account_last4`, `timestamp`)"
+          },
+          {
+            "name": "index_account_balances_bank_name_account_last4",
+            "unique": false,
+            "columnNames": [
+              "bank_name",
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4` ON `${TABLE_NAME}` (`bank_name`, `account_last4`)"
+          },
+          {
+            "name": "index_account_balances_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "unrecognized_sms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sender` TEXT NOT NULL, `sms_body` TEXT NOT NULL, `received_at` TEXT NOT NULL, `reported` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receivedAt",
+            "columnName": "received_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reported",
+            "columnName": "reported",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_unrecognized_sms_sender_sms_body",
+            "unique": true,
+            "columnNames": [
+              "sender",
+              "sms_body"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_unrecognized_sms_sender_sms_body` ON `${TABLE_NAME}` (`sender`, `sms_body`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `card_last4` TEXT NOT NULL, `card_type` TEXT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT, `nickname` TEXT, `is_active` INTEGER NOT NULL DEFAULT 1, `last_balance` TEXT, `last_balance_source` TEXT, `last_balance_date` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardLast4",
+            "columnName": "card_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardType",
+            "columnName": "card_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastBalance",
+            "columnName": "last_balance",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceSource",
+            "columnName": "last_balance_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceDate",
+            "columnName": "last_balance_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cards_bank_name_card_last4",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cards_bank_name_card_last4` ON `${TABLE_NAME}` (`bank_name`, `card_last4`)"
+          },
+          {
+            "name": "index_cards_card_last4",
+            "unique": false,
+            "columnNames": [
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_card_last4` ON `${TABLE_NAME}` (`card_last4`)"
+          },
+          {
+            "name": "index_cards_account_last4",
+            "unique": false,
+            "columnNames": [
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_account_last4` ON `${TABLE_NAME}` (`account_last4`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `conditions` TEXT NOT NULL, `actions` TEXT NOT NULL, `is_active` INTEGER NOT NULL, `is_system_template` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conditions",
+            "columnName": "conditions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actions",
+            "columnName": "actions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemTemplate",
+            "columnName": "is_system_template",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_rules_priority_is_active",
+            "unique": false,
+            "columnNames": [
+              "priority",
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_priority_is_active` ON `${TABLE_NAME}` (`priority`, `is_active`)"
+          },
+          {
+            "name": "index_transaction_rules_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "rule_applications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `rule_id` TEXT NOT NULL, `rule_name` TEXT NOT NULL, `transaction_id` TEXT NOT NULL, `fields_modified` TEXT NOT NULL, `applied_at` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`rule_id`) REFERENCES `transaction_rules`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "rule_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleName",
+            "columnName": "rule_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fieldsModified",
+            "columnName": "fields_modified",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedAt",
+            "columnName": "applied_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rule_applications_rule_id",
+            "unique": false,
+            "columnNames": [
+              "rule_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_rule_id` ON `${TABLE_NAME}` (`rule_id`)"
+          },
+          {
+            "name": "index_rule_applications_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          },
+          {
+            "name": "index_rule_applications_applied_at",
+            "unique": false,
+            "columnNames": [
+              "applied_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_applied_at` ON `${TABLE_NAME}` (`applied_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transaction_rules",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "rule_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "exchange_rates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `from_currency` TEXT NOT NULL, `to_currency` TEXT NOT NULL, `rate` TEXT NOT NULL, `provider` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `updated_at_unix` INTEGER NOT NULL DEFAULT 0, `expires_at` TEXT NOT NULL, `expires_at_unix` INTEGER NOT NULL DEFAULT 0, `is_custom_rate` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCurrency",
+            "columnName": "from_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCurrency",
+            "columnName": "to_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtUnix",
+            "columnName": "updated_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expires_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAtUnix",
+            "columnName": "expires_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isCustomRate",
+            "columnName": "is_custom_rate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_exchange_rates_from_currency_to_currency",
+            "unique": true,
+            "columnNames": [
+              "from_currency",
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_exchange_rates_from_currency_to_currency` ON `${TABLE_NAME}` (`from_currency`, `to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_from_currency",
+            "unique": false,
+            "columnNames": [
+              "from_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_from_currency` ON `${TABLE_NAME}` (`from_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_to_currency",
+            "unique": false,
+            "columnNames": [
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_to_currency` ON `${TABLE_NAME}` (`to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          },
+          {
+            "name": "index_exchange_rates_expires_at_unix",
+            "unique": false,
+            "columnNames": [
+              "expires_at_unix"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_expires_at_unix` ON `${TABLE_NAME}` (`expires_at_unix`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `period_type` TEXT NOT NULL, `start_date` TEXT NOT NULL, `end_date` TEXT NOT NULL, `weekday_anchor` INTEGER, `month_anchor` INTEGER, `currency` TEXT NOT NULL DEFAULT 'INR', `is_active` INTEGER NOT NULL DEFAULT 1, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "periodType",
+            "columnName": "period_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weekStartDay",
+            "columnName": "weekday_anchor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "monthStartDay",
+            "columnName": "month_anchor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budgets_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_budgets_is_active",
+            "unique": false,
+            "columnNames": [
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_is_active` ON `${TABLE_NAME}` (`is_active`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budget_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL DEFAULT '0', `match_type` TEXT DEFAULT NULL, FOREIGN KEY(`budget_id`) REFERENCES `budgets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          },
+          {
+            "fieldPath": "matchType",
+            "columnName": "match_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budget_categories_budget_id",
+            "unique": false,
+            "columnNames": [
+              "budget_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budget_categories_budget_id` ON `${TABLE_NAME}` (`budget_id`)"
+          },
+          {
+            "name": "index_budget_categories_budget_id_category_name",
+            "unique": true,
+            "columnNames": [
+              "budget_id",
+              "category_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_budget_categories_budget_id_category_name` ON `${TABLE_NAME}` (`budget_id`, `category_name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "budgets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "budget_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "budget_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `budget_name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetName",
+            "columnName": "budget_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "budget_category_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL, `match_type` TEXT DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchType",
+            "columnName": "match_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "transaction_splits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `transaction_id` INTEGER NOT NULL, `category` TEXT NOT NULL, `amount` TEXT NOT NULL, `created_at` TEXT NOT NULL, FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_splits_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_splits_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bank_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `package_name` TEXT NOT NULL, `sender_alias` TEXT NOT NULL, `message_body` TEXT NOT NULL, `message_hash` TEXT NOT NULL, `posted_at` TEXT NOT NULL, `processed` INTEGER NOT NULL, `transaction_id` INTEGER, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderAlias",
+            "columnName": "sender_alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageBody",
+            "columnName": "message_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageHash",
+            "columnName": "message_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postedAt",
+            "columnName": "posted_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "processed",
+            "columnName": "processed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bank_notifications_package_name_message_hash",
+            "unique": true,
+            "columnNames": [
+              "package_name",
+              "message_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_bank_notifications_package_name_message_hash` ON `${TABLE_NAME}` (`package_name`, `message_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "loans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `person_name` TEXT NOT NULL, `direction` TEXT NOT NULL, `original_amount` TEXT NOT NULL, `remaining_amount` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `status` TEXT NOT NULL DEFAULT 'ACTIVE', `note` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `settled_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personName",
+            "columnName": "person_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalAmount",
+            "columnName": "original_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remainingAmount",
+            "columnName": "remaining_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'ACTIVE'"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settledAt",
+            "columnName": "settled_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_loans_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_loans_person_name",
+            "unique": false,
+            "columnNames": [
+              "person_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_person_name` ON `${TABLE_NAME}` (`person_name`)"
+          },
+          {
+            "name": "index_loans_created_at",
+            "unique": false,
+            "columnNames": [
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_created_at` ON `${TABLE_NAME}` (`created_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `note` TEXT DEFAULT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_groups_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_groups_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `color_hex` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorHex",
+            "columnName": "color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tags_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tags_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_tag_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transaction_id` INTEGER NOT NULL, `tag_id` INTEGER NOT NULL, PRIMARY KEY(`transaction_id`, `tag_id`), FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tag_id`) REFERENCES `tags`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tag_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transaction_id",
+            "tag_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_tag_cross_ref_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_tag_cross_ref_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          },
+          {
+            "name": "index_transaction_tag_cross_ref_tag_id",
+            "unique": false,
+            "columnNames": [
+              "tag_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_tag_cross_ref_tag_id` ON `${TABLE_NAME}` (`tag_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "tags",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tag_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9f6d8287abfad753d6b69656f3dd2683')"
+    ]
+  }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
@@ -81,6 +81,8 @@ class BackupExporter @Inject constructor(
         val profiles = database.profileDao().getAllProfiles()
         val budgetMonthSnapshots = database.budgetSnapshotDao().getAllGroupSnapshots()
         val budgetCategoryMonthSnapshots = database.budgetSnapshotDao().getAllCategorySnapshots()
+        val tags = database.tagDao().getAllTagsSync()
+        val transactionTagCrossRefs = database.tagDao().getAllCrossRefs()
         
         // Get preferences from repository
         val prefs = userPreferencesRepository.userPreferences.first()
@@ -138,7 +140,11 @@ class BackupExporter @Inject constructor(
         // Aliases carry raw merchant names (UPI VPAs, store names) + the user's
         // custom labels — exactly what MASKED/ANONYMOUS is meant to hide (#583).
         val exportedMerchantAliases = if (privacy == ExportPrivacy.FULL) merchantAliases else emptyList()
-        
+        // Tags are user-defined labels (no PII), so tag names are kept in all modes;
+        // the cross-refs point at transaction ids that only survive a FULL export.
+        val exportedTags = tags
+        val exportedTransactionTagCrossRefs = if (privacy == ExportPrivacy.FULL) transactionTagCrossRefs else emptyList()
+
         return PennyWiseBackup(
             metadata = BackupMetadata(
                 exportId = UUID.randomUUID().toString(),
@@ -188,7 +194,9 @@ class BackupExporter @Inject constructor(
                 transactionGroups = exportedTransactionGroups,
                 profiles = exportedProfiles,
                 budgetMonthSnapshots = exportedBudgetMonthSnapshots,
-                budgetCategoryMonthSnapshots = exportedBudgetCategoryMonthSnapshots
+                budgetCategoryMonthSnapshots = exportedBudgetCategoryMonthSnapshots,
+                tags = exportedTags,
+                transactionTagCrossRefs = exportedTransactionTagCrossRefs
             ),
             preferences = PreferencesSnapshot(
                 theme = ThemePreferences(

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
@@ -130,6 +130,10 @@ class BackupImporter @Inject constructor(
                 database.transactionGroupDao().deleteAllGroups()
                 database.budgetSnapshotDao().deleteAllGroupSnapshots()
                 database.budgetSnapshotDao().deleteAllCategorySnapshots()
+                // Cross-refs are cascade-deleted when transactions are cleared,
+                // but tags live in their own table — clear both explicitly.
+                database.tagDao().deleteAllCrossRefs()
+                database.tagDao().deleteAllTags()
                 // Note: budget categories and transaction splits are deleted via cascade (budget categories via budget deletion, transaction splits via transaction deletion)
                 // Profiles deliberately preserved — defaults (Personal=1, Business=2)
                 // are seeded on first launch and we don't want to wipe them.
@@ -245,6 +249,16 @@ class BackupImporter @Inject constructor(
                 }
                 backup.database.bankNotifications.insertEachCounting({ skippedRows++ }) { notification ->
                     database.bankNotificationDao().insertOrReplace(notification)
+                }
+
+                // Tags + cross-refs: ids are preserved in REPLACE_ALL (so are
+                // transaction ids), so insert tags first then the links. Insert
+                // tags before cross-refs to satisfy the foreign keys.
+                backup.database.tags.insertEachCounting({ skippedRows++ }) { tag ->
+                    database.tagDao().insertTag(tag)
+                }
+                backup.database.transactionTagCrossRefs.insertEachCounting({ skippedRows++ }) { ref ->
+                    database.tagDao().insertCrossRef(ref)
                 }
 
                 // Profiles were already imported earlier (before transactions /
@@ -446,6 +460,34 @@ class BackupImporter @Inject constructor(
                 }
                 backup.database.bankNotifications.insertEachCounting({ skippedRows++ }) { notification ->
                     database.bankNotificationDao().insertOrReplace(notification)
+                }
+
+                // Tags: dedup by name (case-insensitive) like categories, then
+                // remap the cross-refs' tag_id and transaction_id to their new
+                // local ids. A ref is skipped if its transaction wasn't imported
+                // (missing from the id map). insertCrossRef IGNOREs duplicates,
+                // so a repeat MERGE is idempotent.
+                val existingTagIdByName = database.tagDao().getAllTagsSync()
+                    .associate { it.name.lowercase() to it.id }
+                    .toMutableMap()
+                val oldToNewTagIdMap = mutableMapOf<Long, Long>()
+                backup.database.tags.insertEachCounting({ skippedRows++ }) { tag ->
+                    val key = tag.name.trim().lowercase()
+                    if (key.isNotEmpty()) {
+                        val newId = existingTagIdByName[key]
+                            ?: database.tagDao().insertTag(tag.copy(id = 0))
+                                .also { id -> if (id > 0L) existingTagIdByName[key] = id }
+                        if (newId > 0L && tag.id != 0L) oldToNewTagIdMap[tag.id] = newId
+                    }
+                }
+                backup.database.transactionTagCrossRefs.insertEachCounting({ skippedRows++ }) { ref ->
+                    val mappedTransactionId = oldToNewTransactionIdMap[ref.transactionId]
+                    val mappedTagId = oldToNewTagIdMap[ref.tagId]
+                    if (mappedTransactionId != null && mappedTagId != null) {
+                        database.tagDao().insertCrossRef(
+                            ref.copy(transactionId = mappedTransactionId, tagId = mappedTagId)
+                        )
+                    }
                 }
 
                 // Profiles were already imported earlier (before transactions /

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
@@ -221,7 +221,13 @@ data class DatabaseSnapshot(
     val budgetMonthSnapshots: List<BudgetMonthSnapshotEntity> = emptyList(),
 
     @SerialName("budget_category_month_snapshots")
-    val budgetCategoryMonthSnapshots: List<BudgetCategoryMonthSnapshotEntity> = emptyList()
+    val budgetCategoryMonthSnapshots: List<BudgetCategoryMonthSnapshotEntity> = emptyList(),
+
+    @SerialName("tags")
+    val tags: List<TagEntity> = emptyList(),
+
+    @SerialName("transaction_tag_cross_refs")
+    val transactionTagCrossRefs: List<TransactionTagCrossRef> = emptyList()
 )
 
 /**

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
@@ -12,6 +12,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import com.pennywiseai.tracker.data.database.converter.Converters
 import com.pennywiseai.tracker.data.database.dao.AccountBalanceDao
 import com.pennywiseai.tracker.data.database.dao.ProfileDao
+import com.pennywiseai.tracker.data.database.dao.TagDao
 import com.pennywiseai.tracker.data.database.dao.BankNotificationDao
 import com.pennywiseai.tracker.data.database.dao.BudgetDao
 import com.pennywiseai.tracker.data.database.dao.CardDao
@@ -32,6 +33,8 @@ import com.pennywiseai.tracker.data.database.dao.TransactionSplitDao
 import com.pennywiseai.tracker.data.database.dao.UnrecognizedSmsDao
 import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.data.database.entity.ProfileEntity
+import com.pennywiseai.tracker.data.database.entity.TagEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionTagCrossRef
 import com.pennywiseai.tracker.data.database.entity.BankNotificationEntity
 import com.pennywiseai.tracker.data.database.entity.BudgetCategoryEntity
 import com.pennywiseai.tracker.data.database.entity.BudgetCategoryMonthSnapshotEntity
@@ -59,7 +62,7 @@ import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
  * that needs to record the version it was exported against. Bump this in lock-
  * step with any schema change.
  */
-const val SCHEMA_VERSION = 57
+const val SCHEMA_VERSION = 58
 
 /**
  * The PennyWise Room database.
@@ -72,7 +75,7 @@ const val SCHEMA_VERSION = 57
  * @property autoMigrations List of automatic migrations between versions.
  */
 @Database(
-    entities = [TransactionEntity::class, SubscriptionEntity::class, ChatMessage::class, MerchantMappingEntity::class, MerchantAliasEntity::class, CategoryEntity::class, AccountBalanceEntity::class, UnrecognizedSmsEntity::class, CardEntity::class, RuleEntity::class, RuleApplicationEntity::class, ExchangeRateEntity::class, BudgetEntity::class, BudgetCategoryEntity::class, BudgetMonthSnapshotEntity::class, BudgetCategoryMonthSnapshotEntity::class, TransactionSplitEntity::class, BankNotificationEntity::class, LoanEntity::class, TransactionGroupEntity::class, ProfileEntity::class],
+    entities = [TransactionEntity::class, SubscriptionEntity::class, ChatMessage::class, MerchantMappingEntity::class, MerchantAliasEntity::class, CategoryEntity::class, AccountBalanceEntity::class, UnrecognizedSmsEntity::class, CardEntity::class, RuleEntity::class, RuleApplicationEntity::class, ExchangeRateEntity::class, BudgetEntity::class, BudgetCategoryEntity::class, BudgetMonthSnapshotEntity::class, BudgetCategoryMonthSnapshotEntity::class, TransactionSplitEntity::class, BankNotificationEntity::class, LoanEntity::class, TransactionGroupEntity::class, ProfileEntity::class, TagEntity::class, TransactionTagCrossRef::class],
     version = SCHEMA_VERSION,
     exportSchema = true,
     autoMigrations = [
@@ -148,6 +151,7 @@ abstract class PennyWiseDatabase : RoomDatabase() {
     abstract fun transactionGroupDao(): TransactionGroupDao
     abstract fun budgetSnapshotDao(): BudgetSnapshotDao
     abstract fun profileDao(): ProfileDao
+    abstract fun tagDao(): TagDao
 
     companion object {
         const val DATABASE_NAME = "pennywise_database"
@@ -580,6 +584,20 @@ abstract class PennyWiseDatabase : RoomDatabase() {
             }
         }
 
+        val MIGRATION_57_58 = object : Migration(57, 58) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // Free-text tags with a many-to-many link to transactions.
+                // SQL mirrors Room's generated schema (schemas/.../58.json) so
+                // the migrated DB matches the compiled identity hash.
+                db.execSQL("CREATE TABLE IF NOT EXISTS `tags` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `created_at` TEXT NOT NULL)")
+                db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_tags_name` ON `tags` (`name`)")
+
+                db.execSQL("CREATE TABLE IF NOT EXISTS `transaction_tag_cross_ref` (`transaction_id` INTEGER NOT NULL, `tag_id` INTEGER NOT NULL, PRIMARY KEY(`transaction_id`, `tag_id`), FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tag_id`) REFERENCES `tags`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_transaction_tag_cross_ref_transaction_id` ON `transaction_tag_cross_ref` (`transaction_id`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_transaction_tag_cross_ref_tag_id` ON `transaction_tag_cross_ref` (`tag_id`)")
+            }
+        }
+
         val MIGRATION_38_39 = object : Migration(38, 39) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 // Add receipt_path to transactions if missing
@@ -635,6 +653,7 @@ abstract class PennyWiseDatabase : RoomDatabase() {
             MIGRATION_52_53,
             MIGRATION_53_54,
             MIGRATION_54_55,
+            MIGRATION_57_58,
         )
     }
     

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TagDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TagDao.kt
@@ -1,0 +1,83 @@
+package com.pennywiseai.tracker.data.database.dao
+
+import androidx.room.*
+import com.pennywiseai.tracker.data.database.entity.TagEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionTagCrossRef
+import com.pennywiseai.tracker.data.database.entity.TransactionTagName
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface TagDao {
+
+    // ── Tags ──────────────────────────────────────────────────────────────
+
+    @Query("SELECT * FROM tags ORDER BY name COLLATE NOCASE ASC")
+    fun getAllTags(): Flow<List<TagEntity>>
+
+    @Query("SELECT * FROM tags ORDER BY name COLLATE NOCASE ASC")
+    suspend fun getAllTagsSync(): List<TagEntity>
+
+    @Query("SELECT * FROM tags WHERE name = :name COLLATE NOCASE LIMIT 1")
+    suspend fun getTagByName(name: String): TagEntity?
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertTag(tag: TagEntity): Long
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertTags(tags: List<TagEntity>)
+
+    @Query("DELETE FROM tags")
+    suspend fun deleteAllTags()
+
+    /** Removes tags that are no longer referenced by any transaction. */
+    @Query("DELETE FROM tags WHERE id NOT IN (SELECT DISTINCT tag_id FROM transaction_tag_cross_ref)")
+    suspend fun deleteOrphanTags()
+
+    // ── Cross references ─────────────────────────────────────────────────
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertCrossRef(ref: TransactionTagCrossRef)
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertCrossRefs(refs: List<TransactionTagCrossRef>)
+
+    @Query("DELETE FROM transaction_tag_cross_ref WHERE transaction_id = :transactionId")
+    suspend fun deleteCrossRefsForTransaction(transactionId: Long)
+
+    @Query("DELETE FROM transaction_tag_cross_ref")
+    suspend fun deleteAllCrossRefs()
+
+    @Query("SELECT * FROM transaction_tag_cross_ref")
+    suspend fun getAllCrossRefs(): List<TransactionTagCrossRef>
+
+    // ── Joins ─────────────────────────────────────────────────────────────
+
+    @Query(
+        """
+        SELECT t.* FROM tags t
+        INNER JOIN transaction_tag_cross_ref cr ON t.id = cr.tag_id
+        WHERE cr.transaction_id = :transactionId
+        ORDER BY t.name COLLATE NOCASE ASC
+        """
+    )
+    fun getTagsForTransaction(transactionId: Long): Flow<List<TagEntity>>
+
+    @Query(
+        """
+        SELECT t.* FROM tags t
+        INNER JOIN transaction_tag_cross_ref cr ON t.id = cr.tag_id
+        WHERE cr.transaction_id = :transactionId
+        ORDER BY t.name COLLATE NOCASE ASC
+        """
+    )
+    suspend fun getTagsForTransactionSync(transactionId: Long): List<TagEntity>
+
+    @Query(
+        """
+        SELECT cr.transaction_id AS transactionId, t.name AS name
+        FROM transaction_tag_cross_ref cr
+        INNER JOIN tags t ON cr.tag_id = t.id
+        """
+    )
+    fun getAllTransactionTagPairs(): Flow<List<TransactionTagName>>
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/TagEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/TagEntity.kt
@@ -1,0 +1,85 @@
+package com.pennywiseai.tracker.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.time.LocalDateTime
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+/**
+ * A user-defined, free-text tag that can be attached to any number of
+ * transactions (and a transaction can have any number of tags). Tags are
+ * created on demand from the transaction add/edit screens — typing a new name
+ * creates a row here, while an existing name is reused.
+ *
+ * Backup contract: every field has a Kotlin default so an older backup that
+ * omits a column still restores (see docs/backup-format.md).
+ */
+@Entity(
+    tableName = "tags",
+    indices = [Index(value = ["name"], unique = true)]
+)
+@Serializable
+data class TagEntity(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "id")
+    val id: Long = 0,
+
+    @ColumnInfo(name = "name")
+    val name: String = "",
+
+    @ColumnInfo(name = "created_at")
+    @Contextual
+    val createdAt: LocalDateTime = LocalDateTime.now()
+)
+
+/**
+ * Junction table implementing the many-to-many relationship between
+ * transactions and tags. Rows are removed automatically (CASCADE) when either
+ * the transaction or the tag is deleted.
+ */
+@Entity(
+    tableName = "transaction_tag_cross_ref",
+    primaryKeys = ["transaction_id", "tag_id"],
+    indices = [
+        Index(value = ["transaction_id"]),
+        Index(value = ["tag_id"])
+    ],
+    foreignKeys = [
+        ForeignKey(
+            entity = TransactionEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["transaction_id"],
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = TagEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["tag_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ]
+)
+@Serializable
+data class TransactionTagCrossRef(
+    @ColumnInfo(name = "transaction_id")
+    val transactionId: Long = 0,
+
+    @ColumnInfo(name = "tag_id")
+    val tagId: Long = 0
+)
+
+/**
+ * Lightweight projection used to load all (transaction, tagName) pairs in a
+ * single query, for in-memory tag search and tag analytics aggregation.
+ */
+data class TransactionTagName(
+    @ColumnInfo(name = "transactionId")
+    val transactionId: Long,
+
+    @ColumnInfo(name = "name")
+    val name: String
+)

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TagRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TagRepository.kt
@@ -1,0 +1,79 @@
+package com.pennywiseai.tracker.data.repository
+
+import com.pennywiseai.tracker.data.database.dao.TagDao
+import com.pennywiseai.tracker.data.database.entity.TagEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionTagCrossRef
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Manages the many-to-many relationship between transactions and free-text
+ * [TagEntity]s. Tags are created on demand: setting a tag name that doesn't
+ * exist yet inserts a new row, otherwise the existing tag is reused.
+ */
+@Singleton
+class TagRepository @Inject constructor(
+    private val tagDao: TagDao
+) {
+
+    fun observeAllTags(): Flow<List<TagEntity>> = tagDao.getAllTags()
+
+    /** All tag names currently in use, for autocomplete suggestions. */
+    fun observeAllTagNames(): Flow<List<String>> =
+        tagDao.getAllTags().map { tags -> tags.map { it.name } }
+
+    fun observeTagsForTransaction(transactionId: Long): Flow<List<TagEntity>> =
+        tagDao.getTagsForTransaction(transactionId)
+
+    fun observeTagNamesForTransaction(transactionId: Long): Flow<List<String>> =
+        tagDao.getTagsForTransaction(transactionId).map { tags -> tags.map { it.name } }
+
+    /**
+     * Emits a map of transactionId -> list of tag names, used by search and
+     * analytics which need every transaction's tags in one pass.
+     */
+    fun observeTransactionTagNames(): Flow<Map<Long, List<String>>> =
+        tagDao.getAllTransactionTagPairs().map { pairs ->
+            pairs.groupBy({ it.transactionId }, { it.name })
+        }
+
+    suspend fun getTagNamesForTransaction(transactionId: Long): List<String> =
+        tagDao.getTagsForTransactionSync(transactionId).map { it.name }
+
+    /**
+     * Returns the id of the tag with [name], creating it if necessary. Returns
+     * -1 for a blank name (which is never persisted).
+     */
+    suspend fun getOrCreateTag(name: String): Long {
+        val normalized = name.trim()
+        if (normalized.isEmpty()) return -1L
+        tagDao.getTagByName(normalized)?.let { return it.id }
+        val inserted = tagDao.insertTag(TagEntity(name = normalized))
+        // IGNORE conflict returns -1 on a race; re-read the existing row.
+        return if (inserted != -1L) inserted else tagDao.getTagByName(normalized)?.id ?: -1L
+    }
+
+    /**
+     * Replaces the full set of tags on a transaction with [tagNames]
+     * (deduplicated, case-insensitively). Creates any missing tags and prunes
+     * tags that no longer reference any transaction.
+     */
+    suspend fun setTagsForTransaction(transactionId: Long, tagNames: List<String>) {
+        tagDao.deleteCrossRefsForTransaction(transactionId)
+
+        val tagIds = tagNames
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .distinctBy { it.lowercase() }
+            .map { getOrCreateTag(it) }
+            .filter { it > 0L }
+            .distinct()
+
+        if (tagIds.isNotEmpty()) {
+            tagDao.insertCrossRefs(tagIds.map { TransactionTagCrossRef(transactionId, it) })
+        }
+        tagDao.deleteOrphanTags()
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TagRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TagRepository.kt
@@ -1,5 +1,7 @@
 package com.pennywiseai.tracker.data.repository
 
+import androidx.room.withTransaction
+import com.pennywiseai.tracker.data.database.PennyWiseDatabase
 import com.pennywiseai.tracker.data.database.dao.TagDao
 import com.pennywiseai.tracker.data.database.entity.TagEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionTagCrossRef
@@ -15,6 +17,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class TagRepository @Inject constructor(
+    private val database: PennyWiseDatabase,
     private val tagDao: TagDao
 ) {
 
@@ -61,19 +64,24 @@ class TagRepository @Inject constructor(
      * tags that no longer reference any transaction.
      */
     suspend fun setTagsForTransaction(transactionId: Long, tagNames: List<String>) {
-        tagDao.deleteCrossRefsForTransaction(transactionId)
+        // Atomic: a crash/cancellation between the delete and the re-insert would
+        // otherwise silently strip a transaction's tags. Room's withTransaction is
+        // reentrant, so getOrCreateTag's inner DAO calls join this transaction.
+        database.withTransaction {
+            tagDao.deleteCrossRefsForTransaction(transactionId)
 
-        val tagIds = tagNames
-            .map { it.trim() }
-            .filter { it.isNotEmpty() }
-            .distinctBy { it.lowercase() }
-            .map { getOrCreateTag(it) }
-            .filter { it > 0L }
-            .distinct()
+            val tagIds = tagNames
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .distinctBy { it.lowercase() }
+                .map { getOrCreateTag(it) }
+                .filter { it > 0L }
+                .distinct()
 
-        if (tagIds.isNotEmpty()) {
-            tagDao.insertCrossRefs(tagIds.map { TransactionTagCrossRef(transactionId, it) })
+            if (tagIds.isNotEmpty()) {
+                tagDao.insertCrossRefs(tagIds.map { TransactionTagCrossRef(transactionId, it) })
+            }
+            tagDao.deleteOrphanTags()
         }
-        tagDao.deleteOrphanTags()
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/di/DatabaseModule.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/di/DatabaseModule.kt
@@ -22,6 +22,7 @@ import com.pennywiseai.tracker.data.database.dao.MerchantAliasDao
 import com.pennywiseai.tracker.data.database.dao.RuleApplicationDao
 import com.pennywiseai.tracker.data.database.dao.RuleDao
 import com.pennywiseai.tracker.data.database.dao.SubscriptionDao
+import com.pennywiseai.tracker.data.database.dao.TagDao
 import com.pennywiseai.tracker.data.database.dao.TransactionDao
 import com.pennywiseai.tracker.data.database.dao.TransactionSplitDao
 import com.pennywiseai.tracker.data.database.dao.UnrecognizedSmsDao
@@ -272,6 +273,12 @@ object DatabaseModule {
     @Singleton
     fun provideProfileDao(database: PennyWiseDatabase): ProfileDao {
         return database.profileDao()
+    }
+
+    @Provides
+    @Singleton
+    fun provideTagDao(database: PennyWiseDatabase): TagDao {
+        return database.tagDao()
     }
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
@@ -8,6 +8,7 @@ import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.SubscriptionRepository
+import com.pennywiseai.tracker.data.repository.TagRepository
 import java.math.BigDecimal
 import java.security.MessageDigest
 import java.time.LocalDateTime
@@ -15,7 +16,8 @@ import javax.inject.Inject
 
 class AddTransactionUseCase @Inject constructor(
     private val subscriptionRepository: SubscriptionRepository,
-    private val accountBalanceRepository: AccountBalanceRepository
+    private val accountBalanceRepository: AccountBalanceRepository,
+    private val tagRepository: TagRepository
 ) {
     suspend fun execute(
         amount: BigDecimal,
@@ -24,6 +26,7 @@ class AddTransactionUseCase @Inject constructor(
         type: TransactionType,
         date: LocalDateTime,
         notes: String? = null,
+        tags: List<String> = emptyList(),
         isRecurring: Boolean = false,
         bankName: String? = null,
         accountLast4: String? = null,
@@ -71,7 +74,12 @@ class AddTransactionUseCase @Inject constructor(
             bankName = bankName,
             accountLast4 = accountLast4
         )
-        
+
+        // Link tags (create-or-select handled in the repository)
+        if (transactionId != -1L && tags.isNotEmpty()) {
+            tagRepository.setTagsForTransaction(transactionId, tags)
+        }
+
         // If marked as recurring, create a subscription
         if (isRecurring && transactionId != -1L) {
             val nextPaymentDate = date.toLocalDate().plusMonths(1) // Default to monthly

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
@@ -6,6 +6,8 @@ import com.pennywiseai.tracker.data.database.entity.SubscriptionState
 import com.pennywiseai.tracker.data.database.entity.BudgetImpactType
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
+import androidx.room.withTransaction
+import com.pennywiseai.tracker.data.database.PennyWiseDatabase
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.SubscriptionRepository
 import com.pennywiseai.tracker.data.repository.TagRepository
@@ -15,6 +17,7 @@ import java.time.LocalDateTime
 import javax.inject.Inject
 
 class AddTransactionUseCase @Inject constructor(
+    private val database: PennyWiseDatabase,
     private val subscriptionRepository: SubscriptionRepository,
     private val accountBalanceRepository: AccountBalanceRepository,
     private val tagRepository: TagRepository
@@ -65,42 +68,49 @@ class AddTransactionUseCase @Inject constructor(
             budgetImpactType = budgetImpactType
         )
 
-        // Insert the transaction and reflect it on the selected account's balance
-        // atomically. For manual/cash accounts the helper pins the opening anchor
-        // from the PRE-insert snapshot before inserting, so the recompute includes
-        // this new transaction. No-op balance side for SMS / no-account adds.
-        val transactionId = accountBalanceRepository.insertTransactionWithBalance(
-            transaction = transaction,
-            bankName = bankName,
-            accountLast4 = accountLast4
-        )
-
-        // Link tags (create-or-select handled in the repository)
-        if (transactionId != -1L && tags.isNotEmpty()) {
-            tagRepository.setTagsForTransaction(transactionId, tags)
-        }
-
-        // If marked as recurring, create a subscription
-        if (isRecurring && transactionId != -1L) {
-            val nextPaymentDate = date.toLocalDate().plusMonths(1) // Default to monthly
-            
-            val subscription = SubscriptionEntity(
-                merchantName = merchant,
-                amount = amount,
-                nextPaymentDate = nextPaymentDate,
-                state = SubscriptionState.ACTIVE,
-                // Carry the funding account onto the auto-created subscription so
-                // marking it paid later moves that account's balance — otherwise
-                // this whole class of subscriptions silently skips the #570 fix.
-                bankName = bankName ?: "Manual Entry",
-                accountLast4 = accountLast4,
-                category = category,
-                currency = currency,
-                createdAt = LocalDateTime.now(),
-                updatedAt = LocalDateTime.now()
+        // Insert the transaction, its tags, and any recurring subscription as a
+        // single atomic unit: if tag-linking (or the subscription insert) fails
+        // after the row is written, the whole add rolls back rather than leaving a
+        // persisted-but-untagged transaction the user might re-save as a duplicate.
+        // Room's withTransaction is reentrant, so insertTransactionWithBalance and
+        // setTagsForTransaction (which each open their own) join this outer one.
+        database.withTransaction {
+            // For manual/cash accounts the helper pins the opening anchor from the
+            // PRE-insert snapshot before inserting, so the recompute includes this
+            // new transaction. No-op balance side for SMS / no-account adds.
+            val transactionId = accountBalanceRepository.insertTransactionWithBalance(
+                transaction = transaction,
+                bankName = bankName,
+                accountLast4 = accountLast4
             )
-            
-            subscriptionRepository.insertSubscription(subscription)
+
+            // Link tags (create-or-select handled in the repository)
+            if (transactionId != -1L && tags.isNotEmpty()) {
+                tagRepository.setTagsForTransaction(transactionId, tags)
+            }
+
+            // If marked as recurring, create a subscription
+            if (isRecurring && transactionId != -1L) {
+                val nextPaymentDate = date.toLocalDate().plusMonths(1) // Default to monthly
+
+                val subscription = SubscriptionEntity(
+                    merchantName = merchant,
+                    amount = amount,
+                    nextPaymentDate = nextPaymentDate,
+                    state = SubscriptionState.ACTIVE,
+                    // Carry the funding account onto the auto-created subscription so
+                    // marking it paid later moves that account's balance — otherwise
+                    // this whole class of subscriptions silently skips the #570 fix.
+                    bankName = bankName ?: "Manual Entry",
+                    accountLast4 = accountLast4,
+                    category = category,
+                    currency = currency,
+                    createdAt = LocalDateTime.now(),
+                    updatedAt = LocalDateTime.now()
+                )
+
+                subscriptionRepository.insertSubscription(subscription)
+            }
         }
     }
     

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
@@ -13,6 +13,7 @@ import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.receipt.ReceiptManager
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository
+import com.pennywiseai.tracker.data.repository.TagRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import com.pennywiseai.tracker.domain.usecase.AddTransactionUseCase
 import com.pennywiseai.tracker.domain.usecase.AddSubscriptionUseCase
@@ -39,9 +40,14 @@ class AddViewModel @Inject constructor(
     private val budgetGroupRepository: BudgetGroupRepository,
     private val userPreferencesRepository: UserPreferencesRepository,
     private val transactionRepository: TransactionRepository,
+    private val tagRepository: TagRepository,
     private val receiptManager: ReceiptManager,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+
+    /** All known tag names for autocomplete in the add form. */
+    val allTagNames: StateFlow<List<String>> = tagRepository.observeAllTagNames()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     // When launched via "Duplicate", this holds the id of the source transaction
     // whose values should pre-fill the form. Null for a fresh add.
@@ -94,6 +100,7 @@ class AddViewModel @Inject constructor(
                 categoryError = null,
                 date = LocalDateTime.now(),
                 notes = source.description ?: "",
+                tags = tagRepository.getTagNamesForTransaction(source.id),
                 isRecurring = source.isRecurring,
                 currency = source.currency,
                 budgetImpactType = source.budgetImpactType,
@@ -226,6 +233,21 @@ class AddViewModel @Inject constructor(
             currentState.copy(notes = notes)
         }
     }
+
+    fun addTransactionTag(tag: String) {
+        val trimmed = tag.trim()
+        if (trimmed.isEmpty()) return
+        _transactionUiState.update { currentState ->
+            if (currentState.tags.any { it.equals(trimmed, ignoreCase = true) }) currentState
+            else currentState.copy(tags = currentState.tags + trimmed)
+        }
+    }
+
+    fun removeTransactionTag(tag: String) {
+        _transactionUiState.update { currentState ->
+            currentState.copy(tags = currentState.tags.filterNot { it.equals(tag, ignoreCase = true) })
+        }
+    }
     
     fun updateTransactionRecurring(isRecurring: Boolean) {
         _transactionUiState.update { currentState ->
@@ -287,6 +309,7 @@ class AddViewModel @Inject constructor(
                     type = state.transactionType,
                     date = state.date,
                     notes = state.notes.takeIf { it.isNotBlank() },
+                    tags = state.tags,
                     isRecurring = state.isRecurring,
                     bankName = selectedAccount?.bankName,
                     accountLast4 = selectedAccount?.accountLast4,
@@ -499,6 +522,7 @@ data class TransactionUiState(
     val categoryError: String? = null,
     val date: LocalDateTime = LocalDateTime.now(),
     val notes: String = "",
+    val tags: List<String> = emptyList(),
     val isRecurring: Boolean = false,
     val isLoading: Boolean = false,
     val error: String? = null,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/TransactionTabContent.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/TransactionTabContent.kt
@@ -36,6 +36,7 @@ import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.domain.model.displayName
 import com.pennywiseai.tracker.domain.model.getAccountType
 import com.pennywiseai.tracker.presentation.accounts.AccountType
+import com.pennywiseai.tracker.ui.components.TagInputField
 import com.pennywiseai.tracker.ui.theme.*
 import com.pennywiseai.tracker.utils.CurrencyFormatter
 import java.time.format.DateTimeFormatter
@@ -168,6 +169,15 @@ fun TransactionTabContent(
                     colors = filledFieldColors()
                 )
             }
+
+            // ── Tags (create or select existing) ──
+            val allTagNames by viewModel.allTagNames.collectAsState()
+            TagInputField(
+                selectedTags = uiState.tags,
+                allTags = allTagNames,
+                onAddTag = viewModel::addTransactionTag,
+                onRemoveTag = viewModel::removeTransactionTag
+            )
 
             // ── Transaction Type chips ──
             FlowRow(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailScreen.kt
@@ -75,6 +75,7 @@ import com.pennywiseai.tracker.ui.components.cards.SectionHeaderV2
 import com.pennywiseai.tracker.ui.components.SplitBreakdownCard
 import com.pennywiseai.tracker.ui.components.SplitEditor
 import com.pennywiseai.tracker.ui.components.SplitItem
+import com.pennywiseai.tracker.ui.components.TagInputField
 import com.pennywiseai.tracker.ui.theme.*
 import com.pennywiseai.tracker.utils.CurrencyFormatter
 import dev.chrisbanes.haze.HazeState
@@ -841,6 +842,17 @@ private fun TransactionReceipt(
                 )
             }
 
+            // Tags
+            val detailTags by viewModel.transactionTags.collectAsStateWithLifecycle()
+            if (detailTags.isNotEmpty()) {
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                DetailInfoRow(
+                    icon = Icons.Default.Sell,
+                    label = if (detailTags.size == 1) "Tag" else "Tags",
+                    value = detailTags.joinToString(", ")
+                )
+            }
+
             // Recurring
             if (transaction.isRecurring) {
                 HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
@@ -1240,6 +1252,16 @@ private fun EditableTransactionHeader(
                 colors = editFilledColors()
             )
         }
+
+        // Tags (optional) — create or select existing
+        val editTags by viewModel.editableTags.collectAsStateWithLifecycle()
+        val allTagNames by viewModel.allTagNames.collectAsStateWithLifecycle()
+        TagInputField(
+            selectedTags = editTags,
+            allTags = allTagNames,
+            onAddTag = { viewModel.addTag(it) },
+            onRemoveTag = { viewModel.removeTag(it) }
+        )
 
         // Transaction Type
         FlowRow(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
@@ -22,6 +22,7 @@ import com.pennywiseai.tracker.data.repository.CategoryRepository
 import com.pennywiseai.tracker.data.repository.LoanRepository
 import com.pennywiseai.tracker.data.repository.MerchantAliasRepository
 import com.pennywiseai.tracker.data.repository.MerchantMappingRepository
+import com.pennywiseai.tracker.data.repository.TagRepository
 import com.pennywiseai.tracker.data.repository.TransactionGroupRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import com.pennywiseai.tracker.data.database.entity.TransactionGroupEntity
@@ -46,6 +47,7 @@ class TransactionDetailViewModel @Inject constructor(
     private val loanRepository: LoanRepository,
     private val budgetGroupRepository: BudgetGroupRepository,
     private val transactionGroupRepository: TransactionGroupRepository,
+    private val tagRepository: TagRepository,
     private val currencyConversionService: CurrencyConversionService,
     private val userPreferencesRepository: UserPreferencesRepository,
     private val receiptManager: ReceiptManager,
@@ -69,6 +71,23 @@ class TransactionDetailViewModel @Inject constructor(
     
     private val _editableTransaction = MutableStateFlow<TransactionEntity?>(null)
     val editableTransaction: StateFlow<TransactionEntity?> = _editableTransaction.asStateFlow()
+
+    // Tags ----------------------------------------------------------------
+    // Read-only set of tag names on the currently loaded transaction.
+    val transactionTags: StateFlow<List<String>> = _transaction
+        .flatMapLatest { tx ->
+            if (tx == null) flowOf(emptyList())
+            else tagRepository.observeTagNamesForTransaction(tx.id)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    // All known tag names, for autocomplete in the editor.
+    val allTagNames: StateFlow<List<String>> = tagRepository.observeAllTagNames()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    // Working copy of tags while in edit mode (persisted on save).
+    private val _editableTags = MutableStateFlow<List<String>>(emptyList())
+    val editableTags: StateFlow<List<String>> = _editableTags.asStateFlow()
     
     private val _isSaving = MutableStateFlow(false)
     val isSaving: StateFlow<Boolean> = _isSaving.asStateFlow()
@@ -346,6 +365,13 @@ class TransactionDetailViewModel @Inject constructor(
         _pendingReceiptUri.value = null
         _receiptRemoved.value = false
 
+        // Seed the editable tag list from the persisted tags.
+        _transaction.value?.let { txn ->
+            viewModelScope.launch {
+                _editableTags.value = tagRepository.getTagNamesForTransaction(txn.id)
+            }
+        }
+
         // Restore split state from original splits
         if (_hasSplits.value) {
             _splits.value = _originalSplits.value
@@ -371,6 +397,7 @@ class TransactionDetailViewModel @Inject constructor(
     fun exitEditMode() {
         _editableTransaction.value = null
         _isEditMode.value = false
+        _editableTags.value = emptyList()
         _errorMessage.value = null
         _applyToAllFromMerchant.value = false
         _updateExistingTransactions.value = false
@@ -493,6 +520,21 @@ class TransactionDetailViewModel @Inject constructor(
     fun updateDescription(description: String?) {
         _editableTransaction.update { current ->
             current?.copy(description = if (description.isNullOrEmpty()) null else description)
+        }
+    }
+
+    fun addTag(name: String) {
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) return
+        _editableTags.update { current ->
+            if (current.any { it.equals(trimmed, ignoreCase = true) }) current
+            else current + trimmed
+        }
+    }
+
+    fun removeTag(name: String) {
+        _editableTags.update { current ->
+            current.filterNot { it.equals(name, ignoreCase = true) }
         }
     }
     
@@ -736,6 +778,9 @@ class TransactionDetailViewModel @Inject constructor(
                 }
 
                 transactionRepository.updateTransaction(normalizedTransaction)
+
+                // Persist the edited tag set (create-or-select handled in repo).
+                tagRepository.setTagsForTransaction(normalizedTransaction.id, _editableTags.value)
 
                 // Update account balance if account was changed or added
                 val originalTxn = _transaction.value

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
@@ -119,6 +119,8 @@ fun TransactionsScreen(
     val profileAccountKeys by viewModel.profileAccountKeys.collectAsState()
     val accountFilter by viewModel.accountFilter.collectAsState()
     val accountOptions by viewModel.accountOptions.collectAsState()
+    val tagFilter by viewModel.tagFilter.collectAsState()
+    val availableTags by viewModel.availableTags.collectAsState()
 
     // Bulk-edit selection (#369)
     val selectedIds by viewModel.selectedIds.collectAsState()
@@ -145,6 +147,7 @@ fun TransactionsScreen(
     var showTypeMenu by remember { mutableStateOf(false) }
     var showMoreFiltersMenu by remember { mutableStateOf(false) }
     var showAccountMenu by remember { mutableStateOf(false) }
+    var showTagMenu by remember { mutableStateOf(false) }
 
     // Focus management for search field
     val searchFocusRequester = remember { FocusRequester() }
@@ -165,6 +168,7 @@ fun TransactionsScreen(
         transactionTypeFilter != TransactionTypeFilter.ALL ||
         selectedProfileId != null ||
         accountFilter != null ||
+        tagFilter != null ||
         hasCurrencyFilter ||
         customDateRange != null
 
@@ -382,7 +386,8 @@ fun TransactionsScreen(
             showTypeMenu = showTypeMenu,
             showMoreFiltersMenu = showMoreFiltersMenu,
             showAccountMenu = showAccountMenu,
-            collapsed = collapseTransactionHeader && !showPeriodMenu && !showTypeMenu && !showMoreFiltersMenu && !showAccountMenu,
+            showTagMenu = showTagMenu,
+            collapsed = collapseTransactionHeader && !showPeriodMenu && !showTypeMenu && !showMoreFiltersMenu && !showAccountMenu && !showTagMenu,
             sortOption = sortOption,
             timePeriods = timePeriods,
             availableCategories = availableCategories,
@@ -390,6 +395,8 @@ fun TransactionsScreen(
             selectedProfileId = selectedProfileId,
             accountOptions = accountOptions,
             accountFilter = accountFilter,
+            availableTags = availableTags,
+            tagFilter = tagFilter,
             onSearchQueryChange = viewModel::updateSearchQuery,
             onSortClick = { showSortMenu = true },
             onSortDismiss = { showSortMenu = false },
@@ -435,6 +442,13 @@ fun TransactionsScreen(
                 view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
                 viewModel.setAccountFilter(accountKey)
                 showAccountMenu = false
+            },
+            onTagClick = { showTagMenu = true },
+            onTagDismiss = { showTagMenu = false },
+            onTagSelected = { tag ->
+                view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+                viewModel.setTagFilter(tag)
+                showTagMenu = false
             },
             onResetFilters = viewModel::resetFilters,
             focusRequester = searchFocusRequester,
@@ -968,6 +982,7 @@ private fun TransactionFilterHeader(
     showTypeMenu: Boolean,
     showMoreFiltersMenu: Boolean,
     showAccountMenu: Boolean,
+    showTagMenu: Boolean,
     collapsed: Boolean,
     sortOption: SortOption,
     timePeriods: List<TimePeriod>,
@@ -976,6 +991,8 @@ private fun TransactionFilterHeader(
     selectedProfileId: Long?,
     accountOptions: List<com.pennywiseai.tracker.presentation.common.AccountOption>,
     accountFilter: String?,
+    availableTags: List<String>,
+    tagFilter: String?,
     onSearchQueryChange: (String) -> Unit,
     onSortClick: () -> Unit,
     onSortDismiss: () -> Unit,
@@ -993,6 +1010,9 @@ private fun TransactionFilterHeader(
     onAccountClick: () -> Unit,
     onAccountDismiss: () -> Unit,
     onAccountSelected: (String?) -> Unit,
+    onTagClick: () -> Unit,
+    onTagDismiss: () -> Unit,
+    onTagSelected: (String?) -> Unit,
     onResetFilters: () -> Unit,
     focusRequester: FocusRequester,
     modifier: Modifier = Modifier
@@ -1226,6 +1246,49 @@ private fun TransactionFilterHeader(
                                     },
                                     onClick = { onProfileSelected(profile.id) }
                                 )
+                            }
+                        }
+                    }
+                }
+
+                if (availableTags.isNotEmpty() || tagFilter != null) {
+                    item {
+                        Box {
+                            ExpressiveFilterChip(
+                                selected = tagFilter != null,
+                                text = tagFilter ?: "Tag",
+                                icon = Icons.Default.Sell,
+                                onClick = onTagClick
+                            )
+
+                            DropdownMenu(
+                                expanded = showTagMenu,
+                                onDismissRequest = onTagDismiss
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text("All tags") },
+                                    leadingIcon = {
+                                        if (tagFilter == null) {
+                                            Icon(Icons.Default.Check, contentDescription = null)
+                                        } else {
+                                            Icon(Icons.Default.Sell, contentDescription = null)
+                                        }
+                                    },
+                                    onClick = { onTagSelected(null) }
+                                )
+                                availableTags.forEach { tag ->
+                                    DropdownMenuItem(
+                                        text = { Text(tag, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                                        leadingIcon = {
+                                            if (tagFilter?.equals(tag, ignoreCase = true) == true) {
+                                                Icon(Icons.Default.Check, contentDescription = null)
+                                            } else {
+                                                Icon(Icons.Default.Sell, contentDescription = null)
+                                            }
+                                        },
+                                        onClick = { onTagSelected(tag) }
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -1162,7 +1162,6 @@ class TransactionsViewModel @Inject constructor(
     ): Flow<List<TransactionEntity>> {
         // Start with the base flow based on category filter
         val baseFlow = if (category != null) {
-            println("DEBUG: Filtering by category: '$category'")
             transactionRepository.getTransactionsByCategory(category)
         } else {
             transactionRepository.getAllTransactions()

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -8,6 +8,7 @@ import com.pennywiseai.tracker.data.database.entity.CategoryEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.repository.CategoryRepository
+import com.pennywiseai.tracker.data.repository.TagRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import com.pennywiseai.tracker.domain.model.BudgetCycle
 import com.pennywiseai.tracker.presentation.common.TimePeriod
@@ -45,6 +46,7 @@ import javax.inject.Inject
 class TransactionsViewModel @Inject constructor(
     private val transactionRepository: TransactionRepository,
     private val categoryRepository: CategoryRepository,
+    private val tagRepository: TagRepository,
     private val transactionSplitDao: TransactionSplitDao,
     private val userPreferencesRepository: com.pennywiseai.tracker.data.preferences.UserPreferencesRepository,
     private val currencyConversionService: CurrencyConversionService,
@@ -57,6 +59,11 @@ class TransactionsViewModel @Inject constructor(
     
     private val _searchQuery = MutableStateFlow("")
     val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    // transactionId -> tag names, kept in sync for in-memory tag search.
+    private val transactionTagsMap: StateFlow<Map<Long, List<String>>> =
+        tagRepository.observeTransactionTagNames()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyMap())
     
     private val _selectedPeriod = MutableStateFlow(TimePeriod.THIS_MONTH)
     val selectedPeriod: StateFlow<TimePeriod> = _selectedPeriod.asStateFlow()
@@ -80,6 +87,13 @@ class TransactionsViewModel @Inject constructor(
     // Account filter — null means "All accounts". Key is "bankName_accountLast4".
     private val _accountFilter = MutableStateFlow<String?>(null)
     val accountFilter: StateFlow<String?> = _accountFilter.asStateFlow()
+
+    // Tag filter — null means "All tags". Matches any transaction that carries the tag.
+    private val _tagFilter = MutableStateFlow<String?>(null)
+    val tagFilter: StateFlow<String?> = _tagFilter.asStateFlow()
+
+    val availableTags: StateFlow<List<String>> = tagRepository.observeAllTagNames()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     // Pickable account options for the account filter dropdown (alias-preferred labels).
     val accountOptions: StateFlow<List<AccountOption>> =
@@ -624,6 +638,14 @@ class TransactionsViewModel @Inject constructor(
                 _profileAccountKeys.value = buildProfileAccountKeys(balances)
             }
         }
+        viewModelScope.launch {
+            availableTags.collect { tags ->
+                val current = _tagFilter.value
+                if (current != null && tags.none { it.equals(current, ignoreCase = true) }) {
+                    _tagFilter.value = null
+                }
+            }
+        }
 
         // Load unified mode preferences
         viewModelScope.launch {
@@ -688,10 +710,12 @@ class TransactionsViewModel @Inject constructor(
             _selectedProfileId.map { "profileFilter" },
             _profileAccountKeys.map { "profileAccountKeys" },
             _accountFilter.map { "accountFilter" },
+            tagFilter.map { "tagFilter" },
             selectedCurrency.map { "currency" },
             _isUnifiedMode.map { "unifiedMode" },
             sortOption.map { "sort" },
-            customDateRange.map { "customDate" }
+            customDateRange.map { "customDate" },
+            transactionTagsMap.map { "tags" }
         )
             .transformLatest { trigger ->
                 // Get current values from all StateFlows
@@ -705,6 +729,7 @@ class TransactionsViewModel @Inject constructor(
 
                 val profileId = _selectedProfileId.value
                 val accountKey = _accountFilter.value
+                val tag = _tagFilter.value
 
                 // Resolve the cycle window up-front so the inner (non-suspend)
                 // filter helper can reuse it for THIS_MONTH. Non-THIS_MONTH
@@ -719,11 +744,19 @@ class TransactionsViewModel @Inject constructor(
                 // Get filtered transactions (without currency filter first)
                 getFilteredTransactions(query, period, category, categories, typeFilter, cycleRange)
                     .collect { allTransactions ->
-                        // Apply profile filter, then account filter
-                        val transactions = filterTransactionsByAccount(
+                        // Apply profile, account, then tag filters
+                        val profileAndAccountFiltered = filterTransactionsByAccount(
                             filterByProfile(allTransactions, profileId),
                             accountKey
                         )
+                        val transactions = if (tag != null) {
+                            profileAndAccountFiltered.filter { tx ->
+                                transactionTagsMap.value[tx.id]
+                                    ?.any { it.equals(tag, ignoreCase = true) } == true
+                            }
+                        } else {
+                            profileAndAccountFiltered
+                        }
                         if (isUnified) {
                             // Show all transactions regardless of currency
                             emit(sortTransactions(transactions, sort))
@@ -829,6 +862,15 @@ class TransactionsViewModel @Inject constructor(
     fun setAccountFilter(accountKey: String?) {
         _accountFilter.value = accountKey
     }
+
+    /** Sets the tag filter; null clears it ("All tags"). */
+    fun setTagFilter(tag: String?) {
+        _tagFilter.value = tag?.takeIf { it.isNotBlank() }
+    }
+
+    fun clearTagFilter() {
+        _tagFilter.value = null
+    }
     
     fun setSelectedProfile(profileId: Long?) {
         _selectedProfileId.value = profileId
@@ -922,6 +964,7 @@ class TransactionsViewModel @Inject constructor(
         selectPeriod(TimePeriod.THIS_MONTH)
         setTransactionTypeFilter(TransactionTypeFilter.ALL)
         setAccountFilter(null)
+        clearTagFilter()
         _selectedProfileId.value = null  // reset local state only; does not update the shared DataStore preference
         setSortOption(SortOption.DATE_NEWEST)
         if (!_isUnifiedMode.value) {
@@ -1234,7 +1277,11 @@ class TransactionsViewModel @Inject constructor(
                     // Check merchant name and description
                     val matchesMerchant = transaction.merchantName.contains(searchQuery, ignoreCase = true)
                     val matchesDescription = transaction.description?.contains(searchQuery, ignoreCase = true) == true
-                    
+
+                    // Check user-set tags
+                    val matchesTag = transactionTagsMap.value[transaction.id]
+                        ?.any { it.contains(searchQuery, ignoreCase = true) } == true
+
                     // Check SMS body (full text search)
                     val matchesSmsBody = transaction.smsBody?.contains(searchQuery, ignoreCase = true) == true
                     
@@ -1257,7 +1304,7 @@ class TransactionsViewModel @Inject constructor(
                         false
                     }
                     
-                    matchesMerchant || matchesDescription || matchesSmsBody || matchesAmount
+                    matchesMerchant || matchesDescription || matchesTag || matchesSmsBody || matchesAmount
                 }
             }
         }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/TagBreakdownCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/TagBreakdownCard.kt
@@ -1,0 +1,174 @@
+package com.pennywiseai.tracker.ui.components
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.pennywiseai.tracker.ui.components.cards.PennyWiseCardV2
+import com.pennywiseai.tracker.ui.screens.analytics.TagData
+import com.pennywiseai.tracker.ui.theme.Spacing
+import com.pennywiseai.tracker.utils.CurrencyFormatter
+import java.math.BigDecimal
+import kotlin.math.absoluteValue
+
+/**
+ * Stable palette for tag visualisations. Tags are free-text and have no
+ * predefined colors (unlike categories), so we deterministically pick a color
+ * from this palette based on the tag name. The same tag therefore always gets
+ * the same color across the chart and list.
+ */
+private val TagPalette = listOf(
+    Color(0xFF4285F4),
+    Color(0xFFEA4335),
+    Color(0xFFFBBC05),
+    Color(0xFF34A853),
+    Color(0xFFAB47BC),
+    Color(0xFF00ACC1),
+    Color(0xFFFF7043),
+    Color(0xFF9E9D24),
+    Color(0xFF5C6BC0),
+    Color(0xFFEC407A)
+)
+
+fun tagColor(name: String): Color {
+    if (TagPalette.isEmpty()) return Color.Gray
+    val index = name.hashCode().absoluteValue % TagPalette.size
+    return TagPalette[index]
+}
+
+@Composable
+fun TagBreakdownCard(
+    tags: List<TagData>,
+    currency: String,
+    modifier: Modifier = Modifier,
+    onTagClick: (TagData) -> Unit = {}
+) {
+    val maxAmount = tags.map { it.amount }.maxOrNull() ?: BigDecimal.ZERO
+
+    PennyWiseCardV2(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(Spacing.md)
+        ) {
+            Text(
+                text = "Spending by Tag",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium
+            )
+
+            ExpandableList(
+                items = tags,
+                visibleItemCount = 5
+            ) { tag ->
+                TagBar(
+                    tag = tag,
+                    maxAmount = maxAmount,
+                    currency = currency,
+                    onClick = { onTagClick(tag) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TagBar(
+    tag: TagData,
+    maxAmount: BigDecimal,
+    currency: String,
+    onClick: () -> Unit = {}
+) {
+    val targetFraction = if (maxAmount > BigDecimal.ZERO) {
+        (tag.amount.toFloat() / maxAmount.toFloat()).coerceIn(0f, 1f)
+    } else 0f
+
+    var visible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { visible = true }
+
+    val animatedFraction by animateFloatAsState(
+        targetValue = if (visible) targetFraction else 0f,
+        animationSpec = tween(800),
+        label = "tag_bar_${tag.name}"
+    )
+
+    val barColor = tagColor(tag.name)
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .clickable { onClick() }
+            .padding(vertical = Spacing.xs),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(
+                modifier = Modifier.weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(10.dp)
+                        .clip(CircleShape)
+                        .background(barColor)
+                )
+                Text(
+                    text = tag.name,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "${tag.percentage.toInt()}%",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = CurrencyFormatter.formatCurrency(tag.amount, currency),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(8.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(animatedFraction)
+                    .fillMaxHeight()
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(barColor)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/TagInputField.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/TagInputField.kt
@@ -1,0 +1,169 @@
+package com.pennywiseai.tracker.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Sell
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.InputChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
+import com.pennywiseai.tracker.ui.theme.Dimensions
+import com.pennywiseai.tracker.ui.theme.Spacing
+
+/**
+ * Free-text tag picker. Shows the currently selected tags as removable chips,
+ * a text field for typing, and live suggestions drawn from existing tags. The
+ * typed value can either match an existing tag (select) or be committed as a
+ * brand-new tag (create) via the IME action, the add icon, or the "Create"
+ * suggestion chip.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun TagInputField(
+    selectedTags: List<String>,
+    allTags: List<String>,
+    onAddTag: (String) -> Unit,
+    onRemoveTag: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    label: String = "Tags (Optional)"
+) {
+    var input by remember { mutableStateOf("") }
+
+    fun commit(raw: String) {
+        val name = raw.trim()
+        if (name.isEmpty()) return
+        if (selectedTags.none { it.equals(name, ignoreCase = true) }) {
+            onAddTag(name)
+        }
+        input = ""
+    }
+
+    val trimmed = input.trim()
+    val suggestions = remember(input, allTags, selectedTags) {
+        if (trimmed.isEmpty()) {
+            emptyList()
+        } else {
+            allTags.filter { tag ->
+                tag.contains(trimmed, ignoreCase = true) &&
+                    selectedTags.none { it.equals(tag, ignoreCase = true) }
+            }.take(5)
+        }
+    }
+    val showCreateOption = trimmed.isNotEmpty() &&
+        allTags.none { it.equals(trimmed, ignoreCase = true) } &&
+        selectedTags.none { it.equals(trimmed, ignoreCase = true) }
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(Spacing.sm)
+    ) {
+        if (selectedTags.isNotEmpty()) {
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                selectedTags.forEach { tag ->
+                    InputChip(
+                        selected = true,
+                        onClick = { onRemoveTag(tag) },
+                        label = {
+                            Text(
+                                tag,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        },
+                        trailingIcon = {
+                            Icon(
+                                Icons.Default.Close,
+                                contentDescription = "Remove $tag",
+                                modifier = Modifier.size(Dimensions.Icon.small)
+                            )
+                        }
+                    )
+                }
+            }
+        }
+
+        TextField(
+            value = input,
+            onValueChange = { input = it },
+            label = { Text(label) },
+            singleLine = true,
+            leadingIcon = {
+                Icon(
+                    Icons.Default.Sell,
+                    contentDescription = null,
+                    modifier = Modifier.size(Dimensions.Icon.medium)
+                )
+            },
+            trailingIcon = {
+                if (trimmed.isNotEmpty()) {
+                    IconButton(onClick = { commit(input) }) {
+                        Icon(
+                            Icons.Default.Add,
+                            contentDescription = "Add tag",
+                            modifier = Modifier.size(Dimensions.Icon.medium)
+                        )
+                    }
+                }
+            },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { commit(input) }),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        if (suggestions.isNotEmpty() || showCreateOption) {
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                suggestions.forEach { suggestion ->
+                    AssistChip(
+                        onClick = { commit(suggestion) },
+                        label = {
+                            Text(
+                                suggestion,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    )
+                }
+                if (showCreateOption) {
+                    AssistChip(
+                        onClick = { commit(trimmed) },
+                        leadingIcon = {
+                            Icon(
+                                Icons.Default.Add,
+                                contentDescription = null,
+                                modifier = Modifier.size(Dimensions.Icon.small)
+                            )
+                        },
+                        label = {
+                            Text(
+                                "Create \"$trimmed\"",
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsScreen.kt
@@ -83,6 +83,7 @@ fun AnalyticsScreen(
     val accountOptions by viewModel.accountOptions.collectAsStateWithLifecycle()
     var showDateRangePicker by rememberSaveable { mutableStateOf(false) }
     var categoryViewType by rememberSaveable { mutableStateOf(CategoryViewType.CHART) }
+    var tagViewType by rememberSaveable { mutableStateOf(CategoryViewType.CHART) }
     var showChartTypeSelector by remember { mutableStateOf(false) }
     var showPeriodMenu by remember { mutableStateOf(false) }
     var showTypeMenu by remember { mutableStateOf(false) }
@@ -424,6 +425,67 @@ fun AnalyticsScreen(
                                 currency = selectedCurrency,
                                 onCategoryClick = { category ->
                                     onNavigateToTransactions(category.name, null, selectedPeriod.name, selectedCurrency)
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // Tag Breakdown Section with Pie/List toggle
+        if (uiState.tagBreakdown.isNotEmpty()) {
+            item {
+                Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                    SectionHeaderV2(
+                        title = "Top Tags",
+                        action = {
+                            IconButton(onClick = {
+                                tagViewType = if (tagViewType == CategoryViewType.CHART) {
+                                    CategoryViewType.LIST
+                                } else {
+                                    CategoryViewType.CHART
+                                }
+                            }) {
+                                Icon(
+                                    imageVector = if (tagViewType == CategoryViewType.CHART)
+                                        Icons.AutoMirrored.Filled.List
+                                    else Icons.Default.PieChart,
+                                    contentDescription = "Toggle View",
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+                    )
+
+                    AnimatedContent(
+                        targetState = tagViewType,
+                        transitionSpec = {
+                            if (targetState == CategoryViewType.CHART) {
+                                (slideInHorizontally { -it } + fadeIn()) togetherWith
+                                    (slideOutHorizontally { it } + fadeOut()) using
+                                    SizeTransform(clip = false)
+                            } else {
+                                (slideInHorizontally { it } + fadeIn()) togetherWith
+                                    (slideOutHorizontally { -it } + fadeOut()) using
+                                    SizeTransform(clip = false)
+                            }
+                        },
+                        label = "tag_view_transition"
+                    ) { viewType ->
+                        when (viewType) {
+                            CategoryViewType.CHART -> TagPieChart(
+                                tags = uiState.tagBreakdown,
+                                currency = selectedCurrency,
+                                onTagClick = { tag ->
+                                    onNavigateToTransactions(null, tag.name, selectedPeriod.name, selectedCurrency)
+                                }
+                            )
+                            CategoryViewType.LIST -> TagBreakdownCard(
+                                tags = uiState.tagBreakdown,
+                                currency = selectedCurrency,
+                                onTagClick = { tag ->
+                                    onNavigateToTransactions(null, tag.name, selectedPeriod.name, selectedCurrency)
                                 }
                             )
                         }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -10,6 +10,7 @@ import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.CategoryRepository
 import com.pennywiseai.tracker.data.repository.ProfileRepository
+import com.pennywiseai.tracker.data.repository.TagRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import com.pennywiseai.tracker.presentation.common.TimePeriod
@@ -43,6 +44,7 @@ class AnalyticsViewModel @Inject constructor(
     private val accountBalanceRepository: AccountBalanceRepository,
     private val profileRepository: ProfileRepository,
     private val categoryRepository: CategoryRepository,
+    private val tagRepository: TagRepository,
     private val savedStateHandle: androidx.lifecycle.SavedStateHandle
 ) : ViewModel() {
 
@@ -165,7 +167,10 @@ class AnalyticsViewModel @Inject constructor(
         fs to balances
     }.combine(categoryColors) { (fs, balances), colors ->
         Triple(fs, balances, colors)
-    }.flatMapLatest { (filterState, balances, categoryColorMap) ->
+    }.combine(tagRepository.observeTransactionTagNames()) { triple, tagMap ->
+        triple to tagMap
+    }.flatMapLatest { (triple, tagMap) ->
+        val (filterState, balances, categoryColorMap) = triple
         // Determine date range based on selected period. THIS_MONTH is special:
         // it follows the user's custom budget cycle (e.g. 25th → 24th) instead
         // of the calendar month, so the analytics range lines up with the
@@ -382,6 +387,38 @@ class AnalyticsViewModel @Inject constructor(
                     )
                 }.sortedByDescending { it.amount }
 
+                // Build tag breakdown from the many-to-many tag map. A
+                // transaction can carry several tags, and its full amount
+                // counts toward each of them (tags overlap, unlike categories),
+                // so tag percentages can sum to more than 100%. Untagged
+                // transactions are skipped.
+                val tagAmounts = mutableMapOf<String, BigDecimal>()
+                val tagTransactionCounts = mutableMapOf<String, Int>()
+
+                for (tx in filteredTransactions) {
+                    val tagNames = tagMap[tx.id]?.takeIf { it.isNotEmpty() } ?: continue
+                    val converted = if (isUnified) {
+                        currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                    } else {
+                        tx.amount
+                    }
+                    for (tagName in tagNames) {
+                        tagAmounts[tagName] = (tagAmounts[tagName] ?: BigDecimal.ZERO) + converted
+                        tagTransactionCounts[tagName] = (tagTransactionCounts[tagName] ?: 0) + 1
+                    }
+                }
+
+                val tagBreakdown = tagAmounts.map { (tagName, tagTotal) ->
+                    TagData(
+                        name = tagName,
+                        amount = tagTotal,
+                        percentage = if (totalSpending > BigDecimal.ZERO) {
+                            (tagTotal.divide(totalSpending, 4, java.math.RoundingMode.HALF_UP) * BigDecimal(100)).toFloat()
+                        } else 0f,
+                        transactionCount = tagTransactionCounts[tagName] ?: 0
+                    )
+                }.sortedByDescending { it.amount }
+
                 // Group by merchant — convert if unified
                 val merchantBreakdown = filteredTransactions
                     .groupBy { it.merchantName }
@@ -469,7 +506,8 @@ class AnalyticsViewModel @Inject constructor(
                         filteredTransactions, dateRange.first, dateRange.second, isUnified, displayCurrency, refundByDay
                     ),
                     availableCategories = allCategoryNames,
-                    accountBreakdown = accountBreakdown
+                    accountBreakdown = accountBreakdown,
+                    tagBreakdown = tagBreakdown
                 )
             }
         }
@@ -685,7 +723,8 @@ data class AnalyticsUiState(
     val isLoading: Boolean = true,
     val spendingTrend: List<BalancePoint> = emptyList(),
     val availableCategories: List<String> = emptyList(),
-    val accountBreakdown: List<AccountBreakdownData> = emptyList()
+    val accountBreakdown: List<AccountBreakdownData> = emptyList(),
+    val tagBreakdown: List<TagData> = emptyList()
 )
 
 data class AccountBreakdownData(
@@ -704,6 +743,13 @@ data class CategoryData(
     // Hex color (e.g. "#4CAF50") of the user's category, when known. Null falls
     // back to the built-in CategoryMapping palette, then gray (#586).
     val color: String? = null
+)
+
+data class TagData(
+    val name: String,
+    val amount: BigDecimal,
+    val percentage: Float,
+    val transactionCount: Int
 )
 
 data class MerchantData(

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -412,8 +412,12 @@ class AnalyticsViewModel @Inject constructor(
                     TagData(
                         name = tagName,
                         amount = tagTotal,
+                        // Clamp at 100% like categoryBreakdown: refunds reduce totalSpending
+                        // but not a tag's summed amount, so the raw ratio for a single tag can
+                        // exceed 100%. (Different tags can still each be <100% yet sum to more,
+                        // since a transaction counts toward every tag it carries.)
                         percentage = if (totalSpending > BigDecimal.ZERO) {
-                            (tagTotal.divide(totalSpending, 4, java.math.RoundingMode.HALF_UP) * BigDecimal(100)).toFloat()
+                            (tagTotal.divide(totalSpending, 4, java.math.RoundingMode.HALF_UP) * BigDecimal(100)).toFloat().coerceAtMost(100f)
                         } else 0f,
                         transactionCount = tagTransactionCounts[tagName] ?: 0
                     )

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/TagPieChart.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/TagPieChart.kt
@@ -1,0 +1,170 @@
+package com.pennywiseai.tracker.ui.screens.analytics
+
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.pennywiseai.tracker.ui.components.tagColor
+import com.pennywiseai.tracker.ui.theme.Spacing
+import com.pennywiseai.tracker.utils.CurrencyFormatter
+import ir.ehsannarmani.compose_charts.PieChart
+import ir.ehsannarmani.compose_charts.models.Pie
+import java.math.BigDecimal
+
+@Composable
+fun TagPieChart(
+    tags: List<TagData>,
+    currency: String,
+    modifier: Modifier = Modifier,
+    onTagClick: (TagData) -> Unit = {}
+) {
+    if (tags.isEmpty()) return
+
+    val total = tags.fold(BigDecimal.ZERO) { acc, tag -> acc + tag.amount }.toDouble()
+    if (total == 0.0) return
+
+    val pieData = remember(tags) {
+        tags.map { tag ->
+            Pie(
+                label = tag.name,
+                data = tag.amount.toDouble(),
+                color = tagColor(tag.name),
+                selectedColor = tagColor(tag.name).copy(alpha = 0.8f),
+                selected = false,
+                scaleAnimEnterSpec = tween(400),
+                colorAnimEnterSpec = tween(500)
+            )
+        }
+    }
+
+    var chartData by remember(pieData) { mutableStateOf(pieData) }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(200.dp)
+            .padding(Spacing.sm),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .weight(1.2f)
+                .fillMaxHeight(),
+            contentAlignment = Alignment.Center
+        ) {
+            PieChart(
+                modifier = Modifier.size(160.dp),
+                data = chartData,
+                onPieClick = { clickedPie ->
+                    val pieIndex = chartData.indexOf(clickedPie)
+                    chartData = chartData.mapIndexed { index, pie ->
+                        pie.copy(selected = index == pieIndex)
+                    }
+                    val tagName = clickedPie.label ?: return@PieChart
+                    tags.find { it.name == tagName }?.let(onTagClick)
+                },
+                selectedScale = 1.1f,
+                scaleAnimEnterSpec = tween(400),
+                colorAnimEnterSpec = tween(500),
+                style = Pie.Style.Stroke(width = 12.dp)
+            )
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight()
+                .padding(start = Spacing.md)
+        ) {
+            items(chartData.sortedByDescending { it.data }) { pie ->
+                TagLegendItem(
+                    label = pie.label ?: "Unknown",
+                    value = pie.data,
+                    color = pie.color,
+                    isSelected = pie.selected,
+                    currency = currency,
+                    totalAmount = total,
+                    onClick = {
+                        val pieIndex = chartData.indexOf(pie)
+                        chartData = chartData.mapIndexed { index, p ->
+                            p.copy(selected = index == pieIndex)
+                        }
+                        val tagName = pie.label ?: return@TagLegendItem
+                        tags.find { it.name == tagName }?.let(onTagClick)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TagLegendItem(
+    label: String,
+    value: Double,
+    color: androidx.compose.ui.graphics.Color,
+    currency: String,
+    isSelected: Boolean,
+    totalAmount: Double,
+    onClick: () -> Unit
+) {
+    val percentage = (value / totalAmount * 100).toInt()
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .sizeIn(minHeight = 48.dp)
+            .padding(vertical = 4.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(
+                if (isSelected) MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                else androidx.compose.ui.graphics.Color.Transparent
+            )
+            .padding(6.dp)
+            .clickable(onClick = onClick),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(10.dp)
+                .clip(CircleShape)
+                .background(color)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = CurrencyFormatter.formatAbbreviated(value, currency),
+                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = "($percentage%)",
+                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupSchemaGuardTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupSchemaGuardTest.kt
@@ -69,6 +69,8 @@ class BackupSchemaGuardTest {
         serializer<ProfileEntity>().descriptor,
         serializer<BudgetMonthSnapshotEntity>().descriptor,
         serializer<BudgetCategoryMonthSnapshotEntity>().descriptor,
+        serializer<TagEntity>().descriptor,
+        serializer<TransactionTagCrossRef>().descriptor,
     )
 
     private fun SerialDescriptor.requiredFields(): List<String> =


### PR DESCRIPTION
## What & why

Revives the stale **#514**, **rebased onto the current schema**: the original PR targeted Room **v53**, but `main` is now at **v57**, so the tag tables migrate as **v57 → v58** (`MIGRATION_57_58`, `schemas/.../58.json`) instead of the PR's v52→v53.

Adds tags as a first-class concept so a transaction can carry multiple free-text labels, with filtering and an analytics breakdown.

## Changes

- **Data**: `TagEntity` (`tags`) + `TransactionTagCrossRef` (`transaction_tag_cross_ref`, many-to-many, `ON DELETE CASCADE`), `TagDao`, `TagRepository` (create-or-select, observe tag names / per-transaction tag map). Registered in `@Database` (v58) + `DatabaseModule`.
- **Add flow**: `TagInputField` (chips with remove) on the transaction tab; `AddTransactionUseCase` links tags after the balance-aware insert.
- **Transactions**: tag dropdown filter; tag names shown on transaction detail.
- **Analytics**: Top Tags section (`TagPieChart` + `TagBreakdownCard`, `TagData`), wired through the analytics flow's tag map.
- **Backup**: `DatabaseSnapshot` gains `tags` + `transactionTagCrossRefs`, both with Kotlin defaults (Hard Constraint #3 — backward-compatible restore); exporter respects privacy modes; importer inserts tags before cross-refs (FK order) and remaps transaction ids. `BackupSchemaGuardTest` passes.

## Verification

- `./init.sh app` — green (compile + unit tests, incl. `BackupSchemaGuardTest` and Room migration/schema validation; `58.json` generated with both tag tables).
- **Emulator** (Pixel_10_Pro), the migration-critical path:
  - Installed the v58 build **over existing v57 data** → app launches cleanly, **57→58 migration succeeds**, all prior transactions/accounts intact (no crash in logcat).
  - Add transaction → **Tags (Optional)** field → typed `roadtrip` → renders as a removable chip → saved.
  - Reopened the transaction → **tag persisted and shown on detail**.
  - Deleted the test transaction afterward to leave data clean.

Closes #514.