### PR TITLE
fix(transactions): include merchant alias in transaction search (#691)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -8,6 +8,7 @@ import com.pennywiseai.tracker.data.database.entity.CategoryEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
 import com.pennywiseai.tracker.data.repository.CategoryRepository
+import com.pennywiseai.tracker.data.repository.MerchantAliasRepository
 import com.pennywiseai.tracker.data.repository.TagRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import com.pennywiseai.tracker.domain.model.BudgetCycle
@@ -49,6 +50,7 @@ class TransactionsViewModel @Inject constructor(
     private val transactionRepository: TransactionRepository,
     private val categoryRepository: CategoryRepository,
     private val tagRepository: TagRepository,
+    private val merchantAliasRepository: MerchantAliasRepository,
     private val transactionSplitDao: TransactionSplitDao,
     private val userPreferencesRepository: com.pennywiseai.tracker.data.preferences.UserPreferencesRepository,
     private val currencyConversionService: CurrencyConversionService,
@@ -72,6 +74,13 @@ class TransactionsViewModel @Inject constructor(
     // transactionId -> tag names, kept in sync for in-memory tag search.
     private val transactionTagsMap: StateFlow<Map<Long, List<String>>> =
         tagRepository.observeTransactionTagNames()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyMap())
+
+    // raw merchant name -> user-set display alias (#583), so a merchant's alias
+    // is searchable too, not just its raw name (#691).
+    private val merchantAliases: StateFlow<Map<String, String>> =
+        merchantAliasRepository.getAllAliases()
+            .map { list -> list.associate { it.merchantName to it.alias } }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyMap())
     
     private val _selectedPeriod = MutableStateFlow(TimePeriod.THIS_MONTH)
@@ -757,7 +766,8 @@ class TransactionsViewModel @Inject constructor(
             _isUnifiedMode.map { "unifiedMode" },
             sortOption.map { "sort" },
             customDateRange.map { "customDate" },
-            transactionTagsMap.map { "tags" }
+            transactionTagsMap.map { "tags" },
+            merchantAliases.map { "aliases" }
         )
             .transformLatest { trigger ->
                 // Get current values from all StateFlows
@@ -1342,6 +1352,10 @@ class TransactionsViewModel @Inject constructor(
                     val matchesTag = transactionTagsMap.value[transaction.id]
                         ?.any { it.contains(searchQuery, ignoreCase = true) } == true
 
+                    // Check the merchant's user-set display alias (#691)
+                    val matchesAlias = merchantAliases.value[transaction.merchantName]
+                        ?.contains(searchQuery, ignoreCase = true) == true
+
                     // Check SMS body (full text search)
                     val matchesSmsBody = transaction.smsBody?.contains(searchQuery, ignoreCase = true) == true
                     
@@ -1364,7 +1378,7 @@ class TransactionsViewModel @Inject constructor(
                         false
                     }
                     
-                    matchesMerchant || matchesDescription || matchesTag || matchesSmsBody || matchesAmount
+                    matchesMerchant || matchesDescription || matchesTag || matchesAlias || matchesSmsBody || matchesAmount
                 }
             }
         }


### PR DESCRIPTION
Closes #691.

## Bug
Transaction search matched merchant name, description, tags, SMS body, and amount — but **not the user-set merchant display alias** (#583, stored in a separate `merchant_aliases` table). So after setting a "Display alias" on a merchant, searching for that alias text returned nothing; only the raw merchant name (e.g. "blinkit") worked.

## Fix
`TransactionsViewModel`:
- inject `MerchantAliasRepository`, expose a `merchant_name → alias` map as a StateFlow (mirroring the existing `transactionTagsMap`),
- add it to the search trigger `merge(...)` so results refresh when an alias changes,
- add `matchesAlias` to the search predicate.

No schema change, no migration — a contained VM change.

## Verified on device
Seeded an alias (`Zomato → "ZorpFoodDelivery"`), searched **"ZorpFoodDelivery"**, and the two Zomato transactions surfaced (they returned nothing before). `./init.sh app` green.