### PR TITLE
fix(web): address #643 review — country-slug collisions + PII anonymization gate

### DIFF
--- a/parser-core/src/test/kotlin/com/pennywiseai/parser/core/BankSamplesDocTest.kt
+++ b/parser-core/src/test/kotlin/com/pennywiseai/parser/core/BankSamplesDocTest.kt
@@ -105,6 +105,24 @@ class BankSamplesDocTest {
         return digits.length > 8 || Regex("""^(9{5,}|0+)$""").matches(digits)
     }
 
+    // --- Anonymization gate --------------------------------------------------------
+    // These messages are published verbatim on public bank pages, so the "already
+    // PII-free" assumption of the source corpus must be *enforced*, not trusted: a
+    // real SMS that slipped into a parser test would leak personal data. We reject a
+    // sample carrying a personal email address — one marker that has no legitimate
+    // place in a bank SMS (real transaction SMS use bank UPI handles like @okhdfcbank
+    // or @ybl, never a personal inbox). Phone numbers are deliberately NOT gated:
+    // bank SMS quote fraud-reporting helplines ("Not you? SMS BLOCK to …"), which are
+    // public bank numbers, not the user's — gating them would drop clean samples for
+    // no privacy gain. (#643 review)
+    private val personalEmailPattern = Regex(
+        """[\w.+-]+@(?:gmail|googlemail|yahoo|ymail|outlook|hotmail|live|icloud|proton(?:mail)?|rediffmail|aol|zoho)\.[a-z.]+""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    private fun containsPersonalData(message: String): Boolean =
+        personalEmailPattern.containsMatchIn(message)
+
     // `message = "..."` / `sender = "..."`, tolerating escaped quotes inside.
     private val messageRe = Regex("""message\s*=\s*"((?:[^"\\]|\\.)*)"""")
     private val senderRe = Regex("""sender\s*=\s*"((?:[^"\\]|\\.)*)"""")
@@ -177,6 +195,8 @@ class BankSamplesDocTest {
             harvest(file.readText()).forEach { (sender, message) ->
                 // Keep the demo readable on a phone.
                 if (message.length !in 40..260 || message.contains('\n')) return@forEach
+                // Never publish a real phone/email that slipped into a fixture.
+                if (containsPersonalData(message)) return@forEach
                 val parser = BankParserFactory.getParser(sender) ?: return@forEach
                 val parsed = runCatching { parser.parse(message, sender, FIXED_TIMESTAMP) }
                     .getOrNull() ?: return@forEach

--- a/pennywise-web/server/src/main/kotlin/SupportedBanks.kt
+++ b/pennywise-web/server/src/main/kotlin/SupportedBanks.kt
@@ -94,6 +94,14 @@ object SupportedBanks {
 
     private val bySlug: Map<String, BankPage> by lazy { banks.associateBy { it.slug } }
     private val countryBySlug: Map<String, CountryEntry> by lazy {
+        // Same hazard as bank slugs: two country names slugging to one URL would
+        // silently shadow each other under associateBy, serving the wrong page.
+        val collisions = catalogue.countries.groupBy { countrySlug(it.country) }.filterValues { it.size > 1 }
+        check(collisions.isEmpty()) {
+            "Country slug collision(s): " + collisions.entries.joinToString("; ") { (slug, entries) ->
+                "$slug <- ${entries.joinToString(", ") { it.country }}"
+            }
+        }
         catalogue.countries.associateBy { countrySlug(it.country) }
     }
 


### PR DESCRIPTION
Addresses the two non-blocking findings Greptile raised on #643 (now on `main`).

## 1. Country-slug collision guard (`SupportedBanks.kt`)
Bank slugs already fail loudly on collision, but country slugs were built with `associateBy { countrySlug(it.country) }` and **no** check — so two country names normalizing to the same slug would silently shadow each other and serve the wrong page. Added the same guard for countries.

## 2. Anonymization gate (`BankSamplesDocTest.kt`)
The sample generator harvests parser-test messages straight into a public resource, trusting the corpus to be PII-free. Now it **enforces** that: a sample whose message carries a **personal email** (gmail/yahoo/outlook/…) is rejected. Those never appear in a real bank SMS (which use bank UPI handles like `@okhdfcbank`, `@ybl`), so it's a high-precision marker of a genuine leak.

**Phone numbers are deliberately *not* gated.** I checked what the "phone numbers" in the current output actually are — every one is a bank **fraud-block helpline** (`Not you? SMS BLOCK to …`, `To dispute call …`). Those are **public bank numbers, not the user's**. An earlier draft gated 10-digit numbers and dropped clean **Axis / HDFC / Yes Bank** samples for containing a helpline — a real content loss with zero privacy benefit — so that was removed.

The current corpus has no personal emails, so **no samples change** (`bank-samples.json` untouched); the gate is enforcement against future leaks.

## Verification
- `./init.sh parser` green (the `bank-samples.json`-in-sync gate passes).
- `pennywise-web :server:test` green (country-slug guard compiles + no collision in current data).