### PR TITLE
feat(android): parse slice small finance bank statement PDFs

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/GPayPdfParser.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/GPayPdfParser.kt
@@ -207,22 +207,19 @@ class GPayPdfParser : PdfStatementParser {
         val merchant  = extractMerchant(anchorLine, isExpense)
 
         if (merchant == null) {
-            Log.w(TAG, "Block[$index] — could not extract merchant from: '$anchorLine'")
+            Log.w(TAG, "Block[$index] — could not extract merchant")
             return null
         }
 
         val amount = extractAmount(lines)
         if (amount == null) {
-            Log.w(TAG, "Block[$index] merchant='$merchant' — no amount found. Lines: $lines")
+            Log.w(TAG, "Block[$index] — no amount found")
             return null
         }
 
         val timestamp = extractTimestamp(lines, merchant)
         val upiId     = lines.firstNotNullOfOrNull { upiIdRegex.find(it)?.groupValues?.get(1) }
         val account   = extractAccountInfo(lines)
-
-        Log.i(TAG, "Block[$index] OK — $type merchant='$merchant' amount=$amount " +
-                "upi=$upiId bank='${account.bankName}' last4=${account.last4}")
 
         return ParsedTransaction(
             amount       = amount,

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/ImportStatementUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/ImportStatementUseCase.kt
@@ -21,7 +21,7 @@ class ImportStatementUseCase @Inject constructor(
 
             val parser = PdfParserFactory.getParser(text)
                 ?: return@withContext StatementImportResult.Error(
-                    "Unsupported statement format. Currently supported: Google Pay, PhonePe."
+                    "Unsupported statement format. Currently supported: Google Pay, PhonePe, Paytm, slice."
                 )
 
             val parsedTransactions = parser.parse(text)

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/PdfParserFactory.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/PdfParserFactory.kt
@@ -5,7 +5,8 @@ object PdfParserFactory {
     private val parsers = listOf(
         GPayPdfParser(),
         PhonePePdfParser(),
-        PaytmPdfParser()
+        PaytmPdfParser(),
+        SlicePdfParser()
     )
 
     fun getParser(extractedText: String): PdfStatementParser? {

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/SlicePdfParser.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/SlicePdfParser.kt
@@ -165,8 +165,6 @@ class SlicePdfParser : PdfStatementParser {
 
         val (type, merchant) = classify(details, isDebit)
 
-        Log.i(TAG, "Block OK — $type merchant='$merchant' amount=$amount ref=$reference")
-
         return ParsedTransaction(
             amount = amount,
             type = type,

--- a/app/src/main/java/com/pennywiseai/tracker/data/statement/SlicePdfParser.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/statement/SlicePdfParser.kt
@@ -1,0 +1,252 @@
+package com.pennywiseai.tracker.data.statement
+
+import android.util.Log
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+import java.util.Calendar
+import java.util.TimeZone
+
+/**
+ * Parses slice small finance bank account statement PDFs.
+ *
+ * Android port of the KMP `SliceSharedStatementParser` (used by iOS) — same
+ * semantics, expressed against the app's [PdfStatementParser] /
+ * [ParsedTransaction] types. Statement shape after text extraction (all values
+ * below are illustrative, not from any real statement):
+ * ```
+ * DATE DETAILS REF NO. AMOUNT BALANCE
+ * 01 Jan '26 Interest Cr. for 31-Dec-2025 111122223333 ₹1.23 ₹10,001.23
+ * 01 Jan '26 UPI-Debit-999900001111-SOME MERCHANT
+ * NAME-ABCD0EFGH11-somevpa@bank-Paid Via ...
+ * 2026010112345678 -₹500 ₹9,501.23
+ * ```
+ * A transaction starts with a `dd MMM 'yy` date. Short rows carry the
+ * ref/amount/balance tail on the same line; UPI rows wrap the details over
+ * several lines and put the tail on its own line, so lines are accumulated
+ * until the tail appears.
+ *
+ * Slice-specific semantics: "atom" rows (pots), "Auto save" and "Round ups"
+ * move money between the user's own slice balances — they are TRANSFERs, not
+ * income/spending, so they never touch the Income/Expenses totals. Round-ups
+ * in particular exist only in statements (the bank never texts them), which is
+ * the whole reason slice statement import exists (#666).
+ */
+class SlicePdfParser : PdfStatementParser {
+
+    companion object {
+        private const val TAG = "SlicePdfParser"
+
+        private val markers = listOf("slice small finance bank", "help@slice.bank.in")
+
+        private val txnStartPattern =
+            Regex("""^(\d{1,2}) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) '(\d{2})(?:\s|$)""")
+
+        // "<ref digits> [-]₹amount ₹balance" at the end of an accumulated block.
+        private val tailPattern =
+            Regex("""(\d{6,})\s+(-?)₹([\d,]+(?:\.\d{1,2})?)(?!\d)\s+₹([\d,]+(?:\.\d{1,2})?)(?!\d)\s*$""")
+
+        private val accountNumberPattern = Regex("""A/C number\s+(\d{6,})""")
+
+        // IFSC-shaped token inside a UPI descriptor (AAAA0XXXXXX).
+        private val ifscPattern = Regex("""^[A-Z]{4}0[A-Z0-9]{6}$""")
+
+        // The summary row above the table also carries ₹ figures; real rows are
+        // only read after this header.
+        private const val TABLE_HEADER = "DATE DETAILS REF NO. AMOUNT BALANCE"
+        private const val FOOTER_PREFIX = "Generated on"
+
+        // Page furniture that repeats per page on multi-page statements. The
+        // range header ("01 Jan '26 - 31 Jan '26") is the treacherous one — it
+        // starts with a date, so without this check it would read as a new
+        // transaction row and clobber a block awaiting its tail.
+        private val pageMarkerPattern = Regex("""^\d+/\d+$""")
+        private val rangeHeaderPattern =
+            Regex("""^\d{1,2} [A-Z][a-z]{2} '\d{2} ?- ?\d{1,2} [A-Z][a-z]{2} '\d{2}$""")
+
+        // Matches the SMS parser's getBankName() so statement rows land on the
+        // same account as SMS-parsed slice transactions.
+        private const val BANK_NAME = "Slice"
+
+        // ₹1 crore, same sanity bound as the shared statement parsers.
+        private val MAX_AMOUNT = BigDecimal(10_000_000)
+
+        private val MONTHS = mapOf(
+            "jan" to 1, "feb" to 2, "mar" to 3, "apr" to 4,
+            "may" to 5, "jun" to 6, "jul" to 7, "aug" to 8,
+            "sep" to 9, "oct" to 10, "nov" to 11, "dec" to 12
+        )
+    }
+
+    private val IST = TimeZone.getTimeZone("Asia/Kolkata")
+
+    override fun canHandle(text: String): Boolean {
+        val lower = text.lowercase()
+        val result = markers.any { it in lower }
+        Log.d(TAG, "canHandle=$result")
+        return result
+    }
+
+    override fun parse(text: String): List<ParsedTransaction> {
+        Log.i(TAG, "Starting parse — text length=${text.length}")
+
+        val accountLast4 = accountNumberPattern.find(text)
+            ?.groupValues?.getOrNull(1)?.takeLast(4)
+
+        val lines = text.lines()
+        val headerIndex = lines.indexOfFirst { it.trim() == TABLE_HEADER }
+        if (headerIndex == -1) {
+            Log.w(TAG, "Table header not found — no transactions parsed")
+            return emptyList()
+        }
+
+        val results = mutableListOf<ParsedTransaction>()
+        var block: StringBuilder? = null
+
+        fun tryFinalize() {
+            val current = block?.toString()?.trim() ?: return
+            parseBlock(current, accountLast4)?.let {
+                results.add(it)
+                block = null
+            }
+        }
+
+        for (line in lines.drop(headerIndex + 1)) {
+            val trimmed = line.trim()
+            if (trimmed.isEmpty()) continue
+            // Page furniture (footer, help line, "2/2" marker, repeated range
+            // and table headers) is skipped WITHOUT touching the open block: a
+            // transaction can straddle a page boundary — details at the end of
+            // one page, its amount tail after the next page's header — and
+            // must keep accumulating across it.
+            if (isPageFurniture(trimmed)) continue
+
+            if (txnStartPattern.containsMatchIn(trimmed)) {
+                // A new date row while a block is still open means the open
+                // block never got its amount tail — drop it rather than guess.
+                block = StringBuilder(trimmed)
+            } else {
+                block?.append(' ')?.append(trimmed)
+            }
+            tryFinalize()
+        }
+
+        Log.i(TAG, "Finished: ${results.size} transactions parsed")
+        return results
+    }
+
+    private fun isPageFurniture(trimmed: String): Boolean =
+        trimmed.startsWith(FOOTER_PREFIX) ||
+            trimmed.startsWith("Need help?") ||
+            trimmed == TABLE_HEADER ||
+            pageMarkerPattern.matches(trimmed) ||
+            rangeHeaderPattern.matches(trimmed)
+
+    private fun parseBlock(block: String, accountLast4: String?): ParsedTransaction? {
+        val start = txnStartPattern.find(block) ?: return null
+        val tail = tailPattern.find(block) ?: return null
+        if (tail.range.first <= start.range.last) return null
+
+        val day = start.groupValues[1].toIntOrNull() ?: return null
+        val month = MONTHS[start.groupValues[2].lowercase()] ?: return null
+        val year = 2000 + (start.groupValues[3].toIntOrNull() ?: return null)
+
+        val reference = tail.groupValues[1]
+        val isDebit = tail.groupValues[2] == "-"
+        val amount = tail.groupValues[3].replace(",", "").toBigDecimalOrNull() ?: return null
+        if (amount.signum() <= 0 || amount > MAX_AMOUNT) return null
+        val balance = tail.groupValues[4].replace(",", "").toBigDecimalOrNull()
+
+        val details = block
+            .substring(start.range.last + 1, tail.range.first)
+            .replace(Regex("""\s+"""), " ")
+            .trim()
+        if (details.isEmpty()) return null
+
+        val (type, merchant) = classify(details, isDebit)
+
+        Log.i(TAG, "Block OK — $type merchant='$merchant' amount=$amount ref=$reference")
+
+        return ParsedTransaction(
+            amount = amount,
+            type = type,
+            merchant = merchant,
+            reference = reference,
+            accountLast4 = accountLast4,
+            balance = balance,
+            smsBody = block,
+            sender = "Slice PDF",
+            timestamp = istEpochMillis(year, month, day),
+            bankName = BANK_NAME,
+        )
+    }
+
+    private fun classify(details: String, isDebit: Boolean): Pair<TransactionType, String> = when {
+        details.startsWith("Interest Cr.", ignoreCase = true) ->
+            TransactionType.INCOME to "slice interest"
+
+        details.startsWith("UPI-", ignoreCase = true) -> {
+            val type = if (isDebit) TransactionType.EXPENSE else TransactionType.INCOME
+            type to upiMerchant(details)
+        }
+
+        // Money moving between the user's own slice balances: pots ("atom"),
+        // automatic saving, and round-ups. Never income or spending. Prefixes
+        // are dropped by length (the startsWith already matched case-
+        // insensitively) so "AUTO SAVE TO … ATOM" normalizes the same way.
+        details.startsWith("Auto save to ", ignoreCase = true) ->
+            TransactionType.TRANSFER to stripPotName(details.drop("Auto save to ".length))
+
+        details.startsWith("Transfer from ", ignoreCase = true) && details.endsWith("atom", ignoreCase = true) ->
+            TransactionType.TRANSFER to stripPotName(details.drop("Transfer from ".length))
+
+        details.startsWith("Transfer to ", ignoreCase = true) && details.endsWith("atom", ignoreCase = true) ->
+            TransactionType.TRANSFER to stripPotName(details.drop("Transfer to ".length))
+
+        details.equals("Round ups", ignoreCase = true) ->
+            TransactionType.TRANSFER to "Round ups"
+
+        else ->
+            (if (isDebit) TransactionType.EXPENSE else TransactionType.INCOME) to details
+    }
+
+    /** "Daily saver atom" → "Daily saver" (any casing of "atom"). */
+    private fun stripPotName(raw: String): String {
+        val trimmed = raw.trim()
+        val stripped = if (trimmed.endsWith(" atom", ignoreCase = true)) {
+            trimmed.dropLast(" atom".length).trim()
+        } else {
+            trimmed
+        }
+        return stripped.ifEmpty { trimmed }
+    }
+
+    /**
+     * Merchant from a UPI descriptor:
+     * `UPI-Debit-<upi ref digits>-MERCHANT NAME-<IFSC>-<vpa>-<narration>`
+     * → the dash-separated segments between the UPI reference number and the
+     * IFSC-shaped token. PDF line wrapping can inject a stray space mid-word;
+     * that is left as-is — a slightly gappy name beats a glued-together one.
+     */
+    private fun upiMerchant(details: String): String {
+        val parts = details.split("-")
+        val refIndex = parts.indexOfFirst { it.trim().length >= 10 && it.trim().all(Char::isDigit) }
+        if (refIndex == -1 || refIndex == parts.lastIndex) return details
+        val ifscIndex = parts.drop(refIndex + 1)
+            .indexOfFirst { ifscPattern.matches(it.trim()) }
+            .let { if (it == -1) -1 else it + refIndex + 1 }
+        val merchantParts = if (ifscIndex > refIndex + 1) {
+            parts.subList(refIndex + 1, ifscIndex)
+        } else {
+            parts.subList(refIndex + 1, minOf(refIndex + 2, parts.size))
+        }
+        return merchantParts.joinToString("-").trim().ifEmpty { details }
+    }
+
+    /** Noon IST on the statement date — same convention as the shared parser. */
+    private fun istEpochMillis(year: Int, month: Int, day: Int): Long =
+        Calendar.getInstance(IST).apply {
+            clear()
+            set(year, month - 1, day, 12, 0, 0)
+        }.timeInMillis
+}

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/statement/ImportStatementScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/statement/ImportStatementScreen.kt
@@ -177,7 +177,7 @@ private fun IdleContent(onSelectPdf: () -> Unit) {
     )
 
     Text(
-        text = "Import transactions from Google Pay, PhonePe, or Paytm PDF statements. Duplicates are automatically detected and skipped.",
+        text = "Import transactions from Google Pay, PhonePe, Paytm, or slice PDF statements. Duplicates are automatically detected and skipped.",
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         textAlign = TextAlign.Center,

--- a/app/src/test/java/com/pennywiseai/tracker/data/statement/SlicePdfParserTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/statement/SlicePdfParserTest.kt
@@ -1,0 +1,167 @@
+package com.pennywiseai.tracker.data.statement
+
+import com.pennywiseai.parser.core.TransactionType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.math.BigDecimal
+
+/**
+ * Fixtures are entirely synthetic — invented names, refs, amounts and VPAs
+ * that only mimic the statement's layout. Never paste real statement content
+ * here (hard constraint: no PII anywhere).
+ */
+class SlicePdfParserTest {
+
+    private val parser = SlicePdfParser()
+
+    private val statement = """
+        01 Jan '26 - 31 Jan '26
+        1/1
+        Mr TEST PERSON
+        Customer ID 100000000001
+        Account SAVINGS
+        A/C number 999900005678
+        IFSC NESF0000999
+        Opening balance Total credits Interest earned Total debits Closing balance
+        + + - =
+        ₹10,000 ₹6,000 ₹1.23 ₹5,679.1 ₹10,322.13
+        DATE DETAILS REF NO. AMOUNT BALANCE
+        02 Jan '26 Interest Cr. for 01-Jan-2026 111122223333 ₹1.23 ₹10,001.23
+        02 Jan '26 Transfer from Holiday fund atom 444455556 ₹6,000 ₹16,001.23
+        02 Jan '26 UPI-Debit-999900001111-SOME MERCHA
+        NT NAME-ABCD0EFGH11-somevpa@bank-Paid V
+        ia Elements
+        2026010212345678 -₹5,000 ₹11,001.23
+        03 Jan '26 Auto save to Daily saver atom 444455557 -₹100 ₹10,901.23
+        03 Jan '26 Round ups 444455558 -₹18.2 ₹10,883.03
+        04 Jan '26 UPI-Debit-999900002222-OTHER SHOP-WXYZ0AB1234-shop@upi-123456 2026010412345679 -₹560.9 ₹10,322.13
+        Generated on 31 Jan '26
+        Need help? Contact our support team at help@slice.bank.in or +91-0000000000 slice small finance bank
+    """.trimIndent()
+
+    @Test
+    fun `handles slice statements only`() {
+        assertTrue(parser.canHandle(statement))
+        assertFalse(parser.canHandle("Paid to Somewhere UPI transaction ID 123 google pay"))
+    }
+
+    @Test
+    fun `parses all rows with amounts dates and refs`() {
+        val txns = parser.parse(statement)
+        assertEquals(6, txns.size)
+
+        val interest = txns[0]
+        assertEquals(BigDecimal("1.23"), interest.amount)
+        assertEquals(TransactionType.INCOME, interest.type)
+        assertEquals("111122223333", interest.reference)
+        assertEquals("5678", interest.accountLast4)
+        assertEquals("Slice", interest.bankName)
+        assertEquals(BigDecimal("10001.23"), interest.balance)
+
+        // 02 Jan 2026 noon IST = 2026-01-02T06:30Z
+        assertEquals(1767335400000L, interest.timestamp)
+    }
+
+    @Test
+    fun `pot movements are transfers not income or spending`() {
+        val txns = parser.parse(statement)
+        val potIn = txns[1]      // Transfer from Holiday fund atom
+        val autoSave = txns[3]   // Auto save to Daily saver atom
+        val roundUps = txns[4]   // Round ups
+
+        assertEquals(TransactionType.TRANSFER, potIn.type)
+        assertEquals("Holiday fund", potIn.merchant)
+        assertEquals(TransactionType.TRANSFER, autoSave.type)
+        assertEquals("Daily saver", autoSave.merchant)
+        assertEquals(TransactionType.TRANSFER, roundUps.type)
+        assertEquals(BigDecimal("18.2"), roundUps.amount)
+    }
+
+    @Test
+    fun `multiline upi debit reassembles merchant between ref and ifsc`() {
+        val txns = parser.parse(statement)
+        val upi = txns[2]
+        assertEquals(TransactionType.EXPENSE, upi.type)
+        assertEquals(BigDecimal("5000"), upi.amount)
+        assertEquals("2026010212345678", upi.reference)
+        // Wrapped mid-word: joined with a space, never glued or truncated.
+        assertEquals("SOME MERCHA NT NAME", upi.merchant)
+    }
+
+    @Test
+    fun `single line upi debit parses merchant and amount`() {
+        val txns = parser.parse(statement)
+        val upi = txns[5]
+        assertEquals(TransactionType.EXPENSE, upi.type)
+        assertEquals(BigDecimal("560.9"), upi.amount)
+        assertEquals("OTHER SHOP", upi.merchant)
+    }
+
+    @Test
+    fun `per page footers do not truncate multipage statements`() {
+        // Page 1 ends with the "Generated on" footer, page 2 continues with
+        // more rows — everything after a mid-stream footer must still parse.
+        val multiPage = """
+            A/C number 999900005678
+            DATE DETAILS REF NO. AMOUNT BALANCE
+            02 Jan '26 Interest Cr. for 01-Jan-2026 111122223333 ₹1.23 ₹10,001.23
+            Generated on 31 Jan '26
+            2/2
+            05 Jan '26 UPI-Debit-999900003333-PAGE TWO SHOP-WXYZ0AB1234-x@upi-1 2026010512345680 -₹200 ₹9,801.23
+            Generated on 31 Jan '26
+        """.trimIndent()
+        val txns = parser.parse(multiPage)
+        assertEquals(2, txns.size)
+        assertEquals("PAGE TWO SHOP", txns[1].merchant)
+    }
+
+    @Test
+    fun `transaction straddling a page boundary is not dropped`() {
+        // The nasty case: a multi-line UPI row starts at the bottom of page 1,
+        // the full page furniture repeats (footer, help line, range header —
+        // which itself starts with a date — page marker, table header), and the
+        // amount tail only arrives on page 2. The block must survive all of it.
+        val straddling = """
+            A/C number 999900005678
+            DATE DETAILS REF NO. AMOUNT BALANCE
+            05 Jan '26 UPI-Debit-999900004444-SPLIT ACROSS
+            Generated on 31 Jan '26
+            Need help? Contact our support team at help@slice.bank.in or +91-0000000000 slice small finance bank
+            01 Jan '26 - 31 Jan '26
+            2/2
+            DATE DETAILS REF NO. AMOUNT BALANCE
+            PAGES SHOP-WXYZ0AB1234-y@upi-2
+            2026010512345681 -₹300 ₹9,501.23
+        """.trimIndent()
+        val txns = parser.parse(straddling)
+        assertEquals(1, txns.size)
+        assertEquals("SPLIT ACROSS PAGES SHOP", txns[0].merchant)
+        assertEquals(BigDecimal("300"), txns[0].amount)
+        assertEquals("2026010512345681", txns[0].reference)
+    }
+
+    @Test
+    fun `pot rows normalize regardless of casing`() {
+        val shouty = """
+            A/C number 999900005678
+            DATE DETAILS REF NO. AMOUNT BALANCE
+            03 Jan '26 AUTO SAVE TO Daily saver ATOM 444455559 -₹50 ₹9,751.23
+        """.trimIndent()
+        val txns = parser.parse(shouty)
+        assertEquals(1, txns.size)
+        assertEquals(TransactionType.TRANSFER, txns[0].type)
+        assertEquals("Daily saver", txns[0].merchant)
+    }
+
+    @Test
+    fun `summary figures above the table are not transactions`() {
+        // The opening/closing summary row also contains ₹ figures; none of the
+        // parsed transactions may come from it.
+        val txns = parser.parse(statement)
+        assertTrue(txns.none { it.amount == BigDecimal("10000") && it.reference == null })
+        assertNull(txns.firstOrNull { it.smsBody.contains("Opening balance") })
+    }
+}


### PR DESCRIPTION
Closes #666

## What

Adds slice small finance bank to the Android statement importer, alongside GPay/PhonePe/Paytm. This is a port of the KMP `SliceSharedStatementParser` (already shipped for iOS in #660) to the Android `PdfStatementParser` pattern — the logic is translated, not shared: the app deliberately does not depend on the `shared` module's parsers.

The motivating case (from Discord, 7 Aug): slice **round-ups never appear in SMS** — the bank only texts the base payment — so SMS parsing can never capture them. The statement carries them explicitly, and this parser classifies them so they never pollute spending totals.

## Semantics (preserved from the shared parser)

- **Detection**: the bank's footer strings ("slice small finance bank" / "help@slice.bank.in").
- **Row shape**: rows start with a `dd MMM 'yy` date and end with a `<ref> [-]₹amount ₹balance` tail. Short rows are single-line; multi-line UPI rows accumulate until the tail arrives. Rows are only read after the `DATE DETAILS REF NO. AMOUNT BALANCE` header, so the ₹ figures in the summary block above the table are never mis-read as transactions.
- **Page furniture** ("Generated on" footer, "Need help?" line, `N/N` page marker, repeated range header — which itself starts with a date — and repeated table header) is skipped **without clearing an open block**, so a transaction whose details end on one page and whose amount tail arrives after the next page's header still parses.
- **UPI merchant** = the dash-separated segments between the UPI ref number and the IFSC-shaped token; mid-word wrap gaps are left as-is.
- **"Interest Cr."** → INCOME.
- **Slice pot rows** — `Transfer to/from … atom`, `Auto save to …`, `Round ups` (case-insensitive, pot name normalized by stripping the "atom" suffix) — → **TRANSFER**, so money moving between the user's own slice balances never counts as income or spending. This is the whole point of the issue.

Android-specific choices:
- `bankName = "Slice"` (matching the SMS `SliceParser`'s `getBankName()`), so statement rows land on the same account as SMS-parsed slice transactions and dedup/enrichment in `StatementImportProcessor` works across both sources.
- The statement's running balance is captured into `ParsedTransaction.balance` → `balanceAfter` (the tail carries it anyway; GPay/Paytm statements simply don't have one).
- Timestamps are noon IST on the statement date, same convention as the shared parser.

## Files

- `app/.../data/statement/SlicePdfParser.kt` — new parser
- `app/.../data/statement/PdfParserFactory.kt` — registration
- `app/.../data/statement/ImportStatementUseCase.kt`, `app/.../presentation/statement/ImportStatementScreen.kt` — supported-format copy now lists Paytm and slice
- `app/src/test/.../SlicePdfParserTest.kt` — 9 tests, fixtures fully synthetic (adapted from the shared module's test)

## Verification

`./init.sh app` green; `SlicePdfParserTest`: 9 tests, 0 failures. Covers detection, all row types, TRANSFER classification of pot/auto-save/round-up rows, multi-line UPI merchant reassembly, mid-stream per-page footers, a transaction straddling a page boundary, casing normalization, and the summary-block guard.