### PR TITLE
fix(accounts): show balance history in the account's own currency (#631)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/BalanceHistoryScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/BalanceHistoryScreen.kt
@@ -44,11 +44,6 @@ fun BalanceHistoryScreen(
     val balanceHistory by viewModel.history.collectAsStateWithLifecycle()
     val bankName = viewModel.bankName
     val accountLast4 = viewModel.accountLast4
-
-    // Get the primary currency for this account
-    val accountPrimaryCurrency = remember(bankName) {
-        CurrencyFormatter.getBankBaseCurrency(bankName)
-    }
     var editingId by remember { mutableStateOf<Long?>(null) }
     var editingValue by remember { mutableStateOf("") }
     var showDeleteConfirmation by remember { mutableStateOf<Long?>(null) }
@@ -107,7 +102,15 @@ fun BalanceHistoryScreen(
                             val isLatest = balance == balanceHistory.first()
                             val isOnlyRecord = balanceHistory.size == 1
                             val isExpanded = expandedSources.contains(balance.id)
-                            
+                            // Resolve the row's currency the same way the rest of the
+                            // account UI does: a MANUAL account keeps its stored currency
+                            // (e.g. MXN); SMS-tracked rows fall back to the bank base. (#631)
+                            val rowCurrency = CurrencyFormatter.resolveAccountCurrency(
+                                sourceType = balance.sourceType,
+                                storedCurrency = balance.currency,
+                                bankName = bankName
+                            )
+
                             BalanceHistoryItem(
                                 balance = balance,
                                 isLatest = isLatest,
@@ -115,7 +118,7 @@ fun BalanceHistoryScreen(
                                 isExpanded = isExpanded,
                                 editingId = editingId,
                                 editingValue = editingValue,
-                                accountPrimaryCurrency = accountPrimaryCurrency,
+                                accountPrimaryCurrency = rowCurrency,
                                 onEditClick = {
                                     editingId = balance.id
                                     editingValue = balance.balance.toPlainString()


### PR DESCRIPTION
Fixes #631.

## Problem
Opening an account's **Balance History** (Manage Accounts → ⋮ → History) showed amounts in the **wrong currency** — a user with a manual **MXN** account saw ₹ (INR) instead of MX\$.

## Root cause
`BalanceHistoryScreen` was the **only** account surface deriving currency from `CurrencyFormatter.getBankBaseCurrency(bankName)`, which falls back to **INR** for manual/unknown banks. Every sibling account screen (`ManageAccountsScreen`) uses `resolveAccountCurrency(sourceType, storedCurrency, bankName)`, which trusts the stored currency for `MANUAL` accounts.

## Fix
Resolve each history row with `resolveAccountCurrency(...)` using the data already stored on each `AccountBalanceEntity` (`currency` + `source_type`). MANUAL accounts keep their stored currency; SMS-tracked rows keep the prior bank-base behavior (no change for them).

One-line-ish change in `BalanceHistoryScreen.kt`.

## Verification
- `./init.sh app` green (build + unit tests)
- **On emulator:** injected a manual MXN account with two balance snapshots → Balance History now renders **MX\$4,200.5 / MX\$5,000** (previously would show ₹). Screenshot confirmed; test data cleaned up afterward.