### PR TITLE
feat(security): pin chat model to versioned URL + verify SHA-256 before load

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/core/Constants.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/core/Constants.kt
@@ -72,10 +72,38 @@ object Constants {
     
     /**
      * LLM Model Configuration
+     *
+     * The chat model is distributed from a **versioned, immutable object key**
+     * and verified against a pinned SHA-256 before it is ever loaded. To publish
+     * a new model: upload it under a fresh [MODEL_VERSION] key (never overwrite an
+     * existing version in place), then bump [MODEL_VERSION] and [MODEL_SHA256]
+     * together. This makes a silently-swapped model impossible to ship.
      */
     object ModelDownload {
-        const val MODEL_URL = "https://pub-fcfb3ffddb184540a758a7fe68249908.r2.dev/Qwen2.5-1.5B-Instruct-q8-ekv4096.litertlm"
         const val MODEL_FILE_NAME = "Qwen2.5-1.5B-Instruct-q8-ekv4096.litertlm"
+
+        /** Bump when a new model build is published under a new versioned key. */
+        const val MODEL_VERSION = "v1"
+
+        private const val R2_PUBLIC_BASE =
+            "https://pub-fcfb3ffddb184540a758a7fe68249908.r2.dev"
+
+        /**
+         * Pinned to an immutable, versioned path — NOT the bare bucket root, so a
+         * given URL always resolves to the same bytes. The object must be uploaded
+         * to this exact key in R2 (`models/$MODEL_VERSION/$MODEL_FILE_NAME`).
+         */
+        const val MODEL_URL = "$R2_PUBLIC_BASE/models/$MODEL_VERSION/$MODEL_FILE_NAME"
+
+        /**
+         * Lowercase-hex SHA-256 of the exact bytes served at [MODEL_URL]. The
+         * downloaded file is hashed and compared against this before it is loaded;
+         * a mismatch is rejected and the file deleted. Recompute and bump on every
+         * model change. Leave blank ONLY to intentionally disable verification (a
+         * warning is logged and any file is accepted).
+         */
+        const val MODEL_SHA256 = "faa60663b333290c1496c499828b21d3e3254a788cacd8cce917ce0f761a2dc9"
+
         const val MODEL_SIZE_MB = 1524L
         const val MODEL_SIZE_BYTES = 1_597_931_520L
         const val REQUIRED_SPACE_BYTES = 3_195_863_040L // ~3.0GB (2x model size for safety)

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/LlmRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/LlmRepository.kt
@@ -140,6 +140,13 @@ class LlmRepository @Inject constructor(
                 throw Exception("Model not downloaded. Please download from Settings.")
             }
 
+            // Integrity gate: never load a model whose bytes don't match the
+            // pinned hash (guards against an in-place-swapped or corrupted file).
+            if (!modelRepository.verifyModelIntegrity()) {
+                modelRepository.deleteModel()
+                throw Exception("AI model failed its integrity check and was removed. Please re-download it from Settings.")
+            }
+
             val initResult = llmService.initialize(modelFile.absolutePath)
             if (initResult.isFailure) {
                 throw initResult.exceptionOrNull() ?: Exception("Failed to initialize LLM")

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/ModelRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/ModelRepository.kt
@@ -22,11 +22,6 @@ class ModelRepository @Inject constructor(
     private val _modelState = MutableStateFlow(ModelState.NOT_DOWNLOADED)
     val modelState: Flow<ModelState> = _modelState.asStateFlow()
 
-    // Length of the file last confirmed to match the pinned hash, so we don't
-    // re-hash 1.5GB on every message once verified within this process.
-    @Volatile
-    private var lastVerifiedLength: Long = -1L
-    
     fun getModelFile(): File {
         val file = File(context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS), Constants.ModelDownload.MODEL_FILE_NAME)
         Log.d("ModelRepository", "Model file path: ${file.absolutePath}")
@@ -49,9 +44,16 @@ class ModelRepository @Inject constructor(
     
     /**
      * Verifies the downloaded model against the pinned [Constants.ModelDownload.MODEL_SHA256]
-     * by streaming its SHA-256. Returns true only when the file exists and matches
-     * (or when no hash is pinned, in which case verification is intentionally
-     * disabled and a warning is logged). Result is cached per process by file length.
+     * by streaming its full SHA-256 — every call actually re-hashes the bytes on disk.
+     *
+     * This is the load-time security boundary, so it must NOT be short-circuited by a
+     * cheap proxy (size, mtime, a cached "already verified" flag): the model has a
+     * fixed length, so a same-length replacement would otherwise pass without ever
+     * being read. On a match it drops a verification marker that [isModelVerified] may
+     * read for UI state only — never as a substitute for this hash.
+     *
+     * Returns true when the bytes match, or when no hash is pinned (verification
+     * intentionally disabled, logged).
      */
     suspend fun verifyModelIntegrity(): Boolean = withContext(Dispatchers.IO) {
         val expected = Constants.ModelDownload.MODEL_SHA256.trim().lowercase()
@@ -63,12 +65,8 @@ class ModelRepository @Inject constructor(
         val file = getModelFile()
         if (!file.exists()) {
             Log.w(TAG, "verifyModelIntegrity: model file missing")
+            clearVerifiedMarker()
             return@withContext false
-        }
-
-        val length = file.length()
-        if (length > 0 && length == lastVerifiedLength) {
-            return@withContext true
         }
 
         val actual = try {
@@ -80,10 +78,10 @@ class ModelRepository @Inject constructor(
 
         val matches = actual == expected
         if (matches) {
-            lastVerifiedLength = length
+            writeVerifiedMarker(expected)
             Log.d(TAG, "Model integrity verified (sha256=$actual)")
         } else {
-            lastVerifiedLength = -1L
+            clearVerifiedMarker()
             Log.e(TAG, "Model integrity check FAILED: expected=$expected actual=$actual")
         }
         matches
@@ -102,24 +100,89 @@ class ModelRepository @Inject constructor(
         return digest.digest().joinToString("") { "%02x".format(it) }
     }
 
+    private fun verifiedMarkerFile(): File =
+        File(getModelFile().parentFile, Constants.ModelDownload.MODEL_FILE_NAME + ".verified")
+
+    private fun writeVerifiedMarker(hash: String) {
+        try {
+            verifiedMarkerFile().writeText(hash)
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not write verification marker", e)
+        }
+    }
+
+    private fun clearVerifiedMarker() {
+        try {
+            val marker = verifiedMarkerFile()
+            if (marker.exists()) marker.delete()
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not clear verification marker", e)
+        }
+    }
+
+    /**
+     * Cheap check (no hashing) of whether the model on disk has previously passed
+     * [verifyModelIntegrity]. For driving UI state ONLY — the load path always
+     * re-hashes via [verifyModelIntegrity] and never trusts this marker.
+     */
+    fun isModelVerified(): Boolean {
+        if (!isModelDownloaded()) return false
+        val expected = Constants.ModelDownload.MODEL_SHA256.trim().lowercase()
+        if (expected.isEmpty()) return true // verification disabled → any downloaded file counts
+        val marker = verifiedMarkerFile()
+        return try {
+            marker.exists() && marker.readText().trim().lowercase() == expected
+        } catch (e: Exception) {
+            false
+        }
+    }
+
     fun updateModelState(state: ModelState) {
         Log.d("ModelRepository", "Updating model state from ${_modelState.value} to $state")
         _modelState.value = state
     }
-    
-    fun checkModelState() {
-        val newState = if (isModelDownloaded()) {
-            ModelState.READY
-        } else {
-            ModelState.NOT_DOWNLOADED
+
+    /**
+     * Resolves the model state on app open. A previously-verified file goes straight to
+     * READY; a present-but-unverified file (a download whose post-download verification
+     * was interrupted, or a model carried over from an older build) is re-hashed before
+     * it is trusted, and deleted if it fails. Never reports READY for an unverified file.
+     */
+    suspend fun refreshModelState() {
+        when {
+            isModelVerified() -> updateModelState(ModelState.READY)
+            isModelDownloaded() -> {
+                updateModelState(ModelState.LOADING)
+                if (verifyModelIntegrity()) {
+                    updateModelState(ModelState.READY)
+                } else {
+                    Log.e(TAG, "Present model failed verification on open — deleting")
+                    deleteModel()
+                }
+            }
+            else -> updateModelState(ModelState.NOT_DOWNLOADED)
         }
-        Log.d("ModelRepository", "checkModelState: setting state to $newState")
-        _modelState.value = newState
     }
-    
+
+    /**
+     * Verifies a freshly-completed download before trusting it. Promotes to READY on a
+     * hash match, otherwise deletes the file and reports failure. Returns true iff the
+     * bytes matched the pinned hash.
+     */
+    suspend fun finalizeDownloadedModel(): Boolean {
+        return if (verifyModelIntegrity()) {
+            updateModelState(ModelState.READY)
+            true
+        } else {
+            Log.e(TAG, "Downloaded model failed verification — deleting")
+            deleteModel()
+            false
+        }
+    }
+
     fun deleteModel(): Boolean {
         val modelFile = getModelFile()
-        lastVerifiedLength = -1L
+        clearVerifiedMarker()
         return if (modelFile.exists()) {
             val deleted = modelFile.delete()
             if (deleted) {
@@ -127,6 +190,7 @@ class ModelRepository @Inject constructor(
             }
             deleted
         } else {
+            _modelState.value = ModelState.NOT_DOWNLOADED
             false
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/ModelRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/ModelRepository.kt
@@ -5,10 +5,13 @@ import android.os.Environment
 import android.util.Log
 import com.pennywiseai.tracker.core.Constants
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
 import java.io.File
+import java.security.MessageDigest
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -18,6 +21,11 @@ class ModelRepository @Inject constructor(
 ) {
     private val _modelState = MutableStateFlow(ModelState.NOT_DOWNLOADED)
     val modelState: Flow<ModelState> = _modelState.asStateFlow()
+
+    // Length of the file last confirmed to match the pinned hash, so we don't
+    // re-hash 1.5GB on every message once verified within this process.
+    @Volatile
+    private var lastVerifiedLength: Long = -1L
     
     fun getModelFile(): File {
         val file = File(context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS), Constants.ModelDownload.MODEL_FILE_NAME)
@@ -39,6 +47,61 @@ class ModelRepository @Inject constructor(
         return isDownloaded
     }
     
+    /**
+     * Verifies the downloaded model against the pinned [Constants.ModelDownload.MODEL_SHA256]
+     * by streaming its SHA-256. Returns true only when the file exists and matches
+     * (or when no hash is pinned, in which case verification is intentionally
+     * disabled and a warning is logged). Result is cached per process by file length.
+     */
+    suspend fun verifyModelIntegrity(): Boolean = withContext(Dispatchers.IO) {
+        val expected = Constants.ModelDownload.MODEL_SHA256.trim().lowercase()
+        if (expected.isEmpty()) {
+            Log.w(TAG, "MODEL_SHA256 is blank — model integrity verification is DISABLED")
+            return@withContext true
+        }
+
+        val file = getModelFile()
+        if (!file.exists()) {
+            Log.w(TAG, "verifyModelIntegrity: model file missing")
+            return@withContext false
+        }
+
+        val length = file.length()
+        if (length > 0 && length == lastVerifiedLength) {
+            return@withContext true
+        }
+
+        val actual = try {
+            file.sha256Hex()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to hash model file", e)
+            return@withContext false
+        }
+
+        val matches = actual == expected
+        if (matches) {
+            lastVerifiedLength = length
+            Log.d(TAG, "Model integrity verified (sha256=$actual)")
+        } else {
+            lastVerifiedLength = -1L
+            Log.e(TAG, "Model integrity check FAILED: expected=$expected actual=$actual")
+        }
+        matches
+    }
+
+    private fun File.sha256Hex(): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        inputStream().use { input ->
+            val buffer = ByteArray(64 * 1024)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
     fun updateModelState(state: ModelState) {
         Log.d("ModelRepository", "Updating model state from ${_modelState.value} to $state")
         _modelState.value = state
@@ -56,6 +119,7 @@ class ModelRepository @Inject constructor(
     
     fun deleteModel(): Boolean {
         val modelFile = getModelFile()
+        lastVerifiedLength = -1L
         return if (modelFile.exists()) {
             val deleted = modelFile.delete()
             if (deleted) {
@@ -65,6 +129,10 @@ class ModelRepository @Inject constructor(
         } else {
             false
         }
+    }
+
+    private companion object {
+        const val TAG = "ModelRepository"
     }
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/chat/ChatViewModel.kt
@@ -73,7 +73,11 @@ class ChatViewModel @Inject constructor(
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
-            initialValue = if (modelRepository.isModelDownloaded()) ModelState.READY else ModelState.NOT_DOWNLOADED
+            initialValue = when {
+                modelRepository.isModelVerified() -> ModelState.READY
+                modelRepository.isModelDownloaded() -> ModelState.LOADING // present, pending re-verify
+                else -> ModelState.NOT_DOWNLOADED
+            }
         )
     
     private val _uiState = MutableStateFlow(ChatUiState())
@@ -131,14 +135,12 @@ class ChatViewModel @Inject constructor(
     )
     
     init {
-        modelRepository.checkModelState()
-
         // Load initial context message for display
         viewModelScope.launch {
             loadContextMessage()
         }
 
-        // Pick up any in-progress download
+        // Resume an in-progress download, or (when idle) resolve + re-verify the model.
         checkAndResumeDownload()
     }
     
@@ -312,12 +314,10 @@ class ChatViewModel @Inject constructor(
                         when (cursor.getInt(statusCol)) {
                             DownloadManager.STATUS_SUCCESSFUL -> {
                                 userPreferencesRepository.clearActiveDownloadId()
+                                _downloadProgress.value = 100
                                 // Verify the freshly-downloaded bytes before trusting the model.
-                                if (modelRepository.verifyModelIntegrity()) {
-                                    _downloadProgress.value = 100
-                                    modelRepository.updateModelState(ModelState.READY)
-                                } else {
-                                    modelRepository.deleteModel()
+                                modelRepository.updateModelState(ModelState.LOADING)
+                                if (!modelRepository.finalizeDownloadedModel()) {
                                     _downloadProgress.value = 0
                                     modelRepository.updateModelState(ModelState.ERROR)
                                     _uiState.value = _uiState.value.copy(
@@ -341,33 +341,38 @@ class ChatViewModel @Inject constructor(
 
     fun checkAndResumeDownload() {
         viewModelScope.launch {
-            val savedDownloadId = userPreferencesRepository.getActiveDownloadId() ?: return@launch
-            val query = DownloadManager.Query().setFilterById(savedDownloadId)
-            val cursor = downloadManager.query(query)
-            if (cursor != null && cursor.moveToFirst()) {
-                val statusIndex = cursor.getColumnIndex(DownloadManager.COLUMN_STATUS)
-                if (statusIndex != -1) {
-                    val status = cursor.getInt(statusIndex)
-                    if (status == DownloadManager.STATUS_RUNNING || status == DownloadManager.STATUS_PENDING) {
-                        currentDownloadId = savedDownloadId
-                        modelRepository.updateModelState(ModelState.DOWNLOADING)
-                        val bytesCol = cursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR)
-                        val totalCol = cursor.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES)
-                        if (bytesCol != -1 && totalCol != -1) {
-                            val bytes = cursor.getLong(bytesCol)
-                            var total = cursor.getLong(totalCol)
-                            if (total <= 0) total = Constants.ModelDownload.MODEL_SIZE_BYTES
-                            _downloadedMB.value = bytes / (1024 * 1024)
-                            _totalMB.value = total / (1024 * 1024)
-                            if (total > 0) _downloadProgress.value = (bytes * 100 / total).toInt()
+            val savedDownloadId = userPreferencesRepository.getActiveDownloadId()
+            if (savedDownloadId != null) {
+                val query = DownloadManager.Query().setFilterById(savedDownloadId)
+                val cursor = downloadManager.query(query)
+                if (cursor != null && cursor.moveToFirst()) {
+                    val statusIndex = cursor.getColumnIndex(DownloadManager.COLUMN_STATUS)
+                    if (statusIndex != -1) {
+                        val status = cursor.getInt(statusIndex)
+                        if (status == DownloadManager.STATUS_RUNNING || status == DownloadManager.STATUS_PENDING) {
+                            currentDownloadId = savedDownloadId
+                            modelRepository.updateModelState(ModelState.DOWNLOADING)
+                            val bytesCol = cursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR)
+                            val totalCol = cursor.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES)
+                            if (bytesCol != -1 && totalCol != -1) {
+                                val bytes = cursor.getLong(bytesCol)
+                                var total = cursor.getLong(totalCol)
+                                if (total <= 0) total = Constants.ModelDownload.MODEL_SIZE_BYTES
+                                _downloadedMB.value = bytes / (1024 * 1024)
+                                _totalMB.value = total / (1024 * 1024)
+                                if (total > 0) _downloadProgress.value = (bytes * 100 / total).toInt()
+                            }
+                            cursor.close()
+                            monitorDownload(savedDownloadId)
+                            return@launch
                         }
-                        cursor.close()
-                        monitorDownload(savedDownloadId)
-                        return@launch
                     }
+                    cursor.close()
                 }
-                cursor.close()
             }
+            // No active download to resume → resolve the model state, re-verifying a
+            // present-but-unverified file before it is shown as READY.
+            modelRepository.refreshModelState()
         }
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/chat/ChatViewModel.kt
@@ -311,9 +311,19 @@ class ChatViewModel @Inject constructor(
                     if (statusCol != -1) {
                         when (cursor.getInt(statusCol)) {
                             DownloadManager.STATUS_SUCCESSFUL -> {
-                                _downloadProgress.value = 100
                                 userPreferencesRepository.clearActiveDownloadId()
-                                modelRepository.updateModelState(ModelState.READY)
+                                // Verify the freshly-downloaded bytes before trusting the model.
+                                if (modelRepository.verifyModelIntegrity()) {
+                                    _downloadProgress.value = 100
+                                    modelRepository.updateModelState(ModelState.READY)
+                                } else {
+                                    modelRepository.deleteModel()
+                                    _downloadProgress.value = 0
+                                    modelRepository.updateModelState(ModelState.ERROR)
+                                    _uiState.value = _uiState.value.copy(
+                                        error = "Downloaded model failed its integrity check and was removed. Please try downloading again."
+                                    )
+                                }
                             }
                             DownloadManager.STATUS_FAILED -> {
                                 userPreferencesRepository.clearActiveDownloadId()

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -172,9 +172,9 @@ class SettingsViewModel @Inject constructor(
         )
     
     init {
+        // Resolves the shared ModelState (verifying a present file when needed) across
+        // every branch below, so it replaces the old size-only checkModelState().
         checkDownloadStatus()
-        // Also sync with model repository
-        modelRepository.checkModelState()
     }
     
     private fun checkDownloadStatus() {
@@ -217,10 +217,16 @@ class SettingsViewModel @Inject constructor(
                                 monitorDownload(savedDownloadId)
                             }
                             DownloadManager.STATUS_SUCCESSFUL -> {
-                                _downloadState.value = DownloadState.COMPLETED
                                 _downloadProgress.value = 100
                                 userPreferencesRepository.clearActiveDownloadId()
-                                modelRepository.updateModelState(ModelState.READY)
+                                // Verify before trusting the completed download.
+                                modelRepository.updateModelState(ModelState.LOADING)
+                                if (modelRepository.finalizeDownloadedModel()) {
+                                    _downloadState.value = DownloadState.COMPLETED
+                                } else {
+                                    _downloadState.value = DownloadState.FAILED
+                                    _downloadProgress.value = 0
+                                }
                             }
                             DownloadManager.STATUS_FAILED -> {
                                 _downloadState.value = DownloadState.FAILED
@@ -250,32 +256,20 @@ class SettingsViewModel @Inject constructor(
         }
     }
     
-    private fun checkModelFile() {
+    private suspend fun checkModelFile() {
         val modelFile = File(context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS), Constants.ModelDownload.MODEL_FILE_NAME)
         Log.d("SettingsViewModel", "Checking model file at: ${modelFile.absolutePath}")
         Log.d("SettingsViewModel", "Model file exists: ${modelFile.exists()}, size: ${modelFile.length()}, expected: ${Constants.ModelDownload.MODEL_SIZE_BYTES}")
-        
+
         // Check against expected size to ensure it's complete
         // Allow 5% variance in file size as download sizes can vary slightly
         val minSize = (Constants.ModelDownload.MODEL_SIZE_BYTES * 0.95).toLong()
-        val maxSize = (Constants.ModelDownload.MODEL_SIZE_BYTES * 1.05).toLong()
-        
-        if (modelFile.exists() && modelFile.length() in minSize..maxSize) {
+
+        if (modelFile.exists() && modelFile.length() >= minSize) {
             _downloadState.value = DownloadState.COMPLETED
             _totalMB.value = modelFile.length() / (1024 * 1024)
             _downloadedMB.value = _totalMB.value
             _downloadProgress.value = 100
-            // Update model repository state
-            Log.d("SettingsViewModel", "Model complete (${modelFile.length()} bytes), updating repository state to READY")
-            modelRepository.updateModelState(ModelState.READY)
-        } else if (modelFile.exists() && modelFile.length() > maxSize) {
-            // File is too large, but might still be valid - mark as complete
-            _downloadState.value = DownloadState.COMPLETED
-            _totalMB.value = modelFile.length() / (1024 * 1024)
-            _downloadedMB.value = _totalMB.value
-            _downloadProgress.value = 100
-            Log.d("SettingsViewModel", "Model file larger than expected (${modelFile.length()} bytes), but marking as complete")
-            modelRepository.updateModelState(ModelState.READY)
         } else if (modelFile.exists()) {
             // Partial file exists, delete it
             Log.d("SettingsViewModel", "Partial model file found (${modelFile.length()} bytes), deleting")
@@ -285,6 +279,10 @@ class SettingsViewModel @Inject constructor(
             Log.d("SettingsViewModel", "Model not found")
             _downloadState.value = DownloadState.NOT_DOWNLOADED
         }
+
+        // Own the shared ModelState here: a present file is re-verified (deleted if it
+        // fails the hash) before it is ever reported READY.
+        modelRepository.refreshModelState()
     }
     
     fun startModelDownload() {
@@ -396,13 +394,19 @@ class SettingsViewModel @Inject constructor(
                     if (statusColumnIndex != -1) {
                         when (cursor.getInt(statusColumnIndex)) {
                             DownloadManager.STATUS_SUCCESSFUL -> {
-                                _downloadState.value = DownloadState.COMPLETED
                                 _downloadProgress.value = 100
                                 // Clear saved download ID
                                 userPreferencesRepository.clearActiveDownloadId()
-                                // Update model repository state
-                                modelRepository.updateModelState(ModelState.READY)
-                                Log.d("SettingsViewModel", "Download completed successfully")
+                                // Verify before trusting the completed download.
+                                modelRepository.updateModelState(ModelState.LOADING)
+                                if (modelRepository.finalizeDownloadedModel()) {
+                                    _downloadState.value = DownloadState.COMPLETED
+                                    Log.d("SettingsViewModel", "Download completed and verified")
+                                } else {
+                                    _downloadState.value = DownloadState.FAILED
+                                    _downloadProgress.value = 0
+                                    Log.e("SettingsViewModel", "Download failed integrity check")
+                                }
                             }
                             DownloadManager.STATUS_FAILED -> {
                                 _downloadState.value = DownloadState.FAILED

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -261,28 +261,29 @@ class SettingsViewModel @Inject constructor(
         Log.d("SettingsViewModel", "Checking model file at: ${modelFile.absolutePath}")
         Log.d("SettingsViewModel", "Model file exists: ${modelFile.exists()}, size: ${modelFile.length()}, expected: ${Constants.ModelDownload.MODEL_SIZE_BYTES}")
 
-        // Check against expected size to ensure it's complete
-        // Allow 5% variance in file size as download sizes can vary slightly
+        // Drop an obviously-incomplete partial file before verifying.
+        // Allow 5% variance in file size as download sizes can vary slightly.
         val minSize = (Constants.ModelDownload.MODEL_SIZE_BYTES * 0.95).toLong()
+        if (modelFile.exists() && modelFile.length() < minSize) {
+            Log.d("SettingsViewModel", "Partial model file found (${modelFile.length()} bytes), deleting")
+            modelFile.delete()
+        }
 
-        if (modelFile.exists() && modelFile.length() >= minSize) {
+        // Re-verify a present full-size file; a hash mismatch deletes it here. This MUST
+        // run before we set DownloadState so a rejected model is never reported COMPLETED.
+        modelRepository.refreshModelState()
+
+        // Mirror the real post-verification outcome into the Settings download state, so
+        // a deleted (hash-invalid) model shows NOT_DOWNLOADED rather than a stale COMPLETED.
+        if (modelRepository.isModelDownloaded()) {
             _downloadState.value = DownloadState.COMPLETED
             _totalMB.value = modelFile.length() / (1024 * 1024)
             _downloadedMB.value = _totalMB.value
             _downloadProgress.value = 100
-        } else if (modelFile.exists()) {
-            // Partial file exists, delete it
-            Log.d("SettingsViewModel", "Partial model file found (${modelFile.length()} bytes), deleting")
-            modelFile.delete()
-            _downloadState.value = DownloadState.NOT_DOWNLOADED
         } else {
-            Log.d("SettingsViewModel", "Model not found")
             _downloadState.value = DownloadState.NOT_DOWNLOADED
+            _downloadProgress.value = 0
         }
-
-        // Own the shared ModelState here: a present file is re-verified (deleted if it
-        // fails the hash) before it is ever reported READY.
-        modelRepository.refreshModelState()
     }
     
     fun startModelDownload() {


### PR DESCRIPTION
## Problem

The on-device chat model (`Qwen2.5-1.5B-Instruct-q8-ekv4096.litertlm`) was downloaded from a **bare R2 bucket path** with no version pinning and **no integrity check**:

- `DownloadManager` fetched the file; on `STATUS_SUCCESSFUL` it was marked `READY`.
- `isModelDownloaded()` accepted it on **file size alone** (≥95% of expected).
- `LlmRepository.ensureConversation()` loaded whatever file was at that path into MediaPipe, unconditionally.

So if the served bytes ever changed in place — host account handover, a CDN issue, or an accidental/hostile overwrite — the app would **silently load a swapped model** inside a finance app, with no version bump to make it noticeable. (HTTPS already covers the in-transit case; this is about the object changing at rest.)

Reported privately by an external researcher as a hardening suggestion (not an exploit).

## Change

1. **Versioned, immutable URL** — `MODEL_URL` is now built from `models/$MODEL_VERSION/$MODEL_FILE_NAME` instead of the bucket root, so a given URL always resolves to the same bytes. Publishing a new model means a new versioned key + a hash bump, never an in-place overwrite.
2. **Pinned SHA-256** — `MODEL_SHA256` ships in the app; the downloaded file is hashed and compared before it is ever loaded.
3. **Verify-before-load** — `LlmRepository.ensureConversation()` calls `verifyModelIntegrity()` and refuses to load (deletes the file) on mismatch.
4. **Verify-before-READY** — `ChatViewModel` verifies a freshly-downloaded file before flipping to `READY`; a bad file is deleted and surfaced as an error.

`verifyModelIntegrity()` streams the SHA-256 (64 KB buffer), caches the result per process by file length so we don't re-hash 1.5 GB on every message, and treats a blank hash as "verification intentionally disabled" (logged warning).

## Infra

The model has been copied server-side in R2 to the new versioned key `models/v1/…`. The public URL was downloaded and confirmed to hash to the pinned value; the old root object is left intact for backward compatibility with already-shipped builds.

## Verification

- `./init.sh app` — green (compile + unit tests).
- Public `models/v1/` URL: `HTTP 200`, `Content-Length` 1,597,931,520, SHA-256 == pinned `faa60663…1a2dc9`.
- Recommended follow-up: on-device pass of the download → verify → ready path before release.