### PR TITLE
feat(pro): gate automatic folder backup + Top Tags analytics behind Pro

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsScreen.kt
@@ -22,6 +22,7 @@ import com.pennywiseai.tracker.ui.effects.rememberOverscrollFlingBehavior
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.automirrored.filled.ShowChart
 import androidx.compose.material.icons.automirrored.filled.TrendingDown
@@ -45,6 +46,7 @@ import com.pennywiseai.tracker.presentation.common.TimePeriod
 import com.pennywiseai.tracker.presentation.common.TransactionTypeFilter
 import com.pennywiseai.tracker.ui.components.*
 import com.pennywiseai.tracker.ui.components.cards.ListItemCardV2
+import com.pennywiseai.tracker.ui.components.cards.PennyWiseCardV2
 import com.pennywiseai.tracker.ui.components.cards.SectionHeaderV2
 import com.pennywiseai.tracker.ui.components.CustomTitleTopAppBar
 import com.pennywiseai.tracker.ui.components.filterIcon
@@ -81,6 +83,8 @@ fun AnalyticsScreen(
     val profiles by viewModel.profiles.collectAsStateWithLifecycle()
     val accountFilter by viewModel.accountFilter.collectAsStateWithLifecycle()
     val accountOptions by viewModel.accountOptions.collectAsStateWithLifecycle()
+    val isProEntitled by viewModel.isProEntitled.collectAsStateWithLifecycle()
+    var showTagsUpgradeSheet by remember { mutableStateOf(false) }
     var showDateRangePicker by rememberSaveable { mutableStateOf(false) }
     var categoryViewType by rememberSaveable { mutableStateOf(CategoryViewType.CHART) }
     var tagViewType by rememberSaveable { mutableStateOf(CategoryViewType.CHART) }
@@ -440,23 +444,35 @@ fun AnalyticsScreen(
                     SectionHeaderV2(
                         title = "Top Tags",
                         action = {
-                            IconButton(onClick = {
-                                tagViewType = if (tagViewType == CategoryViewType.CHART) {
-                                    CategoryViewType.LIST
-                                } else {
-                                    CategoryViewType.CHART
+                            // View-toggle only makes sense once the breakdown is
+                            // unlocked; free users get no toggle over the locked card.
+                            if (isProEntitled) {
+                                IconButton(onClick = {
+                                    tagViewType = if (tagViewType == CategoryViewType.CHART) {
+                                        CategoryViewType.LIST
+                                    } else {
+                                        CategoryViewType.CHART
+                                    }
+                                }) {
+                                    Icon(
+                                        imageVector = if (tagViewType == CategoryViewType.CHART)
+                                            Icons.AutoMirrored.Filled.List
+                                        else Icons.Default.PieChart,
+                                        contentDescription = "Toggle View",
+                                        tint = MaterialTheme.colorScheme.primary
+                                    )
                                 }
-                            }) {
-                                Icon(
-                                    imageVector = if (tagViewType == CategoryViewType.CHART)
-                                        Icons.AutoMirrored.Filled.List
-                                    else Icons.Default.PieChart,
-                                    contentDescription = "Toggle View",
-                                    tint = MaterialTheme.colorScheme.primary
-                                )
                             }
                         }
                     )
+
+                    if (!isProEntitled) {
+                        // Basic tagging (create / apply / filter-by-tag) stays free;
+                        // only the aggregated Top Tags breakdown is Pro. Show a subtle,
+                        // on-brand locked card that routes to the paywall at the buy moment.
+                        TagBreakdownLockedCard(onClick = { showTagsUpgradeSheet = true })
+                        return@Column
+                    }
 
                     AnimatedContent(
                         targetState = tagViewType,
@@ -562,6 +578,49 @@ fun AnalyticsScreen(
             initialStartDate = customDateRange?.first,
             initialEndDate = customDateRange?.second
         )
+    }
+
+    if (showTagsUpgradeSheet) {
+        com.pennywiseai.tracker.presentation.paywall.UpgradeSheet(
+            onDismiss = { showTagsUpgradeSheet = false }
+        )
+    }
+}
+
+@Composable
+private fun TagBreakdownLockedCard(onClick: () -> Unit) {
+    PennyWiseCardV2(onClick = onClick) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.md)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Lock,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary
+            )
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(Spacing.xs)
+            ) {
+                Text(
+                    text = "See your Top Tags with Pro",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = "Unlock a spending breakdown across all your tags. Tagging and filtering stay free.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -45,8 +45,13 @@ class AnalyticsViewModel @Inject constructor(
     private val profileRepository: ProfileRepository,
     private val categoryRepository: CategoryRepository,
     private val tagRepository: TagRepository,
+    entitlementGate: com.pennywiseai.tracker.billing.EntitlementGate,
     private val savedStateHandle: androidx.lifecycle.SavedStateHandle
 ) : ViewModel() {
+
+    // Top Tags analytics breakdown is a Pro feature — basic tagging (create /
+    // apply / filter-by-tag) stays free; only the aggregated breakdown is gated.
+    val isProEntitled: StateFlow<Boolean> = entitlementGate.isProEntitled
 
     // name -> hex color for the user's categories (incl. recolored built-ins), so
     // Analytics renders each category in its assigned color instead of gray (#586).

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -527,11 +527,22 @@ fun SettingsScreen(
                     title = "Automatic Folder Backup",
                     subtitle = if (scheduledFolderBackupEnabled) {
                         "Daily backup at 2:00 AM to your chosen folder"
+                    } else if (!isProEntitled) {
+                        "Pro · Save a backup to a folder every day at 2:00 AM"
                     } else {
                         "Save a backup to a folder every day at 2:00 AM"
                     },
                     checked = scheduledFolderBackupEnabled,
-                    onCheckedChange = { settingsViewModel.setScheduledFolderBackupEnabled(it) },
+                    // Scheduling daily backups is a Pro feature. Turning it ON while
+                    // free routes to the paywall; turning it OFF is always allowed so
+                    // a lapsed/downgraded user can still stop scheduled backups.
+                    onCheckedChange = { enabled ->
+                        if (enabled && !isProEntitled) {
+                            showUpgradeSheet = true
+                        } else {
+                            settingsViewModel.setScheduledFolderBackupEnabled(enabled)
+                        }
+                    },
                     position = ItemPosition.MIDDLE
                 )
                 if (scheduledFolderBackupEnabled) {


### PR DESCRIPTION
## What

Turns two features shipped this revival cycle into Pro entry points, gated at the buy moment using the app's existing route-to-paywall pattern (same as account-merge / rules-quota).

### 1. Automatic Folder Backup (#606)
- Enabling the daily-2AM scheduled-backup toggle now routes **free** users to the `UpgradeSheet` instead of turning on.
- Free subtitle carries a subtle `Pro ·` hint.
- **Turning it OFF is always allowed** — a lapsed/downgraded user can still stop scheduled backups.
- Manual **Export Data** and **Back Up Now** stay free.

### 2. Top Tags analytics (#607)
- The aggregated tag-spending breakdown (pie/list) is now Pro.
- **Basic tagging stays free** — create, apply, and filter-by-tag are untouched.
- Free users see a subtle, on-brand locked card ("See your Top Tags with Pro") that opens the `UpgradeSheet`.
- `AnalyticsViewModel` gains an injected `EntitlementGate` exposing `isProEntitled`.

## Not gated
Smart Rules → Expense (#604) and custom SMS scan date (#605) remain free.

## Verification
- `./init.sh app` green.
- Emulator, **free** state: locked Top Tags card renders and opens paywall on tap; auto-backup toggle opens paywall and stays OFF.
- Emulator, **Pro** state (forced `isProEntitled=true`): Top Tags breakdown renders with view-toggle; auto-backup toggle enables normally with no paywall and no `Pro ·` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)