### PR TITLE
fix(transactions): editing a transaction no longer drops its loan link (#688)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionDetailViewModel.kt
@@ -760,11 +760,19 @@ class TransactionDetailViewModel @Inject constructor(
                     ?.bankName
                     ?: toSave.bankName
 
-                // Normalize merchant name before saving
+                // Loan linkage (loanId / loanContribution) is owned by mark-as-loan
+                // and unmark, never the edit form. The editable copy was snapshotted
+                // when edit mode opened, so if the transaction was linked to a loan
+                // in between, saving `toSave` would clobber that link — the loan would
+                // still count the txn but the txn would show "Mark as loan" again
+                // (#688). Carry the current persisted values through the save.
+                val currentPersisted = _transaction.value
                 val normalizedTransaction = toSave.copy(
                     merchantName = normalizeMerchantName(toSave.merchantName),
                     bankName = resolvedBankName,
-                    receiptPath = newReceiptPath
+                    receiptPath = newReceiptPath,
+                    loanId = if (currentPersisted != null) currentPersisted.loanId else toSave.loanId,
+                    loanContribution = if (currentPersisted != null) currentPersisted.loanContribution else toSave.loanContribution
                 )
 
                 // Pin opening anchors from the PRE-update snapshot for the affected


### PR DESCRIPTION
Closes #688.

## Bug
Mark a transaction as a loan, then edit it (e.g. change amount / add a split) and save → the loan **still counts** the transaction, but the transaction detail shows **"Mark as loan"** again (the link is lost). Reporter's screenshot: a Split (2-category) "Irctc" −₹800 showing "Mark as loan" while it's counted in the loan.

## Cause
`saveChanges()` writes `_editableTransaction` — the `.copy()` snapshotted when edit mode *opened* (before any loan link). Loan linkage (`loanId` / `loanContribution`) is owned by mark-as-loan / unmark, **not** the edit form. So an edit saved after the transaction was linked overwrote `loanId` back to `null`. The DB row was still linked (so the loan's `SUM(… WHERE loan_id = :id)` counted it), but the transaction re-read with `loanId = null` → "Mark as loan" reappears.

## Fix
Carry the **current persisted** `loanId` / `loanContribution` through the save instead of overwriting them with the stale editable snapshot. The edit form never touches those fields, so this is safe (and it correctly respects an unmark that happened mid-edit too).

## Verification
`./init.sh app` green. Diagnosis confirmed by the reporter's screenshot (split txn, loan-counted, "Mark as loan" shown) + tracing the exact clobber in `saveChanges`. The reported trigger is a multi-step UI flow (edit → split → mark → save → re-view) — worth a device repro before merge; **holding for review**.