### PR TITLE
fix(accounts): make Merge Accounts sheet scrollable with many accounts (#624)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/MergeAccountsSheet.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/MergeAccountsSheet.kt
@@ -75,6 +75,10 @@ fun MergeAccountsSheet(
         // the source and target lists share one scroll surface — the second list
         // stays reachable instead of being pushed off-screen (#624). Previously
         // two nested LazyColumns competed for height inside a non-scrolling Column.
+        // No list-wide verticalArrangement: structural items (header, section
+        // labels) keep their own paddings, while account rows carry an xs top
+        // gap so the inter-row rhythm matches the original two-picker layout
+        // instead of spacing every item uniformly.
         LazyColumn(
             modifier = Modifier
                 .fillMaxWidth()
@@ -82,8 +86,7 @@ fun MergeAccountsSheet(
                     start = Dimensions.Padding.content,
                     end = Dimensions.Padding.content,
                     bottom = Spacing.lg
-                ),
-            verticalArrangement = Arrangement.spacedBy(Spacing.xs)
+                )
         ) {
             item(key = "header") {
                 Column {
@@ -230,6 +233,7 @@ private fun AccountPickerRow(
         color = if (isSelected) MaterialTheme.colorScheme.primaryContainer
         else MaterialTheme.colorScheme.surfaceContainerHighest,
         modifier = Modifier
+            .padding(top = Spacing.xs)
             .fillMaxWidth()
             .clickable { onClick() }
     ) {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/MergeAccountsSheet.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/MergeAccountsSheet.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -70,30 +71,40 @@ fun MergeAccountsSheet(
     }
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
-        Column(
+        // A single LazyColumn drives the whole sheet so that, with many accounts,
+        // the source and target lists share one scroll surface — the second list
+        // stays reachable instead of being pushed off-screen (#624). Previously
+        // two nested LazyColumns competed for height inside a non-scrolling Column.
+        LazyColumn(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(
                     start = Dimensions.Padding.content,
                     end = Dimensions.Padding.content,
                     bottom = Spacing.lg
-                )
+                ),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xs)
         ) {
-            Text(
-                text = "Merge accounts",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold
-            )
-            Text(
-                text = "Move all transactions from one account into another. The source account is removed when done.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = Spacing.xs, bottom = Spacing.md)
-            )
+            item(key = "header") {
+                Column {
+                    Text(
+                        text = "Merge accounts",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        text = "Move all transactions from one account into another. The source account is removed when done.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = Spacing.xs, bottom = Spacing.md)
+                    )
+                }
+            }
 
             // Source picker
-            SectionLabel("Move from")
-            AccountPicker(
+            item(key = "from-label") { SectionLabel("Move from") }
+            accountPickerItems(
+                idPrefix = "src",
                 accounts = accounts,
                 selected = source,
                 onSelect = { picked ->
@@ -107,31 +118,38 @@ fun MergeAccountsSheet(
             source?.let { src ->
                 val targets = accounts.filter { compatible(src, it) }
                 if (targets.isEmpty()) {
-                    Text(
-                        text = "No other accounts match this one's currency / type.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.error,
-                        modifier = Modifier.padding(top = Spacing.md)
-                    )
-                } else {
-                    SectionLabel("Into", modifier = Modifier.padding(top = Spacing.md))
-                    Row(
-                        modifier = Modifier.padding(bottom = Spacing.xs),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.ArrowDownward,
-                            contentDescription = null,
-                            modifier = Modifier.padding(end = Spacing.xs),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+                    item(key = "no-targets") {
                         Text(
-                            text = AccountBalanceEntity.accountLabel(src.bankName, src.accountLast4),
+                            text = "No other accounts match this one's currency / type.",
                             style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.padding(top = Spacing.md)
                         )
                     }
-                    AccountPicker(
+                } else {
+                    item(key = "into-header") {
+                        Column(modifier = Modifier.padding(top = Spacing.md)) {
+                            SectionLabel("Into")
+                            Row(
+                                modifier = Modifier.padding(bottom = Spacing.xs),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.ArrowDownward,
+                                    contentDescription = null,
+                                    modifier = Modifier.padding(end = Spacing.xs),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Text(
+                                    text = AccountBalanceEntity.accountLabel(src.bankName, src.accountLast4),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                    accountPickerItems(
+                        idPrefix = "tgt",
                         accounts = targets,
                         selected = target,
                         onSelect = { target = it }
@@ -179,74 +197,84 @@ private fun SectionLabel(text: String, modifier: Modifier = Modifier) {
     )
 }
 
-@Composable
-private fun AccountPicker(
+/**
+ * Emits selectable account rows directly into the parent [LazyColumn] (rather
+ * than nesting its own scroll container), so both the source and target lists
+ * live on the sheet's single scroll surface. [idPrefix] keeps item keys unique
+ * across the two lists.
+ */
+private fun LazyListScope.accountPickerItems(
+    idPrefix: String,
     accounts: List<AccountBalanceEntity>,
     selected: AccountBalanceEntity?,
     onSelect: (AccountBalanceEntity) -> Unit
 ) {
-    LazyColumn(
-        modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(Spacing.xs)
+    items(
+        accounts,
+        key = { "$idPrefix|${it.bankName}|${it.accountLast4}|${it.id}" }
+    ) { acct ->
+        val isSelected = selected?.bankName == acct.bankName &&
+            selected.accountLast4 == acct.accountLast4
+        AccountPickerRow(acct = acct, isSelected = isSelected, onClick = { onSelect(acct) })
+    }
+}
+
+@Composable
+private fun AccountPickerRow(
+    acct: AccountBalanceEntity,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = if (isSelected) MaterialTheme.colorScheme.primaryContainer
+        else MaterialTheme.colorScheme.surfaceContainerHighest,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
     ) {
-        items(
-            accounts,
-            key = { "${it.bankName}|${it.accountLast4}|${it.id}" }
-        ) { acct ->
-            val isSelected = selected?.bankName == acct.bankName &&
-                selected.accountLast4 == acct.accountLast4
-            Surface(
-                shape = RoundedCornerShape(12.dp),
-                color = if (isSelected) MaterialTheme.colorScheme.primaryContainer
-                else MaterialTheme.colorScheme.surfaceContainerHighest,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onSelect(acct) }
-            ) {
-                Row(
-                    modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(Spacing.sm)
-                ) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = acct.bankName,
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal
+        Row(
+            modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm)
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = acct.bankName,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal
+                )
+                Text(
+                    text = buildString {
+                        if (acct.accountLast4 != AccountBalanceEntity.WALLET_ACCOUNT_MARKER) {
+                            append("••")
+                            append(acct.accountLast4)
+                            append(" · ")
+                        }
+                        append(acct.currency)
+                        if (acct.isCreditCard) append(" · Credit")
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            if (isSelected) {
+                AssistChip(
+                    onClick = {},
+                    label = { Text("Selected") },
+                    leadingIcon = {
+                        Icon(
+                            Icons.Default.Check,
+                            contentDescription = null,
+                            modifier = Modifier.padding(end = 2.dp)
                         )
-                        Text(
-                            text = buildString {
-                                if (acct.accountLast4 != AccountBalanceEntity.WALLET_ACCOUNT_MARKER) {
-                                    append("••")
-                                    append(acct.accountLast4)
-                                    append(" · ")
-                                }
-                                append(acct.currency)
-                                if (acct.isCreditCard) append(" · Credit")
-                            },
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    if (isSelected) {
-                        AssistChip(
-                            onClick = {},
-                            label = { Text("Selected") },
-                            leadingIcon = {
-                                Icon(
-                                    Icons.Default.Check,
-                                    contentDescription = null,
-                                    modifier = Modifier.padding(end = 2.dp)
-                                )
-                            },
-                            colors = AssistChipDefaults.assistChipColors(
-                                containerColor = MaterialTheme.colorScheme.primary,
-                                labelColor = MaterialTheme.colorScheme.onPrimary,
-                                leadingIconContentColor = MaterialTheme.colorScheme.onPrimary
-                            )
-                        )
-                    }
-                }
+                    },
+                    colors = AssistChipDefaults.assistChipColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        labelColor = MaterialTheme.colorScheme.onPrimary,
+                        leadingIconContentColor = MaterialTheme.colorScheme.onPrimary
+                    )
+                )
             }
         }
     }


### PR DESCRIPTION
Fixes #624.

## Problem
In **Manage Accounts → Merge accounts**, with 13+ accounts, after picking the first (source) account the user **can't scroll to reach/select the second (target) account** — the target list is off-screen and unreachable.

## Root cause
`MergeAccountsSheet` stacked **two** `AccountPicker` `LazyColumn`s inside a **non-scrolling** parent `Column`. Given no height cap/weight, the first (source) `LazyColumn` expanded to consume the whole bottom-sheet height, leaving no room for the "Into" target list — and the parent `Column` couldn't scroll, so the target list was unreachable.

## Fix
Drive the **entire sheet from a single `LazyColumn`** — header, section labels, and both account lists are item groups on one shared scroll surface. This removes the nested-lazy-in-column anti-pattern and the height competition. `AccountPicker` becomes a `LazyListScope.accountPickerItems(...)` extension + an `AccountPickerRow` composable; item keys are namespaced (`src`/`tgt`) so the two lists don't collide.

Single-file change.

## Verification
- `./init.sh app` green (build + unit tests)
- **On emulator with 21 accounts:** opened Merge → selected a source → **scrolled down to the "Into" list** (previously impossible) → selected a target → the "Merge accounts?" confirmation dialog appeared. Screenshots captured; test accounts cleaned up afterward.