### PR TITLE
feat(fdroid): extend support nudge to PDF-import + merge-accounts moments

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
@@ -580,10 +580,18 @@ class UserPreferencesRepository @Inject constructor(
      */
     suspend fun claimSupportNudge(): Boolean {
         val today = LocalDate.now().toEpochDay()
-        val last = context.dataStore.data.map { it[PreferencesKeys.SUPPORT_NUDGE_LAST_SHOWN_DAY] ?: 0L }.first()
-        if (today - last < SUPPORT_NUDGE_COOLDOWN_DAYS) return false
-        context.dataStore.edit { it[PreferencesKeys.SUPPORT_NUDGE_LAST_SHOWN_DAY] = today }
-        return true
+        // Check-and-set inside a single edit{} so the read and write are one
+        // atomic transaction — DataStore serializes edit blocks, so two
+        // concurrent claims can't both observe the stale timestamp and win.
+        var claimed = false
+        context.dataStore.edit { prefs ->
+            val last = prefs[PreferencesKeys.SUPPORT_NUDGE_LAST_SHOWN_DAY] ?: 0L
+            if (today - last >= SUPPORT_NUDGE_COOLDOWN_DAYS) {
+                prefs[PreferencesKeys.SUPPORT_NUDGE_LAST_SHOWN_DAY] = today
+                claimed = true
+            }
+        }
+        return claimed
     }
 
     /**

--- a/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
@@ -12,6 +12,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
+import java.time.LocalDate
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -146,6 +147,11 @@ class UserPreferencesRepository @Inject constructor(
         val SCHEDULED_FOLDER_BACKUP_ENABLED = booleanPreferencesKey("scheduled_folder_backup_enabled")
         val SCHEDULED_FOLDER_BACKUP_TREE_URI = stringPreferencesKey("scheduled_folder_backup_tree_uri")
         val SCHEDULED_FOLDER_BACKUP_LAST_TIMESTAMP = longPreferencesKey("scheduled_folder_backup_last_timestamp")
+    }
+
+    private companion object {
+        // F-Droid support nudge: at most one contextual prompt per this many days.
+        const val SUPPORT_NUDGE_COOLDOWN_DAYS = 30L
     }
 
     val userPreferences: Flow<UserPreferences> = context.dataStore.data
@@ -565,10 +571,19 @@ class UserPreferencesRepository @Inject constructor(
     val supportNudgeLastShownDay: Flow<Long> = context.dataStore.data
         .map { it[PreferencesKeys.SUPPORT_NUDGE_LAST_SHOWN_DAY] ?: 0L }
 
-    suspend fun setSupportNudgeLastShownDay(epochDay: Long) {
-        context.dataStore.edit { preferences ->
-            preferences[PreferencesKeys.SUPPORT_NUDGE_LAST_SHOWN_DAY] = epochDay
-        }
+    /**
+     * Atomically decides whether to show the contextual F-Droid "Support
+     * development" nudge and, if so, records it as shown before returning — so
+     * back-to-back power-feature moments can't show it twice. Returns true at
+     * most once per [SUPPORT_NUDGE_COOLDOWN_DAYS] days, across every trigger
+     * site (a single global timestamp). Callers gate on the F-Droid flavor.
+     */
+    suspend fun claimSupportNudge(): Boolean {
+        val today = LocalDate.now().toEpochDay()
+        val last = context.dataStore.data.map { it[PreferencesKeys.SUPPORT_NUDGE_LAST_SHOWN_DAY] ?: 0L }.first()
+        if (today - last < SUPPORT_NUDGE_COOLDOWN_DAYS) return false
+        context.dataStore.edit { it[PreferencesKeys.SUPPORT_NUDGE_LAST_SHOWN_DAY] = today }
+        return true
     }
 
     /**

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.pennywiseai.tracker.utils.CurrencyFormatter
+import com.pennywiseai.tracker.ui.components.SupportDevelopmentDialog
+import com.pennywiseai.tracker.ui.components.SupportNudgeCard
 import com.pennywiseai.tracker.ui.components.CustomTitleTopAppBar
 import com.pennywiseai.tracker.ui.components.PennyWiseEmptyState
 import com.pennywiseai.tracker.ui.components.cards.SectionHeaderV2
@@ -61,6 +63,7 @@ fun ManageAccountsScreen(
     var showMergeSheet by remember { mutableStateOf(false) }
     val isProEntitled by viewModel.isProEntitled.collectAsState()
     var showUpgradeSheet by remember { mutableStateOf(false) }
+    var showSupportDialog by remember { mutableStateOf(false) }
     val pendingProfileReassign by viewModel.pendingProfileReassign.collectAsState()
 
     val scrollBehaviorSmall = TopAppBarDefaults.pinnedScrollBehavior()
@@ -168,7 +171,18 @@ fun ManageAccountsScreen(
                         }
                     }
                 }
-                
+
+                // F-Droid tip nudge after a merge — persists past the transient
+                // success banner; tapping opens the tip jar and dismisses it.
+                if (uiState.showSupportNudge) {
+                    item {
+                        SupportNudgeCard(onClick = {
+                            showSupportDialog = true
+                            viewModel.dismissSupportNudge()
+                        })
+                    }
+                }
+
                 // Show error message if available
                 uiState.errorMessage?.let { message ->
                     item {
@@ -551,6 +565,10 @@ fun ManageAccountsScreen(
         com.pennywiseai.tracker.presentation.paywall.UpgradeSheet(
             onDismiss = { showUpgradeSheet = false },
         )
+    }
+
+    if (showSupportDialog) {
+        SupportDevelopmentDialog(onDismiss = { showSupportDialog = false })
     }
 
     // Offer to move existing transactions that carry an explicit, mismatched

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/ManageAccountsViewModel.kt
@@ -29,7 +29,10 @@ data class ManageAccountsUiState(
     val orphanedCards: List<CardEntity> = emptyList(),
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
-    val successMessage: String? = null
+    val successMessage: String? = null,
+    // F-Droid-only contextual support nudge after a merge (a Pro-equivalent
+    // power feature); persists past the transient successMessage until dismissed.
+    val showSupportNudge: Boolean = false
 )
 
 data class AccountFormState(
@@ -646,18 +649,27 @@ class ManageAccountsViewModel @Inject constructor(
                     _uiState.update { it.copy(hiddenAccounts = hidden) }
                 }
 
+                // F-Droid-only tip nudge; gate on flavor first so Play builds
+                // don't silently consume the global cooldown.
+                val nudge = com.pennywiseai.tracker.BuildConfig.IS_FDROID_BUILD &&
+                    userPreferencesRepository.claimSupportNudge()
                 _uiState.update {
                     it.copy(
-                        successMessage = "Merged $moved transactions into ${AccountBalanceEntity.accountLabel(target.bankName, target.accountLast4)}"
+                        successMessage = "Merged $moved transactions into ${AccountBalanceEntity.accountLabel(target.bankName, target.accountLast4)}",
+                        showSupportNudge = it.showSupportNudge || nudge
                     )
                 }
+                loadCards()
                 delay(3000)
                 _uiState.update { it.copy(successMessage = null) }
-                loadCards()
             } catch (e: Exception) {
                 _uiState.update { it.copy(errorMessage = "Merge failed: ${e.message}") }
             }
         }
+    }
+
+    fun dismissSupportNudge() {
+        _uiState.update { it.copy(showSupportNudge = false) }
     }
 
     fun setAccountProfile(bankName: String, accountLast4: String, profileId: Long) {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/statement/ImportStatementScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/statement/ImportStatementScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.pennywiseai.tracker.ui.components.CustomTitleTopAppBar
+import com.pennywiseai.tracker.ui.components.SupportDevelopmentDialog
+import com.pennywiseai.tracker.ui.components.SupportNudgeCard
 import com.pennywiseai.tracker.ui.theme.Dimensions
 import com.pennywiseai.tracker.ui.theme.Spacing
 import dev.chrisbanes.haze.HazeState
@@ -39,7 +41,9 @@ fun ImportStatementScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val canImportThisMonth by viewModel.canImportThisMonth.collectAsStateWithLifecycle()
+    val showSupportNudge by viewModel.showSupportNudge.collectAsStateWithLifecycle()
     var showUpgradeSheet by remember { mutableStateOf(false) }
+    var showSupportDialog by remember { mutableStateOf(false) }
 
     val pdfPicker = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent(),
@@ -119,6 +123,8 @@ fun ImportStatementScreen(
                 is ImportStatementUiState.Loading -> LoadingContent()
                 is ImportStatementUiState.Success -> SuccessContent(
                     result = state.result,
+                    showSupportNudge = showSupportNudge,
+                    onSupportClick = { showSupportDialog = true },
                     onImportAnother = {
                         viewModel.resetState()
                         onTryLaunchPicker()
@@ -140,6 +146,10 @@ fun ImportStatementScreen(
         com.pennywiseai.tracker.presentation.paywall.UpgradeSheet(
             onDismiss = { showUpgradeSheet = false },
         )
+    }
+
+    if (showSupportDialog) {
+        SupportDevelopmentDialog(onDismiss = { showSupportDialog = false })
     }
 }
 
@@ -217,6 +227,8 @@ private fun LoadingContent() {
 @Composable
 private fun SuccessContent(
     result: com.pennywiseai.tracker.data.statement.StatementImportResult.Success,
+    showSupportNudge: Boolean = false,
+    onSupportClick: () -> Unit = {},
     onImportAnother: () -> Unit,
     onDone: () -> Unit
 ) {
@@ -302,6 +314,11 @@ private fun SuccessContent(
                 }
             }
         }
+    }
+
+    if (showSupportNudge) {
+        Spacer(modifier = Modifier.height(Spacing.md))
+        SupportNudgeCard(onClick = onSupportClick)
     }
 
     Spacer(modifier = Modifier.height(Spacing.lg))

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/statement/ImportStatementScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/statement/ImportStatementScreen.kt
@@ -124,7 +124,10 @@ fun ImportStatementScreen(
                 is ImportStatementUiState.Success -> SuccessContent(
                     result = state.result,
                     showSupportNudge = showSupportNudge,
-                    onSupportClick = { showSupportDialog = true },
+                    onSupportClick = {
+                        showSupportDialog = true
+                        viewModel.dismissSupportNudge()
+                    },
                     onImportAnother = {
                         viewModel.resetState()
                         onTryLaunchPicker()

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/statement/ImportStatementViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/statement/ImportStatementViewModel.kt
@@ -93,5 +93,13 @@ class ImportStatementViewModel @Inject constructor(
 
     fun resetState() {
         _uiState.value = ImportStatementUiState.Idle
+        // Clear the nudge so a subsequent import in the same screen instance
+        // doesn't re-show a card the cooldown would otherwise suppress.
+        _showSupportNudge.value = false
+    }
+
+    /** Consume the nudge once the user acts on it (opens the tip jar). */
+    fun dismissSupportNudge() {
+        _showSupportNudge.value = false
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/statement/ImportStatementViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/statement/ImportStatementViewModel.kt
@@ -2,6 +2,7 @@ package com.pennywiseai.tracker.presentation.statement
 
 import android.net.Uri
 import androidx.lifecycle.ViewModel
+import com.pennywiseai.tracker.BuildConfig
 import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.billing.EntitlementGate
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
@@ -37,6 +38,11 @@ class ImportStatementViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<ImportStatementUiState>(ImportStatementUiState.Idle)
     val uiState: StateFlow<ImportStatementUiState> = _uiState.asStateFlow()
 
+    // F-Droid-only contextual support nudge, shown once per global cooldown after
+    // a successful import (a Pro-equivalent power feature on the open build).
+    private val _showSupportNudge = MutableStateFlow(false)
+    val showSupportNudge: StateFlow<Boolean> = _showSupportNudge.asStateFlow()
+
     /**
      * True when the user is allowed to import a statement right now — either
      * Pro (unlimited) or has not yet imported this calendar month. The UI
@@ -71,6 +77,11 @@ class ImportStatementViewModel @Inject constructor(
                     // gated; Pro users will still see canImportThisMonth=true
                     // because the combine() short-circuits on entitlement.
                     preferences.markStatementImported(System.currentTimeMillis())
+                    // Gate the claim on the flavor first so Play builds (where the
+                    // nudge never renders) don't silently consume the global cap.
+                    if (BuildConfig.IS_FDROID_BUILD && preferences.claimSupportNudge()) {
+                        _showSupportNudge.value = true
+                    }
                     _uiState.value = ImportStatementUiState.Success(result)
                 }
                 is StatementImportResult.Error -> {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/ExportViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/ExportViewModel.kt
@@ -9,8 +9,6 @@ import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.first
-import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
@@ -35,24 +33,6 @@ class ExportViewModel @Inject constructor(
         return csvExporter.exportTransactions(transactions, fileName)
     }
 
-    /**
-     * Atomically decides whether to show the contextual "Support development"
-     * nudge and, if so, records it as shown before returning — so back-to-back
-     * exports can't slip through and show it twice. Returns true at most once
-     * per [NUDGE_COOLDOWN_DAYS] days. The caller additionally gates this on the
-     * F-Droid flavor — Play builds sell Pro instead of asking for tips.
-     */
-    suspend fun claimSupportNudge(): Boolean {
-        val today = LocalDate.now().toEpochDay()
-        val last = userPreferencesRepository.supportNudgeLastShownDay.first()
-        if (today - last < NUDGE_COOLDOWN_DAYS) return false
-        // Await the write before returning true so a subsequent claim reads the
-        // updated timestamp rather than the stale one.
-        userPreferencesRepository.setSupportNudgeLastShownDay(today)
-        return true
-    }
-
-    private companion object {
-        const val NUDGE_COOLDOWN_DAYS = 30L
-    }
+    /** @see UserPreferencesRepository.claimSupportNudge — global, frequency-capped. */
+    suspend fun claimSupportNudge(): Boolean = userPreferencesRepository.claimSupportNudge()
 }


### PR DESCRIPTION
Follow-up to #639. The contextual F-Droid "Support development" nudge now fires after **all three** Pro-equivalent power features, not just CSV export.

## Changes
- **Centralized cap** — moved the atomic, frequency-capped claim into `UserPreferencesRepository.claimSupportNudge()` (global 30-day cooldown, awaited write) so every trigger site shares one cap. `ExportViewModel` delegates to it (no behavior change to the export nudge).
- **PDF statement import** — `SupportNudgeCard` in the import success screen (`SuccessContent`).
- **Merge accounts** — nudge card in the success area. Because the merge success banner is transient (3s), the nudge rides its own persistent `showSupportNudge` flag and dismisses on tap.

Every site gates on `BuildConfig.IS_FDROID_BUILD` **before** claiming, so Play builds never render it *or* consume the shared cooldown.

## Verification
- `./init.sh app` + `:app:compileFdroidDebugKotlin` green.
- **On emulator** (flavor guard + Pro + cooldown temporarily relaxed, then reverted): merged two accounts → the yellow "Enjoying PennyWise? Support development 💛" card renders below the success banner → tapping opens the UPI dialog and dismisses the card. Import path uses the identical flag→`SupportNudgeCard`→dialog pattern.

## Note
CSV export (#639) + PDF import + merge accounts now all covered — that's the full set of F-Droid power-feature moments.