### PR TITLE
fix(analytics): exclude DEDUCT_SPENT refunds from the Income view (#629)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -281,6 +281,16 @@ class AnalyticsViewModel @Inject constructor(
                     // stay in history and count toward balance — only these breakdowns,
                     // totals, averages and the spending trend ignore them.
                     .filter { !it.transaction.excludedFromAnalytics }
+                    // On the Income view, drop refunds (INCOME + DEDUCT_SPENT): they
+                    // offset spending and are already netted out of the Expense view
+                    // below, so counting them as income too would double-count them
+                    // (and inflate net savings). Mirrors the Home card, which excludes
+                    // DEDUCT_SPENT from its income figure. Other views are unaffected —
+                    // the Expense view pulls these refunds back in separately. (#629)
+                    .filter {
+                        !(transactionTypeFilter == com.pennywiseai.tracker.data.database.entity.TransactionType.INCOME &&
+                            it.transaction.budgetImpactType == com.pennywiseai.tracker.data.database.entity.BudgetImpactType.DEDUCT_SPENT)
+                    }
 
                 // Compute available categories BEFORE applying category filter
                 val allCategoryNames = filteredTransactionsWithSplits


### PR DESCRIPTION
Closes #629.

## Problem
A refund marked as "refund" is stored as `TransactionType.INCOME` + `budgetImpactType = DEDUCT_SPENT`. It was **excluded from income on the Home card** but **still counted as income on the Analytics → Income page** — the two disagreed.

Since a `DEDUCT_SPENT` refund is already netted *out of* the Expense view, also counting it *as* income double-counts it (and inflates any income − expenses reading).

## Fix
Mirror the Home card (`HomeViewModel`, which excludes `DEDUCT_SPENT` from its income figure): in `AnalyticsViewModel`, when the type filter is **Income**, drop `INCOME + DEDUCT_SPENT` transactions from the total and breakdown. Scoped to the Income view — the Expense view still pulls these refunds back in separately to net them out of spending, and other views are unaffected.

## Verification (emulator)
- Added an income (₹333) → Analytics **Income** total = **₹333** (baseline).
- Marked it as **Refund** (`DEDUCT_SPENT`) → Analytics **Income** view now empty ("Not enough data yet") — the refund is excluded, matching the Home card.
- `./init.sh app` green.

Home card behavior unchanged (it was already correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)