### PR TITLE
fix(parser): Indian Bank "Sent Rs." UPI-debit was dropped (returned null)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/IndianBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/IndianBankParser.kt
@@ -190,12 +190,6 @@ class IndianBankParser : BaseIndianBankParser() {
     }
 
     override fun extractReference(message: String): String? {
-        // Pattern 0: RRN 213416112187 (newer UPI-debit format)
-        val rrnPattern = Regex("""RRN\s+(\d+)""", RegexOption.IGNORE_CASE)
-        rrnPattern.find(message)?.let { match ->
-            return match.groupValues[1]
-        }
-
         // Pattern 1: UPI:515314436916
         val upiRefPattern = Regex("""UPI:(\d+)""", RegexOption.IGNORE_CASE)
         upiRefPattern.find(message)?.let { match ->
@@ -205,6 +199,14 @@ class IndianBankParser : BaseIndianBankParser() {
         // Pattern 1a: UPI Ref no 917477824021
         val upiRefNoPattern = Regex("""UPI\s+Ref\s+no\s+(\d+)""", RegexOption.IGNORE_CASE)
         upiRefNoPattern.find(message)?.let { match ->
+            return match.groupValues[1]
+        }
+
+        // Pattern 1b: RRN 213416112187 (newer UPI-debit format). Checked AFTER the
+        // UPI-ref patterns so that a message carrying both a UPI ref and an RRN keeps
+        // preferring the UPI ref; the "Sent Rs." format carries only the RRN.
+        val rrnPattern = Regex("""RRN\s+(\d+)""", RegexOption.IGNORE_CASE)
+        rrnPattern.find(message)?.let { match ->
             return match.groupValues[1]
         }
 

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/IndianBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/IndianBankParser.kt
@@ -97,11 +97,33 @@ class IndianBankParser : BaseIndianBankParser() {
             }
         }
 
+        // Pattern 5: Sent Rs.440.00 (newer UPI-debit format)
+        val sentPattern =
+            Regex("""Sent\s+Rs\.?\s*(\d+(?:,\d{3})*(?:\.\d{2})?)""", RegexOption.IGNORE_CASE)
+        sentPattern.find(message)?.let { match ->
+            val amount = match.groupValues[1].replace(",", "")
+            return try {
+                BigDecimal(amount)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+
         // Fall back to base class patterns
         return super.extractAmount(message)
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
+        // Pattern 0: newer UPI-debit format "to NARMADA FOODS.RRN 213416112187"
+        // Stop at the period before RRN so the RRN/trailing text is not captured.
+        val sentToPattern = Regex("""to\s+([^.\n]+?)\.RRN\b""", RegexOption.IGNORE_CASE)
+        sentToPattern.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim())
+            if (isValidMerchantName(merchant)) {
+                return merchant
+            }
+        }
+
         // Pattern 1: "to Merchant Name"
         val toPattern = Regex("""to\s+([^.\n]+?)(?:\.\s*UPI:|UPI:|$)""", RegexOption.IGNORE_CASE)
         toPattern.find(message)?.let { match ->
@@ -168,6 +190,12 @@ class IndianBankParser : BaseIndianBankParser() {
     }
 
     override fun extractReference(message: String): String? {
+        // Pattern 0: RRN 213416112187 (newer UPI-debit format)
+        val rrnPattern = Regex("""RRN\s+(\d+)""", RegexOption.IGNORE_CASE)
+        rrnPattern.find(message)?.let { match ->
+            return match.groupValues[1]
+        }
+
         // Pattern 1: UPI:515314436916
         val upiRefPattern = Regex("""UPI:(\d+)""", RegexOption.IGNORE_CASE)
         upiRefPattern.find(message)?.let { match ->
@@ -235,6 +263,8 @@ class IndianBankParser : BaseIndianBankParser() {
             lowerMessage.contains("debited") -> TransactionType.EXPENSE
             lowerMessage.contains("withdrawn") -> TransactionType.EXPENSE
             lowerMessage.contains("upi payment") && !lowerMessage.contains("received") -> TransactionType.EXPENSE
+            // Newer UPI-debit format: "Sent Rs.440.00 from A/c ..."
+            lowerMessage.contains("sent rs") -> TransactionType.EXPENSE
 
             lowerMessage.contains("credited") -> TransactionType.INCOME
             lowerMessage.contains("deposited") -> TransactionType.INCOME
@@ -243,6 +273,28 @@ class IndianBankParser : BaseIndianBankParser() {
             // Fall back to base class for other patterns
             else -> super.extractTransactionType(message)
         }
+    }
+
+    /**
+     * Recognise the newer "Sent Rs.<amt> ... to <merchant>" UPI-debit format as a
+     * transaction. The base [BankParser.isTransactionMessage] only knows verbs like
+     * debited/credited/withdrawn, so without this override the message is dropped
+     * (parse() returns null) even though it is a real debit.
+     */
+    override fun isTransactionMessage(message: String): Boolean {
+        if (super.isTransactionMessage(message)) return true
+        return message.lowercase().contains("sent rs")
+    }
+
+    /**
+     * Guard against classifying a "Sent Rs. ... Avl Bal ..." debit as a
+     * balance-update-only notification. The base guard treats any message with an
+     * "Avl Bal" keyword and no known txn verb as a pure balance update; "sent" is a
+     * txn verb here, so exclude it. Bank-local override keeps other banks unaffected.
+     */
+    override fun isBalanceUpdateNotification(message: String): Boolean {
+        if (message.lowercase().contains("sent rs")) return false
+        return super.isBalanceUpdateNotification(message)
     }
 
     // ==========================================

--- a/parser-core/src/test/kotlin/TestIndianBankParser.kt
+++ b/parser-core/src/test/kotlin/TestIndianBankParser.kt
@@ -131,6 +131,36 @@ class IndianBankParserTest {
                     reference = "213416112187",
                     balance = BigDecimal("4585.65")
                 )
+            ),
+            // Same "Sent Rs." format, comma-grouped amount — exercises comma stripping.
+            ParserTestCase(
+                name = "Sent UPI debit - comma-grouped amount",
+                message = "Sent Rs.1,500.00 from A/c *4512 on 17-07-26 to FLIPKART.RRN 213416112188.Avl Bal Rs.9585.65.Not you? SMS BLOCK to 9289592895-Indian Bank",
+                sender = "AD-INDBNK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("1500.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "4512",
+                    merchant = "FLIPKART",
+                    reference = "213416112188",
+                    balance = BigDecimal("9585.65")
+                )
+            ),
+            // Same "Sent Rs." format, whole-number amount — exercises optional-decimal path.
+            ParserTestCase(
+                name = "Sent UPI debit - whole-number amount",
+                message = "Sent Rs.500 from A/c *4512 on 17-07-26 to ZOMATO.RRN 213416112189.Avl Bal Rs.9085.65.Not you? SMS BLOCK to 9289592895-Indian Bank",
+                sender = "AD-INDBNK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("500"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "4512",
+                    merchant = "ZOMATO",
+                    reference = "213416112189",
+                    balance = BigDecimal("9085.65")
+                )
             )
         )
 

--- a/parser-core/src/test/kotlin/TestIndianBankParser.kt
+++ b/parser-core/src/test/kotlin/TestIndianBankParser.kt
@@ -116,6 +116,21 @@ class IndianBankParserTest {
                     accountLast4 = "1234",
                     balance = BigDecimal("21532.08")
                 )
+            ),
+            // User bug report (#): newer "Sent Rs. ... to MERCHANT.RRN ...Avl Bal" UPI-debit format
+            ParserTestCase(
+                name = "Sent UPI debit - Sent Rs to merchant with RRN",
+                message = "Sent Rs.440.00 from A/c *4512 on 17-07-26 to NARMADA FOODS.RRN 213416112187.Avl Bal Rs.4585.65.Not you? SMS BLOCK to 9289592895-Indian Bank",
+                sender = "AD-INDBNK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("440.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    accountLast4 = "4512",
+                    merchant = "NARMADA FOODS",
+                    reference = "213416112187",
+                    balance = BigDecimal("4585.65")
+                )
             )
         )
 


### PR DESCRIPTION
## Problem
Indian Bank's newer UPI-debit SMS format is **silently dropped** — `BankParserFactory.parse(...)` returns `null`, so the transaction is never recorded (real data loss). Reported from a live SMS:

> Sent Rs.440.00 from A/c *4512 on 17-07-26 to NARMADA FOODS.RRN 213416112187.Avl Bal Rs.4585.65.Not you? SMS BLOCK to 9289592895-Indian Bank

**Root cause:** the base `BankParser.isTransactionMessage` only recognises verbs like `debited/credited/withdrawn` — not `Sent` — so the message fails the is-this-a-transaction gate before any extraction runs. (The "Avl Bal" + no-known-verb combination would also trip the balance-update-only path.)

## Fix
All changes are **bank-local overrides on `IndianBankParser`** — no edits to `BaseIndianBankParser`/`BankParser`, so no other bank that extends the base is affected:
- `isTransactionMessage` — also accept `"sent rs"` so `parse()` no longer drops it.
- `isBalanceUpdateNotification` — return `false` for `"sent rs"` so a debit carrying `Avl Bal` isn't misclassified as a balance-update-only notice.
- `extractAmount` — add `Sent\s+Rs\.?\s*<amt>` pattern.
- `extractTransactionType` — `"sent rs"` → `EXPENSE`.
- `extractMerchant` — `to <merchant>.RRN` → merchant (stops at the period before RRN).
- `extractReference` — `RRN\s+<digits>`.

## Tests
Added a `TestIndianBankParser` case asserting `type=EXPENSE`, `amount=440.00`, `merchant="NARMADA FOODS"`, `accountLast4="4512"`, `reference="213416112187"`, `balance=4585.65`. Full `:parser-core:jvmTest` green via `./init.sh parser`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)