### PR TITLE
fix(ai): stop R8 stripping coroutines methods LiteRT-LM calls (#599)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -24,6 +24,14 @@
 -keep class com.google.ai.edge.litertlm.** { *; }
 -dontwarn com.google.ai.edge.litertlm.**
 
+# LiteRT-LM's generation callbacks are invoked from native code (JNI), so R8
+# can't see that its kept, unminified bytecode still calls into kotlinx-coroutines
+# Channel/Flow APIs. In full mode R8 then strips the referenced members (e.g.
+# SendChannel.close$default), producing a release-only NoSuchMethodError the moment
+# the on-device model finishes generating. Keep the coroutines surface it uses. (#599)
+-keep class kotlinx.coroutines.channels.** { *; }
+-keep class kotlinx.coroutines.flow.** { *; }
+
 # Room
 -keep class * extends androidx.room.RoomDatabase
 -keep @androidx.room.Entity class *

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,3 +35,7 @@ android.r8.optimizedResourceShrinking=false
 
 android.sourceset.disallowProvider=false
 android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false
+# R8 full mode relocates/strips library synthetic methods (e.g.
+# kotlinx-coroutines SendChannel.close$default) that LiteRT-LM calls from kept,
+# JNI-invoked bytecode, causing a release-only NoSuchMethodError. (#599)
+android.enableR8.fullMode=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,9 @@ pdfboxAndroid = "2.0.27.0"
 review = "2.0.2"
 reviewKtx = "2.0.2"
 roomVersion = "2.8.4"
-litertlm = "0.+"
+# Pinned (was "0.+"): a dynamic version made builds non-reproducible and could
+# silently swap the native/ABI surface between releases. See #599.
+litertlm = "0.14.0"
 visionInternalVkp = "18.2.3"
 workVersion = "2.11.2"
 coil = "2.7.0"


### PR DESCRIPTION
Diagnoses and fixes #599. **Draft** — needs on-device verification with the model (see below).

## It's not an OOM — it's an R8 minification bug
The reporter's logcat shows the app **fully crashes** (not hangs) the moment the model finishes generating:

```
FATAL EXCEPTION: Thread-43
java.lang.NoSuchMethodError: No static method close$default(...SendChannel;...)Z
    at com.google.ai.edge.litertlm.Conversation$sendMessageAsync$1$1.onDone(...)
```

LiteRT-LM's completion callback (invoked from **native code via JNI**) calls `kotlinx.coroutines.channels.SendChannel.close$default`. That method **exists in the coroutines jar** (verified across 1.8.1/1.9.0/1.10.2) and works in debug — but R8 **full mode** strips/relocates it in the minified release build, because it can't see the JNI call path. The kept, unminified LiteRT-LM bytecode then hits a dangling reference → crash.

**Proof** (dex diff, debug vs release):
| Build | `SendChannel` close-methods in dex |
|---|---|
| Debug (not minified) | present |
| Release (R8 full mode) | **0 — stripped** |

That's why it's release-only and looked like a device/OOM issue.

## Fix
- **Disable R8 full mode** (`android.enableR8.fullMode=false`) — the canonical fix for R8 stripping library synthetics that kept / JNI-invoked code references.
- **Keep** the `kotlinx.coroutines.channels/flow` surface LiteRT-LM calls into.
- **Pin `litertlm` to 0.14.0** (was `"0.+"`, a dynamic version — non-reproducible builds that could swap this behavior release-to-release).

## ⚠️ Verification status
Verified at the R8/dex level (the stripped methods survive with these changes) and `./init.sh app` is green. **But the end-to-end fix can't be verified here** — the on-device LLM (heavy model + native lib) doesn't run on the x86 emulator/CI. **Please build a release APK and test the AI assistant on a physical device before merging.** If full-mode-off proves insufficient on-device, the fallback is a more targeted `-keep` on the exact coroutines statics LiteRT-LM invokes.

## Trade-off
Disabling R8 full mode is slightly less aggressive optimization app-wide (marginally larger APK). Low risk; it's the pre-AGP-8 default that most apps shipped with.