### PR TITLE
feat(navigation): promote Transactions to a bottom-nav tab (#635)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/navigation/BottomNavItem.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/navigation/BottomNavItem.kt
@@ -2,6 +2,7 @@ package com.pennywiseai.tracker.presentation.navigation
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Chat
+import androidx.compose.material.icons.automirrored.filled.ReceiptLong
 import androidx.compose.material.icons.filled.Analytics
 import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material.icons.filled.Home
@@ -17,7 +18,13 @@ sealed class BottomNavItem(
         title = "Home",
         icon = Icons.Default.Home
     )
-    
+
+    data object Transactions : BottomNavItem(
+        route = "transactions",
+        title = "Transactions",
+        icon = Icons.AutoMirrored.Filled.ReceiptLong
+    )
+
     data object Analytics : BottomNavItem(
         route = "analytics",
         title = "Analytics",

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
@@ -98,9 +98,12 @@ fun TransactionsScreen(
     initialTransactionType: String? = null,
     viewModel: TransactionsViewModel = hiltViewModel(),
     onNavigateBack: () -> Unit = {},
-    // False when shown as a top-level bottom-nav tab (no back arrow, like the
-    // other tab roots); true when reached as a drill-down. (#635)
+    // False for a plain bottom-nav tab tap (no back arrow, like the other tab
+    // roots); true when reached as a filtered drill-down so the user can return. (#635)
     showBackButton: Boolean = true,
+    // True when the app's bottom nav is overlaid on this screen (tab context), so
+    // the list + FAB reserve matching clearance regardless of the back arrow. (#635)
+    reserveBottomBarSpace: Boolean = false,
     onTransactionClick: (Long) -> Unit = {},
     onAddTransactionClick: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {}
@@ -281,10 +284,10 @@ fun TransactionsScreen(
     val scrollBehaviorLarge = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     val hazeState = remember { HazeState() }
 
-    // When shown as the bottom-nav tab (#635), MainScreen overlays an 80.dp nav
-    // bar over this content, so the list + FAB stack need matching bottom
-    // clearance (the Scaffold inset here doesn't know about that overlay).
-    val bottomBarClearance = if (showBackButton) 0.dp else Dimensions.Component.bottomBarHeight
+    // When the app bottom nav is overlaid on this screen (#635), it sits over an
+    // 80.dp strip the Scaffold inset here doesn't know about, so the list + FAB
+    // stack need matching bottom clearance (whether or not a back arrow shows).
+    val bottomBarClearance = if (reserveBottomBarSpace) Dimensions.Component.bottomBarHeight else 0.dp
 
     Scaffold(
         modifier = modifier

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
@@ -281,6 +281,11 @@ fun TransactionsScreen(
     val scrollBehaviorLarge = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     val hazeState = remember { HazeState() }
 
+    // When shown as the bottom-nav tab (#635), MainScreen overlays an 80.dp nav
+    // bar over this content, so the list + FAB stack need matching bottom
+    // clearance (the Scaffold inset here doesn't know about that overlay).
+    val bottomBarClearance = if (showBackButton) 0.dp else Dimensions.Component.bottomBarHeight
+
     Scaffold(
         modifier = modifier
             .fillMaxSize()
@@ -356,6 +361,7 @@ fun TransactionsScreen(
         },
         floatingActionButton = {
             Column(
+                modifier = Modifier.padding(bottom = bottomBarClearance),
                 verticalArrangement = Arrangement.spacedBy(Spacing.sm)
             ) {
                 // Export FAB (only show if transactions exist)
@@ -490,7 +496,7 @@ fun TransactionsScreen(
                         start = Dimensions.Padding.content,
                         end = Dimensions.Padding.content,
                         top = Spacing.md,
-                        bottom = paddingValues.calculateBottomPadding()
+                        bottom = paddingValues.calculateBottomPadding() + bottomBarClearance
                     ),
                     verticalArrangement = Arrangement.spacedBy(Spacing.xs)
                 ) {
@@ -527,7 +533,7 @@ fun TransactionsScreen(
                         start = Dimensions.Padding.content,
                         end = Dimensions.Padding.content,
                         top = Spacing.md,
-                        bottom = paddingValues.calculateBottomPadding()
+                        bottom = paddingValues.calculateBottomPadding() + bottomBarClearance
                     ),
                     verticalArrangement = Arrangement.spacedBy(Spacing.Layout.groupedListGap),
                     flingBehavior = rememberOverscrollFlingBehavior { listState }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsScreen.kt
@@ -98,6 +98,9 @@ fun TransactionsScreen(
     initialTransactionType: String? = null,
     viewModel: TransactionsViewModel = hiltViewModel(),
     onNavigateBack: () -> Unit = {},
+    // False when shown as a top-level bottom-nav tab (no back arrow, like the
+    // other tab roots); true when reached as a drill-down. (#635)
+    showBackButton: Boolean = true,
     onTransactionClick: (Long) -> Unit = {},
     onAddTransactionClick: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {}
@@ -338,7 +341,7 @@ fun TransactionsScreen(
                     scrollBehaviorSmall = scrollBehaviorSmall,
                     scrollBehaviorLarge = scrollBehaviorLarge,
                     title = "Transactions",
-                    hasBackButton = true,
+                    hasBackButton = showBackButton,
                     navigationContent = {
                         IconButton(onClick = onNavigateBack) {
                             Icon(

--- a/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
@@ -297,6 +297,8 @@ fun MainScreen(
                             initialCustomEndEpochDay = endDate,
                             focusSearch = focusSearch,
                             initialTransactionType = transactionType,
+                            // Transactions is a top-level tab (#635) — no back arrow.
+                            showBackButton = false,
                             onNavigateBack = {
                                 navController.safePopBackStack()
                             },
@@ -594,7 +596,7 @@ fun MainScreen(
             }
 
             // Bottom navigation OVERLAID on content
-            if (baseRoute in listOf("home", "analytics", "chat")) {
+            if (baseRoute in listOf("home", "transactions", "analytics", "chat")) {
                 PennyWiseBottomNavigation(
                     navController = navController,
                     currentDestination = navBackStackEntry?.destination,

--- a/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
@@ -297,8 +297,13 @@ fun MainScreen(
                             initialCustomEndEpochDay = endDate,
                             focusSearch = focusSearch,
                             initialTransactionType = transactionType,
-                            // Transactions is a top-level tab (#635) — no back arrow.
-                            showBackButton = false,
+                            // No back arrow for a plain tab tap; show it for a filtered
+                            // drill-down (Home category/search) so the user can return. (#635)
+                            showBackButton = category != null || merchant != null ||
+                                period != null || currency != null || focusSearch ||
+                                transactionType != null || startDate != null || endDate != null,
+                            // The bottom nav is overlaid on this route — always reserve clearance.
+                            reserveBottomBarSpace = true,
                             onNavigateBack = {
                                 navController.safePopBackStack()
                             },

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/PennyWiseBottomNavigation.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/PennyWiseBottomNavigation.kt
@@ -69,6 +69,7 @@ fun PennyWiseBottomNavigation(
 ) {
     val navigationItems = listOf(
         BottomNavItem.Home,
+        BottomNavItem.Transactions,
         BottomNavItem.Analytics,
         BottomNavItem.Chat
     )
@@ -110,7 +111,9 @@ fun PennyWiseBottomNavigation(
                 ) {
                     navigationItems.forEach { item ->
                         val selected = currentDestination?.hierarchy?.any {
-                            it.route == item.route
+                            // Match on the route base so query-arg routes (e.g.
+                            // "transactions?type=…") still light up their tab.
+                            it.route?.substringBefore('?') == item.route
                         } == true
                         NavigationBarItem(
                             selected = selected,
@@ -213,7 +216,9 @@ fun PennyWiseBottomNavigation(
                 ) {
                     navigationItems.forEach { item ->
                         val selected = currentDestination?.hierarchy?.any {
-                            it.route == item.route
+                            // Match on the route base so query-arg routes (e.g.
+                            // "transactions?type=…") still light up their tab.
+                            it.route?.substringBefore('?') == item.route
                         } == true
 
                         TonalToggleButton(


### PR DESCRIPTION
Closes #635.

Transactions was only reachable via Home → "View All" / drill-downs. This promotes it to a **top-level bottom-nav tab** (Home · **Transactions** · Analytics · Chat).

## Changes
- **`BottomNavItem.Transactions`** — `ReceiptLong` icon (the same icon already used for transactions elsewhere), route `transactions`, placed between Home and Analytics.
- **Bottom bar visibility** — `transactions` added to the set of routes that keep the bottom bar; without this the screen rendered as a full-screen sub-page with the nav bar hidden.
- **Tab selection** — matches on the route **base** (`substringBefore('?')`) so the query-arg routes (`transactions?type=…`, `?category=…`) still highlight the tab.
- **No back arrow on the tab root** — `TransactionsScreen` gains `showBackButton` (default `true`); `MainScreen` passes `false` so the tab looks like the other tab roots. Drill-downs from Home now switch to the (pre-filtered) Transactions tab instead of pushing a sub-page.

## Verified on device (Pixel_10_Pro)
- 4-tab bar renders; tapping **Transactions** loads the list.
- Tab **highlights** when selected (selection-base fix).
- Bottom bar **stays visible** on the route.
- **No back arrow** on the tab root — consistent with Home/Analytics/Chat.

`./init.sh app` green.

## Note
This changes drill-down behavior slightly: Home category/"View All" taps now land on the Transactions tab (pre-filtered, no back arrow) rather than a pushed page — you leave via the tabs or system back. Flag if you'd prefer drill-downs to keep a back arrow (easy toggle — pass `showBackButton = true` for arg-carrying entries).