### PR TITLE
feat(add): manual account-to-account Transfer with From/To accounts (#622)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
@@ -318,6 +318,58 @@ class AccountBalanceRepository @Inject constructor(
         rowId
     }
 
+    /**
+     * Atomically insert a manual TRANSFER [transaction] and move BOTH legs'
+     * balances as one Room transaction, so a crash can never leave the money
+     * debited from one account but never credited to the other (or vice-versa).
+     * The [transaction] must already carry `transactionType = TRANSFER`,
+     * `fromAccount = fromLast4` and `toAccount = toLast4`.
+     *
+     * The two legs use different balance mechanics, mirroring the rest of this
+     * class:
+     *  - Manual/cash accounts have a *derived* balance (opening + Σtxns, with
+     *    TRANSFER handled by `from_account`/`to_account` in [signedTransactionSum]).
+     *    Once the row is inserted, [recomputeManualBalance] re-derives the figure —
+     *    no explicit delta needed. Opening anchors for both legs are pinned from
+     *    the PRE-insert snapshot via [ensureManualOpening] before the insert, so
+     *    the recompute includes this new transfer exactly once.
+     *  - SMS-tracked accounts have a bank-reported balance, so we snapshot a signed
+     *    "TRANSACTION" delta off the latest row via [insertBalanceDeltaByLast4]
+     *    (−amount on the FROM leg, +amount on the TO leg). No-op if that account
+     *    has no balance row yet.
+     *
+     * Returns the new row id (-1 on a dedup-conflict insert, in which case no
+     * balance is moved).
+     */
+    suspend fun insertTransferWithBalance(
+        transaction: TransactionEntity,
+        fromBankName: String,
+        fromLast4: String,
+        toBankName: String,
+        toLast4: String
+    ): Long = database.withTransaction {
+        // Pin opening anchors from the PRE-insert snapshot for manual accounts (both legs).
+        ensureManualOpening(fromBankName, fromLast4)
+        ensureManualOpening(toBankName, toLast4)
+        val rowId = transactionDao.insertTransaction(transaction)
+        if (rowId != -1L) {
+            // FROM leg: money out. Bank-aware so a shared last4 (Kotak ••9999 vs
+            // HDFC ••9999) debits the account the user actually picked.
+            if (isManualAccount(fromBankName, fromLast4)) {
+                recomputeManualBalance(fromBankName, fromLast4)
+            } else {
+                insertBalanceDelta(fromBankName, fromLast4, transaction.amount.negate(), transaction.dateTime, rowId)
+            }
+            // TO leg: money in.
+            if (isManualAccount(toBankName, toLast4)) {
+                recomputeManualBalance(toBankName, toLast4)
+            } else {
+                insertBalanceDelta(toBankName, toLast4, transaction.amount, transaction.dateTime, rowId)
+            }
+        }
+        rowId
+    }
+
     private suspend fun insertBalanceDeltaByLast4(
         accountLast4: String,
         delta: BigDecimal,
@@ -325,6 +377,33 @@ class AccountBalanceRepository @Inject constructor(
         transactionId: Long
     ) {
         val latest = accountBalanceDao.getLatestBalanceByLast4(accountLast4) ?: return
+        accountBalanceDao.insertBalance(
+            latest.copy(
+                id = 0,
+                balance = latest.balance + delta,
+                timestamp = timestamp,
+                transactionId = transactionId,
+                sourceType = "TRANSACTION",
+                smsSource = null
+            )
+        )
+    }
+
+    /**
+     * Bank-aware sibling of [insertBalanceDeltaByLast4]: resolves the account by
+     * (bankName, last4) so a transfer leg can't be misattributed to a *different*
+     * account that merely shares the same last4 (e.g. Kotak ••9999 vs HDFC ••9999).
+     * Used by [insertTransferWithBalance], where the full bank name is known for
+     * both legs. No-op if that account has no balance row yet.
+     */
+    private suspend fun insertBalanceDelta(
+        bankName: String,
+        accountLast4: String,
+        delta: BigDecimal,
+        timestamp: LocalDateTime,
+        transactionId: Long
+    ) {
+        val latest = accountBalanceDao.getLatestBalance(bankName, accountLast4) ?: return
         accountBalanceDao.insertBalance(
             latest.copy(
                 id = 0,

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
@@ -114,6 +114,72 @@ class AddTransactionUseCase @Inject constructor(
         }
     }
     
+    /**
+     * Manual account-to-account TRANSFER (#622). Records a single TRANSFER
+     * transaction — its `fromAccount`/`toAccount` last4s drive the two-leg
+     * balance move in [AccountBalanceRepository.insertTransferWithBalance] — and
+     * links any tags. Cross-currency transfers are rejected upstream in the
+     * ViewModel (we never sum across currencies); this path assumes both legs
+     * share [currency].
+     */
+    suspend fun executeTransfer(
+        amount: BigDecimal,
+        date: LocalDateTime,
+        notes: String? = null,
+        tags: List<String> = emptyList(),
+        currency: String = "INR",
+        fromBankName: String,
+        fromLast4: String,
+        toBankName: String,
+        toLast4: String
+    ) {
+        // Unique hash incorporating both legs so two distinct transfers (or a
+        // transfer and its reverse) never collide on the unique hash index.
+        val transactionHash = generateTransferHash(
+            amount = amount,
+            fromLast4 = fromLast4,
+            toLast4 = toLast4,
+            date = date
+        )
+
+        val transaction = TransactionEntity(
+            amount = amount,
+            merchantName = "Transfer",
+            category = "Others",
+            transactionType = TransactionType.TRANSFER,
+            dateTime = date,
+            description = notes,
+            smsBody = null, // null indicates manual entry
+            bankName = fromBankName,
+            smsSender = null,
+            accountNumber = fromLast4,
+            balanceAfter = null,
+            transactionHash = transactionHash,
+            currency = currency,
+            fromAccount = fromLast4,
+            toAccount = toLast4,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
+        )
+
+        // Insert + both-leg balance move + tag-linking as one atomic unit.
+        // Room's withTransaction is reentrant, so the repository's own
+        // withTransaction and setTagsForTransaction join this outer one.
+        database.withTransaction {
+            val transactionId = accountBalanceRepository.insertTransferWithBalance(
+                transaction = transaction,
+                fromBankName = fromBankName,
+                fromLast4 = fromLast4,
+                toBankName = toBankName,
+                toLast4 = toLast4
+            )
+
+            if (transactionId != -1L && tags.isNotEmpty()) {
+                tagRepository.setTagsForTransaction(transactionId, tags)
+            }
+        }
+    }
+
     private fun generateManualTransactionHash(
         amount: BigDecimal,
         merchant: String,
@@ -122,6 +188,20 @@ class AddTransactionUseCase @Inject constructor(
         // Create a unique hash for manual transactions
         // Format: MANUAL_<amount>_<merchant>_<datetime>
         val data = "MANUAL_${amount}_${merchant}_${date}"
+
+        return MessageDigest.getInstance("MD5")
+            .digest(data.toByteArray())
+            .joinToString("") { "%02x".format(it) }
+    }
+
+    private fun generateTransferHash(
+        amount: BigDecimal,
+        fromLast4: String,
+        toLast4: String,
+        date: LocalDateTime
+    ): String {
+        // Format: TRANSFER_<amount>_<from>_<to>_<datetime>
+        val data = "TRANSFER_${amount}_${fromLast4}_${toLast4}_${date}"
 
         return MessageDigest.getInstance("MD5")
             .digest(data.toByteArray())

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/AddTransactionUseCase.kt
@@ -133,11 +133,15 @@ class AddTransactionUseCase @Inject constructor(
         toBankName: String,
         toLast4: String
     ) {
-        // Unique hash incorporating both legs so two distinct transfers (or a
-        // transfer and its reverse) never collide on the unique hash index.
+        // Unique hash incorporating both legs — with bank names, not just last4 —
+        // so two distinct transfers (e.g. Kotak ••9999 vs HDFC ••9999 to the same
+        // destination for the same amount at the same second) never collide on the
+        // unique hash index and silently no-op the second one.
         val transactionHash = generateTransferHash(
             amount = amount,
+            fromBankName = fromBankName,
             fromLast4 = fromLast4,
+            toBankName = toBankName,
             toLast4 = toLast4,
             date = date
         )
@@ -196,12 +200,14 @@ class AddTransactionUseCase @Inject constructor(
 
     private fun generateTransferHash(
         amount: BigDecimal,
+        fromBankName: String,
         fromLast4: String,
+        toBankName: String,
         toLast4: String,
         date: LocalDateTime
     ): String {
-        // Format: TRANSFER_<amount>_<from>_<to>_<datetime>
-        val data = "TRANSFER_${amount}_${fromLast4}_${toLast4}_${date}"
+        // Format: TRANSFER_<amount>_<fromBank>_<from>_<toBank>_<to>_<datetime>
+        val data = "TRANSFER_${amount}_${fromBankName}_${fromLast4}_${toBankName}_${toLast4}_${date}"
 
         return MessageDigest.getInstance("MD5")
             .digest(data.toByteArray())

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
@@ -155,7 +155,21 @@ class AddViewModel @Inject constructor(
     // Transaction Tab Functions
     fun updateSelectedAccount(account: AccountBalanceEntity?) {
         _transactionUiState.update { currentState ->
-            currentState.copy(selectedAccount = account)
+            // For a TRANSFER, the FROM account drives the entry currency so the
+            // two figures can't silently disagree (we never sum across currencies).
+            val currency = if (currentState.transactionType == TransactionType.TRANSFER && account != null) {
+                account.currency
+            } else {
+                currentState.currency
+            }
+            currentState.copy(selectedAccount = account, currency = currency)
+        }
+    }
+
+    /** The TO account for a TRANSFER (see [updateSelectedAccount] for FROM). */
+    fun updateToAccount(account: AccountBalanceEntity?) {
+        _transactionUiState.update { currentState ->
+            currentState.copy(toAccount = account)
         }
     }
 
@@ -277,11 +291,13 @@ class AddViewModel @Inject constructor(
 
     fun saveTransaction(onSuccess: () -> Unit) {
         val state = _transactionUiState.value
-        
+        val isTransfer = state.transactionType == TransactionType.TRANSFER
+
         val amountError = validateAmount(state.amount)
-        val merchantError = validateMerchant(state.merchant)
-        val categoryError = validateCategory(state.category)
-        
+        // Transfers have no merchant/category to validate.
+        val merchantError = if (isTransfer) null else validateMerchant(state.merchant)
+        val categoryError = if (isTransfer) null else validateCategory(state.category)
+
         if (amountError != null || merchantError != null || categoryError != null) {
             _transactionUiState.update { currentState ->
                 currentState.copy(
@@ -292,7 +308,22 @@ class AddViewModel @Inject constructor(
             }
             return
         }
-        
+
+        if (isTransfer) {
+            val from = state.selectedAccount
+            val to = state.toAccount
+            when {
+                from == null || to == null ->
+                    _transactionUiState.update { it.copy(error = "Select both a From and To account") }
+                from.id == to.id ->
+                    _transactionUiState.update { it.copy(error = "From and To accounts must be different") }
+                from.currency != to.currency ->
+                    _transactionUiState.update { it.copy(error = "Both accounts must use the same currency") }
+                else -> saveTransferInternal(state, from, to, onSuccess)
+            }
+            return
+        }
+
         viewModelScope.launch {
             try {
                 _transactionUiState.update { it.copy(isLoading = true) }
@@ -327,6 +358,42 @@ class AddViewModel @Inject constructor(
                     currentState.copy(
                         isLoading = false,
                         error = e.message ?: "Failed to save transaction"
+                    )
+                }
+            }
+        }
+    }
+
+    private fun saveTransferInternal(
+        state: TransactionUiState,
+        from: AccountBalanceEntity,
+        to: AccountBalanceEntity,
+        onSuccess: () -> Unit
+    ) {
+        viewModelScope.launch {
+            try {
+                _transactionUiState.update { it.copy(isLoading = true, error = null) }
+
+                addTransactionUseCase.executeTransfer(
+                    amount = BigDecimal(state.amount),
+                    date = state.date,
+                    notes = state.notes.takeIf { it.isNotBlank() },
+                    tags = state.tags,
+                    currency = from.currency,
+                    fromBankName = from.bankName,
+                    fromLast4 = from.accountLast4,
+                    toBankName = to.bankName,
+                    toLast4 = to.accountLast4
+                )
+
+                com.pennywiseai.tracker.widget.RecentTransactionsWidgetUpdateWorker.enqueueOneShot(appContext)
+
+                onSuccess()
+            } catch (e: Exception) {
+                _transactionUiState.update { currentState ->
+                    currentState.copy(
+                        isLoading = false,
+                        error = e.message ?: "Failed to save transfer"
                     )
                 }
             }
@@ -527,21 +594,36 @@ data class TransactionUiState(
     val isLoading: Boolean = false,
     val error: String? = null,
     val selectedAccount: AccountBalanceEntity? = null,
+    // For a TRANSFER, [selectedAccount] is the FROM account and this is the TO
+    // account. Unused for all other transaction types.
+    val toAccount: AccountBalanceEntity? = null,
     val currency: String = "INR",
     val receiptUri: Uri? = null,
     val budgetImpactType: BudgetImpactType? = null,
     val budgetCategory: String? = null
 ) {
     val isValid: Boolean
-        get() = amount.isNotBlank() &&
-                amount.toDoubleOrNull() != null &&
-                amount.toDouble() > 0 &&
-                merchant.isNotBlank() &&
-                category.isNotBlank() &&
-                amountError == null &&
-                merchantError == null &&
-                categoryError == null &&
-                (budgetImpactType == null || budgetCategory != null)
+        get() {
+            val amountOk = amount.isNotBlank() &&
+                    amount.toDoubleOrNull() != null &&
+                    amount.toDouble() > 0 &&
+                    amountError == null
+            if (!amountOk) return false
+
+            if (transactionType == TransactionType.TRANSFER) {
+                // Transfers move money between two distinct accounts of the same
+                // currency (we never sum across currencies). No merchant needed.
+                val from = selectedAccount ?: return false
+                val to = toAccount ?: return false
+                return from.id != to.id && from.currency == to.currency
+            }
+
+            return merchant.isNotBlank() &&
+                    category.isNotBlank() &&
+                    merchantError == null &&
+                    categoryError == null &&
+                    (budgetImpactType == null || budgetCategory != null)
+        }
 }
 
 data class SubscriptionUiState(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
@@ -199,7 +199,10 @@ class AddViewModel @Inject constructor(
                     else -> currentState.category
                 },
                 budgetImpactType = if (type != TransactionType.INCOME) null else currentState.budgetImpactType,
-                budgetCategory = if (type != TransactionType.INCOME) null else currentState.budgetCategory
+                budgetCategory = if (type != TransactionType.INCOME) null else currentState.budgetCategory,
+                // The To account only applies to a transfer — drop it when leaving
+                // TRANSFER so a stale selection can't silently pre-fill a later one.
+                toAccount = if (type == TransactionType.TRANSFER) currentState.toAccount else null
             )
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/TransactionTabContent.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/TransactionTabContent.kt
@@ -64,6 +64,87 @@ private val bottomShape = RoundedCornerShape(topStart = 4.dp, topEnd = 4.dp, bot
 private val middleShape = RoundedCornerShape(4.dp)
 private val fullShape = RoundedCornerShape(16.dp)
 
+/** Which account picker the shared account dropdown is currently assigning to. */
+private enum class AccountPickerTarget { FROM, TO }
+
+/**
+ * Tappable account card used by the single-account picker and by both legs of a
+ * TRANSFER. Shows the selected account (bank name + ••last4) or [placeholder],
+ * with a clear button when an account is set.
+ */
+@Composable
+private fun AccountSelectorCard(
+    account: AccountBalanceEntity?,
+    placeholder: String,
+    shape: androidx.compose.ui.graphics.Shape,
+    onClick: () -> Unit,
+    onClear: () -> Unit
+) {
+    Card(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        shape = shape,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+        ),
+        border = null
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Icon(
+                when (account?.getAccountType()) {
+                    AccountType.CASH -> Icons.Default.Money
+                    AccountType.CREDIT -> Icons.Default.CreditCard
+                    AccountType.SAVINGS, AccountType.CURRENT -> Icons.Default.AccountBalance
+                    null -> Icons.Default.AccountBalance
+                },
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = account?.bankName ?: placeholder,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = if (account != null)
+                        MaterialTheme.colorScheme.onSurface
+                    else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                if (account != null &&
+                    account.accountLast4 != AccountBalanceEntity.WALLET_ACCOUNT_MARKER) {
+                    Text(
+                        text = "••${account.accountLast4}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            if (account != null) {
+                IconButton(
+                    onClick = onClear,
+                    modifier = Modifier.size(24.dp)
+                ) {
+                    Icon(
+                        Icons.Default.Clear,
+                        contentDescription = "Clear",
+                        modifier = Modifier.size(16.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            Icon(
+                Icons.Rounded.KeyboardArrowDown,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TransactionTabContent(
@@ -77,8 +158,12 @@ fun TransactionTabContent(
     var showDatePicker by remember { mutableStateOf(false) }
     var showTimePicker by remember { mutableStateOf(false) }
     var showCategoryMenu by remember { mutableStateOf(false) }
-    var showAccountMenu by remember { mutableStateOf(false) }
+    // Which account picker is open (null = closed). For a TRANSFER this routes the
+    // chosen account to either the FROM or TO card; for other types only FROM is used.
+    var accountPickerTarget by remember { mutableStateOf<AccountPickerTarget?>(null) }
     var showCurrencyMenu by remember { mutableStateOf(false) }
+
+    val isTransfer = uiState.transactionType == TransactionType.TRANSFER
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(
@@ -142,29 +227,33 @@ fun TransactionTabContent(
             }
 
             // ── Merchant + Notes (connected cards) ──
+            // Merchant is meaningless for a TRANSFER (it moves money between own
+            // accounts), so hide it and show Notes on its own.
             Column(
                 modifier = Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(1.5.dp)
             ) {
-                TextField(
-                    value = uiState.merchant,
-                    onValueChange = viewModel::updateTransactionMerchant,
-                    label = { Text("Merchant", fontWeight = FontWeight.SemiBold) },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = topShape,
-                    leadingIcon = { Icon(Icons.Default.Store, contentDescription = null) },
-                    isError = uiState.merchantError != null,
-                    supportingText = uiState.merchantError?.let { { Text(it) } },
-                    colors = filledFieldColors()
-                )
+                if (!isTransfer) {
+                    TextField(
+                        value = uiState.merchant,
+                        onValueChange = viewModel::updateTransactionMerchant,
+                        label = { Text("Merchant", fontWeight = FontWeight.SemiBold) },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = topShape,
+                        leadingIcon = { Icon(Icons.Default.Store, contentDescription = null) },
+                        isError = uiState.merchantError != null,
+                        supportingText = uiState.merchantError?.let { { Text(it) } },
+                        colors = filledFieldColors()
+                    )
+                }
 
                 TextField(
                     value = uiState.notes,
                     onValueChange = viewModel::updateTransactionNotes,
                     label = { Text("Notes (Optional)", fontWeight = FontWeight.SemiBold) },
                     modifier = Modifier.fillMaxWidth(),
-                    shape = bottomShape,
+                    shape = if (isTransfer) fullShape else bottomShape,
                     leadingIcon = { Icon(Icons.Default.Description, contentDescription = null) },
                     colors = filledFieldColors()
                 )
@@ -338,144 +427,119 @@ fun TransactionTabContent(
                 }
             }
 
-            // ── Account + Category (connected cards) ──
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(1.5.dp)
-            ) {
-                // Account card
-                val accountInteractionSource = remember { MutableInteractionSource() }
-                Card(
-                    onClick = { showAccountMenu = true },
+            // ── Account(s) + Category (connected cards) ──
+            if (isTransfer) {
+                // Two account pickers: From (money out) and To (money in).
+                Column(
                     modifier = Modifier.fillMaxWidth(),
-                    shape = topShape,
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow
-                    ),
-                    border = null
+                    verticalArrangement = Arrangement.spacedBy(1.5.dp)
                 ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 12.dp, vertical = 16.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        Icon(
-                            when (uiState.selectedAccount?.getAccountType()) {
-                                AccountType.CASH -> Icons.Default.Money
-                                AccountType.CREDIT -> Icons.Default.CreditCard
-                                AccountType.SAVINGS, AccountType.CURRENT -> Icons.Default.AccountBalance
-                                null -> Icons.Default.AccountBalance
-                            },
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = uiState.selectedAccount?.bankName ?: "Select Account",
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = if (uiState.selectedAccount != null)
-                                    MaterialTheme.colorScheme.onSurface
-                                else MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                            if (uiState.selectedAccount != null &&
-                                uiState.selectedAccount?.accountLast4 != AccountBalanceEntity.WALLET_ACCOUNT_MARKER) {
-                                Text(
-                                    text = "••${uiState.selectedAccount?.accountLast4}",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
-                        }
-                        if (uiState.selectedAccount != null) {
-                            IconButton(
-                                onClick = { viewModel.updateSelectedAccount(null) },
-                                modifier = Modifier.size(24.dp)
-                            ) {
-                                Icon(
-                                    Icons.Default.Clear,
-                                    contentDescription = "Clear",
-                                    modifier = Modifier.size(16.dp),
-                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
-                        }
-                        Icon(
-                            Icons.Rounded.KeyboardArrowDown,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                }
-
-                // Category field
-                ExposedDropdownMenuBox(
-                    expanded = showCategoryMenu,
-                    onExpandedChange = { showCategoryMenu = it },
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    TextField(
-                        value = uiState.category,
-                        onValueChange = {},
-                        label = { Text("Category", fontWeight = FontWeight.SemiBold) },
-                        readOnly = true,
-                        singleLine = true,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                    AccountSelectorCard(
+                        account = uiState.selectedAccount,
+                        placeholder = "From account",
+                        shape = topShape,
+                        onClick = { accountPickerTarget = AccountPickerTarget.FROM },
+                        onClear = { viewModel.updateSelectedAccount(null) }
+                    )
+                    AccountSelectorCard(
+                        account = uiState.toAccount,
+                        placeholder = "To account",
                         shape = bottomShape,
-                        leadingIcon = {
-                            Icon(Icons.Default.Category, contentDescription = null)
-                        },
-                        trailingIcon = {
-                            Icon(Icons.Rounded.KeyboardArrowDown, contentDescription = null)
-                        },
-                        isError = uiState.categoryError != null,
-                        supportingText = uiState.categoryError?.let { { Text(it) } },
-                        colors = filledFieldColors()
+                        onClick = { accountPickerTarget = AccountPickerTarget.TO },
+                        onClear = { viewModel.updateToAccount(null) }
+                    )
+                }
+            } else {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(1.5.dp)
+                ) {
+                    // Account card
+                    AccountSelectorCard(
+                        account = uiState.selectedAccount,
+                        placeholder = "Select Account",
+                        shape = topShape,
+                        onClick = { accountPickerTarget = AccountPickerTarget.FROM },
+                        onClear = { viewModel.updateSelectedAccount(null) }
                     )
 
-                    ExposedDropdownMenu(
+                    // Category field
+                    ExposedDropdownMenuBox(
                         expanded = showCategoryMenu,
-                        onDismissRequest = { showCategoryMenu = false }
+                        onExpandedChange = { showCategoryMenu = it },
+                        modifier = Modifier.fillMaxWidth()
                     ) {
-                        categories.forEach { category ->
-                            DropdownMenuItem(
-                                text = { Text(category.name) },
-                                onClick = {
-                                    viewModel.updateTransactionCategory(category.name)
-                                    showCategoryMenu = false
-                                }
-                            )
+                        TextField(
+                            value = uiState.category,
+                            onValueChange = {},
+                            label = { Text("Category", fontWeight = FontWeight.SemiBold) },
+                            readOnly = true,
+                            singleLine = true,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                            shape = bottomShape,
+                            leadingIcon = {
+                                Icon(Icons.Default.Category, contentDescription = null)
+                            },
+                            trailingIcon = {
+                                Icon(Icons.Rounded.KeyboardArrowDown, contentDescription = null)
+                            },
+                            isError = uiState.categoryError != null,
+                            supportingText = uiState.categoryError?.let { { Text(it) } },
+                            colors = filledFieldColors()
+                        )
+
+                        ExposedDropdownMenu(
+                            expanded = showCategoryMenu,
+                            onDismissRequest = { showCategoryMenu = false }
+                        ) {
+                            categories.forEach { category ->
+                                DropdownMenuItem(
+                                    text = { Text(category.name) },
+                                    onClick = {
+                                        viewModel.updateTransactionCategory(category.name)
+                                        showCategoryMenu = false
+                                    }
+                                )
+                            }
                         }
                     }
                 }
             }
 
-            // Account selection dropdown menu
+            // Account selection dropdown menu (shared by From/To pickers).
             DropdownMenu(
-                expanded = showAccountMenu,
-                onDismissRequest = { showAccountMenu = false }
+                expanded = accountPickerTarget != null,
+                onDismissRequest = { accountPickerTarget = null }
             ) {
-                DropdownMenuItem(
-                    text = {
-                        Column {
-                            Text("No account (Manual Entry)")
-                            Text(
-                                "Won't affect account balance",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    },
-                    onClick = {
-                        viewModel.updateSelectedAccount(null)
-                        showAccountMenu = false
-                    },
-                    leadingIcon = { Icon(Icons.Default.Block, contentDescription = null) }
-                )
-                HorizontalDivider()
+                val target = accountPickerTarget
+                // "No account" only makes sense outside a transfer — both transfer
+                // legs must reference a real account to move money.
+                if (!isTransfer) {
+                    DropdownMenuItem(
+                        text = {
+                            Column {
+                                Text("No account (Manual Entry)")
+                                Text(
+                                    "Won't affect account balance",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        },
+                        onClick = {
+                            viewModel.updateSelectedAccount(null)
+                            accountPickerTarget = null
+                        },
+                        leadingIcon = { Icon(Icons.Default.Block, contentDescription = null) }
+                    )
+                    HorizontalDivider()
+                }
+                val selectedForTarget = when (target) {
+                    AccountPickerTarget.TO -> uiState.toAccount
+                    else -> uiState.selectedAccount
+                }
                 val groupedAccounts = accounts.groupBy { it.getAccountType() }
                 groupedAccounts.forEach { (accountType, accountList) ->
                     DropdownMenuItem(
@@ -503,8 +567,12 @@ fun TransactionTabContent(
                                 }
                             },
                             onClick = {
-                                viewModel.updateSelectedAccount(account)
-                                showAccountMenu = false
+                                if (target == AccountPickerTarget.TO) {
+                                    viewModel.updateToAccount(account)
+                                } else {
+                                    viewModel.updateSelectedAccount(account)
+                                }
+                                accountPickerTarget = null
                             },
                             leadingIcon = {
                                 Icon(
@@ -517,7 +585,7 @@ fun TransactionTabContent(
                                 )
                             },
                             trailingIcon = {
-                                if (uiState.selectedAccount?.id == account.id) {
+                                if (selectedForTarget?.id == account.id) {
                                     Icon(Icons.Default.Check, "Selected", tint = MaterialTheme.colorScheme.primary)
                                 }
                             }


### PR DESCRIPTION
Closes #622.

## Problem
Selecting **Transfer** in Add Transaction showed the exact same single "Select Account" picker as Expense (reported on Discord) — there was no way to record money moving between two accounts. The Transfer chip existed, but the form/ViewModel/use-case never supported a From→To pair.

## What this does
When `transactionType == TRANSFER`:
- **UI** (`TransactionTabContent`): hides Merchant, shows **From account** + **To account** pickers (a shared account bottom-sheet routes selection to whichever is open via an `AccountPickerTarget`). All other types unchanged.
- **ViewModel**: adds `toAccount` state; `selectedAccount` is the From account. `isValid`/`saveTransaction` become transfer-aware — no merchant required; requires two **distinct** accounts of the **same currency** (the From account fixes the entry currency). Cross-currency is rejected (we never sum across currencies).
- **Use case / repo**: populates `fromAccount`/`toAccount` and moves the money in one atomic Room transaction — `AccountBalanceRepository.insertTransferWithBalance` debits the FROM leg and credits the TO leg, using manual-recompute for cash/manual accounts and a signed delta for SMS-tracked accounts.

## Bug caught during emulator testing (and fixed)
The first on-device run debited the **wrong** account: a transfer from Kotak ••9999 hit HDFC ••9999 instead, because the SMS-delta leg resolved accounts by **last4 alone**. Fixed by resolving the delta by **(bankName, last4)** (`insertBalanceDelta`) — the manual-add path knows the full bank for both legs. Re-verified: Kotak ••9999 −500, Kotak ••7777 +500, HDFC ••9999 untouched.

## Verification (emulator)
- Transfer form shows From/To, Merchant hidden, Save gated until valid.
- Saved transfer is recorded as a transfer — **excluded from "Spent this month"**, shown under "Money in motion".
- From −amount and To +amount both move correctly, including the shared-last4 case.
- `./init.sh app` green.

## Known limitation (follow-up, pre-existing)
Editing/deleting a transfer reverts via the existing last4-only `applyTransferBalanceShift` (the persisted `from_account`/`to_account` columns store only last4, so the bank isn't available at revert time). A shared-last4 **edit/delete** can therefore mis-revert — the same limitation that already affects SMS-detected transfers. Out of scope here; would need the leg columns to carry full account identity.

Same-currency transfers only for this first cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)