### PR TITLE
fix(ios): correctness batch — currency picker, totals, migrations, live rules

### DIFF
--- a/iosApp/iosApp/Screens/Settings/SettingsScreen.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsScreen.swift
@@ -31,6 +31,25 @@ struct SettingsScreen: View {
                             .foregroundStyle(.orange)
                     }
                 }
+
+                // The picker existed but nothing navigated to it, so every user
+                // was stuck on the INR default for display formatting.
+                NavigationLink {
+                    CurrencyPickerScreen()
+                } label: {
+                    Label {
+                        VStack(alignment: .leading, spacing: AppSpacing.xs) {
+                            Text("Currency")
+                                .font(AppTypography.body)
+                            Text("Default currency for totals and new entries")
+                                .font(AppTypography.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } icon: {
+                        Image(systemName: "coloncurrencysign.circle.fill")
+                            .foregroundStyle(.green)
+                    }
+                }
             }
 
             // MARK: - Data Management

--- a/iosApp/iosApp/Screens/Transactions/TransactionListView.swift
+++ b/iosApp/iosApp/Screens/Transactions/TransactionListView.swift
@@ -202,9 +202,12 @@ struct TransactionListView: View {
         var income: Int64 = 0
         var expense: Int64 = 0
         for item in filteredTransactions {
+            // EXPENSE only, mirroring Android and the home snapshot: TRANSFER
+            // moves money between own accounts and CREDIT/INVESTMENT are their
+            // own types — "everything that isn't income" overstated spending.
             if item.transactionType == "INCOME" {
                 income += item.amountMinor
-            } else {
+            } else if item.transactionType == "EXPENSE" {
                 expense += item.amountMinor
             }
         }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.multiplatform.library)
+    alias(libs.plugins.kotlin.serialization)
     id("com.google.devtools.ksp")
 }
 
@@ -29,6 +30,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+                implementation(libs.kotlinx.serialization.json)
                 implementation(libs.androidx.room.runtime)
                 implementation(libs.androidx.sqlite.bundled)
             }

--- a/shared/src/androidMain/kotlin/com/pennywiseai/shared/data/local/SharedDatabaseFactory.android.kt
+++ b/shared/src/androidMain/kotlin/com/pennywiseai/shared/data/local/SharedDatabaseFactory.android.kt
@@ -20,7 +20,8 @@ fun createAndroidSharedDatabase(context: Context): SharedDatabase =
         klass = SharedDatabase::class.java,
         name = SharedDatabase.DATABASE_NAME
     )
-        .fallbackToDestructiveMigration(dropAllTables = true)
+        // No destructive fallback — see SharedDatabaseFactory.ios.kt: schema
+        // changes must ship Migrations, never silently drop a finance DB.
         .setDriver(BundledSQLiteDriver())
         .setQueryCoroutineContext(Dispatchers.IO)
         .build()

--- a/shared/src/commonMain/kotlin/com/pennywiseai/shared/PennyWiseSharedFacade.kt
+++ b/shared/src/commonMain/kotlin/com/pennywiseai/shared/PennyWiseSharedFacade.kt
@@ -125,7 +125,9 @@ class PennyWiseSharedFacade {
     private val graph by lazy { SharedDataGraph.getInstance() }
     private val createUseCase by lazy { CreateManualTransactionUseCase(graph.transactionRepository, graph.accountRepository) }
     private val updateUseCase by lazy { UpdateManualTransactionUseCase(graph.transactionRepository, graph.accountRepository) }
-    private val importStatementUseCase by lazy { ImportStatementUseCase(graph.transactionRepository, graph.accountRepository) }
+    private val importStatementUseCase by lazy {
+        ImportStatementUseCase(graph.transactionRepository, graph.accountRepository, graph.ruleRepository)
+    }
 
     fun initializeAndLoadHome(): SharedHomeSnapshot = safeSnapshot {
         runBlocking {
@@ -396,7 +398,9 @@ class PennyWiseSharedFacade {
                     val categoryNames = categories.map { it.categoryName }.toSet()
                     val periodTxns = transactions.filter { txn ->
                         txn.occurredAtEpochMillis in budget.startEpochMillis..budget.endEpochMillis &&
-                            txn.transactionType != SharedTransactionType.INCOME &&
+                            // EXPENSE only (mirrors the home totals): a TRANSFER
+                            // between own accounts must not eat budget.
+                            txn.transactionType == SharedTransactionType.EXPENSE &&
                             (categoryNames.isEmpty() || txn.category in categoryNames)
                     }
                     val totalSpent = periodTxns.fold(0L) { acc, txn -> acc + txn.amountMinor }
@@ -914,8 +918,12 @@ class PennyWiseSharedFacade {
         val monthlyIncome = thisMonthTxns
             .filter { it.transactionType == SharedTransactionType.INCOME }
             .fold(0L) { acc, txn -> acc + txn.amountMinor }
+        // EXPENSE only, matching Android's home breakdown: TRANSFER moves money
+        // between the user's own accounts, and INVESTMENT/CREDIT are tracked as
+        // their own types — "everything that isn't income" counted a transfer to
+        // your own savings as spending.
         val monthlyExpense = thisMonthTxns
-            .filter { it.transactionType != SharedTransactionType.INCOME }
+            .filter { it.transactionType == SharedTransactionType.EXPENSE }
             .fold(0L) { acc, txn -> acc + txn.amountMinor }
 
         return SharedHomeSnapshot(

--- a/shared/src/commonMain/kotlin/com/pennywiseai/shared/domain/rules/SharedRuleEvaluator.kt
+++ b/shared/src/commonMain/kotlin/com/pennywiseai/shared/domain/rules/SharedRuleEvaluator.kt
@@ -2,8 +2,9 @@ package com.pennywiseai.shared.domain.rules
 
 import com.pennywiseai.shared.data.local.entity.SharedRuleEntity
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Evaluates stored Smart Rules against transactions entering through the
@@ -53,14 +54,14 @@ object SharedRuleEvaluator {
 
     private fun adjustmentIfMatched(rule: SharedRuleEntity, merchant: String): Adjustment? {
         val condition = parseObject(rule.conditionsJson) ?: return null
-        val type = condition["type"]?.jsonPrimitive?.content ?: return null
+        val type = condition.stringOrNull("type") ?: return null
         if (type != "merchant_contains") return null
-        val keyword = condition["value"]?.jsonPrimitive?.content?.trim() ?: return null
+        val keyword = condition.stringOrNull("value")?.trim() ?: return null
         if (keyword.isEmpty() || !merchant.contains(keyword, ignoreCase = true)) return null
 
         val action = parseObject(rule.actionsJson) ?: return null
-        val category = action["category"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
-        val transactionType = action["transactionType"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+        val category = action.stringOrNull("category")?.takeIf { it.isNotBlank() }
+        val transactionType = action.stringOrNull("transactionType")?.takeIf { it.isNotBlank() }
         if (category == null && transactionType == null) return null
         return Adjustment(
             category = category,
@@ -75,4 +76,13 @@ object SharedRuleEvaluator {
     } catch (_: Exception) {
         null
     }
+
+    /**
+     * The string at [key], or null when absent or not a primitive — a
+     * non-primitive (`"value": {…}`) must make the rule a non-match, never an
+     * exception: this runs inside the import pipeline, and a throw here would
+     * abort the whole statement import over one bad rule.
+     */
+    private fun JsonObject.stringOrNull(key: String): String? =
+        (this[key] as? JsonPrimitive)?.content
 }

--- a/shared/src/commonMain/kotlin/com/pennywiseai/shared/domain/rules/SharedRuleEvaluator.kt
+++ b/shared/src/commonMain/kotlin/com/pennywiseai/shared/domain/rules/SharedRuleEvaluator.kt
@@ -1,0 +1,78 @@
+package com.pennywiseai.shared.domain.rules
+
+import com.pennywiseai.shared.data.local.entity.SharedRuleEntity
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Evaluates stored Smart Rules against transactions entering through the
+ * parsing pipeline (statement import). Until this existed, rules were
+ * write-only: the screen created and stored them but nothing ever consulted
+ * them.
+ *
+ * Rules run on *parsed* data only — a manually added transaction carries the
+ * category the user just picked, and a rule silently overriding an explicit
+ * choice would be surprising. This mirrors Android, where the RuleEngine sits
+ * in the SMS parsing pipeline.
+ *
+ * The rule builder currently persists exactly one condition shape
+ * (`{"type":"merchant_contains","value":…}`) and one action shape
+ * (`{"category":…,"transactionType":…}`). Anything unrecognized — future
+ * condition types, malformed JSON — makes that rule a non-match rather than an
+ * error, so old evaluators never misfire on rules written by newer builders.
+ */
+object SharedRuleEvaluator {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** What a matched rule wants to change; null fields mean "leave as is". */
+    data class Adjustment(
+        val category: String?,
+        val transactionType: String?,
+        val ruleId: String,
+        val ruleName: String
+    )
+
+    /**
+     * Returns the adjustment from the first matching active rule, or null.
+     * Rules are tried in ascending [SharedRuleEntity.priority] order (then by
+     * creation time for stability); the first match wins, matching the
+     * priority semantics the rules screen exposes.
+     */
+    fun firstMatch(rules: List<SharedRuleEntity>, merchantName: String): Adjustment? {
+        val merchant = merchantName.trim()
+        if (merchant.isEmpty()) return null
+        return rules
+            .asSequence()
+            .filter { it.isActive }
+            .sortedWith(compareBy({ it.priority }, { it.createdAtEpochMillis }))
+            .mapNotNull { rule -> adjustmentIfMatched(rule, merchant) }
+            .firstOrNull()
+    }
+
+    private fun adjustmentIfMatched(rule: SharedRuleEntity, merchant: String): Adjustment? {
+        val condition = parseObject(rule.conditionsJson) ?: return null
+        val type = condition["type"]?.jsonPrimitive?.content ?: return null
+        if (type != "merchant_contains") return null
+        val keyword = condition["value"]?.jsonPrimitive?.content?.trim() ?: return null
+        if (keyword.isEmpty() || !merchant.contains(keyword, ignoreCase = true)) return null
+
+        val action = parseObject(rule.actionsJson) ?: return null
+        val category = action["category"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+        val transactionType = action["transactionType"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+        if (category == null && transactionType == null) return null
+        return Adjustment(
+            category = category,
+            transactionType = transactionType,
+            ruleId = rule.id,
+            ruleName = rule.name
+        )
+    }
+
+    private fun parseObject(raw: String) = try {
+        json.parseToJsonElement(raw).jsonObject
+    } catch (_: Exception) {
+        null
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pennywiseai/shared/domain/usecase/ImportStatementUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/pennywiseai/shared/domain/usecase/ImportStatementUseCase.kt
@@ -2,17 +2,22 @@ package com.pennywiseai.shared.domain.usecase
 
 import com.pennywiseai.shared.data.local.entity.SharedAccountBalanceEntity
 import com.pennywiseai.shared.data.model.SharedTransaction
+import com.pennywiseai.shared.data.model.SharedTransactionType
 import com.pennywiseai.shared.data.repository.SharedAccountRepository
 import com.pennywiseai.shared.data.repository.SharedTransactionRepository
 import com.pennywiseai.shared.data.statement.SharedPdfTextExtractor
 import com.pennywiseai.shared.data.statement.SharedStatementImportResult
 import com.pennywiseai.shared.data.statement.SharedStatementParserFactory
+import com.pennywiseai.shared.data.repository.SharedRuleRepository
 import com.pennywiseai.shared.data.util.currentTimeMillis
 import com.pennywiseai.shared.domain.mapping.SharedCategoryMapping
+import com.pennywiseai.shared.domain.rules.SharedRuleEvaluator
+import kotlinx.coroutines.flow.first
 
 class ImportStatementUseCase(
     private val transactionRepository: SharedTransactionRepository,
-    private val accountRepository: SharedAccountRepository
+    private val accountRepository: SharedAccountRepository,
+    private val ruleRepository: SharedRuleRepository? = null
 ) {
     suspend fun importFromPdfPath(filePath: String): SharedStatementImportResult {
         return importFromText(SharedPdfTextExtractor.extractText(filePath))
@@ -33,6 +38,11 @@ class ImportStatementUseCase(
         var skippedByReference = 0
         var skippedByAmountDate = 0
 
+        // Smart Rules run on parsed data (this pipeline), never on manual
+        // entry where the user picked the category themselves. Loaded once per
+        // import, applied per transaction after the default category mapping.
+        val rules = ruleRepository?.observeRules()?.first().orEmpty()
+
         val toInsert = parsedTransactions.mapNotNull { parsed ->
             val hash = buildImportHash(parsed.rawText, parsed.amountMinor, parsed.timestampEpochMillis)
             if (transactionRepository.getByHash(hash) != null) {
@@ -52,14 +62,22 @@ class ImportStatementUseCase(
                 return@mapNotNull null
             }
 
+            val merchant = parsed.merchant ?: "Unknown Merchant"
+            val adjustment = SharedRuleEvaluator.firstMatch(rules, merchant)
+            val ruleType = adjustment?.transactionType?.let { raw ->
+                // An unknown type string in a stored action must not sink the
+                // import — fall back to the parsed type.
+                SharedTransactionType.entries.firstOrNull { it.name == raw }
+            }
+
             SharedTransaction(
                 amountMinor = parsed.amountMinor,
-                merchantName = parsed.merchant ?: "Unknown Merchant",
-                category = SharedCategoryMapping.determineCategory(
-                    parsed.merchant ?: "Unknown Merchant",
+                merchantName = merchant,
+                category = adjustment?.category ?: SharedCategoryMapping.determineCategory(
+                    merchant,
                     parsed.transactionType.name
                 ),
-                transactionType = parsed.transactionType,
+                transactionType = ruleType ?: parsed.transactionType,
                 occurredAtEpochMillis = parsed.timestampEpochMillis,
                 note = null,
                 currency = "INR",

--- a/shared/src/commonTest/kotlin/com/pennywiseai/shared/domain/rules/SharedRuleEvaluatorTest.kt
+++ b/shared/src/commonTest/kotlin/com/pennywiseai/shared/domain/rules/SharedRuleEvaluatorTest.kt
@@ -67,6 +67,27 @@ class SharedRuleEvaluatorTest {
     }
 
     @Test
+    fun non_primitive_fields_are_non_matches_not_exceptions() {
+        // Valid JSON whose fields aren't primitives must not throw — this runs
+        // inside the import pipeline, where an exception aborts the whole
+        // statement import over one bad rule.
+        val objectValue = rule(conditionsJson = """{"type":"merchant_contains","value":{"nested":true}}""")
+        val arrayType = rule(conditionsJson = """{"type":["merchant_contains"],"value":"swiggy"}""")
+        assertNull(SharedRuleEvaluator.firstMatch(listOf(objectValue, arrayType), "swiggy"))
+
+        // A matching condition with a non-primitive action field: the broken
+        // field is ignored; with no usable action left, the rule is a non-match.
+        val badAction = SharedRuleEntity(
+            id = "bad-action", name = "bad", priority = 0,
+            conditionsJson = """{"type":"merchant_contains","value":"swiggy"}""",
+            actionsJson = """{"category":{"x":1}}""",
+            isActive = true, isSystemTemplate = false,
+            createdAtEpochMillis = 0, updatedAtEpochMillis = 0
+        )
+        assertNull(SharedRuleEvaluator.firstMatch(listOf(badAction), "swiggy"))
+    }
+
+    @Test
     fun action_can_change_the_transaction_type() {
         val hit = SharedRuleEvaluator.firstMatch(
             listOf(rule(keyword = "salary", category = null, type = "INCOME")),

--- a/shared/src/commonTest/kotlin/com/pennywiseai/shared/domain/rules/SharedRuleEvaluatorTest.kt
+++ b/shared/src/commonTest/kotlin/com/pennywiseai/shared/domain/rules/SharedRuleEvaluatorTest.kt
@@ -1,0 +1,88 @@
+package com.pennywiseai.shared.domain.rules
+
+import com.pennywiseai.shared.data.local.entity.SharedRuleEntity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SharedRuleEvaluatorTest {
+
+    private fun rule(
+        id: String = "r1",
+        keyword: String = "swiggy",
+        category: String? = "Food & Dining",
+        type: String? = null,
+        active: Boolean = true,
+        priority: Int = 0,
+        createdAt: Long = 0L,
+        conditionsJson: String? = null
+    ) = SharedRuleEntity(
+        id = id,
+        name = "rule-$id",
+        priority = priority,
+        conditionsJson = conditionsJson
+            ?: """{"type":"merchant_contains","value":"$keyword"}""",
+        actionsJson = buildString {
+            append("{")
+            category?.let { append("\"category\":\"$it\"") }
+            if (category != null && type != null) append(",")
+            type?.let { append("\"transactionType\":\"$it\"") }
+            append("}")
+        },
+        isActive = active,
+        isSystemTemplate = false,
+        createdAtEpochMillis = createdAt,
+        updatedAtEpochMillis = createdAt
+    )
+
+    @Test
+    fun matches_case_insensitively_and_returns_the_action() {
+        val hit = SharedRuleEvaluator.firstMatch(listOf(rule()), "SWIGGY BANGALORE")
+        assertEquals("Food & Dining", hit?.category)
+        assertNull(hit?.transactionType)
+    }
+
+    @Test
+    fun inactive_rules_never_match() {
+        assertNull(SharedRuleEvaluator.firstMatch(listOf(rule(active = false)), "Swiggy"))
+    }
+
+    @Test
+    fun lower_priority_value_wins_when_both_match() {
+        val hit = SharedRuleEvaluator.firstMatch(
+            listOf(
+                rule(id = "late", category = "Late", priority = 5),
+                rule(id = "early", category = "Early", priority = 1)
+            ),
+            "swiggy order"
+        )
+        assertEquals("Early", hit?.category)
+    }
+
+    @Test
+    fun malformed_or_unknown_condition_shapes_are_non_matches_not_errors() {
+        val malformed = rule(conditionsJson = "not json at all")
+        val unknownType = rule(conditionsJson = """{"type":"amount_over","value":"100"}""")
+        assertNull(SharedRuleEvaluator.firstMatch(listOf(malformed, unknownType), "swiggy"))
+    }
+
+    @Test
+    fun action_can_change_the_transaction_type() {
+        val hit = SharedRuleEvaluator.firstMatch(
+            listOf(rule(keyword = "salary", category = null, type = "INCOME")),
+            "SALARY CREDIT AUG"
+        )
+        assertEquals("INCOME", hit?.transactionType)
+        assertNull(hit?.category)
+    }
+
+    @Test
+    fun empty_action_is_a_non_match() {
+        assertNull(
+            SharedRuleEvaluator.firstMatch(
+                listOf(rule(category = null, type = null)),
+                "swiggy"
+            )
+        )
+    }
+}

--- a/shared/src/iosMain/kotlin/com/pennywiseai/shared/data/local/SharedDatabaseFactory.ios.kt
+++ b/shared/src/iosMain/kotlin/com/pennywiseai/shared/data/local/SharedDatabaseFactory.ios.kt
@@ -9,8 +9,12 @@ actual class SharedDatabaseFactory actual constructor() {
     actual fun createDatabase(): SharedDatabase {
         val dbPath = "${NSHomeDirectory()}/Documents/${SharedDatabase.DATABASE_NAME}"
 
+        // No destructive fallback: this is a finance database — a schema bump
+        // must ship a Migration or fail loudly in development, never silently
+        // wipe the user's data. The schema was born at version 2, so there is
+        // no legacy version to migrate from yet; add migrations here as the
+        // version grows.
         return Room.databaseBuilder<SharedDatabase>(name = dbPath)
-            .fallbackToDestructiveMigration(dropAllTables = true)
             .setDriver(BundledSQLiteDriver())
             .setQueryCoroutineContext(Dispatchers.Default)
             .build()


### PR DESCRIPTION
Tier 1 of the iOS parity plan — the four "already broken" defects found in the iOS/Android comparison:

## 1. Currency picker was unreachable
`CurrencyPickerScreen` existed but nothing presented it — every user was permanently stuck on INR display formatting. Settings → Personalization now has a **Currency** row.

## 2. Totals counted transfers as spending
Home snapshot, transaction-list totals and budget spent all used *"everything that isn't INCOME"* — so a TRANSFER to your own savings inflated "Spent this month" and ate budget. All three now count **EXPENSE only**, mirroring Android's home breakdown semantics.

## 3. Destructive migration fallback removed
`fallbackToDestructiveMigration(dropAllTables = true)` silently wipes the finance DB on any future schema bump. The schema was born at v2 (no legacy to migrate), so the fallback is simply removed — future bumps must ship real `Migration`s or fail loudly in development. Applied to both platform factories (the Android one is currently unused).

## 4. Smart Rules now evaluate
Rules were write-only. New `SharedRuleEvaluator` (kotlinx-serialization; malformed/unknown shapes are non-matches, never errors) runs in the **statement-import pipeline**: first active match by priority sets category/type. Manual entry is deliberately exempt — the user just picked those values, same philosophy as Android's RuleEngine living in the SMS pipeline. Unit-tested in `commonTest`, green on Android-host and iOS-simulator targets.

## Android safety
Shared-module changes touch only iOS-consumed paths (Android imports just `DefaultCategoryData`/`SharedCategoryMapping`); the full `./init.sh` gate passes. New dependency: `kotlinx-serialization-json` in shared (same version the app module already uses).

## Verification
- `./init.sh` (full) green; `:shared:testAndroidHostTest` + `:shared:iosSimulatorArm64Test` green.
- iPhone 17 Pro simulator: Currency row present and navigable; switching to USD reformats all figures; seeded `$100 EXPENSE + $50 TRANSFER + $200 INCOME` renders **Spent $100 / Income $200 / Saved $100** (pre-fix: Spent $150).