### PR TITLE
fix(parser): parse Kotak credit-card refund SMS (#616)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KotakBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/KotakBankParser.kt
@@ -29,6 +29,19 @@ class KotakBankParser : BankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
+        // Credit-card refund: "INR <amt> from <Merchant> refunded to your Kotak Credit Card xNNNN".
+        // The merchant is the payee that money is coming back from — capture the text between
+        // "<amount> from " and " refunded". Without this the base TO_PATTERN would wrongly grab
+        // "your Kotak Credit Card xNNNN" from the "refunded to your ..." clause. (#616)
+        val refundMerchantPattern = Regex(
+            """(?:INR|Rs\.?|₹)\s*[0-9,]+(?:\.\d{2})?\s+from\s+(.+?)\s+refunded\b""",
+            RegexOption.IGNORE_CASE
+        )
+        refundMerchantPattern.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim())
+            if (merchant.isNotEmpty()) return merchant
+        }
+
         // IMPS credit from mobile: "linked to mobile xNNNN"
         val mobileLinkedPattern = Regex(
             """linked\s+to\s+mobile\s+([xX*]+\d{2,})""",
@@ -341,7 +354,10 @@ class KotakBankParser : BankParser() {
         val kotakTransactionKeywords = listOf(
             "sent", // Kotak uses "Sent Rs.X from Kotak Bank"
             "debited", "credited", "withdrawn", "deposited",
-            "spent", "received", "transferred", "paid"
+            "spent", "received", "transferred", "paid",
+            // Credit-card refund: "INR X from <Merchant> refunded to your Kotak Credit Card ...".
+            // The base keyword list doesn't cover "refunded", so parse() would drop it. (#616)
+            "refund"
         )
 
         return kotakTransactionKeywords.any { lowerMessage.contains(it) }

--- a/parser-core/src/test/kotlin/TestKotakBankParser.kt
+++ b/parser-core/src/test/kotlin/TestKotakBankParser.kt
@@ -195,6 +195,23 @@ class KotakBankParserTest {
                     reference = "9999999999",
                     accountLast4 = "5555"
                 )
+            ),
+            // Issue #616: credit-card refund. "refunded" is not a base transaction
+            // keyword, so isTransactionMessage must recognise it or parse() drops it.
+            // Type is INCOME (money back to the card), isFromCard=true, merchant is the
+            // payee between "<amount> from" and "refunded", card last4 from "Card xNNNN".
+            ParserTestCase(
+                name = "Issue #616 - Credit card refund",
+                message = "INR 2 from Airport Lounge refunded to your Kotak Credit Card x8848 on 17-Jul-2026. Opted for EMI? Please call 18602662666 to cancel.",
+                sender = "JM-Kotakb-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2"),
+                    currency = "INR",
+                    type = TransactionType.INCOME,
+                    merchant = "Airport Lounge",
+                    accountLast4 = "8848",
+                    isFromCard = true
+                )
             )
         )
 
@@ -204,6 +221,8 @@ class KotakBankParserTest {
             "JD-KOTAKB-T" to true,
             "VM-KOTAKD-S" to true,
             "JD-KOTAKD-S" to true,
+            // Issue #616: mixed-case DLT header for Kotak credit card refunds
+            "JM-Kotakb-S" to true,
             // RCS display-name senders (issue #360) match via the contains("KOTAK") branch
             "Kotak" to true,
             "Kotak Mahindra Bank" to true,


### PR DESCRIPTION
Closes #616.

## Problem
Kotak **credit-card refund** SMS were silently dropped — `parse()` returned `null`:

> INR 2 from Airport Lounge refunded to your Kotak Credit Card x8848 on 17-Jul-2026. Opted for EMI? Please call 18602662666 to cancel.

**Root cause:** the verb is `refunded`, which isn't in Kotak's transaction-keyword list, so the message failed `isTransactionMessage` before any extraction ran.

## Fix (both in the existing `KotakBankParser`)
- **`isTransactionMessage`** — add `"refund"` to `kotakTransactionKeywords` so the refund isn't dropped (same shape as the IndusInd #486 refund fix).
- **`extractMerchant`** — add a refund pattern capturing the payee between `<amount> from` and `refunded`, so the merchant is `Airport Lounge` (otherwise the base `TO_PATTERN` grabs `your Kotak Credit Card x8848` from the `refunded to your …` clause).

Type (`INCOME` — money back to the card), `isFromCard`, amount, and card last4 were already handled by existing branches/base patterns. `canHandle` already accepts `JM-Kotakb-S` via the DLT regex (added a handle-check to lock it in).

## Tests
New `TestKotakBankParser` case asserting `type=INCOME`, `amount=2`, `merchant="Airport Lounge"`, `accountLast4="8848"`, `isFromCard=true`. Full `:parser-core:jvmTest` green via `./init.sh parser`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)