### PR TITLE
feat(import): CSV transaction importer (#299)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/csv/CsvTransactionImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/csv/CsvTransactionImporter.kt
@@ -96,7 +96,9 @@ class CsvTransactionImporter @Inject constructor() {
                 return ImportParseResult(
                     transactions = emptyList(),
                     failedCount = 0,
-                    failureReasons = listOf("Missing required column(s): $missing")
+                    failureReasons = listOf(
+                        "This doesn't look like a PennyWise CSV export — missing column(s): $missing"
+                    )
                 )
             }
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/csv/CsvTransactionImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/csv/CsvTransactionImporter.kt
@@ -1,0 +1,278 @@
+package com.pennywiseai.tracker.data.csv
+
+import com.opencsv.CSVReader
+import com.pennywiseai.tracker.data.database.entity.TransactionEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionType
+import java.io.Reader
+import java.math.BigDecimal
+import java.security.MessageDigest
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Parses PennyWise's own CSV export format (the 12 columns [CsvExporter] writes)
+ * back into [TransactionEntity] rows, so historical data can be re-imported and
+ * an export can round-trip.
+ *
+ * Pure/testable: takes a [Reader] (no Android `Uri`), so it can be exercised from
+ * a plain JUnit test with a `StringReader`. The Android side (opening the picked
+ * document, dedup against the DB, insertion) lives in `ImportCsvUseCase`.
+ *
+ * Columns are matched **by header name**, so extra columns or a different column
+ * order are tolerated. Only Date, Amount and Type are required; missing optional
+ * columns become null/empty (with sensible defaults matching manual entry).
+ */
+@Singleton
+class CsvTransactionImporter @Inject constructor() {
+
+    companion object {
+        private val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        private val timeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss")
+
+        // Header labels as written by CsvExporter (matched case-insensitively).
+        private const val COL_DATE = "Date"
+        private const val COL_TIME = "Time"
+        private const val COL_MERCHANT = "Merchant"
+        private const val COL_CATEGORY = "Category"
+        private const val COL_TYPE = "Type"
+        private const val COL_AMOUNT = "Amount"
+        private const val COL_CURRENCY = "Currency"
+        private const val COL_BANK = "Bank"
+        private const val COL_ACCOUNT = "Account"
+        private const val COL_BALANCE = "Balance After"
+        private const val COL_DESCRIPTION = "Description"
+
+        private const val DEFAULT_BANK = "Imported"
+        private const val DEFAULT_CATEGORY = "Others"
+        private const val DEFAULT_CURRENCY = "INR"
+    }
+
+    /**
+     * Result of parsing a CSV: the successfully parsed [transactions] plus a count
+     * (and reasons) for rows that could not be parsed. Nothing is inserted here.
+     */
+    data class ImportParseResult(
+        val transactions: List<TransactionEntity>,
+        val failedCount: Int,
+        val failureReasons: List<String> = emptyList()
+    )
+
+    /**
+     * Parses the given CSV [reader]. The first row must be the header; column
+     * indices are resolved from it by name. Rows that are blank, or missing a
+     * required field, or malformed, are counted as failed rather than throwing.
+     */
+    fun parse(reader: Reader): ImportParseResult {
+        val transactions = mutableListOf<TransactionEntity>()
+        val failureReasons = mutableListOf<String>()
+        var failedCount = 0
+
+        CSVReader(reader).use { csvReader ->
+            val header = csvReader.readNext()
+                ?: return ImportParseResult(emptyList(), 0)
+
+            // Map normalized header label -> column index.
+            val columnIndex = HashMap<String, Int>()
+            header.forEachIndexed { index, name ->
+                columnIndex[name.trim().lowercase()] = index
+            }
+
+            fun indexOf(label: String): Int? = columnIndex[label.lowercase()]
+
+            val dateIdx = indexOf(COL_DATE)
+            val amountIdx = indexOf(COL_AMOUNT)
+            val typeIdx = indexOf(COL_TYPE)
+
+            if (dateIdx == null || amountIdx == null || typeIdx == null) {
+                val missing = buildList {
+                    if (dateIdx == null) add(COL_DATE)
+                    if (amountIdx == null) add(COL_AMOUNT)
+                    if (typeIdx == null) add(COL_TYPE)
+                }.joinToString(", ")
+                return ImportParseResult(
+                    transactions = emptyList(),
+                    failedCount = 0,
+                    failureReasons = listOf("Missing required column(s): $missing")
+                )
+            }
+
+            val timeIdx = indexOf(COL_TIME)
+            val merchantIdx = indexOf(COL_MERCHANT)
+            val categoryIdx = indexOf(COL_CATEGORY)
+            val currencyIdx = indexOf(COL_CURRENCY)
+            val bankIdx = indexOf(COL_BANK)
+            val accountIdx = indexOf(COL_ACCOUNT)
+            val balanceIdx = indexOf(COL_BALANCE)
+            val descriptionIdx = indexOf(COL_DESCRIPTION)
+
+            var row = csvReader.readNext()
+            var rowNumber = 1 // data rows, 1-based (header already consumed)
+            while (row != null) {
+                // Skip fully blank lines silently (OpenCSV can yield a single empty cell).
+                if (row.all { it.isBlank() }) {
+                    row = csvReader.readNext()
+                    rowNumber++
+                    continue
+                }
+
+                try {
+                    transactions.add(parseRow(
+                        row = row,
+                        dateIdx = dateIdx,
+                        timeIdx = timeIdx,
+                        merchantIdx = merchantIdx,
+                        categoryIdx = categoryIdx,
+                        typeIdx = typeIdx,
+                        amountIdx = amountIdx,
+                        currencyIdx = currencyIdx,
+                        bankIdx = bankIdx,
+                        accountIdx = accountIdx,
+                        balanceIdx = balanceIdx,
+                        descriptionIdx = descriptionIdx
+                    ))
+                } catch (e: Exception) {
+                    failedCount++
+                    failureReasons.add("Row $rowNumber: ${e.message}")
+                }
+
+                row = csvReader.readNext()
+                rowNumber++
+            }
+        }
+
+        return ImportParseResult(transactions, failedCount, failureReasons)
+    }
+
+    private fun parseRow(
+        row: Array<String>,
+        dateIdx: Int,
+        timeIdx: Int?,
+        merchantIdx: Int?,
+        categoryIdx: Int?,
+        typeIdx: Int,
+        amountIdx: Int,
+        currencyIdx: Int?,
+        bankIdx: Int?,
+        accountIdx: Int?,
+        balanceIdx: Int?,
+        descriptionIdx: Int?
+    ): TransactionEntity {
+        val dateText = row.cell(dateIdx)
+            ?: throw IllegalArgumentException("Missing Date")
+        val date = try {
+            LocalDate.parse(dateText, dateFormatter)
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Invalid Date '$dateText'")
+        }
+
+        val timeText = row.cell(timeIdx)
+        val time = if (timeText.isNullOrBlank()) {
+            LocalTime.MIDNIGHT
+        } else {
+            try {
+                LocalTime.parse(timeText, timeFormatter)
+            } catch (e: Exception) {
+                throw IllegalArgumentException("Invalid Time '$timeText'")
+            }
+        }
+        val dateTime = LocalDateTime.of(date, time)
+
+        val amountText = row.cell(amountIdx)
+            ?: throw IllegalArgumentException("Missing Amount")
+        val amount = try {
+            BigDecimal(amountText.trim())
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Invalid Amount '$amountText'")
+        }
+
+        val typeText = row.cell(typeIdx)
+            ?: throw IllegalArgumentException("Missing Type")
+        val type = parseType(typeText)
+            ?: throw IllegalArgumentException("Unknown Type '$typeText'")
+
+        val merchant = row.cell(merchantIdx)?.takeIf { it.isNotBlank() } ?: "Unknown"
+        val category = row.cell(categoryIdx)?.takeIf { it.isNotBlank() } ?: DEFAULT_CATEGORY
+        val currency = row.cell(currencyIdx)?.takeIf { it.isNotBlank() } ?: DEFAULT_CURRENCY
+        val bank = row.cell(bankIdx)?.takeIf { it.isNotBlank() } ?: DEFAULT_BANK
+        val account = row.cell(accountIdx)?.takeIf { it.isNotBlank() }
+        val description = row.cell(descriptionIdx)?.takeIf { it.isNotBlank() }
+        val balanceAfter = row.cell(balanceIdx)?.takeIf { it.isNotBlank() }?.let {
+            try {
+                BigDecimal(it.trim())
+            } catch (e: Exception) {
+                null // balance is best-effort; a bad value shouldn't fail the row
+            }
+        }
+
+        return TransactionEntity(
+            amount = amount,
+            merchantName = merchant,
+            category = category,
+            transactionType = type,
+            dateTime = dateTime,
+            description = description,
+            smsBody = null, // null indicates a non-SMS (imported/manual) entry
+            bankName = bank,
+            smsSender = null,
+            accountNumber = account,
+            balanceAfter = balanceAfter,
+            transactionHash = generateImportHash(
+                dateTime = dateTime,
+                merchant = merchant,
+                amount = amount,
+                type = type,
+                currency = currency,
+                account = account
+            ),
+            currency = currency,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
+        )
+    }
+
+    /**
+     * Maps a Type label back to [TransactionType]. Accepts the export labels
+     * ("Income", "Expense", "Credit Card", "Transfer", "Investment") as well as
+     * the bare enum names ("CREDIT", etc.), case-insensitively.
+     */
+    private fun parseType(raw: String): TransactionType? {
+        return when (raw.trim().lowercase()) {
+            "income" -> TransactionType.INCOME
+            "expense" -> TransactionType.EXPENSE
+            "credit card", "credit" -> TransactionType.CREDIT
+            "transfer" -> TransactionType.TRANSFER
+            "investment" -> TransactionType.INVESTMENT
+            else -> null
+        }
+    }
+
+    /**
+     * Deterministic dedup hash from the row's content, so re-importing the same
+     * CSV skips duplicates. Mirrors the MD5 style of
+     * `AddTransactionUseCase.generateManualTransactionHash`.
+     */
+    private fun generateImportHash(
+        dateTime: LocalDateTime,
+        merchant: String,
+        amount: BigDecimal,
+        type: TransactionType,
+        currency: String,
+        account: String?
+    ): String {
+        val date = dateTime.toLocalDate()
+        val time = dateTime.toLocalTime()
+        val data = "CSV_v1_${date}T${time}_${merchant}_${amount}_${type}_${currency}_${account ?: ""}"
+        return MessageDigest.getInstance("MD5")
+            .digest(data.toByteArray())
+            .joinToString("") { "%02x".format(it) }
+    }
+
+    private fun Array<String>.cell(index: Int?): String? {
+        if (index == null || index >= size) return null
+        return this[index].trim().takeIf { it.isNotEmpty() }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/csv/CsvTransactionImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/csv/CsvTransactionImporter.kt
@@ -188,6 +188,12 @@ class CsvTransactionImporter @Inject constructor() {
         } catch (e: Exception) {
             throw IllegalArgumentException("Invalid Amount '$amountText'")
         }
+        // Amounts are always positive; direction is carried by Type (matching the
+        // export). Reject non-positive values so a hand-crafted CSV using signed
+        // debits can't silently corrupt analytics totals — fail the row instead.
+        if (amount.signum() <= 0) {
+            throw IllegalArgumentException("Amount must be positive: '$amountText'")
+        }
 
         val typeText = row.cell(typeIdx)
             ?: throw IllegalArgumentException("Missing Type")

--- a/app/src/main/java/com/pennywiseai/tracker/data/csv/ImportCsvUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/csv/ImportCsvUseCase.kt
@@ -1,0 +1,82 @@
+package com.pennywiseai.tracker.data.csv
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import com.pennywiseai.tracker.data.database.entity.TransactionEntity
+import com.pennywiseai.tracker.data.repository.TransactionRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Imports historical transactions from a CSV in PennyWise's own export format
+ * (see [CsvTransactionImporter]). Opens the picked [Uri] via the ContentResolver,
+ * parses it, dedups the parsed rows against what's already in the DB (by the
+ * deterministic import hash) and inserts the rest.
+ *
+ * Free feature (onboarding/migration) — not gated behind Pro.
+ */
+@Singleton
+class ImportCsvUseCase @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val importer: CsvTransactionImporter,
+    private val transactionRepository: TransactionRepository
+) {
+
+    sealed class Result {
+        data class Success(
+            val imported: Int,
+            val skippedDuplicate: Int,
+            val failed: Int
+        ) : Result()
+
+        data class Error(val message: String) : Result()
+    }
+
+    suspend fun execute(uri: Uri): Result = withContext(Dispatchers.IO) {
+        try {
+            val parseResult = context.contentResolver.openInputStream(uri)?.use { inputStream ->
+                BufferedReader(InputStreamReader(inputStream)).use { reader ->
+                    importer.parse(reader)
+                }
+            } ?: return@withContext Result.Error("Failed to read the selected file")
+
+            // Dedup against existing rows by hash. Also guard against duplicates
+            // *within* the same CSV (two identical rows) by tracking seen hashes.
+            val toInsert = mutableListOf<TransactionEntity>()
+            val seenHashes = HashSet<String>()
+            var skippedDuplicate = 0
+
+            for (transaction in parseResult.transactions) {
+                val hash = transaction.transactionHash
+                if (!seenHashes.add(hash)) {
+                    skippedDuplicate++
+                    continue
+                }
+                if (transactionRepository.getTransactionByHash(hash) != null) {
+                    skippedDuplicate++
+                    continue
+                }
+                toInsert.add(transaction)
+            }
+
+            if (toInsert.isNotEmpty()) {
+                transactionRepository.insertTransactions(toInsert)
+            }
+
+            Result.Success(
+                imported = toInsert.size,
+                skippedDuplicate = skippedDuplicate,
+                failed = parseResult.failedCount
+            )
+        } catch (e: Exception) {
+            Log.e("ImportCsvUseCase", "CSV import failed", e)
+            Result.Error("Import failed: ${e.message}")
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/csv/ImportCsvUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/csv/ImportCsvUseCase.kt
@@ -46,19 +46,19 @@ class ImportCsvUseCase @Inject constructor(
                 }
             } ?: return@withContext Result.Error("Failed to read the selected file")
 
-            // Dedup against existing rows by hash. Also guard against duplicates
-            // *within* the same CSV (two identical rows) by tracking seen hashes.
+            // Dedup against existing rows by hash — one batch query for the whole
+            // file instead of a per-row lookup (a large CSV would otherwise issue
+            // N queries). Also guard against duplicates *within* the same CSV.
+            val existingHashes = transactionRepository
+                .getExistingHashes(parseResult.transactions.map { it.transactionHash })
+                .toHashSet()
             val toInsert = mutableListOf<TransactionEntity>()
             val seenHashes = HashSet<String>()
             var skippedDuplicate = 0
 
             for (transaction in parseResult.transactions) {
                 val hash = transaction.transactionHash
-                if (!seenHashes.add(hash)) {
-                    skippedDuplicate++
-                    continue
-                }
-                if (transactionRepository.getTransactionByHash(hash) != null) {
+                if (!seenHashes.add(hash) || hash in existingHashes) {
                     skippedDuplicate++
                     continue
                 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/csv/ImportCsvUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/csv/ImportCsvUseCase.kt
@@ -46,6 +46,12 @@ class ImportCsvUseCase @Inject constructor(
                 }
             } ?: return@withContext Result.Error("Failed to read the selected file")
 
+            // A structural problem (e.g. wrong file / missing required columns)
+            // yields no rows and a reason — surface it instead of a bare "Imported 0".
+            if (parseResult.transactions.isEmpty() && parseResult.failureReasons.isNotEmpty()) {
+                return@withContext Result.Error(parseResult.failureReasons.first())
+            }
+
             // Dedup against existing rows by hash — one batch query for the whole
             // file instead of a per-row lookup (a large CSV would otherwise issue
             // N queries). Also guard against duplicates *within* the same CSV.

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
@@ -168,6 +168,14 @@ interface TransactionDao {
     suspend fun getTransactionByHash(transactionHash: String): TransactionEntity?
 
     /**
+     * The subset of [hashes] that already exist (including soft-deleted rows).
+     * One query for the whole batch — used by CSV import to dedup a whole file
+     * without issuing a per-row lookup.
+     */
+    @Query("SELECT transaction_hash FROM transactions WHERE transaction_hash IN (:hashes)")
+    suspend fun getExistingHashes(hashes: List<String>): List<String>
+
+    /**
      * Find recent EXPENSE transactions whose merchant AND amount match —
      * used to surface candidate auto-pay charges when the user opens the
      * mark-as-paid sheet for a subscription (#412). Both filters matter:

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
@@ -145,9 +145,13 @@ class TransactionRepository @Inject constructor(
     suspend fun getTransactionByHash(transactionHash: String): TransactionEntity? =
         transactionDao.getTransactionByHash(transactionHash)
 
-    /** The subset of [hashes] already present (one query — see [TransactionDao.getExistingHashes]). */
+    /**
+     * The subset of [hashes] already present. Chunked under SQLite's 999
+     * bind-variable limit (Room does not auto-chunk `IN (:list)`), so a large
+     * CSV import can't crash with "too many SQL variables".
+     */
     suspend fun getExistingHashes(hashes: List<String>): List<String> =
-        transactionDao.getExistingHashes(hashes)
+        hashes.chunked(900).flatMap { transactionDao.getExistingHashes(it) }
 
     /** See [TransactionDao.findRecentExpensesByMerchantAndAmount]. */
     suspend fun findRecentExpensesByMerchantAndAmount(

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
@@ -145,6 +145,10 @@ class TransactionRepository @Inject constructor(
     suspend fun getTransactionByHash(transactionHash: String): TransactionEntity? =
         transactionDao.getTransactionByHash(transactionHash)
 
+    /** The subset of [hashes] already present (one query — see [TransactionDao.getExistingHashes]). */
+    suspend fun getExistingHashes(hashes: List<String>): List<String> =
+        transactionDao.getExistingHashes(hashes)
+
     /** See [TransactionDao.findRecentExpensesByMerchantAndAmount]. */
     suspend fun findRecentExpensesByMerchantAndAmount(
         merchant: String,

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -157,6 +157,16 @@ fun SettingsScreen(
         }
     )
 
+    // File picker for CSV transaction import
+    val csvImportLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent(),
+        onResult = { uri ->
+            uri?.let {
+                settingsViewModel.importCsv(it)
+            }
+        }
+    )
+
     // File saver for export
     val exportSaveLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.CreateDocument("application/octet-stream"),
@@ -577,6 +587,15 @@ fun SettingsScreen(
                     title = "Import Data",
                     subtitle = "Restore data from backup",
                     onClick = { importLauncher.launch("*/*") },
+                    position = ItemPosition.MIDDLE
+                )
+                SettingsNavItem(
+                    icon = Icons.Default.Download,
+                    iconBgColor = cyan_light,
+                    iconTint = cyan_dark,
+                    title = "Import Transactions (CSV)",
+                    subtitle = "Import from a PennyWise CSV export",
+                    onClick = { csvImportLauncher.launch("*/*") },
                     position = ItemPosition.MIDDLE
                 )
                 SettingsNavItem(

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -59,6 +59,7 @@ class SettingsViewModel @Inject constructor(
     private val accountBalanceRepository: AccountBalanceRepository,
     private val backupExporter: BackupExporter,
     private val backupImporter: BackupImporter,
+    private val importCsvUseCase: com.pennywiseai.tracker.data.csv.ImportCsvUseCase,
     private val folderBackupWriter: FolderBackupWriter,
     private val scheduledFolderBackupScheduler: ScheduledFolderBackupScheduler,
     private val contactsResolver: com.pennywiseai.tracker.data.contacts.ContactsResolver,
@@ -663,6 +664,34 @@ class SettingsViewModel @Inject constructor(
         }
     }
     
+    /**
+     * Imports historical transactions from a CSV in PennyWise's own export format.
+     * Free feature (onboarding/migration) — not gated behind Pro.
+     */
+    fun importCsv(uri: android.net.Uri) {
+        viewModelScope.launch {
+            try {
+                _importExportMessage.value = "Importing transactions..."
+                when (val result = importCsvUseCase.execute(uri)) {
+                    is com.pennywiseai.tracker.data.csv.ImportCsvUseCase.Result.Success -> {
+                        val failedSuffix = if (result.failed > 0) {
+                            ", ${result.failed} rows could not be parsed"
+                        } else ""
+                        _importExportMessage.value =
+                            "Imported ${result.imported} transactions, skipped ${result.skippedDuplicate} duplicates$failedSuffix"
+                    }
+                    is com.pennywiseai.tracker.data.csv.ImportCsvUseCase.Result.Error -> {
+                        _importExportMessage.value = result.message
+                        Log.e("SettingsViewModel", "CSV import failed: ${result.message}")
+                    }
+                }
+            } catch (e: Exception) {
+                _importExportMessage.value = "Import error: ${e.message}"
+                Log.e("SettingsViewModel", "CSV import error", e)
+            }
+        }
+    }
+
     fun clearImportExportMessage() {
         _importExportMessage.value = null
     }

--- a/app/src/test/java/com/pennywiseai/tracker/data/csv/CsvTransactionImporterTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/csv/CsvTransactionImporterTest.kt
@@ -1,0 +1,129 @@
+package com.pennywiseai.tracker.data.csv
+
+import com.pennywiseai.tracker.data.database.entity.TransactionType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.StringReader
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+class CsvTransactionImporterTest {
+
+    private val importer = CsvTransactionImporter()
+
+    private val header =
+        "Date,Time,Merchant,Category,Type,Amount,Currency,Bank,Account,Balance After,Description,SMS Body"
+
+    @Test
+    fun `parses valid rows into transactions`() {
+        val csv = buildString {
+            appendLine(header)
+            appendLine("2026-01-15,09:30:00,Coffee Shop,Food,Expense,250.00,INR,DemoBank,1234,4750.00,Morning coffee,")
+            appendLine("2026-01-16,18:00:00,Employer,Income,Income,50000.00,INR,DemoBank,1234,54750.00,Salary,")
+            appendLine("2026-01-17,12:00:00,Broker,Investments,Investment,1000.00,USD,DemoBank,9876,,,")
+        }
+
+        val result = importer.parse(StringReader(csv))
+
+        assertEquals(0, result.failedCount)
+        assertEquals(3, result.transactions.size)
+
+        val expense = result.transactions[0]
+        assertEquals(BigDecimal("250.00"), expense.amount)
+        assertEquals(TransactionType.EXPENSE, expense.transactionType)
+        assertEquals("Coffee Shop", expense.merchantName)
+        assertEquals("INR", expense.currency)
+        assertEquals(LocalDateTime.of(2026, 1, 15, 9, 30, 0), expense.dateTime)
+        assertEquals("DemoBank", expense.bankName)
+        assertEquals("1234", expense.accountNumber)
+        assertEquals(BigDecimal("4750.00"), expense.balanceAfter)
+        assertNull(expense.smsBody)
+
+        val income = result.transactions[1]
+        assertEquals(BigDecimal("50000.00"), income.amount)
+        assertEquals(TransactionType.INCOME, income.transactionType)
+        assertEquals("Employer", income.merchantName)
+
+        // Currency must be per-row, never assumed to be a single currency.
+        val investment = result.transactions[2]
+        assertEquals(TransactionType.INVESTMENT, investment.transactionType)
+        assertEquals("USD", investment.currency)
+        // Missing Time falls back to midnight; missing balance/description -> null.
+        assertNull(investment.balanceAfter)
+        assertNull(investment.description)
+    }
+
+    @Test
+    fun `bad amount row is counted as failed not crashed`() {
+        val csv = buildString {
+            appendLine(header)
+            appendLine("2026-01-15,09:30:00,Coffee Shop,Food,Expense,250.00,INR,DemoBank,1234,,,")
+            appendLine("2026-01-16,10:00:00,Broken,Food,Expense,not-a-number,INR,DemoBank,1234,,,")
+        }
+
+        val result = importer.parse(StringReader(csv))
+
+        assertEquals(1, result.transactions.size)
+        assertEquals(1, result.failedCount)
+        assertTrue(result.failureReasons.any { it.contains("Amount") })
+    }
+
+    @Test
+    fun `type labels and bare enum names map back case-insensitively`() {
+        val csv = buildString {
+            appendLine(header)
+            appendLine("2026-01-15,09:30:00,Card Merchant,Shopping,Credit Card,99.00,INR,DemoBank,1234,,,")
+            appendLine("2026-01-16,09:30:00,Enum Merchant,Shopping,credit,99.00,INR,DemoBank,1234,,,")
+        }
+
+        val result = importer.parse(StringReader(csv))
+
+        assertEquals(2, result.transactions.size)
+        assertEquals(TransactionType.CREDIT, result.transactions[0].transactionType)
+        assertEquals(TransactionType.CREDIT, result.transactions[1].transactionType)
+    }
+
+    @Test
+    fun `column order and extra columns are tolerated via header matching`() {
+        // Reordered columns plus an unknown extra column.
+        val reorderedHeader = "Amount,Type,Date,Merchant,ExtraCol,Currency"
+        val csv = buildString {
+            appendLine(reorderedHeader)
+            appendLine("500.00,Expense,2026-02-01,Reordered Merchant,ignore-me,EUR")
+        }
+
+        val result = importer.parse(StringReader(csv))
+
+        assertEquals(0, result.failedCount)
+        assertEquals(1, result.transactions.size)
+        val txn = result.transactions[0]
+        assertEquals(BigDecimal("500.00"), txn.amount)
+        assertEquals(TransactionType.EXPENSE, txn.transactionType)
+        assertEquals("Reordered Merchant", txn.merchantName)
+        assertEquals("EUR", txn.currency)
+        // Missing Category/Bank -> defaults.
+        assertEquals("Others", txn.category)
+        assertEquals("Imported", txn.bankName)
+    }
+
+    @Test
+    fun `identical rows produce identical dedup hashes`() {
+        val csv = buildString {
+            appendLine(header)
+            appendLine("2026-01-15,09:30:00,Coffee Shop,Food,Expense,250.00,INR,DemoBank,1234,,,")
+            appendLine("2026-01-15,09:30:00,Coffee Shop,Food,Expense,250.00,INR,DemoBank,1234,,,")
+        }
+
+        val result = importer.parse(StringReader(csv))
+
+        assertEquals(2, result.transactions.size)
+        assertNotNull(result.transactions[0].transactionHash)
+        assertEquals(
+            result.transactions[0].transactionHash,
+            result.transactions[1].transactionHash
+        )
+    }
+}

--- a/app/src/test/java/com/pennywiseai/tracker/data/csv/CsvTransactionImporterTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/csv/CsvTransactionImporterTest.kt
@@ -72,6 +72,24 @@ class CsvTransactionImporterTest {
     }
 
     @Test
+    fun `non-positive amount row is rejected as failed`() {
+        // Amounts must be positive (direction is carried by Type). A signed-debit
+        // CSV must fail the row rather than silently corrupt analytics totals.
+        val csv = buildString {
+            appendLine(header)
+            appendLine("2026-01-15,09:30:00,Ok,Food,Expense,250.00,INR,DemoBank,1234,,,")
+            appendLine("2026-01-16,10:00:00,Negative,Food,Expense,-250.00,INR,DemoBank,1234,,,")
+            appendLine("2026-01-17,10:00:00,Zero,Food,Expense,0,INR,DemoBank,1234,,,")
+        }
+
+        val result = importer.parse(StringReader(csv))
+
+        assertEquals(1, result.transactions.size)
+        assertEquals(2, result.failedCount)
+        assertTrue(result.failureReasons.all { it.contains("Amount") })
+    }
+
+    @Test
     fun `type labels and bare enum names map back case-insensitively`() {
         val csv = buildString {
             appendLine(header)


### PR DESCRIPTION
Closes #299.

## What
Lets users import historical transactions from a CSV in **PennyWise's own export format** — the 12 columns `CsvExporter` writes (`Date, Time, Merchant, Category, Type, Amount, Currency, Bank, Account, Balance After, Description, SMS Body`). So an export round-trips, and someone migrating from another app (axio, etc.) can carry their history over by reformatting to that standard layout.

MVP scope is deliberately the round-trip format — no per-app column-mapping UI (that's a possible fast-follow).

## How
- **`CsvTransactionImporter`** (pure/testable — takes a `java.io.Reader`): OpenCSV parse, **header-name** column matching (tolerant of column reorder / extra columns), requires Date/Amount/Type, sensible defaults for the rest (`bank`→"Imported", `category`→"Others", `currency`→"INR"). Per-row failures (bad amount/date/unknown type) are **counted, not thrown**. Currency is set per-row from the CSV — nothing summed across currencies.
- **`ImportCsvUseCase`**: opens the picked `Uri`, dedups by a **deterministic content hash** (against the DB via `getTransactionByHash` and within the same file), inserts the rest; returns imported / skippedDuplicate / failed.
- **Settings**: an "Import Transactions (CSV)" entry (GetContent picker) beside "Import Data"; result surfaced via the existing import/export snackbar. **Free** — it's a migration/onboarding driver, not Pro-gated.
- **Test**: `CsvTransactionImporterTest` (5 cases, incl. a bad-amount row counted as failed).

## Verification (emulator)
Pushed a 2-row CSV (Expense + Income) and imported via the new entry → **"Imported 2 transactions, skipped 0 duplicates"**; both appeared with correct amount/type/category/description/currency. Re-imported the same file → **"Imported 0 transactions, skipped 2 duplicates"** (dedup works). `./init.sh app` green.

## Note / possible follow-up
Imports populate history & analytics but **don't retroactively recompute account balances** (historical imports shouldn't rewrite *current* balances); rows without a Bank land in an "Imported" pseudo-account. If balance-affecting imports are wanted for manual/cash accounts, that's a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)