### PR TITLE
fix(settings): make Display Currency dialog scrollable (#615)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -719,7 +719,12 @@ fun SettingsScreen(
             onDismissRequest = { showDisplayCurrencyDialog = false },
             title = { Text("Display Currency") },
             text = {
-                Column {
+                // Scrollable: the full currency list overflows the dialog's max
+                // height, so without this the entries below the fold (e.g. MXN)
+                // are unreachable. (#615)
+                Column(
+                    modifier = Modifier.verticalScroll(rememberScrollState())
+                ) {
                     availableCurrencies.forEach { currency ->
                         Row(
                             modifier = Modifier


### PR DESCRIPTION
Closes #615.

## Problem
A user from México reported the **Display Currency** menu "doesn't slide" and they can't select **$MXN**.

**Root cause:** the Display Currency dialog listed every supported currency in a plain `Column { }` with **no `verticalScroll`**. Once the list exceeds the dialog's max height, entries below the fold — including MXN, which sits mid-list — are simply unreachable. The sibling Budget Cycle dialog right below it already had `.verticalScroll(...)`; this one just missed it.

MXN itself was already fully supported (symbol `MX$`, `es-MX` locale, exchange rate) — only the picker couldn't reach it, so no data change was needed.

## Fix
One line: add `.verticalScroll(rememberScrollState())` to the dialog's `Column` (imports already present).

## Verification (emulator)
Enabled Unified Currency Mode → opened **Display Currency** → the dialog now **scrolls**, `MX$ MXN` is reachable, and selecting it applies (row updates to "MX$ MXN"). `./init.sh app` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)