### PR TITLE
fix(parser): parse Scapia Federal 'earned you rewards' txn variant

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/FederalBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/FederalBankParser.kt
@@ -537,6 +537,14 @@ class FederalBankParser : BaseIndianBankParser() {
             return false
         }
 
+        if (lowerMessage.contains("txn of") &&
+            (lowerMessage.contains("rewards") || lowerMessage.contains("was successful")) &&
+            !lowerMessage.contains("failed") &&
+            !lowerMessage.contains("declined")
+        ) {
+            return true
+        }
+
         // Federal Bank specific transaction keywords
         val federalKeywords = listOf(
             "sent via upi",

--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/FederalBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/FederalBankParser.kt
@@ -619,6 +619,10 @@ class FederalBankParser : BaseIndianBankParser() {
         return null
     }
 
+    override fun extractReference(message: String): String? {
+        return super.extractReference(message)?.takeIf { ref -> ref.any(Char::isDigit) }
+    }
+
     override fun extractBalance(message: String): BigDecimal? {
         // Don't extract credit limit as balance
         return super.extractBalance(message)

--- a/parser-core/src/test/kotlin/TestFederalBankParser.kt
+++ b/parser-core/src/test/kotlin/TestFederalBankParser.kt
@@ -450,5 +450,15 @@ class FederalBankParserTest {
         assertNull(paymentDueResult?.umn, "Payment due notifications don't have UMN")
     }
 
+    @Test
+    fun `Scapia txn message does not capture a fabricated reference`() {
+        val parser = FederalBankParser()
+        val message =
+            "Your txn of ₹2,351.00 at Amazon on your Scapia Federal Visa credit card earned you 10% rewards! Not you? Call 18002961199. - Federal Bank"
 
+        val parsed = parser.parse(message, "TX-FEDSCP-S", 0L)
+
+        assertNotNull(parsed, "Scapia rewards txn should parse")
+        assertNull(parsed?.reference, "The word after 'txn' must not be captured as a reference")
+    }
 }

--- a/parser-core/src/test/kotlin/TestFederalBankParser.kt
+++ b/parser-core/src/test/kotlin/TestFederalBankParser.kt
@@ -256,13 +256,6 @@ class FederalBankParserTest {
 
             // Messages that should not parse
             ParserTestCase(
-                name = "Scapia Declined Transaction Should Not Parse",
-                message = "Your txn of ₹2,351.00 at Amazon on your Scapia Federal Visa credit card was declined. You would have earned 10% rewards! Not you? Call 18002961199. - Federal Bank",
-                sender = "TX-FEDSCP-S",
-                shouldParse = false
-            ),
-
-            ParserTestCase(
                 name = "Failed Transaction Should Not Parse",
                 message = "Hi, txn of Rs. 1500.00 using card XX**3456 failed due to insufficient funds. Current Bal: Rs.250.75. Call 18004251199 if txn not initiated by you -Federal Bank",
                 sender = "AD-FEDBNK",

--- a/parser-core/src/test/kotlin/TestFederalBankParser.kt
+++ b/parser-core/src/test/kotlin/TestFederalBankParser.kt
@@ -227,6 +227,19 @@ class FederalBankParserTest {
             ),
 
             ParserTestCase(
+                name = "Scapia Federal Credit Card Transaction - earned you rewards variant",
+                message = "Your txn of ₹2,351.00 at Amazon on your Scapia Federal Visa credit card earned you 10% rewards! Not you? Call 18002961199. - Federal Bank",
+                sender = "TX-FEDSCP-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2351.00"),
+                    currency = "INR",
+                    type = com.pennywiseai.parser.core.TransactionType.CREDIT,
+                    merchant = "Amazon",
+                    isFromCard = true
+                )
+            ),
+
+            ParserTestCase(
                 name = "Debit Card Transaction - Masked Card",
                 message = "Rs 1500.00 debited via card XX**3456 at MERCHANT on 14-05-2025 15:30:45. Current Bal: Rs.250.75 -Federal Bank",
                 sender = "AD-FEDBNK",

--- a/parser-core/src/test/kotlin/TestFederalBankParser.kt
+++ b/parser-core/src/test/kotlin/TestFederalBankParser.kt
@@ -256,6 +256,13 @@ class FederalBankParserTest {
 
             // Messages that should not parse
             ParserTestCase(
+                name = "Scapia Declined Transaction Should Not Parse",
+                message = "Your txn of ₹2,351.00 at Amazon on your Scapia Federal Visa credit card was declined. You would have earned 10% rewards! Not you? Call 18002961199. - Federal Bank",
+                sender = "TX-FEDSCP-S",
+                shouldParse = false
+            ),
+
+            ParserTestCase(
                 name = "Failed Transaction Should Not Parse",
                 message = "Hi, txn of Rs. 1500.00 using card XX**3456 failed due to insufficient funds. Current Bal: Rs.250.75. Call 18004251199 if txn not initiated by you -Federal Bank",
                 sender = "AD-FEDBNK",


### PR DESCRIPTION
## Problem

Scapia Federal Visa credit card SMS in the format:

> Your txn of ₹2,351.00 at Amazon on your Scapia Federal Visa credit card earned you 10% rewards! Not you? Call XXXXXXXXXX. - Federal Bank

was silently dropped. The sender (`TX-FEDSCP-S`) routes to `FederalBankParser` correctly, but the message was rejected at the `isTransactionMessage` gate. The parser only recognized the older Scapia shape ("...credit card **was successful**...") via keyword; this newer "...credit card **earned you** 10% rewards!" variant matched no keyword.

Everything downstream (amount `₹` pattern, `at <merchant> on your` merchant extraction, `txn of → CREDIT` type) already handled the message once past the gate.

## Fix

Accept a `txn of` message that carries a success signal (`rewards` / `was successful`) while excluding `failed` / `declined` txns. The exclusion matters — a blunt `"txn of"` keyword would have regressed the existing "Failed Transaction Should Not Parse" case, which also contains "txn of".

## Test

Added a case to `TestFederalBankParser` asserting the new variant parses to amount `2351.00`, type `CREDIT`, merchant `Amazon`, `isFromCard = true`. Existing "was successful" and failed-txn cases are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)