### PR TITLE
feat(add): suggest learned merchant category in manual entry (#678)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
@@ -14,6 +14,7 @@ import com.pennywiseai.tracker.data.receipt.ReceiptManager
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.BudgetGroupRepository
 import com.pennywiseai.tracker.data.repository.TagRepository
+import com.pennywiseai.tracker.data.repository.MerchantMappingRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import com.pennywiseai.tracker.domain.usecase.AddTransactionUseCase
 import com.pennywiseai.tracker.domain.usecase.AddSubscriptionUseCase
@@ -40,6 +41,7 @@ class AddViewModel @Inject constructor(
     private val budgetGroupRepository: BudgetGroupRepository,
     private val userPreferencesRepository: UserPreferencesRepository,
     private val transactionRepository: TransactionRepository,
+    private val merchantMappingRepository: MerchantMappingRepository,
     private val tagRepository: TagRepository,
     private val receiptManager: ReceiptManager,
     savedStateHandle: SavedStateHandle
@@ -64,6 +66,12 @@ class AddViewModel @Inject constructor(
     // Subscription Tab State
     private val _subscriptionUiState = MutableStateFlow(SubscriptionUiState())
     val subscriptionUiState: StateFlow<SubscriptionUiState> = _subscriptionUiState.asStateFlow()
+
+    // Per-type default category placeholders (see [updateTransactionType]) — treated
+    // as "unset" so a learned merchant→category mapping can fill in without
+    // clobbering a category the user actually chose. (#678)
+    private val DEFAULT_CATEGORY_PLACEHOLDERS =
+        setOf("Others", "Shopping", "Income", "Investment")
     
     
     init {
@@ -213,6 +221,24 @@ class AddViewModel @Inject constructor(
                 merchant = merchant,
                 merchantError = validateMerchant(merchant)
             )
+        }
+        // Suggest the category previously learned for this merchant (#678) — the
+        // same mapping SMS parsing already applies. Only fills in when the user
+        // hasn't chosen a specific category yet (still a per-type default), so an
+        // explicit choice is never overridden.
+        viewModelScope.launch {
+            val name = merchant.trim()
+            if (name.isEmpty()) return@launch
+            val mapped = merchantMappingRepository.getCategoryForMerchant(name) ?: return@launch
+            _transactionUiState.update { currentState ->
+                if (currentState.merchant.trim() == name &&
+                    currentState.category in DEFAULT_CATEGORY_PLACEHOLDERS
+                ) {
+                    currentState.copy(category = mapped, categoryError = validateCategory(mapped))
+                } else {
+                    currentState
+                }
+            }
         }
     }
     


### PR DESCRIPTION
Addresses #678 (the actionable part).

## What I found first
The app **already** learns merchant→category mappings:
- `MerchantMappingRepository.getCategoryForMerchant()` / `setMapping()`
- `SmsTransactionProcessor` applies the learned category to **SMS-parsed** transactions
- `TransactionDetailViewModel` **learns** the mapping when you re-categorize a transaction

So the core request already works — for SMS. The gap was the **manual Add form**: `updateTransactionMerchant` never consulted the mapping.

## Change
When you type/select a merchant in manual entry that has a saved category, that category now pre-fills — the same behavior SMS parsing already has. It only fills when the category is still a per-type default placeholder (`Others`/`Shopping`/`Income`/`Investment`), so it **never overrides a category you actually chose**; the lookup runs off the main thread.

## Out of scope (needs reporter info)
The issue also says *"new transactions default to Credit."* The **manual form already defaults to `EXPENSE`** (`TransactionUiState.transactionType = EXPENSE`), so that complaint is about **SMS classification** for the reporter's specific bank — it needs their sender + a sample SMS to diagnose, which I'll ask for on the issue.

## Verification
`./init.sh app` green. Reuses the exact `getCategoryForMerchant` path SMS parsing already relies on. On-device confirmation (categorize a merchant → add a new txn with that merchant → category pre-fills) is worth a quick check before merge.