### PR TITLE
feat(transactions): show totals for the selected rows (#634)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionTotalsCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionTotalsCard.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.TrendingDown
 import androidx.compose.material.icons.automirrored.filled.TrendingUp
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CreditCard
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.SettingsEthernet
 import androidx.compose.material3.*
@@ -36,6 +37,13 @@ fun TransactionTotalsCard(
     onCurrencySelected: (String) -> Unit = {},
     isUnifiedMode: Boolean = false,
     isLoading: Boolean = false,
+    // Optional fourth tile (#634): credit-card spend of the shown set. The
+    // regular list totals leave it off — credit lives on the Cash-Flow card —
+    // but selection totals show it, since the ask was income/expense/credit
+    // for exactly the rows the user picked.
+    credit: BigDecimal? = null,
+    // Optional heading, e.g. "3 selected".
+    title: String? = null,
     modifier: Modifier = Modifier
 ) {
     val incomeAlpha by animateFloatAsState(
@@ -79,6 +87,14 @@ fun TransactionTotalsCard(
                     .fillMaxWidth()
                     .padding(Spacing.sm)
             ) {
+                if (title != null) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(start = Spacing.xs, bottom = Spacing.xs)
+                    )
+                }
                 // Totals Row
                 Row(
                     modifier = Modifier
@@ -147,11 +163,45 @@ fun TransactionTotalsCard(
                                     tint = if (!isSystemInDarkTheme()) expense_light else expense_dark
                                 )
                             },
-                            label = "Expenses",
+                            // Four tiles leave no room for the plural — it wraps.
+                            label = if (credit != null) "Expense" else "Expenses",
                             amount = CurrencyFormatter.formatCurrency(expenses, currency),
                             color = if (!isSystemInDarkTheme()) expense_light else expense_dark,
                             modifier = Modifier.alpha(expenseAlpha)
                         )
+                    }
+
+                    if (credit != null) {
+                        Spacer(modifier = Modifier.width(Spacing.xxs))
+
+                        // Credit Column (selection totals only)
+                        val creditColor = if (!isSystemInDarkTheme()) credit_light else credit_dark
+                        Box(
+                            modifier = Modifier
+                                .fillMaxHeight()
+                                .weight(1f)
+                                .background(
+                                    color = MaterialTheme.colorScheme.surfaceContainerLow,
+                                    shape = RoundedCornerShape(Spacing.xs)
+                                )
+                                .padding(Spacing.sm),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            TotalColumn(
+                                icon = {
+                                    Icon(
+                                        imageVector = Icons.Filled.CreditCard,
+                                        contentDescription = "Credit",
+                                        modifier = Modifier.size(Dimensions.Icon.inline),
+                                        tint = creditColor
+                                    )
+                                },
+                                label = "Credit",
+                                amount = CurrencyFormatter.formatCurrency(credit, currency),
+                                color = creditColor,
+                                modifier = Modifier.alpha(expenseAlpha)
+                            )
+                        }
                     }
 
                     Spacer(modifier = Modifier.width(Spacing.xxs))

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
@@ -128,6 +128,7 @@ fun TransactionsScreen(
 
     // Bulk-edit selection (#369)
     val selectedIds by viewModel.selectedIds.collectAsState()
+    val selectionTotals by viewModel.selectionTotals.collectAsState()
     val bulkSnack by viewModel.bulkSnack.collectAsState()
     val selectionMode = selectedIds.isNotEmpty()
     var showBulkCategorySheet by remember { mutableStateOf(false) }
@@ -536,10 +537,20 @@ fun TransactionsScreen(
                             color = MaterialTheme.colorScheme.background,
                             modifier = Modifier.fillMaxWidth()
                         ) {
+                            // In selection mode the sticky card shows the totals of
+                            // just the selected rows (#634), with the credit tile the
+                            // reporter asked for; otherwise the filtered-list totals.
+                            val cardTotals = if (selectionMode) selectionTotals else filteredTotals
                             TransactionTotalsCard(
-                                income = filteredTotals.income,
-                                expenses = filteredTotals.expenses,
-                                netBalance = filteredTotals.netBalance,
+                                income = cardTotals.income,
+                                expenses = cardTotals.expenses,
+                                netBalance = cardTotals.netBalance,
+                                credit = if (selectionMode) cardTotals.credit else null,
+                                title = if (selectionMode) {
+                                    "${selectedIds.size} selected"
+                                } else {
+                                    null
+                                },
                                 currency = selectedCurrency,
                                 availableCurrencies = availableCurrencies,
                                 onCurrencySelected = { viewModel.selectCurrency(it) },

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -191,7 +191,27 @@ class TransactionsViewModel @Inject constructor(
     ) { groupedTotals, currency, isUnified ->
         Triple(groupedTotals, currency, isUnified)
     }.mapLatest { (groupedTotals, currency, isUnified) ->
-        if (isUnified && groupedTotals.totalsByCurrency.size > 1) {
+        resolveTotals(groupedTotals, currency, isUnified)
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = FilteredTotals()
+    )
+
+    /**
+     * Collapses per-currency grouped totals into the figures for [currency]:
+     * either that one currency's bucket, or — in unified mode — every bucket
+     * converted into it. This is the ONLY way a single-figure total may be
+     * produced from mixed currencies (hard constraint 2); shared by the list
+     * totals and the selection totals so the two cards can never disagree on
+     * the currency rules.
+     */
+    private suspend fun resolveTotals(
+        groupedTotals: CurrencyGroupedTotals,
+        currency: String,
+        isUnified: Boolean
+    ): FilteredTotals {
+        return if (isUnified && groupedTotals.totalsByCurrency.size > 1) {
             // Aggregate all currencies converted to display currency
             var income = BigDecimal.ZERO
             var expenses = BigDecimal.ZERO
@@ -234,12 +254,8 @@ class TransactionsViewModel @Inject constructor(
                 transactionCount = currencyTotals.transactionCount
             )
         }
-    }.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
-        initialValue = FilteredTotals()
-    )
-    
+    }
+
     private val _deletedTransaction = MutableStateFlow<TransactionEntity?>(null)
     val deletedTransaction: StateFlow<TransactionEntity?> = _deletedTransaction.asStateFlow()
 
@@ -249,6 +265,29 @@ class TransactionsViewModel @Inject constructor(
     // Long-press in the list enters this mode and tap-toggles add/remove rows.
     private val _selectedIds = MutableStateFlow<Set<Long>>(emptySet())
     val selectedIds: StateFlow<Set<Long>> = _selectedIds.asStateFlow()
+
+    /**
+     * Income / expense / credit totals of just the selected rows (#634),
+     * resolved through [resolveTotals] so the selection card obeys exactly the
+     * same currency rules as the list card — one currency at a time, or
+     * converted in unified mode. Never a raw cross-currency sum.
+     */
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    val selectionTotals: StateFlow<FilteredTotals> = combine(
+        _selectedIds,
+        _uiState,
+        _selectedCurrency,
+        _isUnifiedMode
+    ) { ids, state, currency, isUnified ->
+        val selected = state.transactions.filter { it.id in ids }
+        Triple(selected, currency, isUnified)
+    }.mapLatest { (selected, currency, isUnified) ->
+        resolveTotals(calculateCurrencyGroupedTotals(selected), currency, isUnified)
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = FilteredTotals()
+    )
 
     /** One-shot snackbar payload for a bulk action; cleared by the UI after showing. */
     data class BulkSnack(val message: String, val undo: (() -> Unit)? = null)

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -211,7 +211,11 @@ class TransactionsViewModel @Inject constructor(
         currency: String,
         isUnified: Boolean
     ): FilteredTotals {
-        return if (isUnified && groupedTotals.totalsByCurrency.size > 1) {
+        // isNotEmpty, not size > 1: in unified mode even a single-currency set
+        // needs converting when that one currency isn't the display currency —
+        // a selection of only-USD rows under an INR display would otherwise
+        // look up the empty INR bucket and show zeros.
+        return if (isUnified && groupedTotals.totalsByCurrency.isNotEmpty()) {
             // Aggregate all currencies converted to display currency
             var income = BigDecimal.ZERO
             var expenses = BigDecimal.ZERO


### PR DESCRIPTION
## What (#634)

While multi-selecting transactions, the sticky totals card switches to the selection: an **"N selected"** heading plus **Income / Expense / Credit / Net** computed over exactly the picked rows — the reporter's ask, reusing the existing card widget. The credit tile appears only in selection mode; the regular list card keeps its three tiles (credit deliberately lives on the Cash-Flow card).

## Currency safety

The per-currency resolution logic was extracted from `filteredTotals` into a shared `resolveTotals`, and the new `selectionTotals` flow goes through it — so the selection card obeys exactly the same rules as the list card: one currency at a time (picker pill), or converted in unified mode. A raw ₹+$ sum is impossible by construction.

## Verification

`./init.sh app` green. Emulator: long-press-selected two expenses (₹54 + ₹53) → card shows "2 selected", Income ₹0, Expense ₹107, Credit ₹0, Net −₹107; deselecting returns the normal filtered totals.

Fixes #634