### PR TITLE
fix(loans): show assigned loan contribution, not full transaction amount (#681)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/loans/LoanDetailScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/loans/LoanDetailScreen.kt
@@ -418,7 +418,9 @@ private fun LoanTransactionItem(
                 )
             }
             Text(
-                text = "${sign}${CurrencyFormatter.formatCurrency(transaction.amount, transaction.currency)}",
+                // Show the portion assigned to this loan, not the full transaction
+                // amount — matches how the loan total is computed (#681).
+                text = "${sign}${CurrencyFormatter.formatCurrency(transaction.loanContribution ?: transaction.amount, transaction.currency)}",
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.SemiBold,
                 color = color


### PR DESCRIPTION
Closes #681.

## Bug
When only a portion of a transaction is assigned to a loan (e.g. ₹75 of a ₹150 transaction), the loan detail's linked-transaction row displayed the **full ₹150** instead of the assigned **₹75**.

## Cause & fix
`LoanDetailScreen` rendered `transaction.amount`. The rest of the loan code is already contribution-aware:
- `LoanDao.getTotalRepaidByType` sums `COALESCE(loan_contribution, amount)`
- `HomeViewModel` uses `loanContribution ?: amount`

So only the display was out of step. Changed the row to `transaction.loanContribution ?: transaction.amount` — now the shown amount matches the computed loan total.

**Scope:** display-only, one line. The totals/remaining were already correct (verified `getTotalRepaidByType` uses the contribution). `./init.sh app` green.