### PR TITLE
feat(transactions): mark any two selected as a transfer + wider auto-detect (#614)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
@@ -300,6 +300,17 @@ fun TransactionsScreen(
                         // Wrap explicitly in a Row so both action IconButtons render
                         // even when the top-bar's actions slot is constrained.
                         Row(verticalAlignment = Alignment.CenterVertically) {
+                            // Link exactly two selected rows as a transfer — the
+                            // manual counterpart to the auto-detected chip (#614),
+                            // covering pairs the detector misses (fees, wide gaps).
+                            if (selectedIds.size == 2) {
+                                IconButton(onClick = { viewModel.bulkMarkAsTransfer() }) {
+                                    Icon(
+                                        Icons.Default.SwapHoriz,
+                                        contentDescription = "Mark as transfer"
+                                    )
+                                }
+                            }
                             IconButton(onClick = { showBulkCategorySheet = true }) {
                                 Icon(Icons.Default.Category, contentDescription = "Change category")
                             }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -327,7 +327,12 @@ class TransactionsViewModel @Inject constructor(
 
     private fun findSelfTransferPairs(txns: List<TransactionEntity>): Map<Long, Long> {
         if (txns.size < 2) return emptyMap()
-        val matchWindowMinutes = 10L
+        // Transfers between the user's own accounts often reflect more than a few
+        // minutes apart (bank posting lag), so use a generous window. The pairing
+        // still requires an exact amount + currency match on a different account,
+        // and only *suggests* the link (the user confirms), so a wider window is
+        // low-risk. (#614)
+        val matchWindowMinutes = 60L
         val acctOf: (TransactionEntity) -> String =
             { "${it.bankName.orEmpty()}|${it.accountNumber.orEmpty()}" }
 
@@ -377,6 +382,33 @@ class TransactionsViewModel @Inject constructor(
      * `toAccount` for each row. No structural link is created between the
      * rows — TRANSFER already excludes them from Net cash flow.
      */
+    /**
+     * Link the two currently-selected transactions as a transfer (#614) — the
+     * manual counterpart to the auto-detected [suggestedTransferPartnerOf] chip,
+     * for pairs the detector misses (transfer fees, gaps beyond the window, a
+     * single-leg SMS the user pairs by hand). Requires exactly two selected rows,
+     * one outgoing (expense) and one incoming (income); otherwise it surfaces a
+     * hint. Reuses [markPairAsTransfer] so undo behaves identically.
+     */
+    fun bulkMarkAsTransfer() {
+        val ids = _selectedIds.value.toList()
+        if (ids.size != 2) {
+            _bulkSnack.value = BulkSnack("Select exactly 2 transactions to mark as a transfer")
+            return
+        }
+        val all = _uiState.value.transactions
+        val a = all.firstOrNull { it.id == ids[0] } ?: return
+        val b = all.firstOrNull { it.id == ids[1] } ?: return
+        val hasExpense = listOf(a, b).any { it.transactionType == TransactionType.EXPENSE }
+        val hasIncome = listOf(a, b).any { it.transactionType == TransactionType.INCOME }
+        if (!(hasExpense && hasIncome)) {
+            _bulkSnack.value = BulkSnack("Pick one outgoing (expense) and one incoming (income) transaction")
+            return
+        }
+        clearSelection()
+        markPairAsTransfer(a.id, b.id)
+    }
+
     fun markPairAsTransfer(aId: Long, bId: Long) {
         viewModelScope.launch {
             val all = _uiState.value.transactions


### PR DESCRIPTION
Fixes #614.

## Problem
The self-transfer affordance only appears when the auto-detector (`findSelfTransferPairs`) pairs two rows — exact amount, different account, opposite direction, within a 10-min window. So a self-transfer with a **fee** (amounts differ), a **wide time gap**, or only a **single-leg SMS** was never linkable, and there was no way to mark *any two* transactions as a transfer after the fact.

## Changes
1. **Bulk "Mark as transfer"** — in multi-select, when **exactly two** rows are selected (one expense, one income), a swap-icon action links them. Reuses `markPairAsTransfer`, so the flip-to-TRANSFER + `from`/`to` account population + **undo snackbar** behave identically to the auto-detected chip. The action is shown **only at `size == 2`**; a wrong pairing (not one expense + one income) surfaces a hint snackbar instead of acting.
2. **Wider auto-detect window** — `matchWindowMinutes` 10 → 60. Pairing still requires an exact amount + currency match on a different account and only *suggests* the link (user confirms), so a longer posting-lag window is low-risk and catches more real transfers automatically.

No schema change — a transfer is already `type=TRANSFER` + `from/to` accounts.

## Verification (on emulator)
- Selected an expense + income pair → **Mark as transfer** → both rows become `TRANSFER` with from(Kotak)/to(HDFC) accounts; **"Marked as transfer" + Undo** snackbar; selection exits.
- The action is **hidden at 1 selected**, appears at **2**.
- Two expenses → **"Pick one outgoing (expense) and one incoming (income) transaction"**, no change.
- `./init.sh app` green.