### PR TITLE
fix(add): guard merchant-category suggestion against stale applies + match casing (#678)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/MerchantMappingDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/MerchantMappingDao.kt
@@ -8,8 +8,13 @@ import kotlinx.coroutines.flow.Flow
 interface MerchantMappingDao {
     
     // COLLATE NOCASE so free-text manual entry matches regardless of casing
-    // (e.g. "amazon" finds a mapping saved as "Amazon"). (#678)
-    @Query("SELECT category FROM merchant_mappings WHERE merchant_name = :merchantName COLLATE NOCASE")
+    // (e.g. "amazon" finds a mapping saved as "Amazon"). If case-distinct rows
+    // both match, prefer the most recently updated one so the result is
+    // deterministic ("latest wins"). (#678)
+    @Query(
+        "SELECT category FROM merchant_mappings WHERE merchant_name = :merchantName COLLATE NOCASE " +
+            "ORDER BY updated_at DESC LIMIT 1"
+    )
     suspend fun getCategoryForMerchant(merchantName: String): String?
     
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/MerchantMappingDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/MerchantMappingDao.kt
@@ -7,7 +7,9 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface MerchantMappingDao {
     
-    @Query("SELECT category FROM merchant_mappings WHERE merchant_name = :merchantName")
+    // COLLATE NOCASE so free-text manual entry matches regardless of casing
+    // (e.g. "amazon" finds a mapping saved as "Amazon"). (#678)
+    @Query("SELECT category FROM merchant_mappings WHERE merchant_name = :merchantName COLLATE NOCASE")
     suspend fun getCategoryForMerchant(merchantName: String): String?
     
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/MerchantMappingDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/MerchantMappingDao.kt
@@ -9,11 +9,12 @@ interface MerchantMappingDao {
     
     // COLLATE NOCASE so free-text manual entry matches regardless of casing
     // (e.g. "amazon" finds a mapping saved as "Amazon"). If case-distinct rows
-    // both match, prefer the most recently updated one so the result is
-    // deterministic ("latest wins"). (#678)
+    // both match, prefer the most recently updated one, breaking exact timestamp
+    // ties (possible after a backup restore) by merchant_name — the PK — so the
+    // result is always deterministic. (#678)
     @Query(
         "SELECT category FROM merchant_mappings WHERE merchant_name = :merchantName COLLATE NOCASE " +
-            "ORDER BY updated_at DESC LIMIT 1"
+            "ORDER BY updated_at DESC, merchant_name ASC LIMIT 1"
     )
     suspend fun getCategoryForMerchant(merchantName: String): String?
     

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/add/AddViewModel.kt
@@ -23,6 +23,7 @@ import android.util.Log
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
 import java.time.Instant
@@ -72,6 +73,10 @@ class AddViewModel @Inject constructor(
     // clobbering a category the user actually chose. (#678)
     private val DEFAULT_CATEGORY_PLACEHOLDERS =
         setOf("Others", "Shopping", "Income", "Investment")
+
+    // Tracks the in-flight merchant→category lookup so a newer merchant/type
+    // change supersedes a slower earlier one instead of landing stale. (#678)
+    private var merchantSuggestionJob: Job? = null
     
     
     init {
@@ -226,12 +231,18 @@ class AddViewModel @Inject constructor(
         // same mapping SMS parsing already applies. Only fills in when the user
         // hasn't chosen a specific category yet (still a per-type default), so an
         // explicit choice is never overridden.
-        viewModelScope.launch {
-            val name = merchant.trim()
-            if (name.isEmpty()) return@launch
+        merchantSuggestionJob?.cancel() // supersede any slower in-flight lookup
+        val name = merchant.trim()
+        if (name.isEmpty()) return
+        val typeAtRequest = _transactionUiState.value.transactionType
+        merchantSuggestionJob = viewModelScope.launch {
             val mapped = merchantMappingRepository.getCategoryForMerchant(name) ?: return@launch
             _transactionUiState.update { currentState ->
+                // Only fill when the form is still in the state we looked up for:
+                // same merchant, same type (a type change resets the category to a
+                // placeholder), and no category the user has since chosen.
                 if (currentState.merchant.trim() == name &&
+                    currentState.transactionType == typeAtRequest &&
                     currentState.category in DEFAULT_CATEGORY_PLACEHOLDERS
                 ) {
                     currentState.copy(category = mapped, categoryError = validateCategory(mapped))


### PR DESCRIPTION
Follow-up to #679 (already merged), fixing two review findings on the merchant→category suggestion.

## 1. Stale async apply
The lookup coroutine could land **after** the user changed the transaction type — which resets the category to a per-type placeholder — and overwrite it with a suggestion for the *old* context.

Now:
- The lookup captures the type at request time and only applies when **merchant AND type are still unchanged** (plus the category is still a placeholder, as before).
- A new merchant/type change **cancels the prior in-flight job** (`merchantSuggestionJob`) so a slower earlier lookup can't land late.

## 2. Case-sensitive miss
`getCategoryForMerchant` used an exact `=` match, so free-text manual entry (`amazon`) missed a mapping saved as `Amazon`. The query now uses **`COLLATE NOCASE`** — which also improves the SMS single-lookup path.

## Notes
`./init.sh app` green. This is the correctness follow-up the 3/5 review asked for on the (prematurely-merged) #679 — holding this one for the review to clear before merge.