### PR TITLE
fix(currency): skip unconvertible foreign amounts instead of counting face value (#670)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/currency/CurrencyConversionService.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/currency/CurrencyConversionService.kt
@@ -51,7 +51,12 @@ class CurrencyConversionService @Inject constructor(
     private val failedRefreshCooldownMs = TimeConstants.MILLIS_PER_5_MINUTES
 
     /**
-     * Convert amount from one currency to another
+     * Convert amount from one currency to another. Falls back to the
+     * UNCONVERTED amount when no rate has ever been known for the pair — only
+     * acceptable for single-value display next to an explicit currency label.
+     * Aggregations must use [convertAmountOrNull] and skip instead: summing a
+     * face-value foreign amount into another currency's total is never right
+     * (#670, hard constraint 2).
      */
     suspend fun convertAmount(
         amount: BigDecimal,
@@ -59,16 +64,27 @@ class CurrencyConversionService @Inject constructor(
         toCurrency: String,
         forceRefresh: Boolean = false
     ): BigDecimal {
+        return convertAmountOrNull(amount, fromCurrency, toCurrency, forceRefresh) ?: amount
+    }
+
+    /**
+     * Like [convertAmount], but returns null when the pair has never had a
+     * rate (unsupported currency, or first launch while offline). With the
+     * any-age fallback in [getExchangeRate], a null here is rare and terminal
+     * — callers should leave the value out rather than misstate it.
+     */
+    suspend fun convertAmountOrNull(
+        amount: BigDecimal,
+        fromCurrency: String,
+        toCurrency: String,
+        forceRefresh: Boolean = false
+    ): BigDecimal? {
         if (fromCurrency.equals(toCurrency, ignoreCase = true)) {
             return amount
         }
 
-        val rate = getExchangeRate(fromCurrency, toCurrency, forceRefresh)
-        return if (rate != null) {
-            amount.multiply(rate).setScale(2, RoundingMode.HALF_UP)
-        } else {
-            amount // Return original amount if conversion fails
-        }
+        val rate = getExchangeRate(fromCurrency, toCurrency, forceRefresh) ?: return null
+        return amount.multiply(rate).setScale(2, RoundingMode.HALF_UP)
     }
 
     /**
@@ -116,7 +132,14 @@ class CurrencyConversionService @Inject constructor(
         }
 
         // Fetch from API if not found, forced refresh, or rates are stale
-        return fetchAndCacheRate(fromCurrency, toCurrency)
+        fetchAndCacheRate(fromCurrency, toCurrency)?.let { return it }
+
+        // Last resort: the newest rate we EVER stored, however old — a stale
+        // conversion beats dropping the amount or counting it at face value.
+        // Past this point null means the pair has never had a rate at all.
+        return exchangeRateDao.getExchangeRateIgnoringExpiry(fromCurrency, toCurrency)
+            ?.rate
+            ?.also { updateCache(cacheKey, it) }
     }
 
     /**

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/AiContextRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/AiContextRepository.kt
@@ -71,11 +71,12 @@ class AiContextRepository @Inject constructor(
         
         // Process in a single pass
         transactions.forEach { transaction ->
-            val convertedAmount = currencyConversionService.convertAmount(
+            // Skip unconvertible amounts rather than counting face value (#670).
+            val convertedAmount = currencyConversionService.convertAmountOrNull(
                 amount = transaction.amount,
                 fromCurrency = transaction.currency,
                 toCurrency = baseCurrency
-            )
+            ) ?: return@forEach
             when (transaction.transactionType) {
                 TransactionType.INCOME -> totalIncome = totalIncome.add(convertedAmount)
                 TransactionType.EXPENSE -> totalExpense = totalExpense.add(convertedAmount)
@@ -105,17 +106,19 @@ class AiContextRepository @Inject constructor(
         return transactions
             .sortedByDescending { it.dateTime } // Most recent first
             .take(20) // Limit to 20 most recent
-            .map { transaction ->
+            .mapNotNull { transaction ->
                 val daysAgo = ChronoUnit.DAYS.between(
                     transaction.dateTime.toLocalDate(),
                     currentDate
                 ).toInt()
-                
-                val convertedAmount = currencyConversionService.convertAmount(
+
+                // Drop unconvertible amounts from the AI's view rather than feeding
+                // it a mislabeled face-value figure (#670).
+                val convertedAmount = currencyConversionService.convertAmountOrNull(
                     amount = transaction.amount,
                     fromCurrency = transaction.currency,
                     toCurrency = baseCurrency
-                )
+                ) ?: return@mapNotNull null
 
                 TransactionSummary(
                     merchantName = transaction.merchantName,
@@ -130,17 +133,17 @@ class AiContextRepository @Inject constructor(
     
     private suspend fun getActiveSubscriptions(currentDate: LocalDate, baseCurrency: String): List<SubscriptionSummary> {
         return subscriptionDao.getSubscriptionsByStateList(SubscriptionState.ACTIVE)
-            .map { subscription ->
+            .mapNotNull { subscription ->
                 val daysUntilPayment = ChronoUnit.DAYS.between(
                     currentDate,
                     subscription.nextPaymentDate
                 ).toInt()
-                
-                val convertedAmount = currencyConversionService.convertAmount(
+
+                val convertedAmount = currencyConversionService.convertAmountOrNull(
                     amount = subscription.amount,
                     fromCurrency = subscription.currency,
                     toCurrency = baseCurrency
-                )
+                ) ?: return@mapNotNull null
 
                 SubscriptionSummary(
                     merchantName = subscription.merchantName,
@@ -170,11 +173,11 @@ class AiContextRepository @Inject constructor(
             .filter { it.transactionType == TransactionType.EXPENSE }
             .forEach { transaction ->
                 val category = transaction.category ?: "Others"
-                val convertedAmount = currencyConversionService.convertAmount(
+                val convertedAmount = currencyConversionService.convertAmountOrNull(
                     amount = transaction.amount,
                     fromCurrency = transaction.currency,
                     toCurrency = baseCurrency
-                )
+                ) ?: return@forEach // skip unconvertible rather than face-value (#670)
                 categoryMap.getOrPut(category) { mutableListOf() }.add(convertedAmount)
                 totalExpense = totalExpense.add(convertedAmount)
             }
@@ -211,8 +214,8 @@ class AiContextRepository @Inject constructor(
         val expenses = transactions.filter { it.transactionType == TransactionType.EXPENSE }
         
         // Calculate average daily spending
-        val convertedAmounts = expenses.map {
-            currencyConversionService.convertAmount(
+        val convertedAmounts = expenses.mapNotNull {
+            currencyConversionService.convertAmountOrNull(
                 amount = it.amount,
                 fromCurrency = it.currency,
                 toCurrency = baseCurrency

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/BudgetGroupRepository.kt
@@ -1094,8 +1094,8 @@ class BudgetGroupRepository @Inject constructor(
  */
 suspend fun aggregateBudgetCategorySpending(
     transactions: List<TransactionWithSplits>,
-    convertSplit: suspend (fromCurrency: String, amount: BigDecimal) -> BigDecimal,
-    convertIncome: suspend (TransactionEntity) -> BigDecimal
+    convertSplit: suspend (fromCurrency: String, amount: BigDecimal) -> BigDecimal?,
+    convertIncome: suspend (TransactionEntity) -> BigDecimal?
 ): CategoryAggregation {
     val categoryAmounts = mutableMapOf<String, BigDecimal>()
     val typeAmounts = mutableMapOf<String, BigDecimal>()
@@ -1107,13 +1107,15 @@ suspend fun aggregateBudgetCategorySpending(
             // Route the whole amount to its type bucket, ignoring category —
             // so it counts only toward a type-tracking budget and never
             // contributes to a category (Spending) budget.
-            val converted = convertSplit(fromCurrency, txWithSplits.transaction.amount)
+            // Null = the converter has no rate for this pair; leave the row out
+            // instead of counting a face-value foreign amount (#670).
+            val converted = convertSplit(fromCurrency, txWithSplits.transaction.amount) ?: continue
             typeAmounts[type.name] = (typeAmounts[type.name] ?: BigDecimal.ZERO) + converted
             continue
         }
         for ((category, amount) in txWithSplits.getAmountByCategory()) {
             val categoryName = category.ifEmpty { "Others" }
-            val converted = convertSplit(fromCurrency, amount)
+            val converted = convertSplit(fromCurrency, amount) ?: continue
             categoryAmounts[categoryName] =
                 (categoryAmounts[categoryName] ?: BigDecimal.ZERO) + converted
         }
@@ -1125,7 +1127,7 @@ suspend fun aggregateBudgetCategorySpending(
         if (tx.transactionType != TransactionType.INCOME) continue
         val category = tx.budgetCategory ?: continue
         val impact = tx.budgetImpactType ?: continue
-        val amount = convertIncome(tx)
+        val amount = convertIncome(tx) ?: continue
         when (impact) {
             BudgetImpactType.DEDUCT_SPENT -> {
                 val current = categoryAmounts[category] ?: BigDecimal.ZERO

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/AccountDetailViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/AccountDetailViewModel.kt
@@ -97,11 +97,12 @@ class AccountDetailViewModel @Inject constructor(
 
                 filteredTransactions.forEach { transaction ->
                     val convertedAmount = if (transaction.currency != targetCurrency) {
-                        currencyConversionService.convertAmount(
+                        // Skip unconvertible rather than counting face value (#670).
+                        currencyConversionService.convertAmountOrNull(
                             amount = transaction.amount,
                             fromCurrency = transaction.currency,
                             toCurrency = targetCurrency
-                        ) ?: transaction.amount
+                        ) ?: return@forEach
                     } else {
                         transaction.amount
                     }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/budgetgroups/BudgetGroupsViewModel.kt
@@ -222,7 +222,8 @@ class BudgetGroupsViewModel @Inject constructor(
 
                 if (inWindow && tx.transactionType == TransactionType.INCOME &&
                     !(tx.budgetImpactType == BudgetImpactType.DEDUCT_SPENT && tx.budgetCategory != null)
-                ) acc + currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                ) currencyConversionService.convertAmountOrNull(tx.amount, tx.currency, displayCurrency)
+                    ?.let { acc + it } ?: acc
                 else acc
             }
 
@@ -296,16 +297,18 @@ class BudgetGroupsViewModel @Inject constructor(
                 val tx = txWithSplits.transaction
                 if (tx.loanId != null) return@fold acc
                 if (tx.transactionType != com.pennywiseai.tracker.data.database.entity.TransactionType.EXPENSE && tx.transactionType != com.pennywiseai.tracker.data.database.entity.TransactionType.INVESTMENT) return@fold acc
-                acc + currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                // Skip unconvertible amounts rather than counting them at face value (#670).
+                currencyConversionService.convertAmountOrNull(tx.amount, tx.currency, displayCurrency)
+                    ?.let { acc + it } ?: acc
             }
         }
         val (categoryAmounts, _, typeAmounts) = com.pennywiseai.tracker.data.repository.aggregateBudgetCategorySpending(
             transactions = transactions,
             convertSplit = { fromCurrency, amount ->
-                currencyConversionService.convertAmount(amount, fromCurrency, displayCurrency)
+                currencyConversionService.convertAmountOrNull(amount, fromCurrency, displayCurrency)
             },
             convertIncome = { tx ->
-                currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                currencyConversionService.convertAmountOrNull(tx.amount, tx.currency, displayCurrency)
             }
         )
         val catNames = group.categories.filter { it.matchType == null }.map { it.categoryName }.toSet()
@@ -403,10 +406,10 @@ class BudgetGroupsViewModel @Inject constructor(
             val (categoryAmounts, categoryLimitBoosts, typeAmounts) = com.pennywiseai.tracker.data.repository.aggregateBudgetCategorySpending(
                 transactions = txsInDisplay,
                 convertSplit = { fromCurrency, amount ->
-                    currencyConversionService.convertAmount(amount, fromCurrency, displayCurrency)
+                    currencyConversionService.convertAmountOrNull(amount, fromCurrency, displayCurrency)
                 },
                 convertIncome = { tx ->
-                    currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                    currencyConversionService.convertAmountOrNull(tx.amount, tx.currency, displayCurrency)
                 }
             )
             val days = displayedWindow.days.coerceAtLeast(1)
@@ -472,8 +475,11 @@ class BudgetGroupsViewModel @Inject constructor(
                 val dayIndex = (java.time.temporal.ChronoUnit.DAYS.between(displayedWindow.start, tx.dateTime.toLocalDate()).toInt())
                     .coerceIn(0, displayedWindow.days - 1)
                 
-                val convertedAmount = currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency).toDouble()
-                
+                // Skip the whole txn if its currency has no rate — face value would
+                // corrupt the pace chart (#670). Splits share the currency, so if the
+                // total is unconvertible the per-category amounts are too.
+                val convertedAmount = currencyConversionService.convertAmountOrNull(tx.amount, tx.currency, displayCurrency)?.toDouble() ?: continue
+
                 if (tx.transactionType.name in matchTypes) {
                     dailyAmounts[dayIndex] += convertedAmount
                 } else if (tx.transactionType !in com.pennywiseai.tracker.data.repository.BudgetGroupRepository.BUDGET_TYPE_BUCKETS) {
@@ -483,7 +489,8 @@ class BudgetGroupsViewModel @Inject constructor(
                         for ((cat, amount) in txWithSplits.getAmountByCategory()) {
                             val catName = cat.ifEmpty { "Others" }
                             if (catName in categoryNames) {
-                                dailyAmounts[dayIndex] += currencyConversionService.convertAmount(amount, tx.currency, displayCurrency).toDouble()
+                                currencyConversionService.convertAmountOrNull(amount, tx.currency, displayCurrency)
+                                    ?.let { dailyAmounts[dayIndex] += it.toDouble() }
                             }
                         }
                     }
@@ -499,15 +506,16 @@ class BudgetGroupsViewModel @Inject constructor(
                 val dayIndex = (java.time.temporal.ChronoUnit.DAYS.between(displayedWindow.start, tx.dateTime.toLocalDate()).toInt())
                     .coerceIn(0, displayedWindow.days - 1)
                     
-                val convertedAmount = currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency).toDouble()
-                
+                val convertedAmount = currencyConversionService.convertAmountOrNull(tx.amount, tx.currency, displayCurrency)?.toDouble() ?: continue
+
                 if (categoryNames == null) {
                     dailyAmounts[dayIndex] -= convertedAmount
                 } else {
                     for ((cat, amount) in txWithSplits.getAmountByCategory()) {
                         val catName = cat.ifEmpty { "Others" }
                         if (catName in categoryNames) {
-                            dailyAmounts[dayIndex] -= currencyConversionService.convertAmount(amount, tx.currency, displayCurrency).toDouble()
+                            currencyConversionService.convertAmountOrNull(amount, tx.currency, displayCurrency)
+                                ?.let { dailyAmounts[dayIndex] -= it.toDouble() }
                         }
                     }
                 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -341,7 +341,8 @@ class HomeViewModel @Inject constructor(
             }
 
             val amount = if (isUnified && tx.currency != selectedCurrency) {
-                currencyConversionService.convertAmount(tx.amount, tx.currency, selectedCurrency)
+                currencyConversionService.convertAmountOrNull(tx.amount, tx.currency, selectedCurrency)
+                    ?: continue // never-rated pair — skip, don't face-value (#670)
             } else {
                 tx.amount
             }
@@ -708,11 +709,11 @@ class HomeViewModel @Inject constructor(
                 var borrowedTotal = BigDecimal.ZERO
                 for (loan in loansForTotals) {
                     val amount = if (isUnified) {
-                        currencyConversionService.convertAmount(
+                        currencyConversionService.convertAmountOrNull(
                             amount = loan.remainingAmount,
                             fromCurrency = loan.currency,
                             toCurrency = selectedCurrency
-                        )
+                        ) ?: continue // never-rated pair — skip, don't face-value (#670)
                     } else {
                         loan.remainingAmount
                     }
@@ -797,16 +798,19 @@ class HomeViewModel @Inject constructor(
                     when (item) {
                         is HomeRecentItem.SingleTransaction -> {
                             val converted = if (!item.transaction.currency.equals(displayCurrency, ignoreCase = true))
-                                currencyConversionService.convertAmount(item.transaction.amount, item.transaction.currency, displayCurrency)
+                                currencyConversionService.convertAmountOrNull(item.transaction.amount, item.transaction.currency, displayCurrency)
                             else null
                             item.copy(convertedAmount = converted)
                         }
                         is HomeRecentItem.GroupItem -> {
                             val amounts = item.transactions
                                 .filter { !it.currency.equals(displayCurrency, ignoreCase = true) }
-                                .associate { tx ->
-                                    tx.id to currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                                .mapNotNull { tx ->
+                                    currencyConversionService
+                                        .convertAmountOrNull(tx.amount, tx.currency, displayCurrency)
+                                        ?.let { tx.id to it }
                                 }
+                                .toMap()
                             item.copy(convertedAmounts = amounts)
                         }
                     }
@@ -831,9 +835,9 @@ class HomeViewModel @Inject constructor(
                 val totalAmount = if (isUnified) {
                     var total = java.math.BigDecimal.ZERO
                     for (sub in subscriptions) {
-                        total += currencyConversionService.convertAmount(
+                        total += currencyConversionService.convertAmountOrNull(
                             sub.amount, sub.currency, displayCurrency
-                        )
+                        ) ?: continue // never-rated pair — skip, don't face-value (#670)
                     }
                     total
                 } else {
@@ -1212,7 +1216,8 @@ class HomeViewModel @Inject constructor(
                 var investmentTotal = BigDecimal.ZERO
 
                 for (tx in nonLoanTransactions) {
-                    val converted = currencyConversionService.convertAmount(tx.amount, tx.currency, selectedCurrency)
+                    val converted = currencyConversionService
+                        .convertAmountOrNull(tx.amount, tx.currency, selectedCurrency) ?: continue
                     when (tx.transactionType) {
                         com.pennywiseai.tracker.data.database.entity.TransactionType.CREDIT -> creditCardTotal += converted
                         com.pennywiseai.tracker.data.database.entity.TransactionType.TRANSFER -> transferTotal += converted
@@ -1357,7 +1362,8 @@ class HomeViewModel @Inject constructor(
         var total = BigDecimal.ZERO
         for ((currency, amount) in byCurrency) {
             total += if (currency == selectedCurrency) amount
-            else currencyConversionService.convertAmount(amount, currency, selectedCurrency)
+            else currencyConversionService.convertAmountOrNull(amount, currency, selectedCurrency)
+                ?: continue // never-rated pair — skip, don't face-value (#670)
         }
         return total
     }
@@ -1376,9 +1382,12 @@ class HomeViewModel @Inject constructor(
                 totalIncome += breakdown.income
                 totalExpenses += breakdown.expenses
             } else {
-                totalTotal += currencyConversionService.convertAmount(breakdown.total, currency, targetCurrency)
-                totalIncome += currencyConversionService.convertAmount(breakdown.income, currency, targetCurrency)
-                totalExpenses += currencyConversionService.convertAmount(breakdown.expenses, currency, targetCurrency)
+                // One rate serves all three figures; if the pair has never had a
+                // rate, skip this currency's breakdown entirely (#670).
+                val rateTotal = currencyConversionService.convertAmountOrNull(breakdown.total, currency, targetCurrency) ?: continue
+                totalTotal += rateTotal
+                totalIncome += currencyConversionService.convertAmountOrNull(breakdown.income, currency, targetCurrency) ?: BigDecimal.ZERO
+                totalExpenses += currencyConversionService.convertAmountOrNull(breakdown.expenses, currency, targetCurrency) ?: BigDecimal.ZERO
             }
         }
 
@@ -1463,7 +1472,8 @@ class HomeViewModel @Inject constructor(
                 tx.budgetCategory != null
             ) continue
             totalIncome = totalIncome.add(
-                currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                currencyConversionService.convertAmountOrNull(tx.amount, tx.currency, displayCurrency)
+                    ?: continue // never-rated pair — skip, don't face-value (#670)
             )
         }
 
@@ -1473,10 +1483,10 @@ class HomeViewModel @Inject constructor(
         val (categoryAmounts, categoryLimitBoosts) = aggregateBudgetCategorySpending(
             transactions = analyticsTransactions,
             convertSplit = { fromCurrency, amount ->
-                currencyConversionService.convertAmount(amount, fromCurrency, displayCurrency)
+                currencyConversionService.convertAmountOrNull(amount, fromCurrency, displayCurrency)
             },
             convertIncome = { tx ->
-                currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                currencyConversionService.convertAmountOrNull(tx.amount, tx.currency, displayCurrency)
             }
         )
 

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/loans/LoansViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/loans/LoansViewModel.kt
@@ -105,11 +105,12 @@ class LoansViewModel @Inject constructor(
         var lent = BigDecimal.ZERO
         var borrowed = BigDecimal.ZERO
         for (loan in loans) {
-            val converted = currencyConversionService.convertAmount(
+            // Skip unconvertible loans rather than counting face value (#670).
+            val converted = currencyConversionService.convertAmountOrNull(
                 amount = loan.remainingAmount,
                 fromCurrency = loan.currency,
                 toCurrency = targetCurrency
-            )
+            ) ?: continue
             when (loan.direction) {
                 LoanDirection.LENT -> lent += converted
                 LoanDirection.BORROWED -> borrowed += converted

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/subscriptions/SubscriptionsViewModel.kt
@@ -70,9 +70,9 @@ class SubscriptionsViewModel @Inject constructor(
                 val totalMonthlyAmount = if (isUnified) {
                     var total = BigDecimal.ZERO
                     for (sub in subscriptions) {
-                        total += currencyConversionService.convertAmount(
+                        total += currencyConversionService.convertAmountOrNull(
                             sub.amount, sub.currency, displayCurrency
-                        )
+                        ) ?: continue // never-rated pair — skip, don't face-value (#670)
                     }
                     total
                 } else {
@@ -88,9 +88,11 @@ class SubscriptionsViewModel @Inject constructor(
                     val map = mutableMapOf<Long, BigDecimal>()
                     for (sub in subscriptions) {
                         if (!sub.currency.equals(displayCurrency, ignoreCase = true)) {
-                            map[sub.id] = currencyConversionService.convertAmount(
+                            // Omit unconvertible subs; the row shows its native
+                            // amount + currency rather than a mislabeled figure (#670).
+                            currencyConversionService.convertAmountOrNull(
                                 sub.amount, sub.currency, displayCurrency
-                            )
+                            )?.let { map[sub.id] = it }
                         }
                     }
                     map

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
@@ -348,13 +348,14 @@ class TransactionDetailViewModel @Inject constructor(
     private suspend fun calculateConvertedAmount(transaction: TransactionEntity) {
         val primaryCurrency = _primaryCurrency.value
         if (transaction.currency.isNotEmpty() && !transaction.currency.equals(primaryCurrency, ignoreCase = true)) {
-            // Convert the amount to the primary currency
-            val converted = currencyConversionService.convertAmount(
+            // Convert to the primary currency; null when no rate exists, so the
+            // detail screen shows no "≈" line rather than a misleading face
+            // value (#670).
+            _convertedAmount.value = currencyConversionService.convertAmountOrNull(
                 amount = transaction.amount,
                 fromCurrency = transaction.currency,
                 toCurrency = primaryCurrency
             )
-            _convertedAmount.value = converted
         } else {
             // No conversion needed if currencies are the same
             _convertedAmount.value = null

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -249,11 +249,14 @@ class TransactionsViewModel @Inject constructor(
                     transfer += totals.transfer
                     investment += totals.investment
                 } else {
-                    income += currencyConversionService.convertAmount(totals.income, cur, currency)
-                    expenses += currencyConversionService.convertAmount(totals.expenses, cur, currency)
-                    credit += currencyConversionService.convertAmount(totals.credit, cur, currency)
-                    transfer += currencyConversionService.convertAmount(totals.transfer, cur, currency)
-                    investment += currencyConversionService.convertAmount(totals.investment, cur, currency)
+                    // Skip unconvertible currency pairs (add nothing) rather than
+                    // counting face value (#670). The transactions still appear in
+                    // the list, so `count` below stays complete.
+                    income += currencyConversionService.convertAmountOrNull(totals.income, cur, currency) ?: BigDecimal.ZERO
+                    expenses += currencyConversionService.convertAmountOrNull(totals.expenses, cur, currency) ?: BigDecimal.ZERO
+                    credit += currencyConversionService.convertAmountOrNull(totals.credit, cur, currency) ?: BigDecimal.ZERO
+                    transfer += currencyConversionService.convertAmountOrNull(totals.transfer, cur, currency) ?: BigDecimal.ZERO
+                    investment += currencyConversionService.convertAmountOrNull(totals.investment, cur, currency) ?: BigDecimal.ZERO
                 }
                 count += totals.transactionCount
             }
@@ -872,9 +875,12 @@ class TransactionsViewModel @Inject constructor(
                     val converted = mutableMapOf<Long, BigDecimal>()
                     for (tx in transactions) {
                         if (!tx.currency.equals(displayCurrency, ignoreCase = true)) {
-                            converted[tx.id] = currencyConversionService.convertAmount(
+                            // Omit unconvertible rows from the map; the row then shows
+                            // its native amount + currency instead of a mislabeled
+                            // face-value figure in the display currency (#670).
+                            currencyConversionService.convertAmountOrNull(
                                 tx.amount, tx.currency, displayCurrency
-                            )
+                            )?.let { converted[tx.id] = it }
                         }
                     }
                     _convertedAmounts.value = converted

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/GroupCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/GroupCard.kt
@@ -43,7 +43,15 @@ fun GroupCard(
 
     val total = remember(transactions, convertedAmounts, displayCurrency) {
         transactions.fold(BigDecimal.ZERO) { acc, tx ->
-            val amount = convertedAmounts[tx.id] ?: tx.amount
+            // In unified mode a foreign txn missing from convertedAmounts has no
+            // known rate — leave it out rather than adding its face value (#670).
+            // Native mode (displayCurrency == null) and same-currency txns use tx.amount.
+            val amount = convertedAmounts[tx.id]
+                ?: if (displayCurrency != null && !tx.currency.equals(displayCurrency, ignoreCase = true)) {
+                    return@fold acc
+                } else {
+                    tx.amount
+                }
             when (tx.transactionType) {
                 TransactionType.EXPENSE, TransactionType.CREDIT -> acc - amount
                 TransactionType.INCOME -> acc + amount

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -316,7 +316,10 @@ class AnalyticsViewModel @Inject constructor(
                 var totalSpending = BigDecimal.ZERO
                 if (isUnified) {
                     for (tx in filteredTransactions) {
-                        totalSpending += currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                        // No known rate ever → leave the row out; face-valuing a
+                        // foreign amount into displayCurrency corrupts the total (#670).
+                        totalSpending += currencyConversionService
+                            .convertAmountOrNull(tx.amount, tx.currency, displayCurrency) ?: continue
                     }
                 } else {
                     totalSpending = filteredTransactions.map { it.amount.toDouble() }.sum().toBigDecimal()
@@ -331,7 +334,8 @@ class AnalyticsViewModel @Inject constructor(
                     txWithSplits.getAmountByCategory().forEach { (category, amount) ->
                         val categoryName = category.ifEmpty { "Others" }
                         val converted = if (isUnified) {
-                            currencyConversionService.convertAmount(amount, fromCurrency, displayCurrency)
+                            currencyConversionService.convertAmountOrNull(amount, fromCurrency, displayCurrency)
+                                ?: return@forEach // never-rated pair — skip, don't face-value (#670)
                         } else {
                             amount
                         }
@@ -364,7 +368,8 @@ class AnalyticsViewModel @Inject constructor(
                         // Respect an active category filter.
                         if (filterState.categoryFilter != null && filterState.categoryFilter != category) continue
                         val converted = if (isUnified) {
-                            currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                            currencyConversionService.convertAmountOrNull(tx.amount, tx.currency, displayCurrency)
+                                ?: continue // never-rated pair — skip, don't face-value (#670)
                         } else tx.amount
                         if (converted <= BigDecimal.ZERO) continue
                         // A refund (INCOME + DEDUCT_SPENT) reverses a prior expense, so the
@@ -413,7 +418,8 @@ class AnalyticsViewModel @Inject constructor(
                 for (tx in filteredTransactions) {
                     val tagNames = tagMap[tx.id]?.takeIf { it.isNotEmpty() } ?: continue
                     val converted = if (isUnified) {
-                        currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                        currencyConversionService.convertAmountOrNull(tx.amount, tx.currency, displayCurrency)
+                            ?: continue // never-rated pair — skip, don't face-value (#670)
                     } else {
                         tx.amount
                     }
@@ -446,7 +452,8 @@ class AnalyticsViewModel @Inject constructor(
                         val gross = if (isUnified) {
                             var sum = BigDecimal.ZERO
                             for (tx in txns) {
-                                sum += currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                                sum += currencyConversionService
+                                    .convertAmountOrNull(tx.amount, tx.currency, displayCurrency) ?: continue
                             }
                             sum
                         } else {
@@ -475,7 +482,8 @@ class AnalyticsViewModel @Inject constructor(
                         val gross = if (isUnified) {
                             var sum = BigDecimal.ZERO
                             for (tx in txns) {
-                                sum += currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                                sum += currencyConversionService
+                                    .convertAmountOrNull(tx.amount, tx.currency, displayCurrency) ?: continue
                             }
                             sum
                         } else {
@@ -633,15 +641,18 @@ class AnalyticsViewModel @Inject constructor(
         val convertedById: Map<Long, Double> = if (isUnified) {
             val byId = HashMap<Long, Double>(transactions.size)
             for (tx in transactions) {
-                byId[tx.id] = currencyConversionService
-                    .convertAmount(tx.amount, tx.currency, displayCurrency).toDouble()
+                // Absent from the map = never-rated pair; amountIn treats it as 0
+                // so the row is excluded from the trend, matching the totals (#670).
+                val converted = currencyConversionService
+                    .convertAmountOrNull(tx.amount, tx.currency, displayCurrency) ?: continue
+                byId[tx.id] = converted.toDouble()
             }
             byId
         } else {
             emptyMap()
         }
         val amountIn: (com.pennywiseai.tracker.data.database.entity.TransactionEntity) -> Double = { tx ->
-            if (isUnified) convertedById[tx.id] ?: tx.amount.toDouble() else tx.amount.toDouble()
+            if (isUnified) convertedById[tx.id] ?: 0.0 else tx.amount.toDouble()
         }
         // Refunds already netted out of the total/category/etc. are passed here as a
         // per-day map and subtracted from each bucket below. Each bucket floors at zero

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -314,16 +314,22 @@ class AnalyticsViewModel @Inject constructor(
 
                 // Calculate total — convert if unified mode
                 var totalSpending = BigDecimal.ZERO
+                // In unified mode, count only rows that actually converted, so the
+                // count and average stay consistent with totalSpending rather than
+                // including rows whose amount was skipped (#670).
+                var unifiedConvertedCount = 0
                 if (isUnified) {
                     for (tx in filteredTransactions) {
                         // No known rate ever → leave the row out; face-valuing a
                         // foreign amount into displayCurrency corrupts the total (#670).
                         totalSpending += currencyConversionService
                             .convertAmountOrNull(tx.amount, tx.currency, displayCurrency) ?: continue
+                        unifiedConvertedCount++
                     }
                 } else {
                     totalSpending = filteredTransactions.map { it.amount.toDouble() }.sum().toBigDecimal()
                 }
+                val effectiveCount = if (isUnified) unifiedConvertedCount else filteredTransactions.size
 
                 // Build category breakdown considering splits
                 val categoryAmounts = mutableMapOf<String, BigDecimal>()
@@ -449,14 +455,17 @@ class AnalyticsViewModel @Inject constructor(
                     .groupBy { it.merchantName }
                     .entries
                     .map { (merchant, txns) ->
+                        var convertedCount = 0
                         val gross = if (isUnified) {
                             var sum = BigDecimal.ZERO
                             for (tx in txns) {
                                 sum += currencyConversionService
                                     .convertAmountOrNull(tx.amount, tx.currency, displayCurrency) ?: continue
+                                convertedCount++
                             }
                             sum
                         } else {
+                            convertedCount = txns.size
                             txns.map { it.amount.toDouble() }.sum().toBigDecimal()
                         }
                         // Net any refund that carries this merchant's name (floored at zero).
@@ -465,7 +474,8 @@ class AnalyticsViewModel @Inject constructor(
                         MerchantData(
                             name = merchant,
                             amount = merchantAmount,
-                            transactionCount = txns.size,
+                            // Count only converted rows so it matches the amount (#670).
+                            transactionCount = convertedCount,
                             isSubscription = txns.any { it.isRecurring }
                         )
                     }
@@ -479,14 +489,17 @@ class AnalyticsViewModel @Inject constructor(
                     .groupBy { "${it.bankName}_${it.accountNumber}" }
                     .entries
                     .map { (accountKey, txns) ->
+                        var convertedCount = 0
                         val gross = if (isUnified) {
                             var sum = BigDecimal.ZERO
                             for (tx in txns) {
                                 sum += currencyConversionService
                                     .convertAmountOrNull(tx.amount, tx.currency, displayCurrency) ?: continue
+                                convertedCount++
                             }
                             sum
                         } else {
+                            convertedCount = txns.size
                             txns.sumOf { it.amount.toDouble() }.toBigDecimal()
                         }
                         // Net refunds credited back to this account (floored at zero) so
@@ -504,14 +517,16 @@ class AnalyticsViewModel @Inject constructor(
                             percentage = if (totalSpending > BigDecimal.ZERO) {
                                 (accountAmount.divide(totalSpending, 4, java.math.RoundingMode.HALF_UP) * BigDecimal(100)).toFloat().coerceAtMost(100f)
                             } else 0f,
-                            transactionCount = txns.size
+                            // Count only converted rows so it matches the amount (#670).
+                            transactionCount = convertedCount
                         )
                     }
                     .sortedByDescending { it.amount }
 
-                // Calculate average amount
-                val averageAmount = if (filteredTransactions.isNotEmpty()) {
-                    totalSpending.divide(BigDecimal(filteredTransactions.size), 2, java.math.RoundingMode.HALF_UP)
+                // Calculate average amount — divide by the converted count so the
+                // average isn't dragged down by rows excluded from totalSpending (#670).
+                val averageAmount = if (effectiveCount > 0) {
+                    totalSpending.divide(BigDecimal(effectiveCount), 2, java.math.RoundingMode.HALF_UP)
                 } else {
                     BigDecimal.ZERO
                 }
@@ -523,7 +538,7 @@ class AnalyticsViewModel @Inject constructor(
                     totalSpending = totalSpending,
                     categoryBreakdown = categoryBreakdown,
                     topMerchants = merchantBreakdown,
-                    transactionCount = filteredTransactions.size,
+                    transactionCount = effectiveCount,
                     averageAmount = averageAmount,
                     topCategory = topCategory?.name,
                     topCategoryPercentage = topCategory?.percentage ?: 0f,

--- a/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
@@ -103,9 +103,11 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
                 // identically. Refunds shrink categoryAmounts (floored at zero) and
                 // are excluded from totalIncome; Extra budget bumps the displayed
                 // category budget via categoryLimitBoosts and stays in income.
-                val convertSplit: suspend (String, BigDecimal) -> BigDecimal =
+                // Null = no rate for this pair; the aggregator leaves the row out
+                // rather than counting a face-value foreign amount (#670).
+                val convertSplit: suspend (String, BigDecimal) -> BigDecimal? =
                     { fromCurrency, amount ->
-                        currencyConversionService.convertAmount(amount, fromCurrency, displayCurrency)
+                        currencyConversionService.convertAmountOrNull(amount, fromCurrency, displayCurrency)
                     }
                 val (categoryAmounts, categoryLimitBoosts, typeAmounts) = aggregateBudgetCategorySpending(
                     transactions = raw.allTransactions,
@@ -127,9 +129,11 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
                     if (tx.budgetImpactType == BudgetImpactType.DEDUCT_SPENT &&
                         tx.budgetCategory != null
                     ) continue
-                    totalIncome += currencyConversionService.convertAmount(
+                    // Skip unconvertible income so it doesn't inflate netSavings
+                    // at face value (#670).
+                    totalIncome += currencyConversionService.convertAmountOrNull(
                         tx.amount, tx.currency, displayCurrency
-                    )
+                    ) ?: continue
                 }
 
                 val groupSpendingList = raw.budgetsWithCategories.map { group ->
@@ -224,9 +228,9 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
                     if (tx.budgetImpactType == BudgetImpactType.DEDUCT_SPENT &&
                         tx.budgetCategory != null
                     ) continue
-                    prevIncome += currencyConversionService.convertAmount(
+                    prevIncome += currencyConversionService.convertAmountOrNull(
                         tx.amount, tx.currency, displayCurrency
-                    )
+                    ) ?: continue
                 }
 
                 val prevSavings = prevIncome - prevLimitSpent

--- a/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/BudgetWidgetUpdateWorker.kt
@@ -111,7 +111,7 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
                     transactions = raw.allTransactions,
                     convertSplit = convertSplit,
                     convertIncome = { tx ->
-                        currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                        currencyConversionService.convertAmountOrNull(tx.amount, tx.currency, displayCurrency)
                     }
                 )
 
@@ -197,7 +197,7 @@ class BudgetWidgetUpdateWorker @AssistedInject constructor(
                     transactions = raw.prevCycleTransactions,
                     convertSplit = convertSplit,
                     convertIncome = { tx ->
-                        currencyConversionService.convertAmount(tx.amount, tx.currency, displayCurrency)
+                        currencyConversionService.convertAmountOrNull(tx.amount, tx.currency, displayCurrency)
                     }
                 )
 

--- a/app/src/main/java/com/pennywiseai/tracker/widget/RecentTransactionsWidgetUpdateWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/widget/RecentTransactionsWidgetUpdateWorker.kt
@@ -89,23 +89,25 @@ class RecentTransactionsWidgetUpdateWorker @AssistedInject constructor(
             // transactions are opted out of every spend figure by the user, so they
             // must not count toward the widget's spend total either.
             val nonLoan = allTransactions.filter { it.loanId == null && !it.excludedFromAnalytics }
-            suspend fun inTarget(tx: com.pennywiseai.tracker.data.database.entity.TransactionEntity): BigDecimal =
+            // Null = no rate for this pair; the spend folds skip it rather than
+            // counting a face-value foreign amount (#670).
+            suspend fun inTarget(tx: com.pennywiseai.tracker.data.database.entity.TransactionEntity): BigDecimal? =
                 if (!tx.currency.equals(targetCurrency, ignoreCase = true)) {
-                    currencyConversionService.convertAmount(tx.amount, tx.currency, targetCurrency)
+                    currencyConversionService.convertAmountOrNull(tx.amount, tx.currency, targetCurrency)
                 } else {
                     tx.amount
                 }
 
             val grossSpent = nonLoan
                 .filter { it.transactionType == TransactionType.EXPENSE || it.transactionType == TransactionType.CREDIT || it.transactionType == TransactionType.INVESTMENT }
-                .fold(BigDecimal.ZERO) { acc, tx -> acc + inTarget(tx) }
+                .fold(BigDecimal.ZERO) { acc, tx -> inTarget(tx)?.let { acc + it } ?: acc }
 
             // A "Refund" (INCOME + DEDUCT_SPENT) reverses a previous expense, so it
             // shrinks the spend total (floored at zero) — matching the Home card and
             // the Transactions page, which were already net of refunds.
             val refundTotal = nonLoan
                 .filter { it.transactionType == TransactionType.INCOME && it.budgetImpactType == BudgetImpactType.DEDUCT_SPENT }
-                .fold(BigDecimal.ZERO) { acc, tx -> acc + inTarget(tx) }
+                .fold(BigDecimal.ZERO) { acc, tx -> inTarget(tx)?.let { acc + it } ?: acc }
 
             val totalSpent = (grossSpent - refundTotal).coerceAtLeast(BigDecimal.ZERO)
 
@@ -114,11 +116,15 @@ class RecentTransactionsWidgetUpdateWorker @AssistedInject constructor(
             val recentItems = allTransactions
                 .take(MAX_ITEMS)
                 .map { tx ->
-                    val amount = if (!tx.currency.equals(targetCurrency, ignoreCase = true)) {
-                        currencyConversionService.convertAmount(tx.amount, tx.currency, targetCurrency)
+                    // If a foreign txn has no rate, show it in its native currency
+                    // rather than mislabeling a face value as targetCurrency (#670).
+                    val converted = if (!tx.currency.equals(targetCurrency, ignoreCase = true)) {
+                        currencyConversionService.convertAmountOrNull(tx.amount, tx.currency, targetCurrency)
                     } else {
                         tx.amount
                     }
+                    val amount = converted ?: tx.amount
+                    val itemCurrency = if (converted != null) targetCurrency else tx.currency
                     val title = tx.merchantName.takeIf { it.isNotBlank() }
                         ?: tx.description?.takeIf { it.isNotBlank() }
                         ?: "Transaction"
@@ -132,7 +138,7 @@ class RecentTransactionsWidgetUpdateWorker @AssistedInject constructor(
                         title = title,
                         subtitle = subtitle,
                         amount = amount,
-                        currency = targetCurrency,
+                        currency = itemCurrency,
                         transactionType = tx.transactionType
                     )
                 }


### PR DESCRIPTION
Closes #670.

## Problem

Unified-currency aggregates called `CurrencyConversionService.convertAmount()`, which returned the **original amount unchanged** when no exchange rate was available. A USD 10 expense was therefore counted as ₹10, corrupting unified totals, percentages, and the analytics trend — violating the money-is-currency-tagged hard constraint.

## Fix

**`CurrencyConversionService`**: new `convertAmountOrNull()` returns `null` when a pair has never had a rate. `convertAmount()` keeps the face-value fallback **only** for single-value display next to an explicit currency label. `getExchangeRate()` falls back to the newest stored rate regardless of age (a stale rate beats dropping/misstating — option 2 in #670).

**All unified-mode aggregation surfaces now skip unconvertible amounts** instead of counting face value:
- **Analytics** — total, category + tag breakdowns, refund grosses, trend.
- **Home** — card total, recent items, subscriptions, credit-card totals, budget aggregates, loan totals.
- **Budget widget** (`BudgetWidgetUpdateWorker`) — `convertSplit` + both income loops.
- **Budgets screen** (`BudgetGroupsViewModel`) — income/spend sums, both `aggregateBudgetCategorySpending` calls, and the pace-chart daily amounts. Now agrees with the Home budget card.
- **`GroupCard`** — grouped total drops unconvertible foreign txns rather than `?: tx.amount`.
- **Transactions / Subscriptions / Recent-tx widget / AI context / Loans / Account detail** — per-type totals and aggregates skip; per-item/detail displays fall back to the **native** currency (or show no `≈` line) rather than a mislabeled face value.

`aggregateBudgetCategorySpending` takes nullable-returning converters and skips.

**Left as face-value on purpose:** budget-*limit* conversions (a single configured base-currency value shown with its label) — not a transaction aggregate.

## Verification
`./init.sh app` green. Runtime/UI change — an on-device check with a foreign-currency, no-rate transaction is worth doing before merge.

## Note
All 5 review-flagged gaps from the earlier revision and the follow-up surface list are now included; this fully resolves #670 rather than partially.