### PR TITLE
fix(accounts): show the account alias in every account picker (#637)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/AccountBalanceEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/AccountBalanceEntity.kt
@@ -80,6 +80,15 @@ data class AccountBalanceEntity(
     @Contextual
     val lowBalanceThreshold: BigDecimal? = null
 ) {
+    /**
+     * Label to show wherever the user picks or reads this account: the user-set
+     * [alias] when one exists, otherwise [accountLabel]. An account renamed in
+     * Manage Accounts must be recognizable under that name everywhere — pickers
+     * that ignored the alias were the bug in #637.
+     */
+    val displayLabel: String
+        get() = alias?.takeIf { it.isNotBlank() } ?: accountLabel(bankName, accountLast4)
+
     companion object {
         // Sentinel account_last4 for mobile-money wallets (eMola, M-Pesa
         // Mozambique) whose SMS has a running balance but no per-account number —

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/SubscriptionTabContent.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/SubscriptionTabContent.kt
@@ -401,7 +401,11 @@ fun SubscriptionTabContent(
                     )
                     Column(modifier = Modifier.weight(1f)) {
                         Text(
-                            text = uiState.selectedAccount?.bankName ?: "Paid from (optional)",
+                            // Alias-aware like the dropdown items, so the account
+                            // doesn't change name when the menu closes (#637).
+                            text = uiState.selectedAccount
+                                ?.let { it.alias?.takeIf { a -> a.isNotBlank() } ?: it.bankName }
+                                ?: "Paid from (optional)",
                             style = MaterialTheme.typography.bodyLarge,
                             color = if (uiState.selectedAccount != null)
                                 MaterialTheme.colorScheme.onSurface

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/SubscriptionTabContent.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/SubscriptionTabContent.kt
@@ -478,7 +478,7 @@ fun SubscriptionTabContent(
                         DropdownMenuItem(
                             text = {
                                 Column {
-                                    Text(AccountBalanceEntity.accountLabel(account.bankName, account.accountLast4))
+                                    Text(account.displayLabel)
                                     Text(
                                         CurrencyFormatter.formatCurrency(account.balance, account.currency),
                                         style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/TransactionTabContent.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/TransactionTabContent.kt
@@ -69,8 +69,10 @@ private enum class AccountPickerTarget { FROM, TO }
 
 /**
  * Tappable account card used by the single-account picker and by both legs of a
- * TRANSFER. Shows the selected account (bank name + ••last4) or [placeholder],
- * with a clear button when an account is set.
+ * TRANSFER. Shows the selected account (alias when set, else bank name, with a
+ * ••last4 subtitle) or [placeholder], with a clear button when an account is
+ * set. The alias line matches the dropdown items so the account doesn't change
+ * name the moment the menu closes (#637).
  */
 @Composable
 private fun AccountSelectorCard(
@@ -108,7 +110,8 @@ private fun AccountSelectorCard(
             )
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = account?.bankName ?: placeholder,
+                    text = account?.let { it.alias?.takeIf { a -> a.isNotBlank() } ?: it.bankName }
+                        ?: placeholder,
                     style = MaterialTheme.typography.bodyLarge,
                     color = if (account != null)
                         MaterialTheme.colorScheme.onSurface

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/TransactionTabContent.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/TransactionTabContent.kt
@@ -558,7 +558,7 @@ fun TransactionTabContent(
                         DropdownMenuItem(
                             text = {
                                 Column {
-                                    Text(AccountBalanceEntity.accountLabel(account.bankName, account.accountLast4))
+                                    Text(account.displayLabel)
                                     Text(
                                         CurrencyFormatter.formatCurrency(account.balance, account.currency),
                                         style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/common/Filters.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/common/Filters.kt
@@ -128,16 +128,14 @@ data class AccountOption(
 /**
  * Builds the list of [AccountOption]s for the account picker from account balances.
  *
- * The label prefers the account [AccountBalanceEntity.alias] when non-blank,
- * otherwise falls back to "$bankName ••$accountLast4". Deduped by key.
+ * The label is [AccountBalanceEntity.displayLabel] — the user-set alias when
+ * one exists, otherwise "$bankName ••$accountLast4". Deduped by key.
  */
 fun accountOptions(accounts: List<AccountBalanceEntity>): List<AccountOption> {
     return accounts
         .map { account ->
             val key = "${account.bankName}_${account.accountLast4}"
-            val alias = account.alias?.takeIf { it.isNotBlank() }
-            val label = alias ?: AccountBalanceEntity.accountLabel(account.bankName, account.accountLast4)
-            AccountOption(key = key, label = label)
+            AccountOption(key = key, label = account.displayLabel)
         }
         .distinctBy { it.key }
         .sortedBy { it.label.lowercase() }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsScreen.kt
@@ -933,9 +933,7 @@ private fun EditSubscriptionDialog(
                 // the chosen account's balance; "No account" keeps it unlinked.
                 Box(modifier = Modifier.fillMaxWidth()) {
                     OutlinedTextField(
-                        value = selectedAccount?.let {
-                            AccountBalanceEntity.accountLabel(it.bankName, it.accountLast4)
-                        } ?: "No account",
+                        value = selectedAccount?.displayLabel ?: "No account",
                         onValueChange = {},
                         readOnly = true,
                         label = { Text("Paid from") },
@@ -967,7 +965,7 @@ private fun EditSubscriptionDialog(
                             DropdownMenuItem(
                                 text = {
                                     Column {
-                                        Text(AccountBalanceEntity.accountLabel(account.bankName, account.accountLast4))
+                                        Text(account.displayLabel)
                                         Text(
                                             CurrencyFormatter.formatCurrency(account.balance, account.currency),
                                             style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
@@ -255,7 +255,7 @@ class TransactionDetailViewModel @Inject constructor(
                     AccountInfo(
                         bankName = balance.bankName,
                         accountLast4 = balance.accountLast4,
-                        displayName = AccountBalanceEntity.accountLabel(balance.bankName, balance.accountLast4),
+                        displayName = balance.displayLabel,
                         isCreditCard = balance.isCreditCard
                     )
                 }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/RulesViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/RulesViewModel.kt
@@ -87,7 +87,7 @@ class RulesViewModel @Inject constructor(
                     AccountInfo(
                         bankName = balance.bankName,
                         accountLast4 = balance.accountLast4,
-                        displayName = AccountBalanceEntity.accountLabel(balance.bankName, balance.accountLast4),
+                        displayName = balance.displayLabel,
                         isCreditCard = balance.isCreditCard,
                         accountType = balance.accountType
                     )


### PR DESCRIPTION
## Problem (#637)

An alias set in Manage Accounts was honored there and in the account filter chips, but nowhere an account is *picked*: the transaction-edit dropdown (the reported screen), the add-transaction and add-subscription pickers, the subscription paid-from picker, and the rules account list all rendered the bare `Bank ••1234` label. A renamed account was unrecognizable at exactly the moments the user has to choose it.

## Fix

`AccountBalanceEntity.displayLabel` — the user-set alias when non-blank, otherwise the existing `accountLabel()` (wallet-marker aware) — and every picker now renders it:

- `TransactionDetailViewModel.availableAccounts` (transaction edit dropdown)
- `TransactionTabContent` / `SubscriptionTabContent` (add flows)
- `SubscriptionsScreen` paid-from field + menu
- `RulesViewModel` account list
- `Filters.accountOptions` (chips) now delegates to it instead of hand-rolling the same fallback

Not touched: the Home account carousel intentionally shows the bank name; making it alias-aware can follow separately if desired.

## Verification

`./init.sh app` green. On the emulator: set an alias on a parsed Kotak account via Manage Accounts → the transaction-edit account dropdown lists the account by its alias.

Fixes #637