### PR TITLE
fix(parser): handle compact Canara debit SMS

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CanaraBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CanaraBankParser.kt
@@ -8,6 +8,13 @@ import java.math.BigDecimal
  */
 class CanaraBankParser : BaseIndianBankParser() {
 
+    private companion object {
+        val COMPACT_DEBIT_PATTERN = Regex(
+            """\bDr\.?\s*(?:INR|Rs\.?|₹)\s*([\d,]+(?:\.\d{2})?)\b""",
+            RegexOption.IGNORE_CASE
+        )
+    }
+
     override fun getBankName() = "Canara Bank"
 
     override fun canHandle(sender: String): Boolean {
@@ -17,6 +24,10 @@ class CanaraBankParser : BaseIndianBankParser() {
     }
 
     override fun extractAmount(message: String): BigDecimal? {
+        COMPACT_DEBIT_PATTERN.find(message)?.let { match ->
+            return match.groupValues[1].replace(",", "").toBigDecimalOrNull()
+        }
+
         // Pattern: Rs.23.00 paid thru
         val upiAmountPattern = Regex(
             """Rs\.?\s*([\d,]+(?:\.\d{2})?)\s+paid""",
@@ -65,7 +76,7 @@ class CanaraBankParser : BaseIndianBankParser() {
 
         // Pattern 2: UPI - paid thru A/C XX1234 on 08-8-25 16:41:00 to BMTC BUS KA57F6
         val upiMerchantPattern = Regex(
-            """\sto\s+([^,]+?)(?:,\s*UPI|\.|-Canara)""",
+            """\sto\s+([^,;]+?)(?:[,;]\s*UPI|\.|-Canara)""",
             RegexOption.IGNORE_CASE
         )
         upiMerchantPattern.find(message)?.let { match ->
@@ -140,7 +151,8 @@ class CanaraBankParser : BaseIndianBankParser() {
         // Check for Canara-specific transaction keywords
         if (lowerMessage.contains("paid thru") ||
             lowerMessage.contains("has been debited") ||
-            lowerMessage.contains("has been credited")
+            lowerMessage.contains("has been credited") ||
+            COMPACT_DEBIT_PATTERN.containsMatchIn(message)
         ) {
             return true
         }
@@ -155,6 +167,10 @@ class CanaraBankParser : BaseIndianBankParser() {
         // This overrides the base class which would mark "mutual fund" as INVESTMENT
         if (lowerMessage.contains("redemption") && lowerMessage.contains("credited")) {
             return TransactionType.INCOME
+        }
+
+        if (COMPACT_DEBIT_PATTERN.containsMatchIn(message)) {
+            return TransactionType.EXPENSE
         }
 
         // Fall back to base class

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CanaraBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/CanaraBankParser.kt
@@ -148,16 +148,31 @@ class CanaraBankParser : BaseIndianBankParser() {
             return false
         }
 
-        // Check for Canara-specific transaction keywords
-        if (lowerMessage.contains("paid thru") ||
-            lowerMessage.contains("has been debited") ||
-            lowerMessage.contains("has been credited") ||
-            COMPACT_DEBIT_PATTERN.containsMatchIn(message)
-        ) {
+        // Defer to the base class first. It accepts the standard keyword forms
+        // ("paid thru", "has been debited/credited") AND — importantly — rejects
+        // OTP / promotional / payment-request / reminder messages. The previous
+        // version short-circuited to `true` on those keywords (and on the
+        // compact pattern) *before* super, bypassing those guards. (#621)
+        if (super.isTransactionMessage(message)) {
             return true
         }
 
-        return super.isTransactionMessage(message)
+        // The compact debit form ("Dr. INR 500") carries no standard keyword, so
+        // the base class drops it. Accept it here — but not when it appears
+        // inside an OTP / promotional body that merely quotes a "Dr. INR" figure.
+        if (COMPACT_DEBIT_PATTERN.containsMatchIn(message)) {
+            val looksNonTransactional = lowerMessage.contains("otp") ||
+                lowerMessage.contains("one time password") ||
+                lowerMessage.contains("verification code") ||
+                lowerMessage.contains("offer") ||
+                lowerMessage.contains("discount") ||
+                lowerMessage.contains("win ") ||
+                lowerMessage.contains("has requested") ||
+                lowerMessage.contains("payment request")
+            return !looksNonTransactional
+        }
+
+        return false
     }
 
     override fun extractTransactionType(message: String): TransactionType? {

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/CanaraBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/CanaraBankParserTest.kt
@@ -26,9 +26,64 @@ class CanaraBankParserTest {
                     merchant = "AXIS MUTUAL FUND REDEMPTION PO",
                     accountLast4 = "9108"
                 )
+            ),
+            ParserTestCase(
+                name = "Compact Dr INR UPI debit from VK sender",
+                message = "Dear Customer, Acct XXX123 Dr. INR 260.00 on 06/07/26 to SAMPLE MART; UPI: 123456789012; Bal INR 12,345.67.Not you? SMS BLOCKUPI to XXXXXXXXXX-CanaraBank",
+                sender = "VK-CANBNK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("260.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "SAMPLE MART",
+                    reference = "123456789012",
+                    accountLast4 = "123",
+                    balance = BigDecimal("12345.67")
+                )
+            ),
+            ParserTestCase(
+                name = "Compact Dr Rs UPI debit from JK sender",
+                message = "Dear Customer, Acct XXX456 Dr. Rs. 75.50 on 07/07/26 to CITY CAFE; UPI: 987654321098; Bal INR 9,876.54.Not you? SMS BLOCKUPI to XXXXXXXXXX-CanaraBank",
+                sender = "JK-CANBNK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("75.50"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "CITY CAFE",
+                    reference = "987654321098",
+                    accountLast4 = "456",
+                    balance = BigDecimal("9876.54")
+                )
+            ),
+            ParserTestCase(
+                name = "Compact Dr rupee-symbol UPI debit",
+                message = "Dear Customer, Acct XXX789 Dr. ₹41.00 on 08/07/26 to METRO TRANSIT; UPI: 456789012345; Bal INR 8,765.43.Not you? SMS BLOCKUPI to XXXXXXXXXX-CanaraBank",
+                sender = "VK-CANBNK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("41.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "METRO TRANSIT",
+                    reference = "456789012345",
+                    accountLast4 = "789",
+                    balance = BigDecimal("8765.43")
+                )
+            ),
+            ParserTestCase(
+                name = "ATM free-transaction usage notification is ignored",
+                message = "Card ending 4321: Dear Customer, you have done 02 out of 06 free transactions at Canara ATMs in this month. Charges applicable beyond free transactions.-Canara Bank",
+                sender = "JK-CANBNK-S",
+                shouldParse = false
             )
         )
 
-        return ParserTestUtils.runTestSuite(parser, cases)
+        return ParserTestUtils.runTestSuite(
+            parser = parser,
+            testCases = cases,
+            handleCases = listOf(
+                "VK-CANBNK-S" to true,
+                "JK-CANBNK-S" to true
+            )
+        )
     }
 }

--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/CanaraBankParserTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/bank/CanaraBankParserTest.kt
@@ -70,6 +70,26 @@ class CanaraBankParserTest {
                 )
             ),
             ParserTestCase(
+                name = "Compact Dr INR UPI debit with comma-terminated merchant",
+                message = "Dear Customer, Acct XXX321 Dr. INR 88.00 on 09/07/26 to CORNER STORE, UPI: 111222333444; Bal INR 5,000.00.Not you? SMS BLOCKUPI to XXXXXXXXXX-CanaraBank",
+                sender = "VK-CANBNK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("88.00"),
+                    currency = "INR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "CORNER STORE",
+                    reference = "111222333444",
+                    accountLast4 = "321",
+                    balance = BigDecimal("5000.00")
+                )
+            ),
+            ParserTestCase(
+                name = "OTP quoting a Dr. INR amount is ignored (base guard not bypassed)",
+                message = "123456 is your OTP for a Dr. INR 500.00 transaction on your Canara Bank card. Do not share it with anyone.-Canara Bank",
+                sender = "VK-CANBNK-S",
+                shouldParse = false
+            ),
+            ParserTestCase(
                 name = "ATM free-transaction usage notification is ignored",
                 message = "Card ending 4321: Dear Customer, you have done 02 out of 06 free transactions at Canara ATMs in this month. Charges applicable beyond free transactions.-Canara Bank",
                 sender = "JK-CANBNK-S",


### PR DESCRIPTION
## Summary

Recognize Canara Bank compact debit alerts that use `Dr. INR`, `Dr. Rs.`, or `Dr. ₹` instead of spelling out `debited`.

The parser now:

- classifies compact `Dr.` alerts as expenses
- extracts the transaction amount from the compact debit phrase, avoiding a later balance being selected for rupee-symbol messages
- extracts merchants terminated by `; UPI:` as well as the existing comma form
- preserves existing Canara formats and ignores ATM usage-count notifications

Regression coverage uses synthetic data and the shared JUnit 5 parser helpers for both `VK-CANBNK-S` and `JK-CANBNK-S` senders.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Code improvement (no behavior change)
- [ ] perf: Performance improvement
- [ ] style: Formatting (no behavior change)
- [x] test: Add/update tests
- [ ] chore/ci: Build or CI changes

## Screenshots/Recordings (optional)

Not applicable; parser-only change.

## How to test

1. Run `./init.sh parser`.
2. Confirm the Canara dynamic tests parse compact INR, Rs., and rupee-symbol debit samples.
3. Confirm the Canara ATM usage-count notification remains unparsed.

## Breaking changes

- [x] No breaking changes
- [ ] Yes (describe):

## Related issues

Closes #620

## Checklist

- [x] Focused PR (single purpose)
- [x] Tests added/updated (if applicable)
- [x] Docs updated (not applicable; no support matrix or user-facing behavior changed)
- [x] `./gradlew test` passes locally (`./init.sh parser`, the documented parser CI gate)
- [ ] `./gradlew lint` passes locally (not run; upstream agent guide excludes lint from the parser verification gate)
- [x] Follows existing code style and patterns
