### PR TITLE
fix(parser): IndusInd credit-card refund merchant + card detection (#486)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/IndusIndBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/IndusIndBankParser.kt
@@ -65,10 +65,9 @@ class IndusIndBankParser : BaseIndianBankParser() {
         // Credit-card refund SMS say "credited to your IndusInd Bank Credit Card XX1234 ...
         // adjusted against the outstanding on your card account". The trailing "card account"
         // phrase makes the base detectIsCard bail out as an account (non-card) txn, so
-        // recognise the credit card explicitly here. (#486)
-        if (lower.contains("credit card") &&
-            Regex("""card\s+x{2}\d""", RegexOption.IGNORE_CASE).containsMatchIn(message)
-        ) {
+        // recognise the credit card explicitly here. Mask is 2+ X's so XX1234 and
+        // XXXX1234 both match. (#486)
+        if (lower.contains("credit card") && CARD_MASK_PATTERN.containsMatchIn(message)) {
             return true
         }
         return super.detectIsCard(message)
@@ -181,16 +180,9 @@ class IndusIndBankParser : BaseIndianBankParser() {
         // Credit-card refund: "refund of INR <amt> from <Merchant> has been credited ..."
         // IndusInd appends the legal entity + branch/location (e.g. "Swiggy Limited Banga");
         // keep just the brand so the refund nets against the original spend merchant. (#486)
-        val refundPattern = Regex(
-            """refund\s+of\s+(?:INR|Rs\.?|₹)\s*[0-9,]+(?:\.\d{2})?\s+from\s+(.+?)\s+has\s+been\s+credited""",
-            RegexOption.IGNORE_CASE
-        )
-        refundPattern.find(message)?.let { match ->
+        REFUND_MERCHANT_PATTERN.find(message)?.let { match ->
             var m = match.groupValues[1].trim()
-            m = m.replace(
-                Regex("""\s+(?:Limited|Ltd\.?|Pvt\.?|Private).*$""", RegexOption.IGNORE_CASE),
-                ""
-            )
+            m = m.replace(LEGAL_ENTITY_SUFFIX_PATTERN, "")
             if (m.isNotEmpty()) return cleanMerchantName(m)
         }
 
@@ -333,4 +325,21 @@ class IndusIndBankParser : BaseIndianBankParser() {
         return super.extractReference(message)
     }
 
+    private companion object {
+        // Masked card number on a credit-card SMS: "Card XX1234" or "Card XXXX1234".
+        // 2+ X's so both mask widths match. (#486)
+        private val CARD_MASK_PATTERN = Regex("""card\s+x{2,}\d""", RegexOption.IGNORE_CASE)
+
+        // Credit-card refund shape: "refund of INR <amt> from <Merchant> has been credited".
+        private val REFUND_MERCHANT_PATTERN = Regex(
+            """refund\s+of\s+(?:INR|Rs\.?|₹)\s*[0-9,]+(?:\.\d{2})?\s+from\s+(.+?)\s+has\s+been\s+credited""",
+            RegexOption.IGNORE_CASE
+        )
+
+        // Trailing legal-entity/branch noise appended to the brand ("Swiggy Limited Banga").
+        private val LEGAL_ENTITY_SUFFIX_PATTERN = Regex(
+            """\s+(?:Limited|Ltd\.?|Pvt\.?|Private).*$""",
+            RegexOption.IGNORE_CASE
+        )
+    }
 }

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/IndusIndBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/IndusIndBankParser.kt
@@ -62,6 +62,15 @@ class IndusIndBankParser : BaseIndianBankParser() {
         val isAchOrNach =
             lower.contains("ach db") || lower.contains("ach cr") || lower.contains("nach")
         if (isAchOrNach) return false
+        // Credit-card refund SMS say "credited to your IndusInd Bank Credit Card XX1234 ...
+        // adjusted against the outstanding on your card account". The trailing "card account"
+        // phrase makes the base detectIsCard bail out as an account (non-card) txn, so
+        // recognise the credit card explicitly here. (#486)
+        if (lower.contains("credit card") &&
+            Regex("""card\s+x{2}\d""", RegexOption.IGNORE_CASE).containsMatchIn(message)
+        ) {
+            return true
+        }
         return super.detectIsCard(message)
     }
 
@@ -169,6 +178,22 @@ class IndusIndBankParser : BaseIndianBankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
+        // Credit-card refund: "refund of INR <amt> from <Merchant> has been credited ..."
+        // IndusInd appends the legal entity + branch/location (e.g. "Swiggy Limited Banga");
+        // keep just the brand so the refund nets against the original spend merchant. (#486)
+        val refundPattern = Regex(
+            """refund\s+of\s+(?:INR|Rs\.?|₹)\s*[0-9,]+(?:\.\d{2})?\s+from\s+(.+?)\s+has\s+been\s+credited""",
+            RegexOption.IGNORE_CASE
+        )
+        refundPattern.find(message)?.let { match ->
+            var m = match.groupValues[1].trim()
+            m = m.replace(
+                Regex("""\s+(?:Limited|Ltd\.?|Pvt\.?|Private).*$""", RegexOption.IGNORE_CASE),
+                ""
+            )
+            if (m.isNotEmpty()) return cleanMerchantName(m)
+        }
+
         // UPI-style: towards <vpa or merchant>
         // Capture the next token (can include dots) and strip trailing punctuation
         val towardsPattern = Regex("""towards\s+(\S+)""", RegexOption.IGNORE_CASE)

--- a/parser-core/src/test/kotlin/TestIndusIndBankParser.kt
+++ b/parser-core/src/test/kotlin/TestIndusIndBankParser.kt
@@ -207,7 +207,10 @@ class IndusIndBankParserTest {
                 expected = ExpectedTransaction(
                     amount = BigDecimal("250"),
                     currency = "INR",
-                    type = TransactionType.INCOME
+                    type = TransactionType.INCOME,
+                    merchant = "Swiggy",
+                    accountLast4 = "1234",
+                    isFromCard = true
                 )
             )
         )

--- a/parser-core/src/test/kotlin/TestIndusIndBankParser.kt
+++ b/parser-core/src/test/kotlin/TestIndusIndBankParser.kt
@@ -212,6 +212,20 @@ class IndusIndBankParserTest {
                     accountLast4 = "1234",
                     isFromCard = true
                 )
+            ),
+            ParserTestCase(
+                // Same refund shape but a 4-X mask (XXXX5678) — must still detect as card.
+                name = "Credit-card refund with 4-X card mask is detected as card",
+                message = "Dear Customer, refund of INR 499 from Zomato has been credited to your IndusInd Bank Credit Card XXXX5678 on 11-Jun-26 and the refund amount has been adjusted against the outstanding on your card account - IndusInd Bank",
+                sender = "AD-INDUSIND-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("499"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    merchant = "Zomato",
+                    accountLast4 = "5678",
+                    isFromCard = true
+                )
             )
         )
 


### PR DESCRIPTION
Closes #486 (parser-core scope).

## Problem
For an IndusInd **credit card**, the reporter saw: spends not recognised as CREDIT, `Avl Lmt` tracking never running, and refunds mishandled.

On current `main`, spends already type as `CREDIT` and `Avl Lmt: INR ...` is already captured into `creditLimit` (base `extractAvailableLimit` accepts the `INR` token). The remaining gap was the **refund path**:

- refund SMS produced a garbage merchant (`your IndusInd Bank Credit Card XX1234`), and
- was not flagged as a card txn (`isFromCard=false`) — the trailing `on your card account` phrase makes the base `detectIsCard` bail.

Sample refund SMS:
> Dear Customer, refund of INR 250 from Swiggy Limited Banga has been credited to your IndusInd Bank Credit Card XX1234 on 11-Jun-26 and the refund amount has been adjusted against the outstanding on your card account - IndusInd Bank

## Fix
- **`extractMerchant`** — parse the `refund of INR <amt> from <Merchant> has been credited` shape and strip the trailing legal-entity/branch noise (`Swiggy Limited Banga` → `Swiggy`) so the refund nets against the original spend merchant.
- **`detectIsCard`** — recognise `credit card` + `card XX<digits>` as a card transaction.

Spend-side CREDIT typing + available-limit capture were already correct; unchanged.

## Tests
Tightened the existing refund test to assert `merchant = "Swiggy"`, `accountLast4 = "1234"`, `isFromCard = true` (spend case already asserts `CREDIT` + `creditLimit = 48750.00`). All 28 IndusInd tests pass; full `:parser-core:jvmTest` green via `./init.sh parser`.

## Out of scope (app-side, left for owner)
- Whether `Avl Lmt` (remaining limit) should feed the model's `creditLimit - balance` derivation.
- Monthly credit-card refund netting in `HomeViewModel` / `DEDUCT_SPENT` for the CREDIT bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)