### PR TITLE
fix(balance): recalculate account balances on transaction edit and delete (#636)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
@@ -220,11 +220,15 @@ class AccountBalanceRepository @Inject constructor(
      * recompute them — while manual transfer *legs* are recomputed here, since
      * no caller tracks leg accounts.
      *
-     * Revert entries are timestamped with the original transaction's dateTime,
-     * apply entries with the updated one's, so the balance history timeline
-     * stays correct. Effects only ever layer onto an account's *latest* row; the
-     * next SMS that reports an explicit balance re-anchors the account to the
-     * bank's own figure regardless (#636).
+     * Corrective rows are stamped with the current time, NOT the edited
+     * transaction's dateTime: "latest balance" is resolved by `ORDER BY
+     * timestamp DESC`, so a correction stamped into the past (any edit of a
+     * transaction older than the account's newest balance row — the common
+     * case) would never become the latest row and would be invisible. A
+     * correction is a now-event — we learned about it now, and it adjusts the
+     * current figure. Effects only ever layer onto an account's *latest* row;
+     * the next SMS that reports an explicit balance re-anchors the account to
+     * the bank's own figure regardless (#636).
      */
     suspend fun applyTransactionBalanceShift(
         original: TransactionEntity?,
@@ -247,7 +251,7 @@ class AccountBalanceRepository @Inject constructor(
                             latest.isCreditCard, original!!.transactionType, original.amount
                         )
                         if (net.signum() != 0) {
-                            insertBalanceDelta(bank, acct, net, updated.dateTime, updated.id)
+                            insertBalanceDelta(bank, acct, net, LocalDateTime.now(), updated.id)
                         }
                     }
                 }
@@ -257,30 +261,30 @@ class AccountBalanceRepository @Inject constructor(
             if (original != null) {
                 if (original.transactionType == TransactionType.TRANSFER) {
                     shiftTransferLeg(original.fromAccount, incoming = false, revert = true,
-                        original.amount, original.dateTime, updated?.id)
+                        original.amount, updated?.id)
                     shiftTransferLeg(original.toAccount, incoming = true, revert = true,
-                        original.amount, original.dateTime, updated?.id)
+                        original.amount, updated?.id)
                 } else if (origKey != null) {
                     shiftSingleAccount(origKey, original.transactionType, original.amount,
-                        revert = true, original.dateTime, updated?.id)
+                        revert = true, updated?.id)
                 }
             }
             if (updated != null) {
                 if (updated.transactionType == TransactionType.TRANSFER) {
                     shiftTransferLeg(updated.fromAccount, incoming = false, revert = false,
-                        updated.amount, updated.dateTime, updated.id)
+                        updated.amount, updated.id)
                     shiftTransferLeg(updated.toAccount, incoming = true, revert = false,
-                        updated.amount, updated.dateTime, updated.id)
+                        updated.amount, updated.id)
                 } else if (updKey != null) {
                     shiftSingleAccount(updKey, updated.transactionType, updated.amount,
-                        revert = false, updated.dateTime, updated.id)
+                        revert = false, updated.id)
                 }
             }
         }
     }
 
     /**
-     * Reflects a newly-inserted transaction ([transactionId], dated [date]) on
+     * Reflects a newly-inserted transaction ([transactionId]) on
      * its account's running balance. Manual/cash accounts are recomputed from
      * their transactions (so back-dated or later-edited rows stay correct); an
      * SMS-tracked account gets a signed "TRANSACTION" delta snapshot off its
@@ -299,7 +303,6 @@ class AccountBalanceRepository @Inject constructor(
         accountLast4: String,
         amount: BigDecimal,
         type: TransactionType,
-        date: LocalDateTime,
         transactionId: Long
     ) {
         if (isManualAccount(bankName, accountLast4)) {
@@ -315,7 +318,10 @@ class AccountBalanceRepository @Inject constructor(
             currentAccount.copy(
                 id = 0,
                 balance = currentAccount.balance + effect,
-                timestamp = date,
+                // Stamped now, not [date]: a back-dated add stamped into the past
+                // would lose the ORDER BY timestamp DESC race to the row it was
+                // computed from and never become the visible balance.
+                timestamp = LocalDateTime.now(),
                 transactionId = transactionId,
                 sourceType = "TRANSACTION",
                 smsSource = null
@@ -347,7 +353,6 @@ class AccountBalanceRepository @Inject constructor(
                 accountLast4 = accountLast4,
                 amount = transaction.amount,
                 type = transaction.transactionType,
-                date = transaction.dateTime,
                 transactionId = rowId
             )
         }
@@ -397,7 +402,9 @@ class AccountBalanceRepository @Inject constructor(
             } else {
                 getLatestBalance(fromBankName, fromLast4)?.let { latest ->
                     val effect = BalanceCalculator.transferLegEffect(latest.isCreditCard, incoming = false, transaction.amount)
-                    insertBalanceDelta(fromBankName, fromLast4, effect, transaction.dateTime, rowId)
+                    // now() not dateTime: a back-dated leg must still postdate
+                    // the latest row to become the visible balance.
+                    insertBalanceDelta(fromBankName, fromLast4, effect, LocalDateTime.now(), rowId)
                 }
             }
             // TO leg: money in.
@@ -406,7 +413,7 @@ class AccountBalanceRepository @Inject constructor(
             } else {
                 getLatestBalance(toBankName, toLast4)?.let { latest ->
                     val effect = BalanceCalculator.transferLegEffect(latest.isCreditCard, incoming = true, transaction.amount)
-                    insertBalanceDelta(toBankName, toLast4, effect, transaction.dateTime, rowId)
+                    insertBalanceDelta(toBankName, toLast4, effect, LocalDateTime.now(), rowId)
                 }
             }
         }
@@ -435,7 +442,6 @@ class AccountBalanceRepository @Inject constructor(
         type: TransactionType,
         amount: BigDecimal,
         revert: Boolean,
-        timestamp: LocalDateTime,
         transactionId: Long?
     ) {
         val (bank, acct) = key
@@ -444,7 +450,7 @@ class AccountBalanceRepository @Inject constructor(
         var effect = BalanceCalculator.signedBalanceEffect(latest.isCreditCard, type, amount)
         if (revert) effect = effect.negate()
         if (effect.signum() == 0) return
-        insertBalanceDelta(bank, acct, effect, timestamp, transactionId)
+        insertBalanceDelta(bank, acct, effect, LocalDateTime.now(), transactionId)
     }
 
     /**
@@ -460,7 +466,6 @@ class AccountBalanceRepository @Inject constructor(
         incoming: Boolean,
         revert: Boolean,
         amount: BigDecimal,
-        timestamp: LocalDateTime,
         transactionId: Long?
     ) {
         if (accountLast4 == null) return
@@ -477,7 +482,7 @@ class AccountBalanceRepository @Inject constructor(
             latest.copy(
                 id = 0,
                 balance = latest.balance + effect,
-                timestamp = timestamp,
+                timestamp = LocalDateTime.now(),
                 transactionId = transactionId,
                 sourceType = "TRANSACTION",
                 smsSource = null

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
@@ -8,6 +8,7 @@ import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.data.database.entity.ProfileEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
+import com.pennywiseai.tracker.utils.BalanceCalculator
 import kotlinx.coroutines.flow.Flow
 import java.math.BigDecimal
 import java.time.LocalDateTime
@@ -206,36 +207,73 @@ class AccountBalanceRepository @Inject constructor(
     }
 
     /**
-     * Atomically revert the balance impact of the [original] TRANSFER (if it was
-     * one) and apply the [updated] TRANSFER's impact (if it is one) — wrapped in
-     * a Room transaction so a crash mid-sequence can't leave accounts in a
-     * half-reverted state. Revert entries are timestamped with the original
-     * transaction's dateTime, apply entries with the updated transaction's, so
-     * the balance history timeline stays correct.
+     * Atomically shift account balances to reflect replacing [original] with
+     * [updated] — the single owner of "what does this edit do to balances".
+     * Pass `updated = null` for a deletion. Wrapped in a Room transaction so a
+     * crash mid-sequence can't leave accounts half-reverted.
      *
-     * Looks up accounts by `accountLast4` alone — `from_account` / `to_account`
-     * only persist the last4. A missing balance row for a referenced last4 is
-     * silently skipped (account not tracked yet); the other side still runs.
+     * Covers every shape of change: type or amount edits on the same account
+     * (netted into one corrective row), account moves (revert the old account,
+     * apply to the new), and TRANSFER conversions in either direction (legs
+     * reverted/applied per account, credit-card aware). Manual/cash accounts are
+     * skipped for the assigned account — their balance is *derived*, so callers
+     * recompute them — while manual transfer *legs* are recomputed here, since
+     * no caller tracks leg accounts.
+     *
+     * Revert entries are timestamped with the original transaction's dateTime,
+     * apply entries with the updated one's, so the balance history timeline
+     * stays correct. Effects only ever layer onto an account's *latest* row; the
+     * next SMS that reports an explicit balance re-anchors the account to the
+     * bank's own figure regardless (#636).
      */
-    suspend fun applyTransferBalanceShift(
+    suspend fun applyTransactionBalanceShift(
         original: TransactionEntity?,
-        updated: TransactionEntity
+        updated: TransactionEntity?
     ) {
         database.withTransaction {
-            if (original != null && original.transactionType == TransactionType.TRANSFER) {
-                original.fromAccount?.let {
-                    insertBalanceDeltaByLast4(it, original.amount, original.dateTime, updated.id)
+            val origKey = singleAccountKey(original)
+            val updKey = singleAccountKey(updated)
+
+            // Same-account non-transfer edit: one net corrective row instead of a
+            // revert/apply pair, so the history doesn't grow two entries per edit.
+            if (origKey != null && origKey == updKey) {
+                val (bank, acct) = origKey
+                if (!isManualAccount(bank, acct)) {
+                    val latest = getLatestBalance(bank, acct)
+                    if (latest != null) {
+                        val net = BalanceCalculator.signedBalanceEffect(
+                            latest.isCreditCard, updated!!.transactionType, updated.amount
+                        ) - BalanceCalculator.signedBalanceEffect(
+                            latest.isCreditCard, original!!.transactionType, original.amount
+                        )
+                        if (net.signum() != 0) {
+                            insertBalanceDelta(bank, acct, net, updated.dateTime, updated.id)
+                        }
+                    }
                 }
-                original.toAccount?.let {
-                    insertBalanceDeltaByLast4(it, original.amount.negate(), original.dateTime, updated.id)
+                return@withTransaction
+            }
+
+            if (original != null) {
+                if (original.transactionType == TransactionType.TRANSFER) {
+                    shiftTransferLeg(original.fromAccount, incoming = false, revert = true,
+                        original.amount, original.dateTime, updated?.id)
+                    shiftTransferLeg(original.toAccount, incoming = true, revert = true,
+                        original.amount, original.dateTime, updated?.id)
+                } else if (origKey != null) {
+                    shiftSingleAccount(origKey, original.transactionType, original.amount,
+                        revert = true, original.dateTime, updated?.id)
                 }
             }
-            if (updated.transactionType == TransactionType.TRANSFER) {
-                updated.fromAccount?.let {
-                    insertBalanceDeltaByLast4(it, updated.amount.negate(), updated.dateTime, updated.id)
-                }
-                updated.toAccount?.let {
-                    insertBalanceDeltaByLast4(it, updated.amount, updated.dateTime, updated.id)
+            if (updated != null) {
+                if (updated.transactionType == TransactionType.TRANSFER) {
+                    shiftTransferLeg(updated.fromAccount, incoming = false, revert = false,
+                        updated.amount, updated.dateTime, updated.id)
+                    shiftTransferLeg(updated.toAccount, incoming = true, revert = false,
+                        updated.amount, updated.dateTime, updated.id)
+                } else if (updKey != null) {
+                    shiftSingleAccount(updKey, updated.transactionType, updated.amount,
+                        revert = false, updated.dateTime, updated.id)
                 }
             }
         }
@@ -269,16 +307,14 @@ class AccountBalanceRepository @Inject constructor(
             return
         }
         val currentAccount = getLatestBalance(bankName, accountLast4) ?: return
-        val newBalance = when (type) {
-            TransactionType.INCOME -> currentAccount.balance + amount
-            TransactionType.EXPENSE, TransactionType.CREDIT -> currentAccount.balance - amount
-            TransactionType.TRANSFER -> currentAccount.balance - amount
-            TransactionType.INVESTMENT -> currentAccount.balance - amount
-        }
+        // Credit-card aware (#636): a purchase on a card must *raise* its
+        // outstanding, which the old debit-only formula got backwards.
+        val effect = BalanceCalculator.signedBalanceEffect(currentAccount.isCreditCard, type, amount)
+        if (effect.signum() == 0) return
         insertBalance(
             currentAccount.copy(
                 id = 0,
-                balance = newBalance,
+                balance = currentAccount.balance + effect,
                 timestamp = date,
                 transactionId = transactionId,
                 sourceType = "TRANSACTION",
@@ -334,9 +370,9 @@ class AccountBalanceRepository @Inject constructor(
      *    the PRE-insert snapshot via [ensureManualOpening] before the insert, so
      *    the recompute includes this new transfer exactly once.
      *  - SMS-tracked accounts have a bank-reported balance, so we snapshot a signed
-     *    "TRANSACTION" delta off the latest row via [insertBalanceDeltaByLast4]
-     *    (−amount on the FROM leg, +amount on the TO leg). No-op if that account
-     *    has no balance row yet.
+     *    "TRANSACTION" delta off the latest row via [insertBalanceDelta]
+     *    (money out on the FROM leg, in on the TO leg, sign-flipped for credit
+     *    cards). No-op if that account has no balance row yet.
      *
      * Returns the new row id (-1 on a dedup-conflict insert, in which case no
      * balance is moved).
@@ -354,33 +390,93 @@ class AccountBalanceRepository @Inject constructor(
         val rowId = transactionDao.insertTransaction(transaction)
         if (rowId != -1L) {
             // FROM leg: money out. Bank-aware so a shared last4 (Kotak ••9999 vs
-            // HDFC ••9999) debits the account the user actually picked.
+            // HDFC ••9999) debits the account the user actually picked. Legs are
+            // credit-card aware: money arriving at a card pays down outstanding.
             if (isManualAccount(fromBankName, fromLast4)) {
                 recomputeManualBalance(fromBankName, fromLast4)
             } else {
-                insertBalanceDelta(fromBankName, fromLast4, transaction.amount.negate(), transaction.dateTime, rowId)
+                getLatestBalance(fromBankName, fromLast4)?.let { latest ->
+                    val effect = BalanceCalculator.transferLegEffect(latest.isCreditCard, incoming = false, transaction.amount)
+                    insertBalanceDelta(fromBankName, fromLast4, effect, transaction.dateTime, rowId)
+                }
             }
             // TO leg: money in.
             if (isManualAccount(toBankName, toLast4)) {
                 recomputeManualBalance(toBankName, toLast4)
             } else {
-                insertBalanceDelta(toBankName, toLast4, transaction.amount, transaction.dateTime, rowId)
+                getLatestBalance(toBankName, toLast4)?.let { latest ->
+                    val effect = BalanceCalculator.transferLegEffect(latest.isCreditCard, incoming = true, transaction.amount)
+                    insertBalanceDelta(toBankName, toLast4, effect, transaction.dateTime, rowId)
+                }
             }
         }
         rowId
     }
 
-    private suspend fun insertBalanceDeltaByLast4(
-        accountLast4: String,
-        delta: BigDecimal,
+    /**
+     * The (bankName, accountLast4) pair a non-TRANSFER transaction's balance
+     * effect lands on, or null when there is nothing to shift (no account, or a
+     * TRANSFER — whose effects travel through its legs instead).
+     */
+    private fun singleAccountKey(txn: TransactionEntity?): Pair<String, String>? {
+        if (txn == null || txn.transactionType == TransactionType.TRANSFER) return null
+        val bank = txn.bankName ?: return null
+        val acct = txn.accountNumber ?: return null
+        return bank to acct
+    }
+
+    /**
+     * Applies (or, with [revert], undoes) a non-TRANSFER transaction's effect on
+     * its account as a delta off the latest row. Skips manual accounts (derived
+     * balance — callers recompute) and accounts with no balance row (no anchor).
+     */
+    private suspend fun shiftSingleAccount(
+        key: Pair<String, String>,
+        type: TransactionType,
+        amount: BigDecimal,
+        revert: Boolean,
         timestamp: LocalDateTime,
-        transactionId: Long
+        transactionId: Long?
     ) {
+        val (bank, acct) = key
+        if (isManualAccount(bank, acct)) return
+        val latest = getLatestBalance(bank, acct) ?: return
+        var effect = BalanceCalculator.signedBalanceEffect(latest.isCreditCard, type, amount)
+        if (revert) effect = effect.negate()
+        if (effect.signum() == 0) return
+        insertBalanceDelta(bank, acct, effect, timestamp, transactionId)
+    }
+
+    /**
+     * Applies (or, with [revert], undoes) one TRANSFER leg's effect. Resolved by
+     * last4 alone — `from_account`/`to_account` only persist the last4. Manual
+     * leg accounts are re-derived instead of getting a delta row (their MANUAL
+     * row would fight it); an account with no anchor yet stays untouched, in
+     * line with the rest of this class. Credit-card legs flip sign — money
+     * arriving at a card pays down outstanding.
+     */
+    private suspend fun shiftTransferLeg(
+        accountLast4: String?,
+        incoming: Boolean,
+        revert: Boolean,
+        amount: BigDecimal,
+        timestamp: LocalDateTime,
+        transactionId: Long?
+    ) {
+        if (accountLast4 == null) return
         val latest = accountBalanceDao.getLatestBalanceByLast4(accountLast4) ?: return
+        if (isManualAccount(latest.bankName, latest.accountLast4)) {
+            ensureManualOpening(latest.bankName, latest.accountLast4)
+            recomputeManualBalance(latest.bankName, latest.accountLast4)
+            return
+        }
+        var effect = BalanceCalculator.transferLegEffect(latest.isCreditCard, incoming, amount)
+        if (revert) effect = effect.negate()
+        if (effect.signum() == 0) return
         accountBalanceDao.insertBalance(
             latest.copy(
                 id = 0,
-                balance = latest.balance + delta,
+                balance = latest.balance + effect,
                 timestamp = timestamp,
                 transactionId = transactionId,
                 sourceType = "TRANSACTION",
@@ -390,18 +486,17 @@ class AccountBalanceRepository @Inject constructor(
     }
 
     /**
-     * Bank-aware sibling of [insertBalanceDeltaByLast4]: resolves the account by
-     * (bankName, last4) so a transfer leg can't be misattributed to a *different*
-     * account that merely shares the same last4 (e.g. Kotak ••9999 vs HDFC ••9999).
-     * Used by [insertTransferWithBalance], where the full bank name is known for
-     * both legs. No-op if that account has no balance row yet.
+     * Inserts a signed delta snapshot off an account's latest balance row,
+     * resolved by (bankName, last4) so an effect can't be misattributed to a
+     * *different* account that merely shares the same last4 (e.g. Kotak ••9999
+     * vs HDFC ••9999). No-op if that account has no balance row yet.
      */
     private suspend fun insertBalanceDelta(
         bankName: String,
         accountLast4: String,
         delta: BigDecimal,
         timestamp: LocalDateTime,
-        transactionId: Long
+        transactionId: Long?
     ) {
         val latest = accountBalanceDao.getLatestBalance(bankName, accountLast4) ?: return
         accountBalanceDao.insertBalance(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
@@ -782,7 +782,12 @@ class TransactionDetailViewModel @Inject constructor(
                 // Persist the edited tag set (create-or-select handled in repo).
                 tagRepository.setTagsForTransaction(normalizedTransaction.id, _editableTags.value)
 
-                // Update account balance if account was changed or added
+                // Reflect the edit on account balances (#636). One repository
+                // call owns every shape of change — type or amount edits on the
+                // same account, account moves (revert the old account, apply to
+                // the new), and TRANSFER conversions in either direction. It
+                // skips manual/cash accounts, whose derived balances the
+                // recompute below re-derives.
                 val originalTxn = _transaction.value
                 val oldBank = originalTxn?.bankName
                 val oldAccount = originalTxn?.accountNumber
@@ -790,57 +795,18 @@ class TransactionDetailViewModel @Inject constructor(
                 val newAccount = normalizedTransaction.accountNumber
                 val accountChanged = oldBank != newBank || oldAccount != newAccount
 
-                val isTransfer = normalizedTransaction.transactionType == TransactionType.TRANSFER
-                val wasTransfer = originalTxn?.transactionType == TransactionType.TRANSFER
-                val transferFieldsChanged = (isTransfer || wasTransfer) && (
-                    isTransfer != wasTransfer ||
-                    originalTxn?.fromAccount != normalizedTransaction.fromAccount ||
-                    originalTxn?.toAccount != normalizedTransaction.toAccount ||
-                    originalTxn?.amount != normalizedTransaction.amount
+                val balanceRelevantChange = originalTxn != null && (
+                    accountChanged ||
+                    originalTxn.transactionType != normalizedTransaction.transactionType ||
+                    originalTxn.amount.compareTo(normalizedTransaction.amount) != 0 ||
+                    originalTxn.fromAccount != normalizedTransaction.fromAccount ||
+                    originalTxn.toAccount != normalizedTransaction.toAccount
                 )
-
-                if (transferFieldsChanged) {
-                    // Atomically revert the old transfer pair and apply the new
-                    // one. When the user converts FROM a TRANSFER to another
-                    // type, the new type's single-account effect still needs to
-                    // land — handled by the branch below.
-                    accountBalanceRepository.applyTransferBalanceShift(
+                if (balanceRelevantChange) {
+                    accountBalanceRepository.applyTransactionBalanceShift(
                         original = originalTxn,
                         updated = normalizedTransaction
                     )
-                }
-
-                // Single-account update fires for non-TRANSFER edits when the
-                // account changed, OR when this save converted a TRANSFER into a
-                // non-TRANSFER (so the new type still moves the new account's
-                // balance). Skipped entirely when the saved type is TRANSFER —
-                // that path is handled atomically above.
-                val convertedFromTransfer = wasTransfer && !isTransfer
-                val shouldRunSingleAccount = !isTransfer && newBank != null && newAccount != null &&
-                    (accountChanged || convertedFromTransfer)
-
-                // Skip the incremental snapshot for manual accounts — the recompute
-                // below derives their balance, so this row would be redundant clutter.
-                if (shouldRunSingleAccount && !accountBalanceRepository.isManualAccount(newBank!!, newAccount!!)) {
-                    val currentBalance = accountBalanceRepository.getLatestBalance(newBank, newAccount)
-                    if (currentBalance != null) {
-                        val balanceChange = when (normalizedTransaction.transactionType) {
-                            TransactionType.INCOME -> normalizedTransaction.amount
-                            TransactionType.EXPENSE, TransactionType.CREDIT -> -normalizedTransaction.amount
-                            TransactionType.TRANSFER -> BigDecimal.ZERO // handled above
-                            TransactionType.INVESTMENT -> -normalizedTransaction.amount
-                        }
-                        accountBalanceRepository.insertBalance(
-                            currentBalance.copy(
-                                id = 0,
-                                balance = currentBalance.balance + balanceChange,
-                                timestamp = normalizedTransaction.dateTime,
-                                transactionId = normalizedTransaction.id,
-                                sourceType = "TRANSACTION",
-                                smsSource = null
-                            )
-                        )
-                    }
                 }
 
                 // Manual/cash accounts derive their balance from their transactions, so
@@ -1008,6 +974,13 @@ class TransactionDetailViewModel @Inject constructor(
                         accountBalanceRepository.ensureManualOpening(bank, acct)
                     }
                     transactionRepository.deleteTransaction(txn)
+                    // Revert the transaction's effect on SMS-tracked and
+                    // credit-card balances (incl. transfer legs) — the manual
+                    // recompute below doesn't cover those regimes (#636).
+                    accountBalanceRepository.applyTransactionBalanceShift(
+                        original = txn,
+                        updated = null
+                    )
                     if (bank != null && acct != null) {
                         accountBalanceRepository.recomputeManualBalance(bank, acct)
                     }

--- a/app/src/main/java/com/pennywiseai/tracker/utils/BalanceCalculator.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/utils/BalanceCalculator.kt
@@ -47,4 +47,46 @@ object BalanceCalculator {
             }
         }
     }
+
+    /**
+     * Signed delta a non-TRANSFER transaction applies to its own account's stored
+     * balance. This is the single sign convention shared by manual add, edit and
+     * delete (`AccountBalanceRepository`), so a revert can never disagree with the
+     * apply that preceded it.
+     *
+     * Credit cards store outstanding owed, so spending raises the figure and
+     * income (refund/repayment) lowers it. TRANSFER is zero here — transfers move
+     * balances through their from/to legs ([transferLegEffect]), never through
+     * the account the row happens to be filed under.
+     *
+     * Debit CREDIT differs from [calculateNewBalance] (which ignores it) on
+     * purpose: ingestion can't hit that branch — a CREDIT-type SMS forces
+     * isCreditCard=true — while the manual paths have always treated a CREDIT
+     * row on a debit account as money out, and this preserves that.
+     */
+    fun signedBalanceEffect(
+        isCreditCard: Boolean,
+        transactionType: TransactionType,
+        amount: BigDecimal
+    ): BigDecimal = when (transactionType) {
+        TransactionType.INCOME -> if (isCreditCard) amount.negate() else amount
+        TransactionType.EXPENSE,
+        TransactionType.CREDIT,
+        TransactionType.INVESTMENT -> if (isCreditCard) amount else amount.negate()
+        TransactionType.TRANSFER -> BigDecimal.ZERO
+    }
+
+    /**
+     * Signed delta one TRANSFER leg applies to the leg's account. Money arriving
+     * at a debit account raises its balance; arriving at a credit card it pays
+     * down outstanding, so the sign flips.
+     */
+    fun transferLegEffect(
+        isCreditCard: Boolean,
+        incoming: Boolean,
+        amount: BigDecimal
+    ): BigDecimal {
+        val debitEffect = if (incoming) amount else amount.negate()
+        return if (isCreditCard) debitEffect.negate() else debitEffect
+    }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/utils/BalanceCalculatorTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/utils/BalanceCalculatorTest.kt
@@ -186,4 +186,56 @@ class BalanceCalculatorTest {
         )
         assertEquals(BigDecimal("500.00"), newBalance)
     }
+
+    // ── signedBalanceEffect — the shared sign convention for add/edit/delete ──
+
+    @Test
+    fun `signed effect on debit account follows money direction`() {
+        val a = BigDecimal("100.00")
+        assertEquals(a, BalanceCalculator.signedBalanceEffect(false, TransactionType.INCOME, a))
+        assertEquals(a.negate(), BalanceCalculator.signedBalanceEffect(false, TransactionType.EXPENSE, a))
+        assertEquals(a.negate(), BalanceCalculator.signedBalanceEffect(false, TransactionType.INVESTMENT, a))
+        assertEquals(a.negate(), BalanceCalculator.signedBalanceEffect(false, TransactionType.CREDIT, a))
+    }
+
+    @Test
+    fun `signed effect on credit card tracks outstanding owed`() {
+        val a = BigDecimal("100.00")
+        // Spending raises outstanding; income (refund/repayment) lowers it.
+        assertEquals(a, BalanceCalculator.signedBalanceEffect(true, TransactionType.EXPENSE, a))
+        assertEquals(a, BalanceCalculator.signedBalanceEffect(true, TransactionType.CREDIT, a))
+        assertEquals(a, BalanceCalculator.signedBalanceEffect(true, TransactionType.INVESTMENT, a))
+        assertEquals(a.negate(), BalanceCalculator.signedBalanceEffect(true, TransactionType.INCOME, a))
+    }
+
+    @Test
+    fun `transfers have no single-account effect - their legs carry it`() {
+        val a = BigDecimal("100.00")
+        assertEquals(0, BalanceCalculator.signedBalanceEffect(false, TransactionType.TRANSFER, a).signum())
+        assertEquals(0, BalanceCalculator.signedBalanceEffect(true, TransactionType.TRANSFER, a).signum())
+    }
+
+    @Test
+    fun `edit net effect - expense to income on a debit account swings by twice the amount`() {
+        val a = BigDecimal("100.00")
+        val net = BalanceCalculator.signedBalanceEffect(false, TransactionType.INCOME, a) -
+            BalanceCalculator.signedBalanceEffect(false, TransactionType.EXPENSE, a)
+        assertEquals(BigDecimal("200.00"), net)
+    }
+
+    // ── transferLegEffect — credit-card-aware transfer legs ──
+
+    @Test
+    fun `transfer leg on debit account moves with the money`() {
+        val a = BigDecimal("100.00")
+        assertEquals(a, BalanceCalculator.transferLegEffect(false, incoming = true, a))
+        assertEquals(a.negate(), BalanceCalculator.transferLegEffect(false, incoming = false, a))
+    }
+
+    @Test
+    fun `transfer leg on credit card flips sign - a payment reduces outstanding`() {
+        val a = BigDecimal("100.00")
+        assertEquals(a.negate(), BalanceCalculator.transferLegEffect(true, incoming = true, a))
+        assertEquals(a, BalanceCalculator.transferLegEffect(true, incoming = false, a))
+    }
 }


### PR DESCRIPTION
## Problem (#636)

Account balances are stored snapshots, but the transaction-edit path only adjusted them when the **account** changed — never on a **type** or **amount** change — and deletes never touched SMS-tracked or credit-card balances at all. Three concrete defects:

1. Changing expense → income on the same account wrote no balance row at all (the reported bug).
2. Moving a transaction to another account applied the delta to the new account but never credited the old one back — the amount ended up counted twice.
3. Every incremental path (edit + manual add) used the debit-account sign for credit cards, contradicting SMS ingestion's `BalanceCalculator` — cards track outstanding owed, so a purchase must *raise* the figure. That's the commenter's "outstanding increases wrongly" case.

## Fix

- **`AccountBalanceRepository.applyTransactionBalanceShift(original, updated)`** — single owner of "what does replacing A with B do to balances" (`updated = null` = deletion). Same-account edits net into one corrective row; account moves revert old + apply new; TRANSFER conversions revert/apply legs. Subsumes the old transfer-only `applyTransferBalanceShift`. Atomic (Room transaction).
- **`BalanceCalculator.signedBalanceEffect` / `transferLegEffect`** — one credit-card-aware sign convention shared by manual add, edit and delete, so a revert can never disagree with the apply that preceded it. Transfer legs arriving at a card now pay down outstanding (also applied to `insertTransferWithBalance`).
- Manual/cash accounts keep the derived-balance regime; manual transfer legs are now recomputed instead of receiving delta rows that fight their MANUAL row.
- Effects always layer onto the latest row; the next SMS with an explicit balance re-anchors the account to the bank's own figure regardless.

## Verification

- `./init.sh app` green; new unit tests for both effect functions in `BalanceCalculatorTest`.
- Emulator, end to end: parsed a Kotak SMS (₹50 expense, explicit balance 1234.56), reclassified it to income → stored balance moved to **1334.56** (+2×50), then deleted the row → **1284.56**, the exact pre-transaction figure.

## Out of scope (tracked separately)

Bulk mark-as-transfer writes `from`/`to` on **both** rows of the pair, which the manual-account transfer sum counts twice — pre-existing, and balance-neutral for SMS accounts, so left for its own fix.

Fixes #636