### PR TITLE
fix(transactions): suggest self-transfer for account-less manual rows (#611)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -372,61 +372,13 @@ class TransactionsViewModel @Inject constructor(
     // TRANSFER (which already excludes them from Net), with Undo restoring
     // the originals.
     val suggestedTransferPartnerOf: StateFlow<Map<Long, Long>> = _uiState
-        .map { state -> findSelfTransferPairs(state.transactions) }
+        .map { state -> computeSelfTransferPairs(state.transactions) }
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = emptyMap()
         )
 
-    private fun findSelfTransferPairs(txns: List<TransactionEntity>): Map<Long, Long> {
-        if (txns.size < 2) return emptyMap()
-        // Transfers between the user's own accounts often reflect more than a few
-        // minutes apart (bank posting lag), so use a generous window. The pairing
-        // still requires an exact amount + currency match on a different account,
-        // and only *suggests* the link (the user confirms), so a wider window is
-        // low-risk. (#614)
-        val matchWindowMinutes = 60L
-        val acctOf: (TransactionEntity) -> String =
-            { "${it.bankName.orEmpty()}|${it.accountNumber.orEmpty()}" }
-
-        // Bucket INCOME rows by (currency, amount) for O(1) lookup per EXPENSE.
-        val incomesByKey = HashMap<Pair<String, BigDecimal>, MutableList<TransactionEntity>>()
-        for (tx in txns) {
-            if (tx.transactionType == TransactionType.INCOME) {
-                incomesByKey.getOrPut(tx.currency to tx.amount) { mutableListOf() }.add(tx)
-            }
-        }
-        if (incomesByKey.isEmpty()) return emptyMap()
-
-        val pair = HashMap<Long, Long>(txns.size / 8)
-        val claimedIncome = HashSet<Long>()
-        for (expense in txns) {
-            if (expense.transactionType != TransactionType.EXPENSE) continue
-            val candidates = incomesByKey[expense.currency to expense.amount] ?: continue
-            // Closest in time within the window, on a *different* account, not
-            // already claimed by another expense.
-            val expenseAcct = acctOf(expense)
-            val match = candidates
-                .asSequence()
-                .filter { it.id !in claimedIncome }
-                .filter { acctOf(it) != expenseAcct }
-                .filter {
-                    java.time.Duration.between(expense.dateTime, it.dateTime)
-                        .toMinutes().let { d -> kotlin.math.abs(d) <= matchWindowMinutes }
-                }
-                .minByOrNull {
-                    kotlin.math.abs(
-                        java.time.Duration.between(expense.dateTime, it.dateTime).toMinutes()
-                    )
-                }
-                ?: continue
-            pair[expense.id] = match.id
-            pair[match.id] = expense.id
-            claimedIncome.add(match.id)
-        }
-        return pair
-    }
 
     /**
      * User-confirmed self-transfer: flip both rows to TRANSFER and populate
@@ -1596,3 +1548,65 @@ private data class BudgetParams(
     val categories: String?,
     val transactionType: String?
 )
+
+/**
+ * Self-transfer suggestion heuristic (#385): pair each EXPENSE with an INCOME row
+ * of the same currency + amount that landed on a *different* account within the
+ * match window, so the UI can surface a "↔ Mark as transfer" chip (the user
+ * confirms — no silent merge). Pure so it can be unit-tested directly.
+ *
+ * Account identity is null when unknown. A transfer moves between two accounts,
+ * so a pair is rejected only when BOTH legs are on the same *known* account;
+ * account-less manual rows (no accountNumber) are still allowed to pair — without
+ * this they'd all share one key and never pair (#611).
+ */
+internal fun computeSelfTransferPairs(
+    txns: List<TransactionEntity>,
+    matchWindowMinutes: Long = 60L
+): Map<Long, Long> {
+    if (txns.size < 2) return emptyMap()
+    val acctOf: (TransactionEntity) -> String? = { tx ->
+        tx.accountNumber?.takeIf { it.isNotBlank() }
+            ?.let { "${tx.bankName.orEmpty()}|$it" }
+    }
+
+    // Bucket INCOME rows by (currency, amount) for O(1) lookup per EXPENSE.
+    val incomesByKey = HashMap<Pair<String, BigDecimal>, MutableList<TransactionEntity>>()
+    for (tx in txns) {
+        if (tx.transactionType == TransactionType.INCOME) {
+            incomesByKey.getOrPut(tx.currency to tx.amount) { mutableListOf() }.add(tx)
+        }
+    }
+    if (incomesByKey.isEmpty()) return emptyMap()
+
+    val pair = HashMap<Long, Long>(txns.size / 8)
+    val claimedIncome = HashSet<Long>()
+    for (expense in txns) {
+        if (expense.transactionType != TransactionType.EXPENSE) continue
+        val candidates = incomesByKey[expense.currency to expense.amount] ?: continue
+        // Closest in time within the window, not on the same known account, not
+        // already claimed by another expense.
+        val expenseAcct = acctOf(expense)
+        val match = candidates
+            .asSequence()
+            .filter { it.id !in claimedIncome }
+            .filter { income ->
+                val incomeAcct = acctOf(income)
+                incomeAcct == null || expenseAcct == null || incomeAcct != expenseAcct
+            }
+            .filter {
+                java.time.Duration.between(expense.dateTime, it.dateTime)
+                    .toMinutes().let { d -> kotlin.math.abs(d) <= matchWindowMinutes }
+            }
+            .minByOrNull {
+                kotlin.math.abs(
+                    java.time.Duration.between(expense.dateTime, it.dateTime).toMinutes()
+                )
+            }
+            ?: continue
+        pair[expense.id] = match.id
+        pair[match.id] = expense.id
+        claimedIncome.add(match.id)
+    }
+    return pair
+}

--- a/app/src/test/java/com/pennywiseai/tracker/presentation/transactions/ComputeSelfTransferPairsTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/presentation/transactions/ComputeSelfTransferPairsTest.kt
@@ -1,0 +1,107 @@
+package com.pennywiseai.tracker.presentation.transactions
+
+import com.pennywiseai.tracker.data.database.entity.TransactionEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+/**
+ * Unit tests for [computeSelfTransferPairs] — the self-transfer suggestion
+ * heuristic. Focus is #611: account-less manual rows must be pairable.
+ */
+class ComputeSelfTransferPairsTest {
+
+    private val base: LocalDateTime = LocalDateTime.of(2026, 8, 1, 12, 0)
+
+    private fun tx(
+        id: Long,
+        type: TransactionType,
+        amount: String = "500",
+        minutesFromBase: Long = 0,
+        bankName: String? = null,
+        accountNumber: String? = null,
+        currency: String = "INR",
+    ): TransactionEntity = TransactionEntity(
+        id = id,
+        amount = BigDecimal(amount),
+        merchantName = "M",
+        category = "Others",
+        transactionType = type,
+        dateTime = base.plusMinutes(minutesFromBase),
+        bankName = bankName,
+        accountNumber = accountNumber,
+        transactionHash = "hash-$id",
+        currency = currency,
+    )
+
+    /** #611: two manual rows with NO account, same amount, within window → suggested. */
+    @Test
+    fun `account-less manual expense and income are paired`() {
+        val expense = tx(1, TransactionType.EXPENSE)
+        val income = tx(2, TransactionType.INCOME, minutesFromBase = 5)
+
+        val pairs = computeSelfTransferPairs(listOf(expense, income))
+
+        assertEquals(2L, pairs[1L])
+        assertEquals(1L, pairs[2L])
+    }
+
+    /** Same KNOWN account is not a transfer — must NOT be suggested. */
+    @Test
+    fun `same known account is not paired`() {
+        val expense = tx(1, TransactionType.EXPENSE, bankName = "HDFC", accountNumber = "1234")
+        val income = tx(2, TransactionType.INCOME, minutesFromBase = 5, bankName = "HDFC", accountNumber = "1234")
+
+        val pairs = computeSelfTransferPairs(listOf(expense, income))
+
+        assertTrue(pairs.isEmpty())
+    }
+
+    /** Different known accounts → suggested (unchanged existing behaviour). */
+    @Test
+    fun `different known accounts are paired`() {
+        val expense = tx(1, TransactionType.EXPENSE, bankName = "HDFC", accountNumber = "1234")
+        val income = tx(2, TransactionType.INCOME, minutesFromBase = 5, bankName = "ICICI", accountNumber = "9999")
+
+        val pairs = computeSelfTransferPairs(listOf(expense, income))
+
+        assertEquals(2L, pairs[1L])
+        assertEquals(1L, pairs[2L])
+    }
+
+    /** One account-less leg + one known-account leg → still a valid suggestion. */
+    @Test
+    fun `mixed known and account-less legs are paired`() {
+        val expense = tx(1, TransactionType.EXPENSE) // manual, no account
+        val income = tx(2, TransactionType.INCOME, minutesFromBase = 5, bankName = "HDFC", accountNumber = "1234")
+
+        val pairs = computeSelfTransferPairs(listOf(expense, income))
+
+        assertEquals(2L, pairs[1L])
+    }
+
+    /** Outside the match window → not suggested. */
+    @Test
+    fun `pair outside the time window is not paired`() {
+        val expense = tx(1, TransactionType.EXPENSE)
+        val income = tx(2, TransactionType.INCOME, minutesFromBase = 120) // 2h > 60m window
+
+        val pairs = computeSelfTransferPairs(listOf(expense, income))
+
+        assertTrue(pairs.isEmpty())
+    }
+
+    /** Amount mismatch → not suggested. */
+    @Test
+    fun `different amounts are not paired`() {
+        val expense = tx(1, TransactionType.EXPENSE, amount = "500")
+        val income = tx(2, TransactionType.INCOME, amount = "600", minutesFromBase = 5)
+
+        val pairs = computeSelfTransferPairs(listOf(expense, income))
+
+        assertTrue(pairs.isEmpty())
+    }
+}


### PR DESCRIPTION
Addresses #611 (point 1 — the "Mark as transfer" chip never showing for manual transactions).

## Root cause
`findSelfTransferPairs` keyed account identity as `"${bankName}|${accountNumber}"` and required the expense and income legs to be on **different** accounts. Manual entries added without picking an account all have a null account, so they collapsed to the same key `"|"` and every manual expense+income pair was rejected as "same account."

## Fix
- Account identity is now **null when unknown**. A transfer moves between two accounts, so a pair is rejected **only when both legs are on the same *known* account**. Account-less manual rows (and mixed known/unknown pairs) can pair again.
- Extracted the pure heuristic to a testable top-level `computeSelfTransferPairs(...)`; the ViewModel just calls it. No behavior change for accounted transactions.

## Tests
New `ComputeSelfTransferPairsTest` (6 cases):
- ✅ account-less manual expense+income → paired (**the #611 regression**)
- ✅ same known account → not paired
- ✅ different known accounts → paired (unchanged)
- ✅ mixed known + account-less → paired
- ✅ outside the time window → not paired
- ✅ amount mismatch → not paired

`./init.sh app` green.

## Note
This is a *suggestion* chip (user confirms; no silent merge), so widening pairing to account-less rows is low-risk. Point 2 of #611 (separate From/To pickers) already shipped via #623.