### PR TITLE
feat(ios): parse slice small finance bank statement PDFs

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		JJ0004002D39B001007A8A11 /* CurrencyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = JJ0001002D39B001007A8A11 /* CurrencyManager.swift */; };
 		JJ0005002D39B001007A8A11 /* CurrencyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = JJ0002002D39B001007A8A11 /* CurrencyFormatter.swift */; };
 		JJ0006002D39B001007A8A11 /* CurrencyPickerScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = JJ0003002D39B001007A8A11 /* CurrencyPickerScreen.swift */; };
+		JJ0009002D39B001007A8A11 /* StatementImportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = JJ0008002D39B001007A8A11 /* StatementImportService.swift */; };
 		LL0002002D39B001007A8A11 /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = LL0001002D39B001007A8A11 /* ThemeManager.swift */; };
 		LL0004002D39B001007A8A11 /* AppearanceScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = LL0003002D39B001007A8A11 /* AppearanceScreen.swift */; };
 		MM0003002D39B001007A8A11 /* FAQScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = MM0001002D39B001007A8A11 /* FAQScreen.swift */; };
@@ -123,6 +124,7 @@
 		JJ0001002D39B001007A8A11 /* CurrencyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyManager.swift; sourceTree = "<group>"; };
 		JJ0002002D39B001007A8A11 /* CurrencyFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormatter.swift; sourceTree = "<group>"; };
 		JJ0003002D39B001007A8A11 /* CurrencyPickerScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyPickerScreen.swift; sourceTree = "<group>"; };
+		JJ0008002D39B001007A8A11 /* StatementImportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementImportService.swift; sourceTree = "<group>"; };
 		LL0001002D39B001007A8A11 /* ThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManager.swift; sourceTree = "<group>"; };
 		LL0003002D39B001007A8A11 /* AppearanceScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceScreen.swift; sourceTree = "<group>"; };
 		MM0001002D39B001007A8A11 /* FAQScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FAQScreen.swift; sourceTree = "<group>"; };
@@ -339,6 +341,7 @@
 				BB0013002D39B001007A8A11 /* AmountFormatting.swift */,
 				JJ0001002D39B001007A8A11 /* CurrencyManager.swift */,
 				JJ0002002D39B001007A8A11 /* CurrencyFormatter.swift */,
+				JJ0008002D39B001007A8A11 /* StatementImportService.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -507,6 +510,7 @@
 				JJ0004002D39B001007A8A11 /* CurrencyManager.swift in Sources */,
 				JJ0005002D39B001007A8A11 /* CurrencyFormatter.swift in Sources */,
 				JJ0006002D39B001007A8A11 /* CurrencyPickerScreen.swift in Sources */,
+				JJ0009002D39B001007A8A11 /* StatementImportService.swift in Sources */,
 				NN0003002D39B001007A8A11 /* AppLockManager.swift in Sources */,
 				NN0004002D39B001007A8A11 /* LockScreenView.swift in Sources */,
 				LL0002002D39B001007A8A11 /* ThemeManager.swift in Sources */,

--- a/iosApp/iosApp/Extensions/StatementImportService.swift
+++ b/iosApp/iosApp/Extensions/StatementImportService.swift
@@ -1,0 +1,49 @@
+import Foundation
+import PDFKit
+import Shared
+
+/// One statement-import pipeline for every entry point — the Settings picker,
+/// onboarding, and PDFs handed to the app from outside (Files/Mail share →
+/// PennyWise). Previously Settings and Onboarding each carried their own copy
+/// of the extraction + regex + facade sequence.
+enum StatementImportService {
+
+    /// Extracts text from the PDF at [url] and runs it through the shared
+    /// import pipeline. Returns a user-facing result message.
+    /// Handles security-scoped URLs (needed for files arriving via
+    /// "Open in PennyWise"; harmless for the in-app picker's copies).
+    static func importPDF(at url: URL) -> String {
+        let scoped = url.startAccessingSecurityScopedResource()
+        defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+
+        guard let pdfDocument = PDFDocument(url: url) else {
+            return "Could not open PDF file"
+        }
+
+        var fullText = ""
+        for i in 0..<pdfDocument.pageCount {
+            if let page = pdfDocument.page(at: i), let pageText = page.string {
+                fullText += pageText + "\n"
+            }
+        }
+
+        guard !fullText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return "No text found in PDF"
+        }
+
+        // PDFKit concatenates table columns without separators.
+        // Split concatenated amounts: "395.0012,345.00" → "395.00\n12,345.00"
+        // Also handles currency symbol junctions: "395.00₹12,345.00" → "395.00\n₹12,345.00"
+        fullText = fullText
+            .replacingOccurrences(of: #"(\.\d{2})(\d)"#, with: "$1\n$2", options: .regularExpression)
+            .replacingOccurrences(of: #"(\.\d{2})([₹R])"#, with: "$1\n$2", options: .regularExpression)
+
+        let snapshot = PennyWiseSharedFacade.companion.shared.importStatementTextAndLoadHome(statementText: fullText)
+        if snapshot.lastImportParsed > 0 {
+            return "\(snapshot.lastImportImported) transactions imported, \(snapshot.lastImportSkipped) skipped"
+        } else if let error = snapshot.lastError {
+            return error
+        }
+        return "No transactions found in this statement"
+    }
+}

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -4,6 +4,23 @@
 <dict>
     <key>CFBundleDevelopmentRegion</key>
     <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>Bank Statement PDF</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSHandlerRank</key>
+            <string>Alternate</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>com.adobe.pdf</string>
+            </array>
+        </dict>
+    </array>
+    <key>LSSupportsOpeningDocumentsInPlace</key>
+    <true/>
     <key>CFBundleExecutable</key>
     <string>$(EXECUTABLE_NAME)</string>
     <key>CFBundleIdentifier</key>

--- a/iosApp/iosApp/Screens/Analytics/AnalyticsScreen.swift
+++ b/iosApp/iosApp/Screens/Analytics/AnalyticsScreen.swift
@@ -1,8 +1,10 @@
 import SwiftUI
+import Shared
 
 struct AnalyticsScreen: View {
     @ObservedObject private var currencyManager = CurrencyManager.shared
     @StateObject private var viewModel = AnalyticsViewModel()
+    @State private var drillDown: AnalyticsDrillDown?
 
     var body: some View {
         ScrollView {
@@ -32,14 +34,25 @@ struct AnalyticsScreen: View {
                         CategoryPieChart(categories: viewModel.categoryBreakdown)
                     }
 
-                    // Category breakdown list
+                    // Category breakdown list — rows drill through to their
+                    // transactions, like Android's breakdowns.
                     if !viewModel.categoryBreakdown.isEmpty {
-                        CategoryBreakdownList(categories: viewModel.categoryBreakdown)
+                        CategoryBreakdownList(categories: viewModel.categoryBreakdown) { item in
+                            drillDown = AnalyticsDrillDown(
+                                title: item.name,
+                                transactions: viewModel.transactions(inCategory: item.name)
+                            )
+                        }
                     }
 
                     // Top merchants
                     if !viewModel.merchantRanking.isEmpty {
-                        TopMerchantsList(merchants: viewModel.merchantRanking)
+                        TopMerchantsList(merchants: viewModel.merchantRanking) { item in
+                            drillDown = AnalyticsDrillDown(
+                                title: item.name,
+                                transactions: viewModel.transactions(forMerchant: item.name)
+                            )
+                        }
                     }
                 }
             }
@@ -49,6 +62,9 @@ struct AnalyticsScreen: View {
         .navigationTitle("Analytics")
         .onAppear {
             viewModel.loadAnalytics()
+        }
+        .sheet(item: $drillDown) { drill in
+            AnalyticsDrillDownSheet(drill: drill)
         }
     }
 
@@ -124,5 +140,56 @@ struct AnalyticsScreen: View {
         }
         .frame(maxWidth: .infinity, minHeight: 300)
         .padding(AppSpacing.lg)
+    }
+}
+
+// MARK: - Drill-down (Android-parity: breakdown rows open their transactions)
+
+struct AnalyticsDrillDown: Identifiable {
+    let id = UUID()
+    let title: String
+    let transactions: [SharedRecentTransactionItem]
+}
+
+struct AnalyticsDrillDownSheet: View {
+    let drill: AnalyticsDrillDown
+    @State private var selectedDetail: SharedRecentTransactionItem?
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List(drill.transactions) { item in
+                Button {
+                    selectedDetail = item
+                } label: {
+                    HStack(spacing: AppSpacing.sm) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(item.merchantName)
+                                .font(AppTypography.body)
+                                .foregroundStyle(.primary)
+                                .lineLimit(1)
+                            Text(Date(epochMillis: item.occurredAtEpochMillis), style: .date)
+                                .font(AppTypography.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Text(AmountFormatter.format(minorUnits: item.amountMinor, currency: item.currency))
+                            .font(AppTypography.amountSmall)
+                            .foregroundStyle(item.transactionType == "INCOME" ? .green : .primary)
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+            .navigationTitle(drill.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .sheet(item: $selectedDetail) { item in
+                TransactionDetailSheet(item: item)
+            }
+        }
     }
 }

--- a/iosApp/iosApp/Screens/Analytics/AnalyticsSummaryCard.swift
+++ b/iosApp/iosApp/Screens/Analytics/AnalyticsSummaryCard.swift
@@ -1,57 +1,82 @@
 import SwiftUI
 
+/// Android-parity summary: spending hero with a trend-vs-previous-period
+/// badge, then Income / Expenses / Net, then the secondary stats row.
 struct AnalyticsSummaryCard: View {
     @ObservedObject private var currencyManager = CurrencyManager.shared
     let summary: AnalyticsSummaryData
     @Environment(\.isAmoledActive) private var isAmoled
 
+    private var currency: String { currencyManager.displayCurrency }
+
     var body: some View {
         VStack(alignment: .leading, spacing: AppSpacing.md) {
-            // Total spending
+            // Spending hero + trend vs previous period
             VStack(alignment: .leading, spacing: AppSpacing.xs) {
-                Text("TOTAL SPENDING")
+                Text("SPENT THIS PERIOD")
                     .font(AppTypography.caption2)
                     .foregroundStyle(.secondary)
                     .tracking(1)
 
-                Text(AmountFormatter.format(minorUnits: summary.totalSpendingMinor, currency: CurrencyManager.shared.displayCurrency))
-                    .font(AppTypography.amountLarge)
-                    .foregroundStyle(.primary)
+                HStack(alignment: .firstTextBaseline, spacing: AppSpacing.sm) {
+                    Text(AmountFormatter.format(minorUnits: summary.totalSpendingMinor, currency: currency))
+                        .font(AppTypography.amountLarge)
+                        .foregroundStyle(.primary)
+
+                    if let trend = summary.spendingTrendPct {
+                        trendBadge(trend)
+                    }
+                }
+            }
+
+            Divider()
+
+            // Income / Expenses / Net — mirrors the Android summary row.
+            HStack(spacing: AppSpacing.lg) {
+                summaryColumn(
+                    label: "INCOME",
+                    amountMinor: summary.incomeMinor,
+                    tint: .green
+                )
+                Spacer()
+                summaryColumn(
+                    label: "EXPENSES",
+                    amountMinor: summary.totalSpendingMinor,
+                    tint: .red
+                )
+                Spacer()
+                summaryColumn(
+                    label: "NET",
+                    amountMinor: summary.netMinor,
+                    tint: summary.netMinor >= 0 ? .green : .red
+                )
             }
 
             Divider()
 
             HStack(spacing: AppSpacing.lg) {
-                // Transaction count
                 VStack(alignment: .leading, spacing: AppSpacing.xs) {
                     Text("TRANSACTIONS")
                         .font(AppTypography.caption2)
                         .foregroundStyle(.secondary)
                         .tracking(1)
-                    HStack(spacing: AppSpacing.xs) {
-                        Image(systemName: "list.bullet.rectangle")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Text("\(summary.transactionCount)")
-                            .font(AppTypography.amountMedium)
-                    }
-                }
-
-                Spacer()
-
-                // Daily average
-                VStack(alignment: .leading, spacing: AppSpacing.xs) {
-                    Text("DAILY AVG")
-                        .font(AppTypography.caption2)
-                        .foregroundStyle(.secondary)
-                        .tracking(1)
-                    Text(AmountFormatter.format(minorUnits: summary.dailyAverageMinor, currency: CurrencyManager.shared.displayCurrency))
+                    Text("\(summary.transactionCount)")
                         .font(AppTypography.amountMedium)
                 }
 
                 Spacer()
 
-                // Top category
+                VStack(alignment: .leading, spacing: AppSpacing.xs) {
+                    Text("DAILY AVG")
+                        .font(AppTypography.caption2)
+                        .foregroundStyle(.secondary)
+                        .tracking(1)
+                    Text(AmountFormatter.format(minorUnits: summary.dailyAverageMinor, currency: currency))
+                        .font(AppTypography.amountMedium)
+                }
+
+                Spacer()
+
                 if let topCategory = summary.topCategoryName {
                     VStack(alignment: .trailing, spacing: AppSpacing.xs) {
                         Text("TOP CATEGORY")
@@ -74,5 +99,36 @@ struct AnalyticsSummaryCard: View {
         .padding(AppSpacing.md)
         .background(AppColors.secondaryGroupedBackground(isAmoled: isAmoled))
         .clipShape(RoundedRectangle(cornerRadius: AppCornerRadius.medium))
+    }
+
+    private func summaryColumn(label: String, amountMinor: Int64, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: AppSpacing.xs) {
+            Text(label)
+                .font(AppTypography.caption2)
+                .foregroundStyle(.secondary)
+                .tracking(1)
+            Text(AmountFormatter.format(minorUnits: amountMinor, currency: currency))
+                .font(AppTypography.amountMedium)
+                .foregroundStyle(tint)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+    }
+
+    /// "↑ 12%" in red for more spending, "↓ 8%" in green for less.
+    private func trendBadge(_ pct: Int) -> some View {
+        let up = pct >= 0
+        return HStack(spacing: 2) {
+            Image(systemName: up ? "arrow.up.right" : "arrow.down.right")
+                .font(.caption2.bold())
+            Text("\(abs(pct))%")
+                .font(AppTypography.caption)
+                .fontWeight(.semibold)
+        }
+        .foregroundStyle(up ? .red : .green)
+        .padding(.horizontal, AppSpacing.sm)
+        .padding(.vertical, 3)
+        .background(Capsule().fill((up ? Color.red : Color.green).opacity(0.12)))
+        .accessibilityLabel("\(abs(pct)) percent \(up ? "more" : "less") than the previous period")
     }
 }

--- a/iosApp/iosApp/Screens/Analytics/CategoryBreakdownList.swift
+++ b/iosApp/iosApp/Screens/Analytics/CategoryBreakdownList.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct CategoryBreakdownList: View {
     @ObservedObject private var currencyManager = CurrencyManager.shared
     let categories: [CategoryBreakdownItem]
+    /// Drill-through to the category's transactions (Android parity).
+    var onSelect: ((CategoryBreakdownItem) -> Void)? = nil
     @Environment(\.isAmoledActive) private var isAmoled
 
     var body: some View {
@@ -27,6 +29,15 @@ struct CategoryBreakdownList: View {
     }
 
     private func categoryRow(_ item: CategoryBreakdownItem) -> some View {
+        Button {
+            onSelect?(item)
+        } label: {
+            categoryRowContent(item)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func categoryRowContent(_ item: CategoryBreakdownItem) -> some View {
         HStack(spacing: AppSpacing.sm) {
             Circle()
                 .fill(AppColors.categoryColor(for: item.name))
@@ -50,7 +61,14 @@ struct CategoryBreakdownList: View {
                     .font(AppTypography.caption2)
                     .foregroundStyle(.secondary)
             }
+
+            if onSelect != nil {
+                Image(systemName: "chevron.right")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
         }
         .padding(.vertical, AppSpacing.xs)
+        .contentShape(Rectangle())
     }
 }

--- a/iosApp/iosApp/Screens/Analytics/TopMerchantsList.swift
+++ b/iosApp/iosApp/Screens/Analytics/TopMerchantsList.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct TopMerchantsList: View {
     @ObservedObject private var currencyManager = CurrencyManager.shared
     let merchants: [MerchantRankingItem]
+    /// Drill-through to the merchant's transactions (Android parity).
+    var onSelect: ((MerchantRankingItem) -> Void)? = nil
     @Environment(\.isAmoledActive) private var isAmoled
 
     var body: some View {
@@ -27,6 +29,15 @@ struct TopMerchantsList: View {
     }
 
     private func merchantRow(_ merchant: MerchantRankingItem, rank: Int) -> some View {
+        Button {
+            onSelect?(merchant)
+        } label: {
+            merchantRowContent(merchant, rank: rank)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func merchantRowContent(_ merchant: MerchantRankingItem, rank: Int) -> some View {
         HStack(spacing: AppSpacing.sm) {
             Text("\(rank)")
                 .font(AppTypography.caption)
@@ -46,7 +57,14 @@ struct TopMerchantsList: View {
 
             Text(AmountFormatter.format(minorUnits: merchant.totalMinor, currency: CurrencyManager.shared.displayCurrency))
                 .font(AppTypography.amountSmall)
+
+            if onSelect != nil {
+                Image(systemName: "chevron.right")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
         }
         .padding(.vertical, AppSpacing.xs)
+        .contentShape(Rectangle())
     }
 }

--- a/iosApp/iosApp/Screens/Home/HomeScreen.swift
+++ b/iosApp/iosApp/Screens/Home/HomeScreen.swift
@@ -13,6 +13,9 @@ struct HomeScreen: View {
     @State private var showAddTransaction = false
     @State private var selectedDetail: SharedRecentTransactionItem?
     @State private var appeared = false
+    @State private var fabExpanded = false
+    @State private var showImportPicker = false
+    @State private var importResult: String?
     @Environment(\.isAmoledActive) private var isAmoled
 
     var body: some View {
@@ -88,6 +91,26 @@ struct HomeScreen: View {
         }
         .sheet(item: $selectedDetail) { item in
             TransactionDetailSheet(item: item)
+        }
+        .fileImporter(
+            isPresented: $showImportPicker,
+            allowedContentTypes: [.pdf]
+        ) { result in
+            if case .success(let url) = result {
+                importResult = StatementImportService.importPDF(at: url)
+                viewModel.loadHome()
+            }
+        }
+        .alert(
+            "Statement Import",
+            isPresented: Binding(
+                get: { importResult != nil },
+                set: { if !$0 { importResult = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) { importResult = nil }
+        } message: {
+            Text(importResult ?? "")
         }
     }
 
@@ -191,17 +214,66 @@ struct HomeScreen: View {
 
     // MARK: - Floating Add Button
 
+    /// Android-style speed dial: + expands into labeled actions instead of
+    /// jumping straight to one form, so statement import is one tap away.
     private var addButton: some View {
-        Button {
-            showAddTransaction = true
-        } label: {
-            Image(systemName: "plus")
-                .font(.title2.bold())
-                .foregroundStyle(.white)
-                .frame(width: 56, height: 56)
-                .background(Circle().fill(.blue))
-                .shadow(color: .blue.opacity(0.3), radius: 8, x: 0, y: 4)
+        VStack(alignment: .trailing, spacing: AppSpacing.md) {
+            if fabExpanded {
+                fabAction(
+                    label: "Import Statement",
+                    systemImage: "doc.text.fill"
+                ) {
+                    showImportPicker = true
+                }
+                fabAction(
+                    label: "Add Transaction",
+                    systemImage: "square.and.pencil"
+                ) {
+                    showAddTransaction = true
+                }
+            }
+
+            Button {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.75)) {
+                    fabExpanded.toggle()
+                }
+            } label: {
+                Image(systemName: "plus")
+                    .font(.title2.bold())
+                    .foregroundStyle(.white)
+                    .rotationEffect(.degrees(fabExpanded ? 45 : 0))
+                    .frame(width: 56, height: 56)
+                    .background(Circle().fill(.blue))
+                    .shadow(color: .blue.opacity(0.3), radius: 8, x: 0, y: 4)
+            }
         }
         .padding(AppSpacing.lg)
+    }
+
+    private func fabAction(
+        label: String,
+        systemImage: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.75)) {
+                fabExpanded = false
+            }
+            action()
+        } label: {
+            HStack(spacing: AppSpacing.sm) {
+                Text(label)
+                    .font(AppTypography.caption)
+                    .fontWeight(.semibold)
+                Image(systemName: systemImage)
+                    .font(.body)
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, AppSpacing.md)
+            .frame(height: 44)
+            .background(Capsule().fill(.blue))
+            .shadow(color: .blue.opacity(0.25), radius: 6, x: 0, y: 3)
+        }
+        .transition(.scale(scale: 0.6, anchor: .bottomTrailing).combined(with: .opacity))
     }
 }

--- a/iosApp/iosApp/Screens/Settings/SettingsScreen.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsScreen.swift
@@ -341,43 +341,6 @@ struct SettingsScreen: View {
     }
 
     private func importBankStatement(from url: URL) {
-        guard let pdfDocument = PDFDocument(url: url) else {
-            statementImportResult = "Could not open PDF file"
-            return
-        }
-
-        var fullText = ""
-        for i in 0..<pdfDocument.pageCount {
-            if let page = pdfDocument.page(at: i), let pageText = page.string {
-                fullText += pageText + "\n"
-            }
-        }
-
-        guard !fullText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            statementImportResult = "No text found in PDF"
-            return
-        }
-
-        // PDFKit concatenates table columns without separators.
-        // Split concatenated amounts: "395.0012,345.00" → "395.00\n12,345.00"
-        // Also handles currency symbol junctions: "395.00₹12,345.00" → "395.00\n₹12,345.00"
-        fullText = fullText
-            .replacingOccurrences(of: #"(\.\d{2})(\d)"#, with: "$1\n$2", options: .regularExpression)
-            .replacingOccurrences(of: #"(\.\d{2})([₹R])"#, with: "$1\n$2", options: .regularExpression)
-
-        #if DEBUG
-        print("[PDF Import] Extracted text length: \(fullText.count)")
-        print("[PDF Import] First 1000 chars:\n\(String(fullText.prefix(1000)))")
-        #endif
-
-        let facade = PennyWiseSharedFacade.companion.shared
-        let snapshot = facade.importStatementTextAndLoadHome(statementText: fullText)
-        if snapshot.lastImportParsed > 0 {
-            statementImportResult = "\(snapshot.lastImportImported) transactions imported, \(snapshot.lastImportSkipped) skipped"
-        } else if let error = snapshot.lastError {
-            statementImportResult = error
-        } else {
-            statementImportResult = "No transactions found in this statement"
-        }
+        statementImportResult = StatementImportService.importPDF(at: url)
     }
 }

--- a/iosApp/iosApp/Screens/Settings/SettingsScreen.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsScreen.swift
@@ -147,7 +147,7 @@ struct SettingsScreen: View {
                         VStack(alignment: .leading, spacing: AppSpacing.xs) {
                             Text("Import Bank Statement")
                                 .font(AppTypography.body)
-                            Text("Import GPay, PhonePe, or bank PDF")
+                            Text("Import GPay, PhonePe, or slice PDF")
                                 .font(AppTypography.caption)
                                 .foregroundStyle(.secondary)
                         }

--- a/iosApp/iosApp/Screens/Transactions/TransactionListView.swift
+++ b/iosApp/iosApp/Screens/Transactions/TransactionListView.swift
@@ -295,33 +295,18 @@ struct TransactionListView: View {
 
     // MARK: - Filter Bar
 
+    /// Android-parity filter header: ONE row of dropdown chips (period, type,
+    /// category), each opening an anchored menu with checkmarks — instead of
+    /// three stacked always-expanded chip rows. "Clear filters" lives in the
+    /// toolbar's sort menu, same as Android's overflow.
     @ViewBuilder
     private var filterBar: some View {
-        VStack(spacing: AppSpacing.sm) {
-            // Date period filter chips
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: AppSpacing.sm) {
-                    // Clear All chip
-                    if hasActiveFilters {
-                        FilterChipView(
-                            label: "Clear All",
-                            icon: "xmark.circle",
-                            isSelected: false
-                        ) {
-                            let generator = UIImpactFeedbackGenerator(style: .medium)
-                            generator.impactOccurred()
-                            clearAllFilters()
-                        }
-                    }
-
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: AppSpacing.sm) {
+                // Period — always highlighted, like Android's calendar chip.
+                Menu {
                     ForEach(DatePeriodFilter.allCases, id: \.self) { period in
-                        FilterChipView(
-                            label: period == .custom && selectedDatePeriod == .custom
-                                ? customDateLabel
-                                : period.rawValue,
-                            icon: period.icon,
-                            isSelected: selectedDatePeriod == period
-                        ) {
+                        Button {
                             let generator = UIImpactFeedbackGenerator(style: .light)
                             generator.impactOccurred()
                             if period == .custom {
@@ -329,58 +314,83 @@ struct TransactionListView: View {
                             } else {
                                 selectedDatePeriod = period
                             }
-                        }
-                    }
-                }
-                .padding(.horizontal, AppSpacing.md)
-            }
-
-            // Type filter chips
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: AppSpacing.sm) {
-                    ForEach(TransactionTypeFilter.allCases, id: \.self) { filter in
-                        FilterChipView(
-                            label: filter.displayName,
-                            icon: filter == .all ? nil : filter.icon,
-                            isSelected: selectedTypeFilter == filter
-                        ) {
-                            let generator = UIImpactFeedbackGenerator(style: .light)
-                            generator.impactOccurred()
-                            selectedTypeFilter = filter
-                        }
-                    }
-                }
-                .padding(.horizontal, AppSpacing.md)
-            }
-
-            // Category filter chips
-            if !categories.isEmpty {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: AppSpacing.sm) {
-                        FilterChipView(
-                            label: "All Categories",
-                            isSelected: selectedCategory == nil
-                        ) {
-                            let generator = UIImpactFeedbackGenerator(style: .light)
-                            generator.impactOccurred()
-                            selectedCategory = nil
-                        }
-
-                        ForEach(categories, id: \.self) { category in
-                            FilterChipView(
-                                label: category,
-                                dotColor: AppColors.categoryColor(for: category),
-                                isSelected: selectedCategory == category
-                            ) {
-                                let generator = UIImpactFeedbackGenerator(style: .light)
-                                generator.impactOccurred()
-                                selectedCategory = category
+                        } label: {
+                            if selectedDatePeriod == period {
+                                Label(period.rawValue, systemImage: "checkmark")
+                            } else {
+                                Text(period.rawValue)
                             }
                         }
                     }
-                    .padding(.horizontal, AppSpacing.md)
+                } label: {
+                    FilterMenuChipLabel(
+                        label: selectedDatePeriod == .custom ? customDateLabel : selectedDatePeriod.rawValue,
+                        icon: "calendar",
+                        isActive: true
+                    )
+                }
+
+                // Type — highlighted only when narrowed.
+                Menu {
+                    ForEach(TransactionTypeFilter.allCases, id: \.self) { filter in
+                        Button {
+                            let generator = UIImpactFeedbackGenerator(style: .light)
+                            generator.impactOccurred()
+                            selectedTypeFilter = filter
+                        } label: {
+                            if selectedTypeFilter == filter {
+                                Label(filter.displayName, systemImage: "checkmark")
+                            } else {
+                                Label(filter.displayName, systemImage: filter.icon)
+                            }
+                        }
+                    }
+                } label: {
+                    FilterMenuChipLabel(
+                        label: selectedTypeFilter == .all ? "Type" : selectedTypeFilter.displayName,
+                        icon: selectedTypeFilter == .all ? "line.3.horizontal.decrease" : selectedTypeFilter.icon,
+                        isActive: selectedTypeFilter != .all
+                    )
+                }
+
+                // Category — Android's "more filters" chip, minus profiles
+                // (iOS has none yet).
+                if !categories.isEmpty || selectedCategory != nil {
+                    Menu {
+                        Button {
+                            selectedCategory = nil
+                        } label: {
+                            if selectedCategory == nil {
+                                Label("All Categories", systemImage: "checkmark")
+                            } else {
+                                Text("All Categories")
+                            }
+                        }
+                        Divider()
+                        ForEach(categories, id: \.self) { category in
+                            Button {
+                                let generator = UIImpactFeedbackGenerator(style: .light)
+                                generator.impactOccurred()
+                                selectedCategory = category
+                            } label: {
+                                if selectedCategory == category {
+                                    Label(category, systemImage: "checkmark")
+                                } else {
+                                    Text(category)
+                                }
+                            }
+                        }
+                    } label: {
+                        FilterMenuChipLabel(
+                            label: selectedCategory ?? "Category",
+                            dotColor: selectedCategory.map { AppColors.categoryColor(for: $0) },
+                            icon: selectedCategory == nil ? "slider.horizontal.3" : nil,
+                            isActive: selectedCategory != nil
+                        )
+                    }
                 }
             }
+            .padding(.horizontal, AppSpacing.md)
         }
         .padding(.vertical, AppSpacing.sm)
     }
@@ -538,6 +548,17 @@ struct TransactionListView: View {
                     }
                 }
             }
+            // Android keeps "Clear filters" in this same overflow.
+            if hasActiveFilters {
+                Divider()
+                Button(role: .destructive) {
+                    let generator = UIImpactFeedbackGenerator(style: .medium)
+                    generator.impactOccurred()
+                    clearAllFilters()
+                } label: {
+                    Label("Clear filters", systemImage: "xmark.circle")
+                }
+            }
         } label: {
             Image(systemName: "arrow.up.arrow.down")
         }
@@ -568,43 +589,45 @@ private struct SectionHeaderView: View {
     }
 }
 
-// MARK: - Filter Chip
+// MARK: - Filter Chip (dropdown style, Android parity)
 
-private struct FilterChipView: View {
+/// The label half of a filter dropdown chip: current selection + a chevron so
+/// it reads as a menu, highlighted while its filter is narrowing the list.
+private struct FilterMenuChipLabel: View {
     let label: String
-    var icon: String? = nil
     var dotColor: Color? = nil
-    let isSelected: Bool
-    let action: () -> Void
+    var icon: String? = nil
+    let isActive: Bool
     @Environment(\.isAmoledActive) private var isAmoled
 
     var body: some View {
-        Button(action: action) {
-            HStack(spacing: AppSpacing.xs) {
-                if let dotColor {
-                    Circle()
-                        .fill(dotColor)
-                        .frame(width: 8, height: 8)
-                }
-                if let icon {
-                    Image(systemName: icon)
-                        .font(.caption2)
-                }
-                Text(label)
-                    .font(AppTypography.caption)
+        HStack(spacing: AppSpacing.xs) {
+            if let dotColor {
+                Circle()
+                    .fill(dotColor)
+                    .frame(width: 8, height: 8)
             }
-            .padding(.horizontal, AppSpacing.md)
-            .padding(.vertical, 6)
-            .background(isSelected ? Color.accentColor : AppColors.surface(isAmoled: isAmoled))
-            .foregroundStyle(isSelected ? .white : .primary)
-            .clipShape(Capsule())
-            .overlay(
-                Capsule()
-                    .strokeBorder(isSelected ? Color.accentColor : Color.clear, lineWidth: 1.5)
-            )
+            if let icon {
+                Image(systemName: icon)
+                    .font(.caption2)
+            }
+            Text(label)
+                .font(AppTypography.caption)
+                .lineLimit(1)
+            Image(systemName: "chevron.down")
+                .font(.system(size: 9, weight: .semibold))
+                .opacity(0.75)
         }
-        .buttonStyle(.plain)
-        .animation(.easeInOut(duration: 0.2), value: isSelected)
+        .padding(.horizontal, AppSpacing.md)
+        .padding(.vertical, 6)
+        .background(isActive ? Color.accentColor : AppColors.surface(isAmoled: isAmoled))
+        .foregroundStyle(isActive ? .white : .primary)
+        .clipShape(Capsule())
+        .overlay(
+            Capsule()
+                .strokeBorder(isActive ? Color.accentColor : Color(.separator).opacity(0.5), lineWidth: 1)
+        )
+        .animation(.easeInOut(duration: 0.2), value: isActive)
     }
 }
 

--- a/iosApp/iosApp/ViewModels/AnalyticsViewModel.swift
+++ b/iosApp/iosApp/ViewModels/AnalyticsViewModel.swift
@@ -76,11 +76,19 @@ struct MerchantRankingItem: Identifiable {
 }
 
 struct AnalyticsSummaryData {
+    /// EXPENSE transactions only — transfers/investments never count as spend.
     let totalSpendingMinor: Int64
+    /// INCOME transactions only.
+    let incomeMinor: Int64
+    let netMinor: Int64
     let transactionCount: Int
     let dailyAverageMinor: Int64
     let topCategoryName: String?
     let topCategoryIcon: String?
+    /// Spending change vs the equal-length window immediately before this
+    /// period (Android's "vs previous period" badge). Nil when there is no
+    /// baseline (All Time, or an empty previous window).
+    let spendingTrendPct: Int?
 }
 
 class AnalyticsViewModel: ObservableObject {
@@ -91,12 +99,16 @@ class AnalyticsViewModel: ObservableObject {
     @Published var isLoading = false
 
     @Published var summary = AnalyticsSummaryData(
-        totalSpendingMinor: 0, transactionCount: 0,
-        dailyAverageMinor: 0, topCategoryName: nil, topCategoryIcon: nil
+        totalSpendingMinor: 0, incomeMinor: 0, netMinor: 0, transactionCount: 0,
+        dailyAverageMinor: 0, topCategoryName: nil, topCategoryIcon: nil,
+        spendingTrendPct: nil
     )
     @Published var categoryBreakdown: [CategoryBreakdownItem] = []
     @Published var dailySpending: [DailySpendingItem] = []
     @Published var merchantRanking: [MerchantRankingItem] = []
+    /// The period's transactions after the type-filter chip — kept so category
+    /// and merchant rows can drill through to their underlying transactions.
+    @Published var periodTransactions: [SharedRecentTransactionItem] = []
 
     func loadAnalytics() {
         isLoading = true
@@ -104,14 +116,52 @@ class AnalyticsViewModel: ObservableObject {
         let startMs = range.start.epochMillis
         let endMs = range.end.epochMillis
 
-        let transactions = facade.getTransactionsForPeriod(
-            startDateMs: startMs,
-            endDateMs: endMs,
-            type: selectedTypeFilter.transactionTypeFilter
+        // One unfiltered fetch: the summary always needs both sides
+        // (income vs spend), the lists then apply the chip in memory.
+        let all = facade.getTransactionsForPeriod(
+            startDateMs: startMs, endDateMs: endMs, type: nil
         )
+        let filtered: [SharedRecentTransactionItem]
+        if let typeFilter = selectedTypeFilter.transactionTypeFilter {
+            filtered = all.filter { $0.transactionType == typeFilter }
+        } else {
+            filtered = all
+        }
+        periodTransactions = filtered
 
-        computeAnalytics(transactions: transactions, startDate: range.start, endDate: range.end)
+        let previousSpendMinor = previousWindowSpend(range: range)
+        computeAnalytics(
+            all: all,
+            filtered: filtered,
+            startDate: range.start,
+            endDate: range.end,
+            previousSpendMinor: previousSpendMinor
+        )
         isLoading = false
+    }
+
+    /// EXPENSE total of the equal-length window immediately before [range];
+    /// nil when the period has no meaningful baseline.
+    private func previousWindowSpend(range: (start: Date, end: Date)) -> Int64? {
+        guard selectedPeriod != .allTime else { return nil }
+        let length = range.end.timeIntervalSince(range.start)
+        let prevStart = range.start.addingTimeInterval(-length)
+        let prevEnd = range.start.addingTimeInterval(-1)
+        let previous = facade.getTransactionsForPeriod(
+            startDateMs: prevStart.epochMillis,
+            endDateMs: prevEnd.epochMillis,
+            type: "EXPENSE"
+        )
+        guard !previous.isEmpty else { return nil }
+        return previous.reduce(Int64(0)) { $0 + $1.amountMinor }
+    }
+
+    func transactions(inCategory category: String) -> [SharedRecentTransactionItem] {
+        periodTransactions.filter { ($0.category.isEmpty ? "Others" : $0.category) == category }
+    }
+
+    func transactions(forMerchant merchant: String) -> [SharedRecentTransactionItem] {
+        periodTransactions.filter { $0.merchantName == merchant }
     }
 
     func selectPeriod(_ period: AnalyticsPeriod) {
@@ -125,18 +175,30 @@ class AnalyticsViewModel: ObservableObject {
     }
 
     private func computeAnalytics(
-        transactions: [SharedRecentTransactionItem],
+        all: [SharedRecentTransactionItem],
+        filtered transactions: [SharedRecentTransactionItem],
         startDate: Date,
-        endDate: Date
+        endDate: Date,
+        previousSpendMinor: Int64?
     ) {
-        let totalMinor = transactions.reduce(Int64(0)) { $0 + $1.amountMinor }
+        // Summary is always honest regardless of the chip: spend = EXPENSE,
+        // income = INCOME — transfers and investments are neither.
+        let spendMinor = all.filter { $0.transactionType == "EXPENSE" }
+            .reduce(Int64(0)) { $0 + $1.amountMinor }
+        let incomeMinor = all.filter { $0.transactionType == "INCOME" }
+            .reduce(Int64(0)) { $0 + $1.amountMinor }
         let count = transactions.count
 
         let calendar = Calendar.current
         let daysBetween = max(1, calendar.dateComponents([.day], from: startDate, to: endDate).day ?? 1)
-        let dailyAvg = count > 0 ? totalMinor / Int64(daysBetween) : 0
+        let dailyAvg = spendMinor > 0 ? spendMinor / Int64(daysBetween) : 0
 
-        // Category breakdown
+        let trendPct: Int? = previousSpendMinor.flatMap { prev in
+            guard prev > 0 else { return nil }
+            return Int((Double(spendMinor - prev) / Double(prev) * 100.0).rounded())
+        }
+
+        // Category breakdown (follows the chip selection)
         var categoryTotals: [String: (total: Int64, count: Int)] = [:]
         for txn in transactions {
             let cat = txn.category.isEmpty ? "Others" : txn.category
@@ -144,8 +206,9 @@ class AnalyticsViewModel: ObservableObject {
             categoryTotals[cat] = (total: existing.total + txn.amountMinor, count: existing.count + 1)
         }
 
+        let filteredTotal = transactions.reduce(Int64(0)) { $0 + $1.amountMinor }
         let sortedCategories = categoryTotals.sorted { $0.value.total > $1.value.total }
-        let totalForPercentage = max(totalMinor, 1)
+        let totalForPercentage = max(filteredTotal, 1)
         categoryBreakdown = sortedCategories.map { entry in
             CategoryBreakdownItem(
                 name: entry.key,
@@ -158,11 +221,14 @@ class AnalyticsViewModel: ObservableObject {
 
         let topCategory = sortedCategories.first
         summary = AnalyticsSummaryData(
-            totalSpendingMinor: totalMinor,
+            totalSpendingMinor: spendMinor,
+            incomeMinor: incomeMinor,
+            netMinor: incomeMinor - spendMinor,
             transactionCount: count,
             dailyAverageMinor: dailyAvg,
             topCategoryName: topCategory?.key,
-            topCategoryIcon: nil
+            topCategoryIcon: nil,
+            spendingTrendPct: trendPct
         )
 
         // Daily spending

--- a/iosApp/iosApp/ViewModels/OnboardingViewModel.swift
+++ b/iosApp/iosApp/ViewModels/OnboardingViewModel.swift
@@ -1,57 +1,14 @@
 import Foundation
-import PDFKit
-import Shared
 
 class OnboardingViewModel: ObservableObject {
     @Published var currentStep = 0
     @Published var importResult: String?
     @Published var isImporting = false
 
-    private let facade = PennyWiseSharedFacade.companion.shared
-
     func importPDF(url: URL) {
         isImporting = true
         importResult = nil
-
-        guard let pdfDocument = PDFDocument(url: url) else {
-            importResult = "Could not open PDF file"
-            isImporting = false
-            return
-        }
-
-        var fullText = ""
-        for i in 0..<pdfDocument.pageCount {
-            if let page = pdfDocument.page(at: i), let pageText = page.string {
-                fullText += pageText + "\n"
-            }
-        }
-
-        guard !fullText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            importResult = "No text found in PDF"
-            isImporting = false
-            return
-        }
-
-        // PDFKit concatenates table columns without separators.
-        // Split concatenated amounts: "395.0012,345.00" → "395.00\n12,345.00"
-        // Also handles currency symbol junctions: "395.00₹12,345.00" → "395.00\n₹12,345.00"
-        fullText = fullText
-            .replacingOccurrences(of: #"(\.\d{2})(\d)"#, with: "$1\n$2", options: .regularExpression)
-            .replacingOccurrences(of: #"(\.\d{2})([₹R])"#, with: "$1\n$2", options: .regularExpression)
-
-        #if DEBUG
-        print("[PDF Import] Extracted text length: \(fullText.count)")
-        print("[PDF Import] First 1000 chars:\n\(String(fullText.prefix(1000)))")
-        #endif
-
-        let snapshot = facade.importStatementTextAndLoadHome(statementText: fullText)
-        if snapshot.lastImportParsed > 0 {
-            importResult = "\(snapshot.lastImportImported) transactions imported, \(snapshot.lastImportSkipped) skipped"
-        } else if let error = snapshot.lastError {
-            importResult = error
-        } else {
-            importResult = "No transactions found in this statement"
-        }
+        importResult = StatementImportService.importPDF(at: url)
         isImporting = false
     }
 

--- a/iosApp/iosApp/iosAppApp.swift
+++ b/iosApp/iosApp/iosAppApp.swift
@@ -2,9 +2,28 @@ import SwiftUI
 
 @main
 struct iosAppApp: App {
+    // Result of a PDF handed to the app from outside (Files/Mail/WhatsApp
+    // "Open in PennyWise") — the quickest way to import a bank statement.
+    @State private var externalImportResult: String?
+
     var body: some Scene {
         WindowGroup {
             MainTabView()
+                .onOpenURL { url in
+                    guard url.isFileURL, url.pathExtension.lowercased() == "pdf" else { return }
+                    externalImportResult = StatementImportService.importPDF(at: url)
+                }
+                .alert(
+                    "Statement Import",
+                    isPresented: Binding(
+                        get: { externalImportResult != nil },
+                        set: { if !$0 { externalImportResult = nil } }
+                    )
+                ) {
+                    Button("OK", role: .cancel) { externalImportResult = nil }
+                } message: {
+                    Text(externalImportResult ?? "")
+                }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/pennywiseai/shared/data/statement/PhonePeSharedStatementParser.kt
+++ b/shared/src/commonMain/kotlin/com/pennywiseai/shared/data/statement/PhonePeSharedStatementParser.kt
@@ -22,12 +22,6 @@ class PhonePeSharedStatementParser : SharedStatementParser {
         private val accountPattern = Regex("""(?:Paid\s+by|Received\s+by)\s+X+(\d{4})""", RegexOption.IGNORE_CASE)
         // Max reasonable transaction amount: ₹1 crore = 10,000,000.00 = 1_000_000_000 paise
         private const val MAX_AMOUNT_MINOR = 1_000_000_000L
-
-        private val MONTH_MAP = mapOf(
-            "jan" to 1, "feb" to 2, "mar" to 3, "apr" to 4,
-            "may" to 5, "jun" to 6, "jul" to 7, "aug" to 8,
-            "sep" to 9, "oct" to 10, "nov" to 11, "dec" to 12
-        )
     }
 
     override fun canHandle(text: String): Boolean {
@@ -131,7 +125,7 @@ class PhonePeSharedStatementParser : SharedStatementParser {
         val day: Int
         val year: Int
 
-        val firstAsMonth = MONTH_MAP[parts[0].lowercase()]
+        val firstAsMonth = STATEMENT_MONTHS[parts[0].lowercase()]
         if (firstAsMonth != null) {
             // "Mar 02 2026"
             month = firstAsMonth
@@ -140,7 +134,7 @@ class PhonePeSharedStatementParser : SharedStatementParser {
         } else {
             // "02 Mar 2026"
             day = parts[0].toIntOrNull() ?: return null
-            month = MONTH_MAP[parts[1].lowercase()] ?: return null
+            month = STATEMENT_MONTHS[parts[1].lowercase()] ?: return null
             year = parts[2].toIntOrNull() ?: return null
         }
 
@@ -161,19 +155,6 @@ class PhonePeSharedStatementParser : SharedStatementParser {
         }
 
         // Convert to epoch millis (UTC-based, IST = UTC+5:30)
-        return dateToEpochMillis(year, month, day, hour, minute)
-    }
-
-    private fun dateToEpochMillis(year: Int, month: Int, day: Int, hour: Int, minute: Int): Long {
-        // Days from Unix epoch (1970-01-01) to the given date
-        // Using a simple algorithm to compute days since epoch
-        val y = if (month <= 2) year - 1 else year
-        val m = if (month <= 2) month + 9 else month - 3
-        val daysSinceEpoch = 365L * y + y / 4 - y / 100 + y / 400 + (m * 306 + 5) / 10 + (day - 1) - 719468L
-
-        val timeMillis = (hour * 3600L + minute * 60L) * 1000L
-        val istOffsetMillis = 5 * 3600_000L + 30 * 60_000L // IST = UTC+5:30
-
-        return daysSinceEpoch * 86_400_000L + timeMillis - istOffsetMillis
+        return istDateToEpochMillis(year, month, day, hour, minute)
     }
 }

--- a/shared/src/commonMain/kotlin/com/pennywiseai/shared/data/statement/SharedParserUtils.kt
+++ b/shared/src/commonMain/kotlin/com/pennywiseai/shared/data/statement/SharedParserUtils.kt
@@ -16,3 +16,23 @@ internal fun amountToMinor(amount: String): Long? {
 }
 
 internal fun fallbackTimestamp(): Long = currentTimeMillis()
+
+/**
+ * Epoch millis for a civil date/time in IST (statements are Indian bank
+ * documents). Days-from-civil per Howard Hinnant's algorithm — commonMain has
+ * no java.time. Shared by the PhonePe and Slice parsers.
+ */
+internal fun istDateToEpochMillis(year: Int, month: Int, day: Int, hour: Int = 12, minute: Int = 0): Long {
+    val y = if (month <= 2) year - 1 else year
+    val m = if (month <= 2) month + 9 else month - 3
+    val daysSinceEpoch = 365L * y + y / 4 - y / 100 + y / 400 + (m * 306 + 5) / 10 + (day - 1) - 719468L
+    val timeMillis = (hour * 3600L + minute * 60L) * 1000L
+    val istOffsetMillis = 5 * 3600_000L + 30 * 60_000L // IST = UTC+5:30
+    return daysSinceEpoch * 86_400_000L + timeMillis - istOffsetMillis
+}
+
+internal val STATEMENT_MONTHS = mapOf(
+    "jan" to 1, "feb" to 2, "mar" to 3, "apr" to 4,
+    "may" to 5, "jun" to 6, "jul" to 7, "aug" to 8,
+    "sep" to 9, "oct" to 10, "nov" to 11, "dec" to 12
+)

--- a/shared/src/commonMain/kotlin/com/pennywiseai/shared/data/statement/SharedStatementParserFactory.kt
+++ b/shared/src/commonMain/kotlin/com/pennywiseai/shared/data/statement/SharedStatementParserFactory.kt
@@ -3,7 +3,8 @@ package com.pennywiseai.shared.data.statement
 object SharedStatementParserFactory {
     private val parsers: List<SharedStatementParser> = listOf(
         GPaySharedStatementParser(),
-        PhonePeSharedStatementParser()
+        PhonePeSharedStatementParser(),
+        SliceSharedStatementParser()
     )
 
     fun getParser(text: String): SharedStatementParser? = parsers.firstOrNull { it.canHandle(text) }

--- a/shared/src/commonMain/kotlin/com/pennywiseai/shared/data/statement/SliceSharedStatementParser.kt
+++ b/shared/src/commonMain/kotlin/com/pennywiseai/shared/data/statement/SliceSharedStatementParser.kt
@@ -1,0 +1,179 @@
+package com.pennywiseai.shared.data.statement
+
+import com.pennywiseai.shared.data.model.SharedTransactionType
+
+/**
+ * Parses slice small finance bank account statements.
+ *
+ * Statement shape after PDFKit text extraction (all values below are
+ * illustrative, not from any real statement):
+ * ```
+ * DATE DETAILS REF NO. AMOUNT BALANCE
+ * 01 Jan '26 Interest Cr. for 31-Dec-2025 111122223333 ₹1.23 ₹10,001.23
+ * 01 Jan '26 UPI-Debit-999900001111-SOME MERCHANT
+ * NAME-ABCD0EFGH11-somevpa@bank-Paid Via ...
+ * 2026010112345678 -₹500 ₹9,501.23
+ * ```
+ * A transaction starts with a `dd MMM 'yy` date. Short rows carry the
+ * ref/amount/balance tail on the same line; UPI rows wrap the details over
+ * several lines and put the tail on its own line, so lines are accumulated
+ * until the tail appears.
+ *
+ * Slice-specific semantics: "atom" rows (pots), "Auto save" and "Round ups"
+ * move money between the user's own slice balances — they are TRANSFERs, not
+ * income/spending, so they never touch the Income/Expenses totals.
+ */
+class SliceSharedStatementParser : SharedStatementParser {
+    companion object {
+        private val markers = listOf("slice small finance bank", "help@slice.bank.in")
+
+        private val txnStartPattern =
+            Regex("""^(\d{1,2}) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) '(\d{2})(?:\s|$)""")
+
+        // "<ref digits> [-]₹amount ₹balance" at the end of an accumulated block.
+        private val tailPattern =
+            Regex("""(\d{6,})\s+(-?)₹([\d,]+(?:\.\d{1,2})?)(?!\d)\s+₹([\d,]+(?:\.\d{1,2})?)(?!\d)\s*$""")
+
+        private val accountNumberPattern = Regex("""A/C number\s+(\d{6,})""")
+
+        // IFSC-shaped token inside a UPI descriptor (AAAA0XXXXXX).
+        private val ifscPattern = Regex("""^[A-Z]{4}0[A-Z0-9]{6}$""")
+
+        // The summary row above the table also carries ₹ figures; real rows are
+        // only read after this header.
+        private const val TABLE_HEADER = "DATE DETAILS REF NO. AMOUNT BALANCE"
+        private const val FOOTER_PREFIX = "Generated on"
+
+        private const val BANK_NAME = "slice"
+        // ₹1 crore in paise, same sanity bound as the other statement parsers.
+        private const val MAX_AMOUNT_MINOR = 1_000_000_000L
+    }
+
+    override fun canHandle(text: String): Boolean {
+        val lower = text.lowercase()
+        return markers.any { it in lower }
+    }
+
+    override fun parse(text: String): List<SharedParsedStatementTransaction> {
+        val accountLast4 = accountNumberPattern.find(text)
+            ?.groupValues?.getOrNull(1)?.takeLast(4)
+
+        val lines = text.lines()
+        val headerIndex = lines.indexOfFirst { it.trim() == TABLE_HEADER }
+        if (headerIndex == -1) return emptyList()
+
+        val results = mutableListOf<SharedParsedStatementTransaction>()
+        var block: StringBuilder? = null
+
+        fun tryFinalize() {
+            val current = block?.toString()?.trim() ?: return
+            parseBlock(current, accountLast4)?.let {
+                results.add(it)
+                block = null
+            }
+        }
+
+        for (line in lines.drop(headerIndex + 1)) {
+            val trimmed = line.trim()
+            if (trimmed.isEmpty()) continue
+            if (trimmed.startsWith(FOOTER_PREFIX)) break
+
+            if (txnStartPattern.containsMatchIn(trimmed)) {
+                // A new date row while a block is still open means the open
+                // block never got its amount tail — drop it rather than guess.
+                block = StringBuilder(trimmed)
+            } else {
+                block?.append(' ')?.append(trimmed)
+            }
+            tryFinalize()
+        }
+        return results
+    }
+
+    private fun parseBlock(block: String, accountLast4: String?): SharedParsedStatementTransaction? {
+        val start = txnStartPattern.find(block) ?: return null
+        val tail = tailPattern.find(block) ?: return null
+        if (tail.range.first <= start.range.last) return null
+
+        val day = start.groupValues[1].toIntOrNull() ?: return null
+        val month = STATEMENT_MONTHS[start.groupValues[2].lowercase()] ?: return null
+        val year = 2000 + (start.groupValues[3].toIntOrNull() ?: return null)
+
+        val reference = tail.groupValues[1]
+        val isDebit = tail.groupValues[2] == "-"
+        val amountMinor = amountToMinor(tail.groupValues[3]) ?: return null
+        if (amountMinor <= 0 || amountMinor > MAX_AMOUNT_MINOR) return null
+
+        val details = block
+            .substring(start.range.last + 1, tail.range.first)
+            .replace(Regex("""\s+"""), " ")
+            .trim()
+        if (details.isEmpty()) return null
+
+        val (type, merchant) = classify(details, isDebit)
+
+        return SharedParsedStatementTransaction(
+            amountMinor = amountMinor,
+            transactionType = type,
+            merchant = merchant,
+            reference = reference,
+            accountLast4 = accountLast4,
+            bankName = BANK_NAME,
+            timestampEpochMillis = istDateToEpochMillis(year, month, day),
+            rawText = block
+        )
+    }
+
+    private fun classify(details: String, isDebit: Boolean): Pair<SharedTransactionType, String> = when {
+        details.startsWith("Interest Cr.", ignoreCase = true) ->
+            SharedTransactionType.INCOME to "slice interest"
+
+        details.startsWith("UPI-", ignoreCase = true) -> {
+            val type = if (isDebit) SharedTransactionType.EXPENSE else SharedTransactionType.INCOME
+            type to upiMerchant(details)
+        }
+
+        // Money moving between the user's own slice balances: pots ("atom"),
+        // automatic saving, and round-ups. Never income or spending.
+        details.startsWith("Auto save to", ignoreCase = true) ->
+            SharedTransactionType.TRANSFER to stripPotName(details.removePrefix("Auto save to "))
+
+        details.startsWith("Transfer from", ignoreCase = true) && details.endsWith("atom", ignoreCase = true) ->
+            SharedTransactionType.TRANSFER to stripPotName(details.removePrefix("Transfer from "))
+
+        details.startsWith("Transfer to", ignoreCase = true) && details.endsWith("atom", ignoreCase = true) ->
+            SharedTransactionType.TRANSFER to stripPotName(details.removePrefix("Transfer to "))
+
+        details.equals("Round ups", ignoreCase = true) ->
+            SharedTransactionType.TRANSFER to "Round ups"
+
+        else ->
+            (if (isDebit) SharedTransactionType.EXPENSE else SharedTransactionType.INCOME) to details
+    }
+
+    /** "Daily saver atom" → "Daily saver". */
+    private fun stripPotName(raw: String): String =
+        raw.removeSuffix(" atom").removeSuffix(" Atom").trim().ifEmpty { raw.trim() }
+
+    /**
+     * Merchant from a UPI descriptor:
+     * `UPI-Debit-<upi ref digits>-MERCHANT NAME-<IFSC>-<vpa>-<narration>`
+     * → the dash-separated segments between the UPI reference number and the
+     * IFSC-shaped token. PDF line wrapping can inject a stray space mid-word;
+     * that is left as-is — a slightly gappy name beats a glued-together one.
+     */
+    private fun upiMerchant(details: String): String {
+        val parts = details.split("-")
+        val refIndex = parts.indexOfFirst { it.trim().length >= 10 && it.trim().all(Char::isDigit) }
+        if (refIndex == -1 || refIndex == parts.lastIndex) return details
+        val ifscIndex = parts.drop(refIndex + 1)
+            .indexOfFirst { ifscPattern.matches(it.trim()) }
+            .let { if (it == -1) -1 else it + refIndex + 1 }
+        val merchantParts = if (ifscIndex > refIndex + 1) {
+            parts.subList(refIndex + 1, ifscIndex)
+        } else {
+            parts.subList(refIndex + 1, minOf(refIndex + 2, parts.size))
+        }
+        return merchantParts.joinToString("-").trim().ifEmpty { details }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pennywiseai/shared/data/statement/SliceSharedStatementParser.kt
+++ b/shared/src/commonMain/kotlin/com/pennywiseai/shared/data/statement/SliceSharedStatementParser.kt
@@ -44,6 +44,14 @@ class SliceSharedStatementParser : SharedStatementParser {
         private const val TABLE_HEADER = "DATE DETAILS REF NO. AMOUNT BALANCE"
         private const val FOOTER_PREFIX = "Generated on"
 
+        // Page furniture that repeats per page on multi-page statements. The
+        // range header ("01 Jan '26 - 31 Jan '26") is the treacherous one — it
+        // starts with a date, so without this check it would read as a new
+        // transaction row and clobber a block awaiting its tail.
+        private val pageMarkerPattern = Regex("""^\d+/\d+$""")
+        private val rangeHeaderPattern =
+            Regex("""^\d{1,2} [A-Z][a-z]{2} '\d{2} ?- ?\d{1,2} [A-Z][a-z]{2} '\d{2}$""")
+
         private const val BANK_NAME = "slice"
         // ₹1 crore in paise, same sanity bound as the other statement parsers.
         private const val MAX_AMOUNT_MINOR = 1_000_000_000L
@@ -76,14 +84,12 @@ class SliceSharedStatementParser : SharedStatementParser {
         for (line in lines.drop(headerIndex + 1)) {
             val trimmed = line.trim()
             if (trimmed.isEmpty()) continue
-            // Skip, don't stop: on a multi-page statement the "Generated on"
-            // footer can repeat per page with more transactions after it. Any
-            // footer junk absorbed into an open block can never match the
-            // amount tail, so it is dropped at the next date row.
-            if (trimmed.startsWith(FOOTER_PREFIX)) {
-                block = null
-                continue
-            }
+            // Page furniture (footer, help line, "2/2" marker, repeated range
+            // and table headers) is skipped WITHOUT touching the open block: a
+            // transaction can straddle a page boundary — details at the end of
+            // one page, its amount tail after the next page's header — and
+            // must keep accumulating across it.
+            if (isPageFurniture(trimmed)) continue
 
             if (txnStartPattern.containsMatchIn(trimmed)) {
                 // A new date row while a block is still open means the open
@@ -96,6 +102,13 @@ class SliceSharedStatementParser : SharedStatementParser {
         }
         return results
     }
+
+    private fun isPageFurniture(trimmed: String): Boolean =
+        trimmed.startsWith(FOOTER_PREFIX) ||
+            trimmed.startsWith("Need help?") ||
+            trimmed == TABLE_HEADER ||
+            pageMarkerPattern.matches(trimmed) ||
+            rangeHeaderPattern.matches(trimmed)
 
     private fun parseBlock(block: String, accountLast4: String?): SharedParsedStatementTransaction? {
         val start = txnStartPattern.find(block) ?: return null

--- a/shared/src/commonMain/kotlin/com/pennywiseai/shared/data/statement/SliceSharedStatementParser.kt
+++ b/shared/src/commonMain/kotlin/com/pennywiseai/shared/data/statement/SliceSharedStatementParser.kt
@@ -76,7 +76,14 @@ class SliceSharedStatementParser : SharedStatementParser {
         for (line in lines.drop(headerIndex + 1)) {
             val trimmed = line.trim()
             if (trimmed.isEmpty()) continue
-            if (trimmed.startsWith(FOOTER_PREFIX)) break
+            // Skip, don't stop: on a multi-page statement the "Generated on"
+            // footer can repeat per page with more transactions after it. Any
+            // footer junk absorbed into an open block can never match the
+            // amount tail, so it is dropped at the next date row.
+            if (trimmed.startsWith(FOOTER_PREFIX)) {
+                block = null
+                continue
+            }
 
             if (txnStartPattern.containsMatchIn(trimmed)) {
                 // A new date row while a block is still open means the open
@@ -134,15 +141,17 @@ class SliceSharedStatementParser : SharedStatementParser {
         }
 
         // Money moving between the user's own slice balances: pots ("atom"),
-        // automatic saving, and round-ups. Never income or spending.
-        details.startsWith("Auto save to", ignoreCase = true) ->
-            SharedTransactionType.TRANSFER to stripPotName(details.removePrefix("Auto save to "))
+        // automatic saving, and round-ups. Never income or spending. Prefixes
+        // are dropped by length (the startsWith already matched case-
+        // insensitively) so "AUTO SAVE TO … ATOM" normalizes the same way.
+        details.startsWith("Auto save to ", ignoreCase = true) ->
+            SharedTransactionType.TRANSFER to stripPotName(details.drop("Auto save to ".length))
 
-        details.startsWith("Transfer from", ignoreCase = true) && details.endsWith("atom", ignoreCase = true) ->
-            SharedTransactionType.TRANSFER to stripPotName(details.removePrefix("Transfer from "))
+        details.startsWith("Transfer from ", ignoreCase = true) && details.endsWith("atom", ignoreCase = true) ->
+            SharedTransactionType.TRANSFER to stripPotName(details.drop("Transfer from ".length))
 
-        details.startsWith("Transfer to", ignoreCase = true) && details.endsWith("atom", ignoreCase = true) ->
-            SharedTransactionType.TRANSFER to stripPotName(details.removePrefix("Transfer to "))
+        details.startsWith("Transfer to ", ignoreCase = true) && details.endsWith("atom", ignoreCase = true) ->
+            SharedTransactionType.TRANSFER to stripPotName(details.drop("Transfer to ".length))
 
         details.equals("Round ups", ignoreCase = true) ->
             SharedTransactionType.TRANSFER to "Round ups"
@@ -151,9 +160,16 @@ class SliceSharedStatementParser : SharedStatementParser {
             (if (isDebit) SharedTransactionType.EXPENSE else SharedTransactionType.INCOME) to details
     }
 
-    /** "Daily saver atom" → "Daily saver". */
-    private fun stripPotName(raw: String): String =
-        raw.removeSuffix(" atom").removeSuffix(" Atom").trim().ifEmpty { raw.trim() }
+    /** "Daily saver atom" → "Daily saver" (any casing of "atom"). */
+    private fun stripPotName(raw: String): String {
+        val trimmed = raw.trim()
+        val stripped = if (trimmed.endsWith(" atom", ignoreCase = true)) {
+            trimmed.dropLast(" atom".length).trim()
+        } else {
+            trimmed
+        }
+        return stripped.ifEmpty { trimmed }
+    }
 
     /**
      * Merchant from a UPI descriptor:

--- a/shared/src/commonMain/kotlin/com/pennywiseai/shared/domain/usecase/ImportStatementUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/pennywiseai/shared/domain/usecase/ImportStatementUseCase.kt
@@ -26,7 +26,7 @@ class ImportStatementUseCase(
     suspend fun importFromText(statementText: String): SharedStatementImportResult {
         val parser = SharedStatementParserFactory.getParser(statementText)
             ?: return SharedStatementImportResult.Error(
-                "Unsupported statement format. Currently supported: Google Pay, PhonePe."
+                "Unsupported statement format. Currently supported: Google Pay, PhonePe, slice."
             )
 
         val parsedTransactions = parser.parse(statementText)

--- a/shared/src/commonTest/kotlin/com/pennywiseai/shared/data/statement/SliceSharedStatementParserTest.kt
+++ b/shared/src/commonTest/kotlin/com/pennywiseai/shared/data/statement/SliceSharedStatementParserTest.kt
@@ -1,0 +1,108 @@
+package com.pennywiseai.shared.data.statement
+
+import com.pennywiseai.shared.data.model.SharedTransactionType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Fixtures are entirely synthetic — invented names, refs, amounts and VPAs
+ * that only mimic the statement's layout. Never paste real statement content
+ * here (hard constraint: no PII anywhere).
+ */
+class SliceSharedStatementParserTest {
+
+    private val parser = SliceSharedStatementParser()
+
+    private val statement = """
+        01 Jan '26 - 31 Jan '26
+        1/1
+        Mr TEST PERSON
+        Customer ID 100000000001
+        Account SAVINGS
+        A/C number 999900005678
+        IFSC NESF0000999
+        Opening balance Total credits Interest earned Total debits Closing balance
+        + + - =
+        ₹10,000 ₹6,000 ₹1.23 ₹5,679.1 ₹10,322.13
+        DATE DETAILS REF NO. AMOUNT BALANCE
+        02 Jan '26 Interest Cr. for 01-Jan-2026 111122223333 ₹1.23 ₹10,001.23
+        02 Jan '26 Transfer from Holiday fund atom 444455556 ₹6,000 ₹16,001.23
+        02 Jan '26 UPI-Debit-999900001111-SOME MERCHA
+        NT NAME-ABCD0EFGH11-somevpa@bank-Paid V
+        ia Elements
+        2026010212345678 -₹5,000 ₹11,001.23
+        03 Jan '26 Auto save to Daily saver atom 444455557 -₹100 ₹10,901.23
+        03 Jan '26 Round ups 444455558 -₹18.2 ₹10,883.03
+        04 Jan '26 UPI-Debit-999900002222-OTHER SHOP-WXYZ0AB1234-shop@upi-123456 2026010412345679 -₹560.9 ₹10,322.13
+        Generated on 31 Jan '26
+        Need help? Contact our support team at help@slice.bank.in or +91-0000000000 slice small finance bank
+    """.trimIndent()
+
+    @Test
+    fun handles_slice_statements_only() {
+        assertTrue(parser.canHandle(statement))
+        assertTrue(!parser.canHandle("Paid to Somewhere UPI transaction ID 123 google pay"))
+    }
+
+    @Test
+    fun parses_all_rows_with_amounts_dates_and_refs() {
+        val txns = parser.parse(statement)
+        assertEquals(6, txns.size)
+
+        val interest = txns[0]
+        assertEquals(123L, interest.amountMinor)
+        assertEquals(SharedTransactionType.INCOME, interest.transactionType)
+        assertEquals("111122223333", interest.reference)
+        assertEquals("5678", interest.accountLast4)
+        assertEquals("slice", interest.bankName)
+
+        // 02 Jan 2026 noon IST = 2026-01-02T06:30Z
+        assertEquals(1767335400000L, interest.timestampEpochMillis)
+    }
+
+    @Test
+    fun pot_movements_are_transfers_not_income_or_spending() {
+        val txns = parser.parse(statement)
+        val potIn = txns[1]      // Transfer from Holiday fund atom
+        val autoSave = txns[3]   // Auto save to Daily saver atom
+        val roundUps = txns[4]   // Round ups
+
+        assertEquals(SharedTransactionType.TRANSFER, potIn.transactionType)
+        assertEquals("Holiday fund", potIn.merchant)
+        assertEquals(SharedTransactionType.TRANSFER, autoSave.transactionType)
+        assertEquals("Daily saver", autoSave.merchant)
+        assertEquals(SharedTransactionType.TRANSFER, roundUps.transactionType)
+        assertEquals(1820L, roundUps.amountMinor)
+    }
+
+    @Test
+    fun multiline_upi_debit_reassembles_merchant_between_ref_and_ifsc() {
+        val txns = parser.parse(statement)
+        val upi = txns[2]
+        assertEquals(SharedTransactionType.EXPENSE, upi.transactionType)
+        assertEquals(500000L, upi.amountMinor)
+        assertEquals("2026010212345678", upi.reference)
+        // Wrapped mid-word: joined with a space, never glued or truncated.
+        assertEquals("SOME MERCHA NT NAME", upi.merchant)
+    }
+
+    @Test
+    fun single_line_upi_debit_parses_merchant_and_amount() {
+        val txns = parser.parse(statement)
+        val upi = txns[5]
+        assertEquals(SharedTransactionType.EXPENSE, upi.transactionType)
+        assertEquals(56090L, upi.amountMinor)
+        assertEquals("OTHER SHOP", upi.merchant)
+    }
+
+    @Test
+    fun summary_figures_above_the_table_are_not_transactions() {
+        // The opening/closing summary row also contains ₹ figures; none of the
+        // parsed transactions may come from it.
+        val txns = parser.parse(statement)
+        assertTrue(txns.none { it.amountMinor == 1_000_000L && it.reference == null })
+        assertNull(txns.firstOrNull { it.rawText.contains("Opening balance") })
+    }
+}

--- a/shared/src/commonTest/kotlin/com/pennywiseai/shared/data/statement/SliceSharedStatementParserTest.kt
+++ b/shared/src/commonTest/kotlin/com/pennywiseai/shared/data/statement/SliceSharedStatementParserTest.kt
@@ -116,6 +116,31 @@ class SliceSharedStatementParserTest {
     }
 
     @Test
+    fun transaction_straddling_a_page_boundary_is_not_dropped() {
+        // The nasty case: a multi-line UPI row starts at the bottom of page 1,
+        // the full page furniture repeats (footer, help line, range header —
+        // which itself starts with a date — page marker, table header), and the
+        // amount tail only arrives on page 2. The block must survive all of it.
+        val straddling = """
+            A/C number 999900005678
+            DATE DETAILS REF NO. AMOUNT BALANCE
+            05 Jan '26 UPI-Debit-999900004444-SPLIT ACROSS
+            Generated on 31 Jan '26
+            Need help? Contact our support team at help@slice.bank.in or +91-0000000000 slice small finance bank
+            01 Jan '26 - 31 Jan '26
+            2/2
+            DATE DETAILS REF NO. AMOUNT BALANCE
+            PAGES SHOP-WXYZ0AB1234-y@upi-2
+            2026010512345681 -₹300 ₹9,501.23
+        """.trimIndent()
+        val txns = parser.parse(straddling)
+        assertEquals(1, txns.size)
+        assertEquals("SPLIT ACROSS PAGES SHOP", txns[0].merchant)
+        assertEquals(30000L, txns[0].amountMinor)
+        assertEquals("2026010512345681", txns[0].reference)
+    }
+
+    @Test
     fun pot_rows_normalize_regardless_of_casing() {
         val shouty = """
             A/C number 999900005678

--- a/shared/src/commonTest/kotlin/com/pennywiseai/shared/data/statement/SliceSharedStatementParserTest.kt
+++ b/shared/src/commonTest/kotlin/com/pennywiseai/shared/data/statement/SliceSharedStatementParserTest.kt
@@ -98,6 +98,37 @@ class SliceSharedStatementParserTest {
     }
 
     @Test
+    fun per_page_footers_do_not_truncate_multipage_statements() {
+        // Page 1 ends with the "Generated on" footer, page 2 continues with
+        // more rows — everything after a mid-stream footer must still parse.
+        val multiPage = """
+            A/C number 999900005678
+            DATE DETAILS REF NO. AMOUNT BALANCE
+            02 Jan '26 Interest Cr. for 01-Jan-2026 111122223333 ₹1.23 ₹10,001.23
+            Generated on 31 Jan '26
+            2/2
+            05 Jan '26 UPI-Debit-999900003333-PAGE TWO SHOP-WXYZ0AB1234-x@upi-1 2026010512345680 -₹200 ₹9,801.23
+            Generated on 31 Jan '26
+        """.trimIndent()
+        val txns = parser.parse(multiPage)
+        assertEquals(2, txns.size)
+        assertEquals("PAGE TWO SHOP", txns[1].merchant)
+    }
+
+    @Test
+    fun pot_rows_normalize_regardless_of_casing() {
+        val shouty = """
+            A/C number 999900005678
+            DATE DETAILS REF NO. AMOUNT BALANCE
+            03 Jan '26 AUTO SAVE TO Daily saver ATOM 444455559 -₹50 ₹9,751.23
+        """.trimIndent()
+        val txns = parser.parse(shouty)
+        assertEquals(1, txns.size)
+        assertEquals(SharedTransactionType.TRANSFER, txns[0].transactionType)
+        assertEquals("Daily saver", txns[0].merchant)
+    }
+
+    @Test
     fun summary_figures_above_the_table_are_not_transactions() {
         // The opening/closing summary row also contains ₹ figures; none of the
         // parsed transactions may come from it.


### PR DESCRIPTION
Adds **slice small finance bank** account statements to the iOS PDF import (previously GPay + PhonePe only). Requested with a real statement in hand; the parser was built against its PDFKit text extraction.

## How it parses
- **Detection**: the bank's own footer strings ("slice small finance bank" / support email) — unique to these PDFs.
- **Rows**: start with a `dd MMM 'yy` date and end in a `<ref> [-]₹amount ₹balance` tail. UPI rows wrap details across lines, so the parser accumulates lines until the tail appears; the account last4 comes from the statement header.
- **Classification keeps totals honest**: interest credits → INCOME; UPI debits/credits → EXPENSE/INCOME with the merchant reassembled from the descriptor segments between the UPI ref and the IFSC-shaped token; and slice's own pot movements ("atom" transfers, Auto save, Round ups) → **TRANSFER**, so auto-saving never counts as spending (pairs with the totals fix in the base PR).
- Dates are real (noon IST via the shared epoch helper) rather than GPay-style import-time stamps. The IST helper + month table moved from the PhonePe parser into `SharedParserUtils`, now shared.

## Privacy
Test fixtures are **fully synthetic** (layout-alike, invented names/refs/amounts/VPAs). The real statement was used only in a local, uncommitted smoke run — **8/8 rows parsed** with correct types and paisa-exact amounts — and no value from it appears anywhere in the repo, tests, or this PR.

## Verification
- `:shared` tests green on Android-host and iOS-simulator targets (6 new parser tests).
- Full Android `./init.sh` green; iOS simulator build succeeds.
- Supported-formats copy updated (import error message + Settings label).

Stacked on #659 (both touch `ImportStatementUseCase`); will retarget to main when that merges.