### PR TITLE
feat(fdroid): contextual "Support development" nudge after CSV export

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,11 +69,16 @@ android {
             ndk {
                 abiFilters += setOf("arm64-v8a", "armeabi-v7a")
             }
+            // Type-safe flavor check for code that adapts to F-Droid (everything
+            // unlocked, tip-jar instead of Pro). Beats matching BuildConfig.FLAVOR
+            // against the "fdroid" string literal, which a typo would silently break.
+            buildConfigField("boolean", "IS_FDROID_BUILD", "true")
         }
         create("standard") {
             dimension = "version"
             isDefault = true
             // Standard flavor includes all architectures (including x86 for emulators)
+            buildConfigField("boolean", "IS_FDROID_BUILD", "false")
         }
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
@@ -85,6 +85,10 @@ class UserPreferencesRepository @Inject constructor(
         // while the BillingClient connects.
         val PRO_CACHED_IS_PRO = booleanPreferencesKey("pro_cached_is_pro")
 
+        // F-Droid support nudge — epoch-day of the last contextual "Support
+        // development" prompt, so it stays frequency-capped.
+        val SUPPORT_NUDGE_LAST_SHOWN_DAY = longPreferencesKey("support_nudge_last_shown_epoch_day")
+
         // Pro tier — statement-import monthly quota tracking.
         val LAST_STATEMENT_IMPORT_AT = longPreferencesKey("last_statement_import_at")
 
@@ -554,6 +558,16 @@ class UserPreferencesRepository @Inject constructor(
     suspend fun setProCachedIsPro(isPro: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[PreferencesKeys.PRO_CACHED_IS_PRO] = isPro
+        }
+    }
+
+    /** Epoch-day the contextual F-Droid support nudge was last shown (0 = never). */
+    val supportNudgeLastShownDay: Flow<Long> = context.dataStore.data
+        .map { it[PreferencesKeys.SUPPORT_NUDGE_LAST_SHOWN_DAY] ?: 0L }
+
+    suspend fun setSupportNudgeLastShownDay(epochDay: Long) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.SUPPORT_NUDGE_LAST_SHOWN_DAY] = epochDay
         }
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/ExportTransactionsDialog.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/ExportTransactionsDialog.kt
@@ -17,8 +17,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.coroutines.launch
+import com.pennywiseai.tracker.BuildConfig
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.export.ExportResult
+import com.pennywiseai.tracker.ui.components.SupportDevelopmentDialog
+import com.pennywiseai.tracker.ui.components.SupportNudgeCard
 import com.pennywiseai.tracker.ui.components.cards.PennyWiseCardV2
 import com.pennywiseai.tracker.ui.theme.Dimensions
 import com.pennywiseai.tracker.ui.theme.Spacing
@@ -37,6 +40,20 @@ fun ExportTransactionsDialog(
     var exportState by remember { mutableStateOf<ExportState>(ExportState.Ready) }
     val isProEntitled by viewModel.isProEntitled.collectAsState()
     var showUpgradeSheet by remember { mutableStateOf(false) }
+    // F-Droid support nudge: on the open build there's no Pro to sell, so a
+    // successful export (a Pro-equivalent power feature) is a natural, capped
+    // moment to invite a tip. Never shown on Play builds.
+    var showSupportNudge by remember { mutableStateOf(false) }
+    var showSupportDialog by remember { mutableStateOf(false) }
+    LaunchedEffect(exportState) {
+        if (exportState is ExportState.Success &&
+            BuildConfig.FLAVOR == "fdroid" &&
+            viewModel.isSupportNudgeDue()
+        ) {
+            showSupportNudge = true
+            viewModel.recordSupportNudgeShown()
+        }
+    }
     val csvLimit = com.pennywiseai.tracker.billing.FreeTierLimits.MAX_CSV_EXPORT_ROWS_PER_MONTH
     // Free users get the FIRST `csvLimit` rows on every export — never a
     // hard block. The advertised free tier is "first 100 rows," so we
@@ -248,8 +265,14 @@ fun ExportTransactionsDialog(
                                 )
                             }
                         }
+
+                        // F-Droid-only, frequency-capped tip-jar nudge.
+                        if (showSupportNudge) {
+                            Spacer(modifier = Modifier.height(12.dp))
+                            SupportNudgeCard(onClick = { showSupportDialog = true })
+                        }
                     }
-                    
+
                     is ExportState.Error -> {
                         Text(
                             text = state.message,
@@ -379,6 +402,10 @@ fun ExportTransactionsDialog(
         com.pennywiseai.tracker.presentation.paywall.UpgradeSheet(
             onDismiss = { showUpgradeSheet = false },
         )
+    }
+
+    if (showSupportDialog) {
+        SupportDevelopmentDialog(onDismiss = { showSupportDialog = false })
     }
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/ExportTransactionsDialog.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/ExportTransactionsDialog.kt
@@ -47,11 +47,10 @@ fun ExportTransactionsDialog(
     var showSupportDialog by remember { mutableStateOf(false) }
     LaunchedEffect(exportState) {
         if (exportState is ExportState.Success &&
-            BuildConfig.FLAVOR == "fdroid" &&
-            viewModel.isSupportNudgeDue()
+            BuildConfig.IS_FDROID_BUILD &&
+            viewModel.claimSupportNudge()
         ) {
             showSupportNudge = true
-            viewModel.recordSupportNudgeShown()
         }
     }
     val csvLimit = com.pennywiseai.tracker.billing.FreeTierLimits.MAX_CSV_EXPORT_ROWS_PER_MONTH

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/ExportViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/ExportViewModel.kt
@@ -1,18 +1,24 @@
 package com.pennywiseai.tracker.presentation.transactions
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.billing.EntitlementGate
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.export.CsvExporter
 import com.pennywiseai.tracker.data.export.ExportResult
+import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
 class ExportViewModel @Inject constructor(
     private val csvExporter: CsvExporter,
+    private val userPreferencesRepository: UserPreferencesRepository,
     entitlementGate: EntitlementGate,
 ) : ViewModel() {
 
@@ -29,5 +35,25 @@ class ExportViewModel @Inject constructor(
         fileName: String? = null
     ): Flow<ExportResult> {
         return csvExporter.exportTransactions(transactions, fileName)
+    }
+
+    /**
+     * True when the contextual "Support development" nudge hasn't been shown in
+     * the last [NUDGE_COOLDOWN_DAYS] days. The caller additionally gates this on
+     * the F-Droid flavor — Play builds sell Pro instead of asking for tips.
+     */
+    suspend fun isSupportNudgeDue(): Boolean {
+        val last = userPreferencesRepository.supportNudgeLastShownDay.first()
+        return LocalDate.now().toEpochDay() - last >= NUDGE_COOLDOWN_DAYS
+    }
+
+    fun recordSupportNudgeShown() {
+        viewModelScope.launch {
+            userPreferencesRepository.setSupportNudgeLastShownDay(LocalDate.now().toEpochDay())
+        }
+    }
+
+    private companion object {
+        const val NUDGE_COOLDOWN_DAYS = 30L
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/ExportViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/ExportViewModel.kt
@@ -1,7 +1,6 @@
 package com.pennywiseai.tracker.presentation.transactions
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.billing.EntitlementGate
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.export.CsvExporter
@@ -11,7 +10,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -38,19 +36,20 @@ class ExportViewModel @Inject constructor(
     }
 
     /**
-     * True when the contextual "Support development" nudge hasn't been shown in
-     * the last [NUDGE_COOLDOWN_DAYS] days. The caller additionally gates this on
-     * the F-Droid flavor — Play builds sell Pro instead of asking for tips.
+     * Atomically decides whether to show the contextual "Support development"
+     * nudge and, if so, records it as shown before returning — so back-to-back
+     * exports can't slip through and show it twice. Returns true at most once
+     * per [NUDGE_COOLDOWN_DAYS] days. The caller additionally gates this on the
+     * F-Droid flavor — Play builds sell Pro instead of asking for tips.
      */
-    suspend fun isSupportNudgeDue(): Boolean {
+    suspend fun claimSupportNudge(): Boolean {
+        val today = LocalDate.now().toEpochDay()
         val last = userPreferencesRepository.supportNudgeLastShownDay.first()
-        return LocalDate.now().toEpochDay() - last >= NUDGE_COOLDOWN_DAYS
-    }
-
-    fun recordSupportNudgeShown() {
-        viewModelScope.launch {
-            userPreferencesRepository.setSupportNudgeLastShownDay(LocalDate.now().toEpochDay())
-        }
+        if (today - last < NUDGE_COOLDOWN_DAYS) return false
+        // Await the write before returning true so a subsequent claim reads the
+        // updated timestamp rather than the stale one.
+        userPreferencesRepository.setSupportNudgeLastShownDay(today)
+        return true
     }
 
     private companion object {

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/SupportDevelopment.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/SupportDevelopment.kt
@@ -1,0 +1,179 @@
+package com.pennywiseai.tracker.ui.components
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.Column
+import com.pennywiseai.tracker.R
+import com.pennywiseai.tracker.ui.components.cards.PennyWiseCardV2
+import com.pennywiseai.tracker.ui.theme.Dimensions
+import com.pennywiseai.tracker.ui.theme.Spacing
+import com.pennywiseai.tracker.ui.theme.yellow_dark
+import com.pennywiseai.tracker.ui.theme.yellow_light
+
+/**
+ * The "Support development" UPI tip-jar dialog. Shared so both the Settings
+ * entry and contextual F-Droid nudges present an identical ask. F-Droid builds
+ * have everything unlocked (no Pro to sell), so this is a donation prompt —
+ * never a gate.
+ */
+@Composable
+fun SupportDevelopmentDialog(onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val vpa = stringResource(R.string.support_upi_vpa)
+    val payeeName = stringResource(R.string.support_payee_name)
+    val clipboard = LocalClipboardManager.current
+    val copiedMsg = stringResource(R.string.support_copied_toast)
+    val noUpiAppMsg = stringResource(R.string.support_no_upi_app)
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.Favorite, contentDescription = null, tint = yellow_dark) },
+        title = { Text(stringResource(R.string.support_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                Text(
+                    stringResource(R.string.support_dialog_body),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                // Show the VPA so a user without a UPI app (or who'd rather pay
+                // from their bank app) can copy it manually.
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.sm)
+                ) {
+                    Text(
+                        text = vpa,
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.weight(1f)
+                    )
+                    IconButton(onClick = {
+                        clipboard.setText(AnnotatedString(vpa))
+                        Toast.makeText(context, copiedMsg, Toast.LENGTH_SHORT).show()
+                    }) {
+                        Icon(
+                            Icons.Default.ContentCopy,
+                            contentDescription = stringResource(R.string.support_copy_upi_id)
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                // Only dismiss if a UPI app actually opened; otherwise keep the
+                // dialog up so the copy-the-VPA fallback stays on screen.
+                if (launchUpiPayment(context, vpa, payeeName, noUpiAppMsg)) onDismiss()
+            }) {
+                Text(stringResource(R.string.support_pay_via_upi))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.support_close)) }
+        }
+    )
+}
+
+/**
+ * A subtle, tappable tonal card used to nudge F-Droid users toward the tip jar
+ * at a power-feature moment (the F-Droid analog of the Play paywall). Kept low
+ * key on purpose — it never blocks and is frequency-capped by the caller.
+ */
+@Composable
+fun SupportNudgeCard(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    PennyWiseCardV2(
+        onClick = onClick,
+        colors = CardDefaults.cardColors(containerColor = yellow_light),
+        modifier = modifier.fillMaxWidth(),
+        contentPadding = Spacing.md,
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm)
+        ) {
+            Icon(
+                Icons.Default.Favorite,
+                contentDescription = null,
+                tint = yellow_dark,
+                modifier = Modifier.size(Dimensions.Icon.small)
+            )
+            Text(
+                text = stringResource(R.string.support_nudge_body),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = yellow_dark,
+                modifier = Modifier.weight(1f)
+            )
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = yellow_dark,
+                modifier = Modifier.size(Dimensions.Icon.small)
+            )
+        }
+    }
+}
+
+/**
+ * Opens the user's UPI app pre-filled to pay the developer's [vpa] via the
+ * standard `upi://pay` deep link (amount left blank). Falls back to a toast.
+ * @return true if a UPI app was launched; false (with a toast) if none exists.
+ */
+fun launchUpiPayment(
+    context: Context,
+    vpa: String,
+    payeeName: String,
+    noUpiAppMessage: String
+): Boolean {
+    val uri = Uri.Builder()
+        .scheme("upi")
+        .authority("pay")
+        .appendQueryParameter("pa", vpa)
+        .appendQueryParameter("pn", payeeName)
+        .appendQueryParameter("cu", "INR")
+        .appendQueryParameter("tn", "PennyWise support")
+        .build()
+    val intent = Intent(Intent.ACTION_VIEW, uri)
+    return try {
+        context.startActivity(intent)
+        true
+    } catch (e: ActivityNotFoundException) {
+        Toast.makeText(context, noUpiAppMessage, Toast.LENGTH_LONG).show()
+        false
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/SupportDevelopment.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/SupportDevelopment.kt
@@ -7,11 +7,9 @@ import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.ContentCopy

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -46,6 +46,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.pennywiseai.tracker.core.Constants
 import com.pennywiseai.tracker.ui.components.CustomTitleTopAppBar
+import com.pennywiseai.tracker.ui.components.SupportDevelopmentDialog
 import com.pennywiseai.tracker.ui.components.cards.SectionHeaderV2
 import com.pennywiseai.tracker.ui.theme.Dimensions
 import com.pennywiseai.tracker.ui.theme.Spacing
@@ -1205,95 +1206,7 @@ fun SettingsScreen(
     }
 
     if (showSupportDialog) {
-        val vpa = stringResource(R.string.support_upi_vpa)
-        val payeeName = stringResource(R.string.support_payee_name)
-        AlertDialog(
-            onDismissRequest = { showSupportDialog = false },
-            icon = {
-                Icon(Icons.Default.Favorite, contentDescription = null, tint = yellow_dark)
-            },
-            title = { Text(stringResource(R.string.support_title)) },
-            text = {
-                Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
-                    Text(
-                        stringResource(R.string.support_dialog_body),
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-                    // Show the VPA so a user without a UPI app (or who'd rather pay
-                    // from their bank app) can copy it manually.
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(Spacing.sm)
-                    ) {
-                        Text(
-                            text = vpa,
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = FontWeight.SemiBold,
-                            modifier = Modifier.weight(1f)
-                        )
-                        val clipboard = LocalClipboardManager.current
-                        val copiedMsg = stringResource(R.string.support_copied_toast)
-                        IconButton(onClick = {
-                            clipboard.setText(AnnotatedString(vpa))
-                            Toast.makeText(context, copiedMsg, Toast.LENGTH_SHORT).show()
-                        }) {
-                            Icon(
-                                Icons.Default.ContentCopy,
-                                contentDescription = stringResource(R.string.support_copy_upi_id)
-                            )
-                        }
-                    }
-                }
-            },
-            confirmButton = {
-                val noUpiAppMsg = stringResource(R.string.support_no_upi_app)
-                TextButton(onClick = {
-                    // Only dismiss if a UPI app actually opened; otherwise keep the
-                    // dialog up so the copy-the-VPA fallback stays on screen.
-                    if (launchUpiPayment(context, vpa, payeeName, noUpiAppMsg)) {
-                        showSupportDialog = false
-                    }
-                }) {
-                    Text(stringResource(R.string.support_pay_via_upi))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showSupportDialog = false }) {
-                    Text(stringResource(R.string.support_close))
-                }
-            }
-        )
-    }
-}
-
-/**
- * Opens the user's UPI app pre-filled to pay the developer's [vpa]. Uses the
- * standard `upi://pay` deep link, so the amount is left blank for the user to
- * choose. Falls back to a toast if no UPI app is installed.
- */
-/** @return true if a UPI app was launched; false (with a toast) if none is installed. */
-private fun launchUpiPayment(context: Context, vpa: String, payeeName: String, noUpiAppMessage: String): Boolean {
-    val uri = Uri.Builder()
-        .scheme("upi")
-        .authority("pay")
-        .appendQueryParameter("pa", vpa)
-        .appendQueryParameter("pn", payeeName)
-        .appendQueryParameter("cu", "INR")
-        .appendQueryParameter("tn", "PennyWise support")
-        .build()
-    // Plain ACTION_VIEW (not createChooser): Android opens the UPI app directly,
-    // or shows its own picker if several are installed. When none is installed it
-    // throws ActivityNotFoundException, which we turn into a helpful hint (the
-    // dialog already offers a copy-the-VPA fallback) instead of the system's
-    // generic "No apps can perform this action".
-    val intent = Intent(Intent.ACTION_VIEW, uri)
-    return try {
-        context.startActivity(intent)
-        true
-    } catch (e: ActivityNotFoundException) {
-        Toast.makeText(context, noUpiAppMessage, Toast.LENGTH_LONG).show()
-        false
+        SupportDevelopmentDialog(onDismiss = { showSupportDialog = false })
     }
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -132,7 +132,7 @@ fun SettingsScreen(
     var showSupportDialog by remember { mutableStateOf(false) }
     // F-Droid builds have no Play billing, so they show a "Support development"
     // tip jar instead of the (un-buyable) Pro upsell. Play builds keep Pro.
-    val isFdroidBuild = com.pennywiseai.tracker.BuildConfig.FLAVOR == "fdroid"
+    val isFdroidBuild = com.pennywiseai.tracker.BuildConfig.IS_FDROID_BUILD
     // Launches the runtime permission request. If granted, we flip the
     // preference on; if denied, leave the switch off so the user can try
     // again without us silently turning the feature on later.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,4 +21,5 @@
     <string name="support_copy_upi_id">Copy UPI ID</string>
     <string name="support_copied_toast">UPI ID copied</string>
     <string name="support_no_upi_app">No UPI app found. Copy the UPI ID instead.</string>
+    <string name="support_nudge_body">Enjoying PennyWise? Support development 💛</string>
 </resources>


### PR DESCRIPTION
## Why
On F-Droid the app is fully unlocked (`FdroidBillingGateway` forces `isPro = true`, no Play Billing dep exists), so we **can't and shouldn't gate** features there. But we can still *invite* support. This adds the F-Droid analog of the Play paywall moment: a subtle, frequency-capped "Support development" nudge at a **power-feature moment** — right after a successful CSV export (a Pro-equivalent on F-Droid).

## What
- **Extract** the existing tip-jar `AlertDialog` + `launchUpiPayment` out of `SettingsScreen` into a shared `ui/components/SupportDevelopment.kt` (`SupportDevelopmentDialog` + a new `SupportNudgeCard`). Settings now reuses it — no behavior change there.
- **Frequency cap** in DataStore (`support_nudge_last_shown_epoch_day`); `ExportViewModel` exposes `isSupportNudgeDue()` (30-day cooldown) + `recordSupportNudgeShown()`.
- **Trigger**: in the export success card, when `BuildConfig.FLAVOR == "fdroid"` **and** the cooldown has elapsed, show a subtle yellow tonal `SupportNudgeCard` that opens the UPI dialog.

Design intent: subtle, on-brand (yellow tonal), contextual, **never blocking**, and capped so it can't nag. **Never shown on Play builds.**

## Verification
- `./init.sh app` green; `:app:compileFdroidDebugKotlin` green (the flavor the nudge actually runs on).
- **On emulator** (flavor guard temporarily relaxed, then reverted): nudge appears in the export success card → tapping opens the UPI "Support development" dialog → a second export within the cooldown correctly **suppresses** it (Export Complete shown, nudge absent). Test hack removed; diff is feature-only.

## Notes / follow-ups
- CSV export is the first trigger (cleanest shared component + strongest "data-out" moment). PDF-statement-import and merge-accounts success are natural future triggers using the same `SupportNudgeCard` + cap.