### PR TITLE
feat(export): carry analytics custom range into drill-down + group CSV export

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/groups/TransactionGroupDetailScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/groups/TransactionGroupDetailScreen.kt
@@ -25,6 +25,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
+import com.pennywiseai.tracker.presentation.transactions.ExportTransactionsDialog
 import com.pennywiseai.tracker.ui.components.CustomTitleTopAppBar
 import com.pennywiseai.tracker.ui.components.cards.PennyWiseCardV2
 import com.pennywiseai.tracker.ui.effects.overScrollVertical
@@ -46,6 +47,7 @@ fun TransactionGroupDetailScreen(
     val scrollBehaviorSmall = TopAppBarDefaults.pinnedScrollBehavior()
     val scrollBehaviorLarge = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     val hazeState = remember { HazeState() }
+    var showExportDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(uiState.isDeleted) {
         if (uiState.isDeleted) onNavigateBack()
@@ -83,6 +85,13 @@ fun TransactionGroupDetailScreen(
                                 onClick = { showMenu = false; viewModel.showEditDialog() },
                                 leadingIcon = { Icon(Icons.Default.Edit, null) }
                             )
+                            if (uiState.linkedTransactions.isNotEmpty()) {
+                                DropdownMenuItem(
+                                    text = { Text("Export CSV") },
+                                    onClick = { showMenu = false; showExportDialog = true },
+                                    leadingIcon = { Icon(Icons.Default.FileDownload, null) }
+                                )
+                            }
                             DropdownMenuItem(
                                 text = { Text("Delete", color = MaterialTheme.colorScheme.error) },
                                 onClick = { showMenu = false; viewModel.showDeleteDialog() },
@@ -278,6 +287,15 @@ fun TransactionGroupDetailScreen(
             currentNote = group.note,
             onDismiss = { viewModel.hideEditDialog() },
             onSave = { name, note -> viewModel.updateGroupName(name, note) }
+        )
+    }
+
+    // Export dialog — reuses the transactions CSV exporter (same Pro/free
+    // row-limit behavior) on this group's linked transactions.
+    if (showExportDialog) {
+        ExportTransactionsDialog(
+            transactions = uiState.linkedTransactions,
+            onDismiss = { showExportDialog = false }
         )
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
@@ -86,6 +86,9 @@ fun TransactionsScreen(
     initialMerchant: String? = null,
     initialPeriod: String? = null,
     initialCurrency: String? = null,
+    // Custom date range carried by an analytics drill-down (period == CUSTOM)
+    initialCustomStartEpochDay: Long? = null,
+    initialCustomEndEpochDay: Long? = null,
     focusSearch: Boolean = false,
     // New parameters for budget navigation
     initialStartDateEpochDay: Long? = null,
@@ -196,7 +199,9 @@ fun TransactionsScreen(
             initialCategory,
             initialMerchant,
             initialPeriod,
-            initialCurrency
+            initialCurrency,
+            initialCustomStartEpochDay,
+            initialCustomEndEpochDay
         )
     }
 
@@ -204,13 +209,15 @@ fun TransactionsScreen(
     var processedNavParams by rememberSaveable { mutableStateOf(false) }
 
     // Apply navigation filters only ONCE when actually navigating (not when returning from detail)
-    LaunchedEffect(initialCategory, initialMerchant, initialPeriod, initialCurrency) {
+    LaunchedEffect(initialCategory, initialMerchant, initialPeriod, initialCurrency, initialCustomStartEpochDay, initialCustomEndEpochDay) {
         if (!processedNavParams && (initialCategory != null || initialMerchant != null || initialPeriod != null || initialCurrency != null)) {
             viewModel.applyNavigationFilters(
                 initialCategory,
                 initialMerchant,
                 initialPeriod,
-                initialCurrency
+                initialCurrency,
+                initialCustomStartEpochDay,
+                initialCustomEndEpochDay
             )
             processedNavParams = true
         }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -984,7 +984,9 @@ class TransactionsViewModel @Inject constructor(
         category: String?,
         merchant: String?,
         period: String?,
-        currency: String?
+        currency: String?,
+        startDateEpochDay: Long? = null,
+        endDateEpochDay: Long? = null
     ) {
         if (!hasAppliedInitialFilters) {
             // Only apply filters once, when first navigating to the screen
@@ -1005,14 +1007,7 @@ class TransactionsViewModel @Inject constructor(
             }
 
             period?.let { periodName ->
-                val timePeriod = when (periodName) {
-                    "THIS_MONTH" -> TimePeriod.THIS_MONTH
-                    "LAST_MONTH" -> TimePeriod.LAST_MONTH
-                    "CURRENT_FY" -> TimePeriod.CURRENT_FY
-                    "ALL" -> TimePeriod.ALL
-                    else -> null
-                }
-                timePeriod?.let { selectPeriod(it) }
+                applyNavigatedPeriod(periodName, startDateEpochDay, endDateEpochDay)
             }
 
             // Only set currency if it's provided (from navigation)
@@ -1022,14 +1017,42 @@ class TransactionsViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Maps a navigated period name onto the period filter. A "CUSTOM" period
+     * carries its date range as epoch days (analytics custom range drill-down);
+     * without both dates it is ignored and the current period is kept.
+     */
+    private fun applyNavigatedPeriod(
+        periodName: String,
+        startDateEpochDay: Long?,
+        endDateEpochDay: Long?
+    ) {
+        when (periodName) {
+            "THIS_MONTH" -> selectPeriod(TimePeriod.THIS_MONTH)
+            "LAST_MONTH" -> selectPeriod(TimePeriod.LAST_MONTH)
+            "CURRENT_FY" -> selectPeriod(TimePeriod.CURRENT_FY)
+            "ALL" -> selectPeriod(TimePeriod.ALL)
+            "CUSTOM" -> if (startDateEpochDay != null && endDateEpochDay != null) {
+                setCustomDateRange(
+                    LocalDate.ofEpochDay(startDateEpochDay),
+                    LocalDate.ofEpochDay(endDateEpochDay)
+                )
+            }
+        }
+    }
+
     fun applyNavigationFilters(
         category: String?,
         merchant: String?,
         period: String?,
-        currency: String?
+        currency: String?,
+        startDateEpochDay: Long? = null,
+        endDateEpochDay: Long? = null
     ) {
         // Create current params to compare
-        val currentParams = NavigationParams(category, merchant, period, currency)
+        val currentParams = NavigationParams(
+            category, merchant, period, currency, startDateEpochDay, endDateEpochDay
+        )
 
         // Only apply navigation filters if:
         // 1. This is the first time (appliedNavigationParams is null)
@@ -1060,14 +1083,7 @@ class TransactionsViewModel @Inject constructor(
         }
 
         period?.let { periodName ->
-            val timePeriod = when (periodName) {
-                "THIS_MONTH" -> TimePeriod.THIS_MONTH
-                "LAST_MONTH" -> TimePeriod.LAST_MONTH
-                "CURRENT_FY" -> TimePeriod.CURRENT_FY
-                "ALL" -> TimePeriod.ALL
-                else -> null
-            }
-            timePeriod?.let { selectPeriod(it) }
+            applyNavigatedPeriod(periodName, startDateEpochDay, endDateEpochDay)
         }
 
         // Only set currency if it's provided (from navigation)
@@ -1466,7 +1482,9 @@ private data class NavigationParams(
     val category: String?,
     val merchant: String?,
     val period: String?,
-    val currency: String?
+    val currency: String?,
+    val startDateEpochDay: Long? = null,
+    val endDateEpochDay: Long? = null
 )
 
 /**

--- a/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
@@ -230,7 +230,7 @@ fun MainScreen(
                 )
 
                 composable(
-                    route = "transactions?category={category}&merchant={merchant}&period={period}&currency={currency}&focusSearch={focusSearch}&type={type}",
+                    route = "transactions?category={category}&merchant={merchant}&period={period}&currency={currency}&focusSearch={focusSearch}&type={type}&startDate={startDate}&endDate={endDate}",
                     arguments = listOf(
                         navArgument("category") {
                             type = NavType.StringType
@@ -260,6 +260,16 @@ fun MainScreen(
                             type = NavType.StringType
                             nullable = true
                             defaultValue = null
+                        },
+                        navArgument("startDate") {
+                            type = NavType.StringType
+                            nullable = true
+                            defaultValue = null
+                        },
+                        navArgument("endDate") {
+                            type = NavType.StringType
+                            nullable = true
+                            defaultValue = null
                         }
                     ),
                     content = { backStackEntry: NavBackStackEntry ->
@@ -269,6 +279,8 @@ fun MainScreen(
                         val currency = backStackEntry.arguments?.getString("currency")
                         val focusSearch = backStackEntry.arguments?.getBoolean("focusSearch") ?: false
                         val transactionType = backStackEntry.arguments?.getString("type")
+                        val startDate = backStackEntry.arguments?.getString("startDate")?.toLongOrNull()
+                        val endDate = backStackEntry.arguments?.getString("endDate")?.toLongOrNull()
 
                         TransactionsScreen(
                             modifier = Modifier.imePadding(),
@@ -276,6 +288,8 @@ fun MainScreen(
                             initialMerchant = merchant,
                             initialPeriod = period,
                             initialCurrency = currency,
+                            initialCustomStartEpochDay = startDate,
+                            initialCustomEndEpochDay = endDate,
                             focusSearch = focusSearch,
                             initialTransactionType = transactionType,
                             onNavigateBack = {
@@ -335,7 +349,7 @@ fun MainScreen(
                                     launchSingleTop = true
                                 }
                             },
-                            onNavigateToTransactions = { category, merchant, period, currency ->
+                            onNavigateToTransactions = { category, merchant, period, currency, startDateEpochDay, endDateEpochDay ->
                                 val route = buildString {
                                     append("transactions")
                                     val params = mutableListOf<String>()
@@ -352,6 +366,12 @@ fun MainScreen(
                                     }
                                     currency?.let {
                                         params.add("currency=$it")
+                                    }
+                                    startDateEpochDay?.let {
+                                        params.add("startDate=$it")
+                                    }
+                                    endDateEpochDay?.let {
+                                        params.add("endDate=$it")
                                     }
                                     if (params.isNotEmpty()) {
                                         append("?")

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsScreen.kt
@@ -67,7 +67,14 @@ private enum class CategoryViewType { CHART, LIST }
 fun AnalyticsScreen(
     viewModel: AnalyticsViewModel = hiltViewModel(),
     onNavigateToChat: () -> Unit = {},
-    onNavigateToTransactions: (category: String?, merchant: String?, period: String?, currency: String?) -> Unit = { _, _, _, _ -> },
+    onNavigateToTransactions: (
+        category: String?,
+        merchant: String?,
+        period: String?,
+        currency: String?,
+        startDateEpochDay: Long?,
+        endDateEpochDay: Long?
+    ) -> Unit = { _, _, _, _, _, _ -> },
     onNavigateToHome: () -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -106,6 +113,10 @@ fun AnalyticsScreen(
     val customRangeLabel = remember(customDateRange) {
         DateRangeUtils.formatDateRange(customDateRange)
     }
+    // Carry the custom range through drill-down navigation so the Transactions
+    // screen (and its CSV export) shows exactly the slice being viewed here.
+    val navStartEpochDay = if (selectedPeriod == TimePeriod.CUSTOM) customDateRange?.first?.toEpochDay() else null
+    val navEndEpochDay = if (selectedPeriod == TimePeriod.CUSTOM) customDateRange?.second?.toEpochDay() else null
     val primaryVisibleCurrency = availableCurrencies.firstOrNull() ?: selectedCurrency
     val hasCurrencyFilter = !isUnifiedMode &&
             availableCurrencies.size > 1 &&
@@ -421,14 +432,14 @@ fun AnalyticsScreen(
                                 categories = uiState.categoryBreakdown,
                                 currency = selectedCurrency,
                                 onCategoryClick = { category ->
-                                    onNavigateToTransactions(category.name, null, selectedPeriod.name, selectedCurrency)
+                                    onNavigateToTransactions(category.name, null, selectedPeriod.name, selectedCurrency, navStartEpochDay, navEndEpochDay)
                                 }
                             )
                             CategoryViewType.LIST -> CategoryBreakdownCard(
                                 categories = uiState.categoryBreakdown,
                                 currency = selectedCurrency,
                                 onCategoryClick = { category ->
-                                    onNavigateToTransactions(category.name, null, selectedPeriod.name, selectedCurrency)
+                                    onNavigateToTransactions(category.name, null, selectedPeriod.name, selectedCurrency, navStartEpochDay, navEndEpochDay)
                                 }
                             )
                         }
@@ -494,14 +505,14 @@ fun AnalyticsScreen(
                                 tags = uiState.tagBreakdown,
                                 currency = selectedCurrency,
                                 onTagClick = { tag ->
-                                    onNavigateToTransactions(null, tag.name, selectedPeriod.name, selectedCurrency)
+                                    onNavigateToTransactions(null, tag.name, selectedPeriod.name, selectedCurrency, navStartEpochDay, navEndEpochDay)
                                 }
                             )
                             CategoryViewType.LIST -> TagBreakdownCard(
                                 tags = uiState.tagBreakdown,
                                 currency = selectedCurrency,
                                 onTagClick = { tag ->
-                                    onNavigateToTransactions(null, tag.name, selectedPeriod.name, selectedCurrency)
+                                    onNavigateToTransactions(null, tag.name, selectedPeriod.name, selectedCurrency, navStartEpochDay, navEndEpochDay)
                                 }
                             )
                         }
@@ -529,7 +540,7 @@ fun AnalyticsScreen(
                         merchant = merchant,
                         currency = selectedCurrency,
                         onClick = {
-                            onNavigateToTransactions(null, merchant.name, selectedPeriod.name, selectedCurrency)
+                            onNavigateToTransactions(null, merchant.name, selectedPeriod.name, selectedCurrency, navStartEpochDay, navEndEpochDay)
                         }
                     )
                 }


### PR DESCRIPTION
## What

Two gaps in "export exactly what I'm looking at":

### 1. Analytics custom range now carries into the drill-down
Tapping a merchant / category / tag in Analytics while a **custom date range** was active previously landed on the Transactions screen reset to **This Month** (the nav handoff only mapped THIS_MONTH / LAST_MONTH / CURRENT_FY / ALL). The custom range now travels with the navigation as epoch-day route args and is applied on arrival — so the existing Export FAB exports exactly the slice that was on screen in Analytics.

- `AnalyticsScreen`: passes `customDateRange` (epoch days) through `onNavigateToTransactions` when the period is CUSTOM
- `MainScreen`: `startDate`/`endDate` route args on the transactions destination
- `TransactionsViewModel`: shared `applyNavigatedPeriod()` used by both `applyInitialFilters` and `applyNavigationFilters`; `NavigationParams` includes the range so the dedup check stays correct

### 2. Group-wise CSV export
The transaction-group detail screen's ⋮ menu gains **Export CSV** (hidden while the group is empty), reusing `ExportTransactionsDialog` on the group's linked transactions — free-tier row limit / Pro behavior identical to the Transactions screen export.

## Verification
- `./init.sh app` green (build + unit tests)
- On-emulator E2E:
  - Custom range **Jul 19–23** → tap Zomato in Top Merchants → Transactions shows the **"Jul 19 - Jul 23"** chip + only the 2 in-range Zomato txns → export dialog offers exactly 2 transactions
  - Range filtering proven exclusive: switching the range to Jul 20–22 correctly hides Jul 23 transactions
  - Created a group with 2 txns → ⋮ → Export CSV → "Export Complete! 2 transactions" → pulled the CSV and verified both rows in the standard 12-column format