### PR TITLE
fix(transactions): drop analytics-excluded txns from Income/Expense totals

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -1387,10 +1387,14 @@ class TransactionsViewModel @Inject constructor(
     }
     
     private fun calculateCurrencyGroupedTotals(transactions: List<TransactionEntity>): CurrencyGroupedTotals {
-        // Loan disbursements/repayments still appear in the list (it's the full ledger)
-        // but must not count toward the period's Income/Expense/etc. totals — they're
-        // tracked in the Loans feature. Matches the Home/Analytics convention.
-        val nonLoanTransactions = transactions.filter { it.loanId == null }
+        // Loan disbursements/repayments and analytics-excluded transactions still
+        // appear in the list (it's the full ledger) but must not count toward the
+        // period's Income/Expense/etc. totals — loans are tracked in the Loans
+        // feature, and excluded txns are opted out of every spend figure by the
+        // user. Matches the Home/Analytics convention (HomeViewModel#1142).
+        val nonLoanTransactions = transactions.filter {
+            it.loanId == null && !it.excludedFromAnalytics
+        }
         val transactionsByCurrency = nonLoanTransactions.groupBy { it.currency }
 
         val totalsByCurrency = transactionsByCurrency.mapValues { (currency, currencyTransactions) ->

--- a/app/src/main/java/com/pennywiseai/tracker/widget/RecentTransactionsWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/RecentTransactionsWidgetUpdateWorker.kt
@@ -85,8 +85,10 @@ class RecentTransactionsWidgetUpdateWorker @AssistedInject constructor(
                 .first()
 
             // Loan disbursements/repayments are tracked in the Loans feature, not
-            // spending — exclude them, matching Home/Analytics.
-            val nonLoan = allTransactions.filter { it.loanId == null }
+            // spending — exclude them, matching Home/Analytics. Analytics-excluded
+            // transactions are opted out of every spend figure by the user, so they
+            // must not count toward the widget's spend total either.
+            val nonLoan = allTransactions.filter { it.loanId == null && !it.excludedFromAnalytics }
             suspend fun inTarget(tx: com.pennywiseai.tracker.data.database.entity.TransactionEntity): BigDecimal =
                 if (!tx.currency.equals(targetCurrency, ignoreCase = true)) {
                     currencyConversionService.convertAmount(tx.amount, tx.currency, targetCurrency)


### PR DESCRIPTION
## The bug (reported by veal7404 on Discord)

The **Transactions page** totals card and the **Recent Transactions widget** summed *every* non-loan, non-deleted transaction — ignoring the user's **"Exclude from analytics"** flag. So a transaction the user opted out of stats still inflated both **Income** and **Expense**, even though the toggle explicitly promises *"Kept in history & balance, ignored in spending stats."*

Home, Analytics, and Budget already honour the flag (`HomeViewModel#1142`, `AnalyticsViewModel`, `BudgetRepository`) — these two surfaces were the outliers.

## The fix

Add `!it.excludedFromAnalytics` to the totals' `nonLoan` filter on both surfaces, matching the existing Home/Analytics/Budget convention:

- `TransactionsViewModel.calculateCurrencyGroupedTotals` (page totals)
- `RecentTransactionsWidgetUpdateWorker` (widget spend)

Excluded transactions stay visible in the ledger list (labelled **"Excluded"**) but no longer count toward the totals. The BudgetWidget already filtered via `BudgetRepository`/`unionTxs`, so it needed no change.

## Verification

- **On-device (emulator):** toggling *Exclude* on a ₹799 expense dropped the Expenses tile from **₹2,62,035 → ₹2,61,236** (exactly its amount), Net moved by the same, and the row stayed in the list marked "Excluded." Re-including restored it.
- **`./init.sh app`** — green.

## Not included (separate issue)

veal's other point — *"paid 24, refunded 12 → expense should show 12"* — is **not** this bug. Reproduced on-device: tagging an income as **Budget impact → Refund** *does* correctly net it out of expenses. That symptom appears to come from using the **Tags** field (a label that doesn't net) rather than **Budget impact → Refund**, or expecting auto-detection. Tracking that separately pending clarification from the reporter.