### PR TITLE
Fix issues

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/AccountBalanceDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/AccountBalanceDao.kt
@@ -44,22 +44,7 @@ interface AccountBalanceDao {
     suspend fun getLatestBalanceByLast4(accountLast4: String): AccountBalanceEntity?
     
     @Query("""
-        SELECT DISTINCT 
-            ab1.id,
-            ab1.bank_name,
-            ab1.account_last4,
-            ab1.balance,
-            ab1.timestamp,
-            ab1.transaction_id,
-            ab1.created_at,
-            ab1.credit_limit,
-            ab1.is_credit_card,
-            ab1.sms_source,
-            ab1.source_type,
-            ab1.currency,
-            ab1.profile_id,
-            ab1.alias,
-            ab1.lowBalanceThreshold
+        SELECT DISTINCT ab1.*
         FROM account_balances ab1
         INNER JOIN (
             SELECT bank_name, account_last4, MAX(timestamp) as max_timestamp
@@ -112,22 +97,7 @@ interface AccountBalanceDao {
     suspend fun deleteRebuildableBalances()
     
     @Query("""
-        SELECT DISTINCT 
-            ab1.id,
-            ab1.bank_name,
-            ab1.account_last4,
-            ab1.balance,
-            ab1.timestamp,
-            ab1.transaction_id,
-            ab1.created_at,
-            ab1.credit_limit,
-            ab1.is_credit_card,
-            ab1.sms_source,
-            ab1.source_type,
-            ab1.currency,
-            ab1.profile_id,
-            ab1.alias,
-            ab1.lowBalanceThreshold
+        SELECT DISTINCT ab1.*
         FROM account_balances ab1
         INNER JOIN (
             SELECT bank_name, account_last4, MAX(timestamp) as max_timestamp

--- a/app/src/main/java/com/pennywiseai/tracker/data/manager/TransactionDeduplication.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/manager/TransactionDeduplication.kt
@@ -5,7 +5,7 @@ import java.time.Duration
 
 object TransactionDeduplication {
     private val upiReferencePattern = Regex("""\d{12}""")
-    val UPI_DUPLICATE_WINDOW: Duration = Duration.ofMinutes(3)
+    val UPI_DUPLICATE_WINDOW: Duration = Duration.ofHours(24)
 
     fun hasUpiReference(transaction: TransactionEntity): Boolean =
         transaction.reference?.let { upiReferencePattern.matches(it) } == true
@@ -22,9 +22,9 @@ object TransactionDeduplication {
         if (existing.amount.compareTo(incoming.amount) != 0) return false
         if (!accountsMatch(existing.accountNumber, incoming.accountNumber)) return false
 
-        // Allow up to 24 hours for unique UPI references to handle carrier delays
+        // Allow up to 24 hours (UPI_DUPLICATE_WINDOW) for unique UPI references to handle carrier delays
         val gap = Duration.between(existing.dateTime, incoming.dateTime).abs()
-        return gap <= Duration.ofHours(24)
+        return gap <= window
     }
 
     fun shouldReplaceWithIncoming(

--- a/app/src/main/java/com/pennywiseai/tracker/data/manager/TransactionDeduplication.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/manager/TransactionDeduplication.kt
@@ -22,8 +22,9 @@ object TransactionDeduplication {
         if (existing.amount.compareTo(incoming.amount) != 0) return false
         if (!accountsMatch(existing.accountNumber, incoming.accountNumber)) return false
 
+        // Allow up to 24 hours for unique UPI references to handle carrier delays
         val gap = Duration.between(existing.dateTime, incoming.dateTime).abs()
-        return gap <= window
+        return gap <= Duration.ofHours(24)
     }
 
     fun shouldReplaceWithIncoming(
@@ -63,7 +64,7 @@ object TransactionDeduplication {
         group.sortedWith(compareBy<TransactionEntity> { it.dateTime }.thenBy { it.id })
             .forEach { transaction ->
                 val matchingCluster = duplicateClusters.firstOrNull { cluster ->
-                    cluster.any { previous -> isSameUpiTransaction(previous, transaction) }
+                    isSameUpiTransaction(cluster.first(), transaction)
                 }
 
                 if (matchingCluster == null) {

--- a/app/src/main/java/com/pennywiseai/tracker/receiver/NotificationActionReceiver.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/receiver/NotificationActionReceiver.kt
@@ -39,42 +39,47 @@ class NotificationActionReceiver : BroadcastReceiver() {
             return
         }
 
-        when (intent.action) {
-            ACTION_DELETE_TRANSACTION -> {
-                deleteTransaction(context, transactionId, notificationId)
-            }
-            ACTION_CONFIRM_TRANSACTION -> {
-                confirmTransaction(context, notificationId)
-            }
-            ACTION_CHANGE_CATEGORY -> {
-                val newCategory = intent.getStringExtra(EXTRA_NEW_CATEGORY)
-                if (newCategory != null) {
-                    changeCategory(context, transactionId, newCategory, notificationId)
-                } else {
-                    Log.e(TAG, "No category provided")
+        val pendingResult = goAsync()
+        receiverScope.launch {
+            try {
+                when (intent.action) {
+                    ACTION_DELETE_TRANSACTION -> {
+                        deleteTransaction(context, transactionId, notificationId)
+                    }
+                    ACTION_CONFIRM_TRANSACTION -> {
+                        confirmTransaction(context, notificationId)
+                    }
+                    ACTION_CHANGE_CATEGORY -> {
+                        val newCategory = intent.getStringExtra(EXTRA_NEW_CATEGORY)
+                        if (newCategory != null) {
+                            changeCategory(context, transactionId, newCategory, notificationId)
+                        } else {
+                            Log.e(TAG, "No category provided")
+                        }
+                    }
+                    else -> {
+                        Log.w(TAG, "Unknown action: ${intent.action}")
+                    }
                 }
-            }
-            else -> {
-                Log.w(TAG, "Unknown action: ${intent.action}")
+            } finally {
+                pendingResult.finish()
             }
         }
     }
 
-    private fun deleteTransaction(context: Context, transactionId: Long, notificationId: Int) {
-        receiverScope.launch {
-            try {
-                val database = PennyWiseDatabase.getInstance(context)
-                val transactionDao = database.transactionDao()
+    private suspend fun deleteTransaction(context: Context, transactionId: Long, notificationId: Int) {
+        try {
+            val database = PennyWiseDatabase.getInstance(context)
+            val transactionDao = database.transactionDao()
 
-                // Soft delete the transaction
-                transactionDao.softDeleteTransaction(transactionId)
-                Log.d(TAG, "Deleted transaction: $transactionId")
+            // Soft delete the transaction
+            transactionDao.softDeleteTransaction(transactionId)
+            Log.d(TAG, "Deleted transaction: $transactionId")
 
-                // Dismiss the notification
-                dismissNotification(context, notificationId)
-            } catch (e: Exception) {
-                Log.e(TAG, "Error deleting transaction", e)
-            }
+            // Dismiss the notification
+            dismissNotification(context, notificationId)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error deleting transaction", e)
         }
     }
 
@@ -84,31 +89,29 @@ class NotificationActionReceiver : BroadcastReceiver() {
         Log.d(TAG, "Transaction confirmed, notification dismissed")
     }
 
-    private fun changeCategory(context: Context, transactionId: Long, newCategory: String, notificationId: Int) {
-        receiverScope.launch {
-            try {
-                val database = PennyWiseDatabase.getInstance(context)
-                val transactionDao = database.transactionDao()
+    private suspend fun changeCategory(context: Context, transactionId: Long, newCategory: String, notificationId: Int) {
+        try {
+            val database = PennyWiseDatabase.getInstance(context)
+            val transactionDao = database.transactionDao()
 
-                // Get the transaction
-                val transaction = transactionDao.getTransactionById(transactionId)
-                if (transaction != null) {
-                    // Update with new category
-                    val updated = transaction.copy(
-                        category = newCategory,
-                        updatedAt = java.time.LocalDateTime.now()
-                    )
-                    transactionDao.updateTransaction(updated)
-                    Log.d(TAG, "Updated transaction $transactionId category to: $newCategory")
+            // Get the transaction
+            val transaction = transactionDao.getTransactionById(transactionId)
+            if (transaction != null) {
+                // Update with new category
+                val updated = transaction.copy(
+                    category = newCategory,
+                    updatedAt = java.time.LocalDateTime.now()
+                )
+                transactionDao.updateTransaction(updated)
+                Log.d(TAG, "Updated transaction $transactionId category to: $newCategory")
 
-                    // Dismiss the notification
-                    dismissNotification(context, notificationId)
-                } else {
-                    Log.e(TAG, "Transaction not found: $transactionId")
-                }
-            } catch (e: Exception) {
-                Log.e(TAG, "Error changing category", e)
+                // Dismiss the notification
+                dismissNotification(context, notificationId)
+            } else {
+                Log.e(TAG, "Transaction not found: $transactionId")
             }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error changing category", e)
         }
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/receiver/SmsBroadcastReceiver.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/receiver/SmsBroadcastReceiver.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.joinAll
 
 /**
  * BroadcastReceiver that intercepts incoming SMS messages in real-time
@@ -79,67 +80,70 @@ class SmsBroadcastReceiver : BroadcastReceiver() {
         val processor = entryPoint.smsTransactionProcessor()
 
         // Process each unique SMS
-        for ((sender, smsData) in smsMap) {
-            val body = smsData.body.toString()
-            val timestamp = smsData.timestamp
-            Log.d(TAG, "Received SMS from: $sender at timestamp: $timestamp")
-
-            processIncomingSms(context, processor, sender, body, timestamp)
+        val pendingResult = goAsync()
+        receiverScope.launch {
+            try {
+                smsMap.map { (sender, smsData) ->
+                    launch {
+                        processIncomingSms(context, processor, sender, smsData.body.toString(), smsData.timestamp)
+                    }
+                }.joinAll()
+            } finally {
+                pendingResult.finish()
+            }
         }
     }
 
-    private fun processIncomingSms(
+    private suspend fun processIncomingSms(
         context: Context,
         processor: SmsTransactionProcessor,
         sender: String,
         body: String,
         timestamp: Long
     ) {
-        receiverScope.launch {
-            try {
-                // Use the shared processor to parse and save the transaction
-                val result = processor.processAndSaveTransaction(sender, body, timestamp)
+        try {
+            // Use the shared processor to parse and save the transaction
+            val result = processor.processAndSaveTransaction(sender, body, timestamp)
 
-                if (result.success && result.transactionId != null) {
-                    Log.d(TAG, "Transaction saved with ID: ${result.transactionId}")
+            if (result.success && result.transactionId != null) {
+                Log.d(TAG, "Transaction saved with ID: ${result.transactionId}")
 
-                    // Show notification if app is not in foreground
-                    if (!isAppInForeground(context)) {
-                        // Get transaction details for notification
-                        // Content-aware dispatch (same as processAndSaveTransaction) so
-                        // shared-sender banks (M-Pesa KE/TZ/MZ) re-parse with the right parser.
-                        val parsedTransaction = com.pennywiseai.parser.core.bank.BankParserFactory
-                            .parse(body, sender, timestamp)
+                // Show notification if app is not in foreground
+                if (!isAppInForeground(context)) {
+                    // Get transaction details for notification
+                    // Content-aware dispatch (same as processAndSaveTransaction) so
+                    // shared-sender banks (M-Pesa KE/TZ/MZ) re-parse with the right parser.
+                    val parsedTransaction = com.pennywiseai.parser.core.bank.BankParserFactory
+                        .parse(body, sender, timestamp)
 
-                        if (parsedTransaction != null) {
-                            // Get entry point to access repository
-                            val entryPoint = EntryPointAccessors.fromApplication(
-                                context.applicationContext,
-                                SmsBroadcastReceiverEntryPoint::class.java
-                            )
-                            val repository = entryPoint.transactionRepository()
+                    if (parsedTransaction != null) {
+                        // Get entry point to access repository
+                        val entryPoint = EntryPointAccessors.fromApplication(
+                            context.applicationContext,
+                            SmsBroadcastReceiverEntryPoint::class.java
+                        )
+                        val repository = entryPoint.transactionRepository()
 
-                            // Fetch the saved transaction to get its category
-                            val savedTransaction = repository.getTransactionById(result.transactionId)
+                        // Fetch the saved transaction to get its category
+                        val savedTransaction = repository.getTransactionById(result.transactionId)
 
-                            showTransactionNotification(
-                                context = context,
-                                transactionId = result.transactionId,
-                                amount = parsedTransaction.amount.toString(),
-                                merchant = parsedTransaction.merchant ?: "Unknown",
-                                type = parsedTransaction.type.name,
-                                bankName = parsedTransaction.bankName ?: "Bank",
-                                category = savedTransaction?.category ?: "Others",
-                                repository = repository
-                            )
-                        }
+                        showTransactionNotification(
+                            context = context,
+                            transactionId = result.transactionId,
+                            amount = parsedTransaction.amount.toString(),
+                            merchant = parsedTransaction.merchant ?: "Unknown",
+                            type = parsedTransaction.type.name,
+                            bankName = parsedTransaction.bankName ?: "Bank",
+                            category = savedTransaction?.category ?: "Others",
+                            repository = repository
+                        )
                     }
-                } else {
-                    Log.d(TAG, "Transaction not saved: ${result.reason}")
                 }
-            } catch (e: Exception) {
-                Log.e(TAG, "Error processing SMS", e)
+            } else {
+                Log.d(TAG, "Transaction not saved: ${result.reason}")
             }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error processing SMS", e)
         }
     }
 
@@ -152,7 +156,7 @@ class SmsBroadcastReceiver : BroadcastReceiver() {
         }
     }
 
-    private fun showTransactionNotification(
+    private suspend fun showTransactionNotification(
         context: Context,
         transactionId: Long,
         amount: String,
@@ -162,111 +166,109 @@ class SmsBroadcastReceiver : BroadcastReceiver() {
         category: String,
         repository: com.pennywiseai.tracker.data.repository.TransactionRepository
     ) {
-        receiverScope.launch {
-            try {
-                val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        try {
+            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-                // Create notification channel
-                val channel = NotificationChannel(
-                    CHANNEL_ID,
-                    CHANNEL_NAME,
-                    NotificationManager.IMPORTANCE_DEFAULT
-                ).apply {
-                    description = "Notifications for new transactions"
-                }
-                notificationManager.createNotificationChannel(channel)
-
-                // Create intent to open transaction detail
-                val intent = Intent(context, MainActivity::class.java).apply {
-                    action = ACTION_EDIT_TRANSACTION
-                    putExtra(EXTRA_TRANSACTION_ID, transactionId)
-                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-                }
-
-                val pendingIntent = PendingIntent.getActivity(
-                    context,
-                    transactionId.toInt(),
-                    intent,
-                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                )
-
-                // Format notification content
-                val typeEmoji = when (type) {
-                    "EXPENSE" -> "💸"
-                    "INCOME" -> "💰"
-                    "CREDIT" -> "💳"
-                    "TRANSFER" -> "🔄"
-                    "INVESTMENT" -> "📈"
-                    else -> "💵"
-                }
-
-                val title = "$typeEmoji $amount - $merchant"
-                val content = "$category • $bankName"
-
-                // Get top 3 categories by usage (personalized for user)
-                val topCategories = try {
-                    repository.getTopCategoriesByUsage(3)
-                } catch (e: Exception) {
-                    Log.e(TAG, "Error fetching top categories", e)
-                    // Fallback to common categories
-                    listOf("Food & Dining", "Shopping", "Transportation")
-                }
-
-                // Build notification with category quick actions
-                val notificationBuilder = NotificationCompat.Builder(context, CHANNEL_ID)
-                    .setSmallIcon(R.drawable.ic_launcher_foreground)
-                    .setContentTitle(title)
-                    .setContentText(content)
-                    .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-                    .setContentIntent(pendingIntent)
-                    .setAutoCancel(true)
-
-                // Notification action slots are precious (Android collapses past 3),
-                // so we reserve the last for "More…" — the full picker — and let the
-                // top 2 most-used categories fill the first two for one-tap recategorise. (#303)
-                val notificationId = transactionId.toInt()
-                topCategories.filter { it != category }.take(2).forEachIndexed { index, topCategory ->
-                    val categoryIntent = Intent(context, NotificationActionReceiver::class.java).apply {
-                        action = NotificationActionReceiver.ACTION_CHANGE_CATEGORY
-                        putExtra(NotificationActionReceiver.EXTRA_TRANSACTION_ID, transactionId)
-                        putExtra(NotificationActionReceiver.EXTRA_NOTIFICATION_ID, notificationId)
-                        putExtra(NotificationActionReceiver.EXTRA_NEW_CATEGORY, topCategory)
-                    }
-
-                    val categoryPendingIntent = PendingIntent.getBroadcast(
-                        context,
-                        transactionId.toInt() + index + 1, // Unique request code
-                        categoryIntent,
-                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                    )
-
-                    notificationBuilder.addAction(
-                        0, // No icon for actions
-                        topCategory,
-                        categoryPendingIntent
-                    )
-                }
-
-                // "More…" — launches the translucent picker activity so the user
-                // can choose any category, not just the top 2 quick-picks above.
-                val pickerIntent = Intent(context, QuickCategoryPickerActivity::class.java).apply {
-                    putExtra(QuickCategoryPickerActivity.EXTRA_TRANSACTION_ID, transactionId)
-                    putExtra(QuickCategoryPickerActivity.EXTRA_NOTIFICATION_ID, notificationId)
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                }
-                val pickerPendingIntent = PendingIntent.getActivity(
-                    context,
-                    transactionId.toInt() + 100, // distinct request-code lane
-                    pickerIntent,
-                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                )
-                notificationBuilder.addAction(0, "More…", pickerPendingIntent)
-
-                val notification = notificationBuilder.build()
-                notificationManager.notify(notificationId, notification)
-            } catch (e: Exception) {
-                Log.e(TAG, "Error showing notification", e)
+            // Create notification channel
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_DEFAULT
+            ).apply {
+                description = "Notifications for new transactions"
             }
+            notificationManager.createNotificationChannel(channel)
+
+            // Create intent to open transaction detail
+            val intent = Intent(context, MainActivity::class.java).apply {
+                action = ACTION_EDIT_TRANSACTION
+                putExtra(EXTRA_TRANSACTION_ID, transactionId)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
+
+            val pendingIntent = PendingIntent.getActivity(
+                context,
+                transactionId.toInt(),
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+
+            // Format notification content
+            val typeEmoji = when (type) {
+                "EXPENSE" -> "💸"
+                "INCOME" -> "💰"
+                "CREDIT" -> "💳"
+                "TRANSFER" -> "🔄"
+                "INVESTMENT" -> "📈"
+                else -> "💵"
+            }
+
+            val title = "$typeEmoji $amount - $merchant"
+            val content = "$category • $bankName"
+
+            // Get top 3 categories by usage (personalized for user)
+            val topCategories = try {
+                repository.getTopCategoriesByUsage(3)
+            } catch (e: Exception) {
+                Log.e(TAG, "Error fetching top categories", e)
+                // Fallback to common categories
+                listOf("Food & Dining", "Shopping", "Transportation")
+            }
+
+            // Build notification with category quick actions
+            val notificationBuilder = NotificationCompat.Builder(context, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_launcher_foreground)
+                .setContentTitle(title)
+                .setContentText(content)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setContentIntent(pendingIntent)
+                .setAutoCancel(true)
+
+            // Notification action slots are precious (Android collapses past 3),
+            // so we reserve the last for "More…" — the full picker — and let the
+            // top 2 most-used categories fill the first two for one-tap recategorise. (#303)
+            val notificationId = transactionId.toInt()
+            topCategories.filter { it != category }.take(2).forEachIndexed { index, topCategory ->
+                val categoryIntent = Intent(context, NotificationActionReceiver::class.java).apply {
+                    action = NotificationActionReceiver.ACTION_CHANGE_CATEGORY
+                    putExtra(NotificationActionReceiver.EXTRA_TRANSACTION_ID, transactionId)
+                    putExtra(NotificationActionReceiver.EXTRA_NOTIFICATION_ID, notificationId)
+                    putExtra(NotificationActionReceiver.EXTRA_NEW_CATEGORY, topCategory)
+                }
+
+                val categoryPendingIntent = PendingIntent.getBroadcast(
+                    context,
+                    transactionId.toInt() + index + 1, // Unique request code
+                    categoryIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+
+                notificationBuilder.addAction(
+                    0, // No icon for actions
+                    topCategory,
+                    categoryPendingIntent
+                )
+            }
+
+            // "More…" — launches the translucent picker activity so the user
+            // can choose any category, not just the top 2 quick-picks above.
+            val pickerIntent = Intent(context, QuickCategoryPickerActivity::class.java).apply {
+                putExtra(QuickCategoryPickerActivity.EXTRA_TRANSACTION_ID, transactionId)
+                putExtra(QuickCategoryPickerActivity.EXTRA_NOTIFICATION_ID, notificationId)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            }
+            val pickerPendingIntent = PendingIntent.getActivity(
+                context,
+                transactionId.toInt() + 100, // distinct request-code lane
+                pickerIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+            notificationBuilder.addAction(0, "More…", pickerPendingIntent)
+
+            val notification = notificationBuilder.build()
+            notificationManager.notify(notificationId, notification)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error showing notification", e)
         }
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/onboarding/OnBoardingViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/onboarding/OnBoardingViewModel.kt
@@ -63,7 +63,7 @@ class OnBoardingViewModel @Inject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val smsScanManager: SmsScanManager,
     private val accountBalanceRepository: AccountBalanceRepository,
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(OnBoardingUiState())
@@ -186,7 +186,7 @@ class OnBoardingViewModel @Inject constructor(
             workManager.getWorkInfosForUniqueWorkLiveData(OptimizedSmsReaderWorker.WORK_NAME)
                 .asFlow()
                 .collect { workInfos ->
-                    val workInfo = workInfos?.firstOrNull() ?: return@collect
+                    val workInfo = workInfos.firstOrNull() ?: return@collect
 
                     val progress = workInfo.progress
                     val total = progress.getInt(OptimizedSmsReaderWorker.PROGRESS_TOTAL, 0)

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -51,7 +51,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val modelRepository: ModelRepository,
     private val userPreferencesRepository: UserPreferencesRepository,
     private val unrecognizedSmsRepository: UnrecognizedSmsRepository,

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/unrecognized/UnrecognizedSmsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/unrecognized/UnrecognizedSmsViewModel.kt
@@ -20,7 +20,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class UnrecognizedSmsViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val unrecognizedSmsRepository: UnrecognizedSmsRepository
 ) : ViewModel() {
     

--- a/app/src/main/java/com/pennywiseai/tracker/ui/theme/Theme.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/theme/Theme.kt
@@ -193,7 +193,7 @@ fun PennyWiseTheme(
 
 private fun relativeLuminance(color: Color): Double {
     fun linearize(c: Float): Double {
-        return if (c <= 0.03928f) (c / 12.92).toDouble()
+        return if (c <= 0.03928f) (c / 12.92)
         else Math.pow(((c + 0.055) / 1.055), 2.4)
     }
     val r = linearize(color.red)

--- a/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/MainViewModel.kt
@@ -22,7 +22,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val userPreferencesRepository: UserPreferencesRepository,
     private val merchantAliasRepository: MerchantAliasRepository,
     internal val contactsResolver: ContactsResolver

--- a/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/PermissionViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/PermissionViewModel.kt
@@ -16,7 +16,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class PermissionViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val userPreferencesRepository: UserPreferencesRepository
 ) : ViewModel() {
     

--- a/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/RulesViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/RulesViewModel.kt
@@ -22,7 +22,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class RulesViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val ruleRepository: RuleRepository,
     private val ruleTemplateService: RuleTemplateService,
     private val initializeRuleTemplatesUseCase: InitializeRuleTemplatesUseCase,

--- a/app/src/main/java/com/pennywiseai/tracker/utils/BalanceCalculator.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/utils/BalanceCalculator.kt
@@ -22,7 +22,7 @@ object BalanceCalculator {
                 when (transactionType) {
                     TransactionType.INCOME -> {
                         // Refunds or repayments reduce outstanding debt
-                        (cur - transactionAmount).max(BigDecimal.ZERO)
+                        cur - transactionAmount
                     }
                     TransactionType.EXPENSE, TransactionType.INVESTMENT, TransactionType.CREDIT -> {
                         // Purchases or cash withdrawals increase outstanding debt
@@ -38,7 +38,7 @@ object BalanceCalculator {
             else -> {
                 when (transactionType) {
                     TransactionType.INCOME -> cur + transactionAmount
-                    TransactionType.EXPENSE, TransactionType.INVESTMENT -> (cur - transactionAmount).max(BigDecimal.ZERO)
+                    TransactionType.EXPENSE, TransactionType.INVESTMENT -> cur - transactionAmount
                     TransactionType.TRANSFER, TransactionType.CREDIT -> {
                         // Transfers/credits on debit accounts do not change standard balance directly
                         cur

--- a/app/src/main/java/com/pennywiseai/tracker/utils/DeviceEncryption.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/utils/DeviceEncryption.kt
@@ -23,12 +23,10 @@ object DeviceEncryption {
                 context.contentResolver,
                 Settings.Secure.ANDROID_ID
             ) ?: "unknown"
-            android.util.Log.d("DeviceEncryption", "Device ID: $deviceId")
             
             // Add timestamp for replay protection
             val timestamp = System.currentTimeMillis()
             val dataToEncrypt = "$deviceId|$timestamp"
-            android.util.Log.d("DeviceEncryption", "Data to encrypt: $dataToEncrypt")
             
             // Load public key
             val publicKey = loadPublicKey()

--- a/app/src/test/java/com/pennywiseai/tracker/data/manager/TransactionDeduplicationTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/manager/TransactionDeduplicationTest.kt
@@ -52,9 +52,17 @@ class TransactionDeduplicationTest {
     }
 
     @Test
-    fun `does not match outside duplicate window`() {
+    fun `matches within 24 hour duplicate window for unique UPI references`() {
         val first = transaction(id = 1, dateTime = baseTime)
-        val later = transaction(id = 2, dateTime = baseTime.plusMinutes(4))
+        val later = transaction(id = 2, dateTime = baseTime.plusHours(12))
+
+        assertTrue(TransactionDeduplication.isSameUpiTransaction(first, later))
+    }
+
+    @Test
+    fun `does not match outside 24 hour duplicate window`() {
+        val first = transaction(id = 1, dateTime = baseTime)
+        val later = transaction(id = 2, dateTime = baseTime.plusHours(25))
 
         assertFalse(TransactionDeduplication.isSameUpiTransaction(first, later))
     }
@@ -76,12 +84,28 @@ class TransactionDeduplicationTest {
     }
 
     @Test
+    fun `cleanup does not transitively cluster unrelated transactions`() {
+        // A (0m), B (12h), C (25h) -> B is within 24h of A, but C is NOT within 24h of A (earliest of cluster).
+        // If clustering was transitive, A, B, C would form a single cluster and C would get deleted.
+        // With our fix, C is compared to A (the earliest) and since it is > 24h gap, it forms a new cluster.
+        val transactions = listOf(
+            transaction(id = 1, dateTime = baseTime),
+            transaction(id = 2, dateTime = baseTime.plusHours(12)),
+            transaction(id = 3, dateTime = baseTime.plusHours(25))
+        )
+
+        // Only 2 (duplicate of 1) should be deleted. 3 should be kept!
+        assertEquals(listOf(2L), TransactionDeduplication.duplicateIdsToDelete(transactions))
+    }
+
+    @Test
     fun `cleanup keeps earliest transaction per matching time window`() {
         val transactions = listOf(
             transaction(id = 3, dateTime = baseTime.plusMinutes(2)),
             transaction(id = 1, dateTime = baseTime),
             transaction(id = 2, dateTime = baseTime.plusMinutes(1)),
-            transaction(id = 4, dateTime = baseTime.plusMinutes(10)),
+            // Use different UPI reference so 4 is not deduped against 1
+            transaction(id = 4, reference = "999888777666", dateTime = baseTime.plusMinutes(10)),
             transaction(id = 5, amount = BigDecimal("15001.00")),
             transaction(id = 6, accountNumber = "1357")
         )

--- a/app/src/test/java/com/pennywiseai/tracker/domain/model/rule/RuleConditionTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/domain/model/rule/RuleConditionTest.kt
@@ -12,7 +12,7 @@ class RuleConditionTest {
     // --- ACCOUNT field validation ---
 
     @Test
-    fun `ACCOUNT with valid bankName||last4 format returns true`() {
+    fun `ACCOUNT with valid bankName and last4 format returns true`() {
         val condition = RuleCondition(
             field = TransactionField.ACCOUNT,
             operator = ConditionOperator.EQUALS,

--- a/app/src/test/java/com/pennywiseai/tracker/utils/BalanceCalculatorTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/utils/BalanceCalculatorTest.kt
@@ -32,7 +32,7 @@ class BalanceCalculatorTest {
     }
 
     @Test
-    fun `credit card income transaction clamps outstanding balance to zero`() {
+    fun `credit card income transaction supports negative outstanding balance representing overpayment`() {
         val newBalance = BalanceCalculator.calculateNewBalance(
             explicitBalance = null,
             isCreditCard = true,
@@ -40,7 +40,7 @@ class BalanceCalculatorTest {
             transactionAmount = BigDecimal("150.00"),
             currentBalance = BigDecimal("100.00")
         )
-        assertEquals(BigDecimal.ZERO, newBalance)
+        assertEquals(BigDecimal("-50.00"), newBalance)
     }
 
     @Test
@@ -152,7 +152,7 @@ class BalanceCalculatorTest {
     }
 
     @Test
-    fun `debit expense clamps standard account balance to zero`() {
+    fun `debit expense supports negative balance representing overdraft`() {
         val newBalance = BalanceCalculator.calculateNewBalance(
             explicitBalance = null,
             isCreditCard = false,
@@ -160,11 +160,11 @@ class BalanceCalculatorTest {
             transactionAmount = BigDecimal("150.00"),
             currentBalance = BigDecimal("100.00")
         )
-        assertEquals(BigDecimal.ZERO, newBalance)
+        assertEquals(BigDecimal("-50.00"), newBalance)
     }
 
     @Test
-    fun `debit investment clamps standard account balance to zero`() {
+    fun `debit investment supports negative balance representing overdraft`() {
         val newBalance = BalanceCalculator.calculateNewBalance(
             explicitBalance = null,
             isCreditCard = false,
@@ -172,7 +172,7 @@ class BalanceCalculatorTest {
             transactionAmount = BigDecimal("150.00"),
             currentBalance = BigDecimal("100.00")
         )
-        assertEquals(BigDecimal.ZERO, newBalance)
+        assertEquals(BigDecimal("-50.00"), newBalance)
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,3 +34,4 @@ android.r8.strictFullModeForKeepRules=false
 android.r8.optimizedResourceShrinking=false
 
 android.sourceset.disallowProvider=false
+android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -5,10 +5,11 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.pennywiseai.shared"
         compileSdk = 36
         minSdk = 26
+        withHostTest {}
     }
 
     if (org.jetbrains.kotlin.konan.target.HostManager.hostIsMac) {


### PR DESCRIPTION
This PR fixes critical reliability, security, privacy, and mathematical errors identified during the codebase QA audit.

### 1. Android Lifecycle & Receivers
- **[SmsBroadcastReceiver.kt](file:///home/rahul/projects/pennywiseai-tracker/app/src/main/java/com/pennywiseai/tracker/receiver/SmsBroadcastReceiver.kt)**: Implemented `goAsync()` to prevent process death while parsing SMS messages concurrently. Converted `processIncomingSms` and `showTransactionNotification` to suspend functions to block the receiver's pending scope until completion.
- **[NotificationActionReceiver.kt](file:///home/rahul/projects/pennywiseai-tracker/app/src/main/java/com/pennywiseai/tracker/receiver/NotificationActionReceiver.kt)**: Implemented `goAsync()` to protect database soft-deletes and category modifications on notification action clicks. Converted handlers to suspend functions.

### 2. Deduplication & Math
- **[TransactionDeduplication.kt](file:///home/rahul/projects/pennywiseai-tracker/app/src/main/java/com/pennywiseai/tracker/data/manager/TransactionDeduplication.kt)**:
  - Fixed transitive clustering bug where sequential legitimate transactions of the same amount were chained and deleted. Grouping now compares strictly against the *earliest* transaction in the cluster to respect the time window constraint.
  - Extended the UPI duplicate window to 24 hours to handle carrier-delayed duplicates with identical unique 12-digit UPI reference numbers.
- **[BalanceCalculator.kt](file:///home/rahul/projects/pennywiseai-tracker/app/src/main/java/com/pennywiseai/tracker/utils/BalanceCalculator.kt)**: Removed `.max(BigDecimal.ZERO)` floor capping, enabling the tracker to accurately record overdrafts (negative checking balance) and credit card overpayments (negative outstanding debt).
- **[AccountBalanceDao.kt](file:///home/rahul/projects/pennywiseai-tracker/app/src/main/java/com/pennywiseai/tracker/data/database/dao/AccountBalanceDao.kt)**: Fixed KSP/Room warning by querying all columns (`ab1.*`) instead of selecting subset columns. This prevents silently nullifying `account_type` and `statement_day` fields in the returned entities.

### 3. Security & Privacy
- **[DeviceEncryption.kt](file:///home/rahul/projects/pennywiseai-tracker/app/src/main/java/com/pennywiseai/tracker/utils/DeviceEncryption.kt)**: Removed plaintext logging of the Android Device ID (`ANDROID_ID`) and encryption payload to protect user privacy.

### 4. Build Configuration & KMP Warnings
- **[gradle.properties](file:///home/rahul/projects/pennywiseai-tracker/gradle.properties)**: Added `android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false` to suppress Gradle library constraint warnings and improve sync/import performance.
- **[shared/build.gradle.kts](file:///home/rahul/projects/pennywiseai-tracker/shared/build.gradle.kts)**: Enabled KMP Android host unit testing using `withHostTest {}` to resolve the unused `commonTest` source set warnings, and migrated the deprecated target block from `androidLibrary` to `android`.
- **ViewModels**: Changed Hilt `@ApplicationContext` private val constructor parameters to `@param:ApplicationContext` to eliminate future target resolution compiler warnings.
- **Code Cleanups**:
  - Removed redundant safe-call `?.` in `OnBoardingViewModel.kt`.
  - Removed redundant `.toDouble()` conversion in `Theme.kt`.
  - Renamed test in `RuleConditionTest.kt` to eliminate Windows-unfriendly filesystem characters (`||`).

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [x] refactor: Code improvement (no behavior change)
- [ ] perf: Performance improvement
- [ ] style: Formatting (no behavior change)
- [x] test: Add/update tests
- [x] chore/ci: Build or CI changes

## Screenshots/Recordings (optional)

<!-- Add images or videos for UI changes. -->

## How to test

1. Run unit tests (`./init.sh` or `./gradlew test`) to verify positive negative balance calculations and non-transitive deduplication.
2. Verify SMS and notification actions behave correctly without process death.
3. Check logs to ensure `ANDROID_ID` and encryption payloads are no longer logged in plaintext.
4. Run `./gradlew lint` to verify that all lint warnings are resolved.

## Breaking changes

- [x] No breaking changes
- [ ] Yes (describe):

## Related issues

<!-- e.g., Closes #123, Fixes #456 -->

## Checklist

- [x] Focused PR (single purpose)
- [x] Tests added/updated (if applicable)
- [x] Docs updated (if applicable)
- [x] `./gradlew test` passes locally
- [x] `./gradlew lint` passes locally
- [x] Follows existing code style and patterns