### PR TITLE
chore(build): upload debug APK artifacts in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,23 @@ jobs:
     - name: Compile standard debug app
       run: ./gradlew :app:compileStandardDebugKotlin --build-cache
 
+    - name: Build debug APK
+      run: ./gradlew :app:assembleDebug --build-cache
+
+    - name: Upload standard debug APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: standard-debug-apk
+        path: app/build/outputs/apk/standard/debug/*.apk
+        retention-days: 7
+
+    - name: Upload fdroid debug APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: fdroid-debug-apk
+        path: app/build/outputs/apk/fdroid/debug/*.apk
+        retention-days: 7
+
     - name: Upload compile report
       uses: actions/upload-artifact@v4
       if: always()


### PR DESCRIPTION
## Summary

Adds CI artifact uploads for debug APK builds so generated Android builds can be downloaded and tested directly from GitHub Actions runs.

## Type of change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Code improvement (no behavior change)
- [ ] perf: Performance improvement
- [ ] style: Formatting (no behavior change)
- [ ] test: Add/update tests
- [x] chore/ci: Build or CI changes

## Screenshots/Recordings (optional)

N/A

## How to test

1. Push a branch or open a pull request to trigger the GitHub Actions workflow.
2. Verify the `App Compile` job successfully builds the standard debug APK.
3. Download the `standard-debug-apk` artifact from the workflow run and verify the APK installs successfully.

## Breaking changes

- [x] No breaking changes
- [ ] Yes (describe): 

## Related issues

N/A

## Checklist

- [x] Focused PR (single purpose)
- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `./gradlew test` passes locally
- [x] `./gradlew lint` passes locally
- [x] Follows existing code style and patterns