### PR TITLE
feat(home): Groups section — a rail of the user's transaction groups (#664)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionGroupDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionGroupDao.kt
@@ -39,6 +39,10 @@ interface TransactionGroupDao {
     @Query("SELECT * FROM transactions WHERE group_id = :groupId AND is_deleted = 0 ORDER BY date_time DESC")
     fun getTransactionsForGroup(groupId: Long): Flow<List<TransactionEntity>>
 
+    /** Every grouped transaction in one query — for building all group summaries at once. */
+    @Query("SELECT * FROM transactions WHERE group_id IS NOT NULL AND is_deleted = 0")
+    fun getAllGroupedTransactions(): Flow<List<TransactionEntity>>
+
     @Query("SELECT COUNT(*) FROM transactions WHERE group_id = :groupId AND is_deleted = 0")
     fun getTransactionCount(groupId: Long): Flow<Int>
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionGroupRepository.kt
@@ -3,16 +3,68 @@ package com.pennywiseai.tracker.data.repository
 import com.pennywiseai.tracker.data.database.dao.TransactionGroupDao
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionGroupEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionType
+import com.pennywiseai.tracker.utils.Money
+import com.pennywiseai.tracker.utils.sumByCurrency
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import java.time.LocalDateTime
 import javax.inject.Inject
 import javax.inject.Singleton
+
+/**
+ * A group with its aggregate figures. Totals are kept per-currency because a
+ * group can mix currencies and summing across them is meaningless (hard
+ * constraint 2). Keyed by currency code. Shared by the groups screen and the
+ * Home "Groups" section so the two can never disagree.
+ */
+data class GroupSummary(
+    val group: TransactionGroupEntity,
+    val transactionCount: Int,
+    val expenseByCurrency: Map<String, Money>,
+    val incomeByCurrency: Map<String, Money>
+) {
+    val hasExpense: Boolean get() = expenseByCurrency.values.any { it.isPositive }
+    val hasIncome: Boolean get() = incomeByCurrency.values.any { it.isPositive }
+}
 
 @Singleton
 class TransactionGroupRepository @Inject constructor(
     private val groupDao: TransactionGroupDao
 ) {
     fun getAllGroups(): Flow<List<TransactionGroupEntity>> = groupDao.getAllGroups()
+
+    /** Live [GroupSummary] per group; empty list when there are no groups. */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun observeGroupSummaries(): Flow<List<GroupSummary>> =
+        getAllGroups().flatMapLatest { groups ->
+            if (groups.isEmpty()) {
+                flowOf(emptyList())
+            } else {
+                combine(
+                    groups.map { group ->
+                        getTransactionsForGroup(group.id).map { txns -> buildSummary(group, txns) }
+                    }
+                ) { it.toList() }
+            }
+        }
+
+    private fun buildSummary(
+        group: TransactionGroupEntity,
+        transactions: List<TransactionEntity>
+    ): GroupSummary {
+        val expense = transactions
+            .filter { it.transactionType == TransactionType.EXPENSE || it.transactionType == TransactionType.CREDIT }
+            .sumByCurrency({ it.currency }, { it.amount })
+        val income = transactions
+            .filter { it.transactionType == TransactionType.INCOME }
+            .sumByCurrency({ it.currency }, { it.amount })
+        return GroupSummary(group, transactions.size, expense, income)
+    }
 
     fun getTransactionsForGroup(groupId: Long): Flow<List<TransactionEntity>> =
         groupDao.getTransactionsForGroup(groupId)

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionGroupRepository.kt
@@ -6,11 +6,8 @@ import com.pennywiseai.tracker.data.database.entity.TransactionGroupEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.utils.Money
 import com.pennywiseai.tracker.utils.sumByCurrency
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import java.time.LocalDateTime
 import javax.inject.Inject
@@ -38,19 +35,15 @@ class TransactionGroupRepository @Inject constructor(
 ) {
     fun getAllGroups(): Flow<List<TransactionGroupEntity>> = groupDao.getAllGroups()
 
-    /** Live [GroupSummary] per group; empty list when there are no groups. */
-    @OptIn(ExperimentalCoroutinesApi::class)
+    /**
+     * Live [GroupSummary] per group; empty list when there are no groups.
+     * All groups' transactions come from a single query (rather than one
+     * reactive query per group), so DB work stays constant as groups grow.
+     */
     fun observeGroupSummaries(): Flow<List<GroupSummary>> =
-        getAllGroups().flatMapLatest { groups ->
-            if (groups.isEmpty()) {
-                flowOf(emptyList())
-            } else {
-                combine(
-                    groups.map { group ->
-                        getTransactionsForGroup(group.id).map { txns -> buildSummary(group, txns) }
-                    }
-                ) { it.toList() }
-            }
+        combine(getAllGroups(), groupDao.getAllGroupedTransactions()) { groups, transactions ->
+            val byGroup = transactions.groupBy { it.groupId }
+            groups.map { group -> buildSummary(group, byGroup[group.id].orEmpty()) }
         }
 
     private fun buildSummary(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/groups/TransactionGroupsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/groups/TransactionGroupsScreen.kt
@@ -31,6 +31,7 @@ import com.pennywiseai.tracker.ui.effects.rememberOverscrollFlingBehavior
 import com.pennywiseai.tracker.ui.theme.*
 import com.pennywiseai.tracker.utils.CurrencyFormatter
 import com.pennywiseai.tracker.ui.components.PennyWiseEmptyState
+import com.pennywiseai.tracker.data.repository.GroupSummary
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
 import java.math.BigDecimal

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/groups/TransactionGroupsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/groups/TransactionGroupsViewModel.kt
@@ -2,34 +2,14 @@ package com.pennywiseai.tracker.presentation.groups
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.pennywiseai.tracker.data.database.entity.TransactionEntity
-import com.pennywiseai.tracker.data.database.entity.TransactionGroupEntity
-import com.pennywiseai.tracker.data.database.entity.TransactionType
+import com.pennywiseai.tracker.data.repository.GroupSummary
 import com.pennywiseai.tracker.data.repository.TransactionGroupRepository
-import com.pennywiseai.tracker.utils.sumByCurrency
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import com.pennywiseai.tracker.utils.Money
 import javax.inject.Inject
-
-data class GroupSummary(
-    val group: TransactionGroupEntity,
-    val transactionCount: Int,
-    // Totals are kept per-currency because a group can mix currencies and summing
-    // across them is meaningless. Keyed by currency code.
-    val expenseByCurrency: Map<String, Money>,
-    val incomeByCurrency: Map<String, Money>
-) {
-    val hasExpense: Boolean get() = expenseByCurrency.values.any { it.isPositive }
-    val hasIncome: Boolean get() = incomeByCurrency.values.any { it.isPositive }
-}
 
 data class TransactionGroupsUiState(
     val groups: List<GroupSummary> = emptyList(),
@@ -51,33 +31,10 @@ class TransactionGroupsViewModel @Inject constructor(
 
     private fun loadGroups() {
         viewModelScope.launch {
-            repository.getAllGroups()
-                .flatMapLatest { groups ->
-                    if (groups.isEmpty()) {
-                        flowOf(emptyList())
-                    } else {
-                        combine(
-                            groups.map { group ->
-                                repository.getTransactionsForGroup(group.id)
-                                    .map { txns -> buildSummary(group, txns) }
-                            }
-                        ) { it.toList() }
-                    }
-                }
-                .collect { summaries ->
-                    _uiState.value = _uiState.value.copy(groups = summaries, isLoading = false)
-                }
+            repository.observeGroupSummaries().collect { summaries ->
+                _uiState.value = _uiState.value.copy(groups = summaries, isLoading = false)
+            }
         }
-    }
-
-    private fun buildSummary(group: TransactionGroupEntity, transactions: List<TransactionEntity>): GroupSummary {
-        val expense = transactions
-            .filter { it.transactionType == TransactionType.EXPENSE || it.transactionType == TransactionType.CREDIT }
-            .sumByCurrency({ it.currency }, { it.amount })
-        val income = transactions
-            .filter { it.transactionType == TransactionType.INCOME }
-            .sumByCurrency({ it.currency }, { it.amount })
-        return GroupSummary(group, transactions.size, expense, income)
     }
 
     fun showCreateDialog() { _uiState.value = _uiState.value.copy(showCreateDialog = true) }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -70,6 +72,7 @@ import com.pennywiseai.tracker.R
 import com.pennywiseai.tracker.core.Constants
 import com.pennywiseai.tracker.data.database.entity.SubscriptionEntity
 import com.pennywiseai.tracker.ui.components.BrandIcon
+import com.pennywiseai.tracker.ui.components.cards.HomeGroupCard
 import com.pennywiseai.tracker.ui.components.cards.PennyWiseCardV2
 import com.pennywiseai.tracker.ui.components.PennyWiseEmptyState
 import com.pennywiseai.tracker.ui.components.cards.SectionHeaderV2
@@ -130,6 +133,7 @@ fun HomeScreen(
     onNavigateToSubscriptions: () -> Unit = {},
     onNavigateToBudgets: () -> Unit = {},
     onNavigateToLoans: () -> Unit = {},
+    onNavigateToTransactionGroups: () -> Unit = {},
     onLoanClick: (Long) -> Unit = {},
     onNavigateToAddScreen: () -> Unit = {},
     onNavigateToManageAccounts: () -> Unit = {},
@@ -144,6 +148,7 @@ fun HomeScreen(
     var showUpgradeSheet by rememberSaveable { mutableStateOf(false) }
     val deletedTransaction by viewModel.deletedTransaction.collectAsState()
     val smsScanWorkInfo by viewModel.smsScanWorkInfo.collectAsState()
+    val groupSummaries by viewModel.groupSummaries.collectAsState()
     val showSharePrompt by viewModel.showSharePrompt.collectAsState()
     val activity = LocalActivity.current
 
@@ -598,6 +603,57 @@ fun HomeScreen(
                                     currency = uiState.selectedCurrency,
                                     onClick = onNavigateToLoans
                                 )
+                            }
+                        }
+                    }
+                }
+            }
+
+            // 2.5. Groups section (#664) — a horizontal rail of the user's
+            // transaction groups, absent entirely when none exist so Home
+            // stays uncluttered for everyone else. Discovery was the ask:
+            // groups only surfaced via Settings or a group card that happened
+            // to have recent activity.
+            if (groupSummaries.isNotEmpty()) {
+                item {
+                    val visible = remember { mutableStateOf(hasAnimated) }
+                    LaunchedEffect(Unit) {
+                        if (!hasAnimated) { delay(100); visible.value = true }
+                    }
+                    AnimatedVisibility(
+                        visible = visible.value,
+                        enter = fadeIn(tween(300)) + slideInVertically(
+                            initialOffsetY = { slideOffsetPx },
+                            animationSpec = tween(300)
+                        )
+                    ) {
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(Spacing.Layout.headerToContent)
+                        ) {
+                            SectionHeaderV2(
+                                title = "Groups",
+                                modifier = Modifier.padding(horizontal = Dimensions.Padding.content),
+                                action = {
+                                    TextButton(onClick = onNavigateToTransactionGroups) {
+                                        Text("View All")
+                                        Icon(
+                                            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(Dimensions.Icon.small)
+                                        )
+                                    }
+                                }
+                            )
+                            LazyRow(
+                                contentPadding = PaddingValues(horizontal = Dimensions.Padding.content),
+                                horizontalArrangement = Arrangement.spacedBy(Spacing.sm)
+                            ) {
+                                items(groupSummaries, key = { it.group.id }) { summary ->
+                                    HomeGroupCard(
+                                        summary = summary,
+                                        onClick = { onGroupClick(summary.group.id) }
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -49,6 +49,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -98,6 +100,15 @@ class HomeViewModel @Inject constructor(
     // SMS scanning work progress tracking
     private val _smsScanWorkInfo = MutableStateFlow<WorkInfo?>(null)
     val smsScanWorkInfo: StateFlow<WorkInfo?> = _smsScanWorkInfo.asStateFlow()
+
+    /**
+     * Groups for the Home "Groups" section (#664). Groups were only reachable
+     * through Settings / the recent list's incidental group cards; an empty
+     * list keeps the section (and its Home footprint) entirely absent.
+     */
+    val groupSummaries: StateFlow<List<com.pennywiseai.tracker.data.repository.GroupSummary>> =
+        transactionGroupRepository.observeGroupSummaries()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     /**
      * The user's current budget cycle window (start, end). Recomputed whenever

--- a/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
@@ -207,6 +207,11 @@ fun MainScreen(
                                     com.pennywiseai.tracker.navigation.TransactionDetail(transactionId)
                                 ) { launchSingleTop = true }
                             },
+                            onNavigateToTransactionGroups = {
+                                rootNavController?.navigate(
+                                    com.pennywiseai.tracker.navigation.TransactionGroups
+                                ) { launchSingleTop = true }
+                            },
                             onGroupClick = { groupId ->
                                 rootNavController?.navigate(
                                     com.pennywiseai.tracker.navigation.TransactionGroupDetail(groupId)

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/HomeGroupCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/HomeGroupCard.kt
@@ -1,0 +1,112 @@
+package com.pennywiseai.tracker.ui.components.cards
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.pennywiseai.tracker.data.repository.GroupSummary
+import com.pennywiseai.tracker.ui.theme.Spacing
+import com.pennywiseai.tracker.ui.theme.expense_dark
+import com.pennywiseai.tracker.ui.theme.expense_light
+import com.pennywiseai.tracker.ui.theme.income_dark
+import com.pennywiseai.tracker.ui.theme.income_light
+import com.pennywiseai.tracker.utils.CurrencyFormatter
+
+/**
+ * Compact group card for the Home "Groups" rail (#664) — a horizontal-scroll
+ * sibling of the full-width card on the groups screen, sharing its visual
+ * language (initial-in-circle accent, per-currency totals) so the two read as
+ * the same object at different sizes.
+ */
+@Composable
+fun HomeGroupCard(
+    summary: GroupSummary,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val isDark = isSystemInDarkTheme()
+    val accentColor = if (isDark) income_dark else income_light
+    val expenseColor = if (isDark) expense_dark else expense_light
+
+    PennyWiseCardV2(
+        modifier = modifier.width(210.dp),
+        onClick = onClick
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(36.dp)
+                        .clip(CircleShape)
+                        .background(accentColor.copy(alpha = 0.15f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = summary.group.name.take(1).uppercase(),
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = accentColor
+                    )
+                }
+                Column {
+                    Text(
+                        text = summary.group.name,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = "${summary.transactionCount} item${if (summary.transactionCount != 1) "s" else ""}",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            // Per-currency figures, same rule as everywhere: mixed currencies
+            // are listed side by side, never summed into one number.
+            when {
+                summary.hasExpense -> Text(
+                    text = CurrencyFormatter.formatByCurrency(summary.expenseByCurrency, signPrefix = "-"),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = expenseColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                summary.hasIncome -> Text(
+                    text = CurrencyFormatter.formatByCurrency(summary.incomeByCurrency, signPrefix = "+"),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = accentColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                else -> Text(
+                    text = "No transactions yet",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/HomeGroupCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/HomeGroupCard.kt
@@ -83,29 +83,35 @@ fun HomeGroupCard(
             }
 
             // Per-currency figures, same rule as everywhere: mixed currencies
-            // are listed side by side, never summed into one number.
-            when {
-                summary.hasExpense -> Text(
-                    text = CurrencyFormatter.formatByCurrency(summary.expenseByCurrency, signPrefix = "-"),
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = expenseColor,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-                summary.hasIncome -> Text(
-                    text = CurrencyFormatter.formatByCurrency(summary.incomeByCurrency, signPrefix = "+"),
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = accentColor,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-                else -> Text(
+            // are listed side by side, never summed into one number. A group
+            // holding both directions shows both lines, like the groups screen.
+            if (!summary.hasExpense && !summary.hasIncome) {
+                Text(
                     text = "No transactions yet",
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
+            } else {
+                if (summary.hasExpense) {
+                    Text(
+                        text = CurrencyFormatter.formatByCurrency(summary.expenseByCurrency, signPrefix = "-"),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = expenseColor,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                if (summary.hasIncome) {
+                    Text(
+                        text = CurrencyFormatter.formatByCurrency(summary.incomeByCurrency, signPrefix = "+"),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = accentColor,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## What (#664, from Discord)

Groups were effectively hidden — reachable only via Settings or a group card that happened to have recent activity. Home now has a **Groups** section: a horizontal rail of compact group cards between Loans and Recent Transactions.

## UI decisions

- **Absent when empty** — users without groups see zero change to Home.
- Cards share the groups screen's visual language (initial-in-circle accent, per-currency expense/income via `formatByCurrency` — mixed currencies listed side by side, never summed) so the rail and the full screen read as the same object at two sizes.
- "View All" → groups screen; card tap → group detail via the **existing** `onGroupClick` wiring (no new nav routes).
- Same entrance animation/delay tier as the neighboring sections.

## Reuse

The summary aggregation (`GroupSummary` + per-currency totals) moved from `TransactionGroupsViewModel` into `TransactionGroupRepository.observeGroupSummaries()` — the groups screen and Home now consume one source and can't drift.

## Verification

`./init.sh app` green. Emulator: created "Goa Trip" via bulk-select → section appears (1 item, −₹54), tap opens the group detail, View All opens the groups screen.

Fixes #664