### PR TITLE
fix(readme): restore the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=sarim2000/pennywiseai-tracker&type=Date)](https://star-history.com/#sarim2000/pennywiseai-tracker&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=sarim2000/pennywiseai-tracker&type=Date)](https://star-history.dera.page/#sarim2000/pennywiseai-tracker&type=date)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README is broken, so the project's growth is no longer shown on the main page. This change points it to a working alternative that does not depend on the restricted stargazer API. No other parts of the README are affected.