### PR TITLE
fix(ai): pin litertlm to 0.13.1 to stop release AI-assistant crash (#599)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,13 @@ pdfboxAndroid = "2.0.27.0"
 review = "2.0.2"
 reviewKtx = "2.0.2"
 roomVersion = "2.8.4"
-litertlm = "0.+"
+# Pinned: litertlm 0.14.0 is compiled with -Xjvm-default=all and calls
+# SendChannel.close$default as an interface static, which no public
+# kotlinx-coroutines build provides (it lives in SendChannel$DefaultImpls) —
+# so the AI assistant hard-crashes with NoSuchMethodError the moment generation
+# finishes. 0.13.1 emits the DefaultImpls call and works. Do NOT float to 0.+
+# again until upstream fixes this. (#599)
+litertlm = "0.13.1"
 visionInternalVkp = "18.2.3"
 workVersion = "2.11.2"
 coil = "2.7.0"


### PR DESCRIPTION
Fixes the top crash on 2.17.1 — the on-device AI assistant dies with `NoSuchMethodError` the instant a generation finishes (**95.8% of crash events, 10 users** per Play Console).

## Root cause (it is *not* R8)

LiteRT-LM **0.14.0** was recompiled with `-Xjvm-default=all`. Its `Conversation$sendMessageAsync$1$1.onDone` callback closes the channel via:

```
invokestatic InterfaceMethod kotlinx/coroutines/channels/SendChannel.close$default(...)Z
```

i.e. `close$default` as a **static method on the `SendChannel` interface**. But **no public `kotlinx-coroutines` build** declares it there — in 1.6.4 / 1.8.0 / 1.9.0 / 1.10.2 (all verified with `javap`) `close$default` lives in `SendChannel$DefaultImpls`. So the call resolves to nothing at runtime and throws `NoSuchMethodError` — in **every build type**.

I initially misdiagnosed this as R8 stripping the method. That was wrong: a `minifyEnabled = false` release produces the **identical** `DefaultImpls`-only structure, and decompiling LiteRT-LM shows it calls the interface static directly. **0.13.1** emits the compatible `DefaultImpls.close$default` call.

The dependency was floating on `"0.+"`, which silently upgraded to the broken 0.14.0 — matching exactly when 2.17.1's crashes started.

## Fix

Pin `litertlm = "0.13.1"` (no more floating `0.+`).

## Verification (on-device, arm64 emulator, real Qwen 2.5 `.litertlm` model)

- **0.14.0:** model loads, generation runs, **crashes on `onDone`** with the reported `NoSuchMethodError`.
- **0.13.1:** model loads, generation completes, assistant replies normally, **no crash** — same emulator, same model, same prompt.
- 0.13.1 still loads the current `.litertlm` model format (the one migration risk — cleared).
- `./init.sh app` green.

Supersedes #644 (which chased the wrong R8 diagnosis).