### PR TITLE
fix(home): show credit-card amount spent, not remaining limit (#684)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceCard.kt
@@ -419,8 +419,9 @@ fun BalanceCard(
                                         Text(
                                             // Show the amount spent (outstanding) on the card, not
                                             // the remaining credit limit — for a credit card
-                                            // `balance` is the outstanding debt. (#684)
-                                            text = if (isBalanceHidden) "••••••" else CurrencyFormatter.formatCurrency(card.balance, currency),
+                                            // `balance` is the outstanding debt. Format in the
+                                            // card's own currency (it may be unconverted). (#684)
+                                            text = if (isBalanceHidden) "••••••" else CurrencyFormatter.formatCurrency(card.balance, card.currency),
                                             style = MaterialTheme.typography.titleSmall,
                                             fontWeight = FontWeight.Bold,
                                             color = MaterialTheme.colorScheme.onSurface
@@ -451,9 +452,15 @@ fun BalanceCard(
                                         "••••••"
                                     } else {
                                         // Net of credit-card spend: bank balances minus what's
-                                        // outstanding on the cards, rather than bank balances
-                                        // alone. (#684)
-                                        val net = totalBalance - creditCards.fold(BigDecimal.ZERO) { acc, c -> acc + c.balance }
+                                        // outstanding on the cards. Only subtract cards already in
+                                        // the total's currency — never sum across currencies
+                                        // (hard constraint #2). Cards left in a native currency
+                                        // (no rate) are excluded, like other unconverted balances,
+                                        // and flagged by the existing `isApproximate`. (#684)
+                                        val cardSpendInCurrency = creditCards
+                                            .filter { it.currency == currency }
+                                            .fold(BigDecimal.ZERO) { acc, c -> acc + c.balance }
+                                        val net = totalBalance - cardSpendInCurrency
                                         "${CurrencyFormatter.formatCurrency(net, currency)}${if (isApproximate) "*" else ""}"
                                     },
                                     style = MaterialTheme.typography.titleSmall,

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceCard.kt
@@ -403,7 +403,6 @@ fun BalanceCard(
                                 Spacer(modifier = Modifier.height(Spacing.sm))
 
                                 creditCards.forEach { card ->
-                                    val availableCredit = (card.creditLimit ?: BigDecimal.ZERO) - card.balance
                                     Row(
                                         modifier = Modifier
                                             .fillMaxWidth()
@@ -418,7 +417,10 @@ fun BalanceCard(
                                             color = MaterialTheme.colorScheme.onSurface
                                         )
                                         Text(
-                                            text = if (isBalanceHidden) "••••••" else CurrencyFormatter.formatCurrency(availableCredit, currency),
+                                            // Show the amount spent (outstanding) on the card, not
+                                            // the remaining credit limit — for a credit card
+                                            // `balance` is the outstanding debt. (#684)
+                                            text = if (isBalanceHidden) "••••••" else CurrencyFormatter.formatCurrency(card.balance, currency),
                                             style = MaterialTheme.typography.titleSmall,
                                             fontWeight = FontWeight.Bold,
                                             color = MaterialTheme.colorScheme.onSurface
@@ -448,7 +450,11 @@ fun BalanceCard(
                                     text = if (isBalanceHidden) {
                                         "••••••"
                                     } else {
-                                        "${CurrencyFormatter.formatCurrency(totalBalance, currency)}${if (isApproximate) "*" else ""}"
+                                        // Net of credit-card spend: bank balances minus what's
+                                        // outstanding on the cards, rather than bank balances
+                                        // alone. (#684)
+                                        val net = totalBalance - creditCards.fold(BigDecimal.ZERO) { acc, c -> acc + c.balance }
+                                        "${CurrencyFormatter.formatCurrency(net, currency)}${if (isApproximate) "*" else ""}"
                                     },
                                     style = MaterialTheme.typography.titleSmall,
                                     fontWeight = FontWeight.Bold,

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceCard.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/cards/BalanceCard.kt
@@ -451,17 +451,7 @@ fun BalanceCard(
                                     text = if (isBalanceHidden) {
                                         "••••••"
                                     } else {
-                                        // Net of credit-card spend: bank balances minus what's
-                                        // outstanding on the cards. Only subtract cards already in
-                                        // the total's currency — never sum across currencies
-                                        // (hard constraint #2). Cards left in a native currency
-                                        // (no rate) are excluded, like other unconverted balances,
-                                        // and flagged by the existing `isApproximate`. (#684)
-                                        val cardSpendInCurrency = creditCards
-                                            .filter { it.currency == currency }
-                                            .fold(BigDecimal.ZERO) { acc, c -> acc + c.balance }
-                                        val net = totalBalance - cardSpendInCurrency
-                                        "${CurrencyFormatter.formatCurrency(net, currency)}${if (isApproximate) "*" else ""}"
+                                        "${CurrencyFormatter.formatCurrency(totalBalance, currency)}${if (isApproximate) "*" else ""}"
                                     },
                                     style = MaterialTheme.typography.titleSmall,
                                     fontWeight = FontWeight.Bold,


### PR DESCRIPTION
Closes #684.

## Request (two asks in the issue)
1. Each credit card in the home balance breakdown shows its **remaining credit limit** (`creditLimit − balance` — the big ₹6L-style figures in the screenshot), which "doesn't make much sense." → show **how much was spent** instead.
2. Also make the **Total** subtract credit-card spend rather than summing bank balances.

## What this PR does (only #1)
UI-only, `BalanceCard`:
- **Per credit card:** show `card.balance` — which *is* the outstanding/spent amount (`BalanceCalculator`: "for credit cards, balance represents outstanding debt") — instead of the computed available credit. Formatted in the card's own currency (it may be unconverted).

## Why not #2
Netting card debt into the **Total** reshapes what that headline figure means: the collapsed "Balance" line stays liquid-only while the expanded "Total" would become net-of-debt, so the same card shows two different numbers, and it opens cross-currency questions. That's a bigger product decision than the reporter's actual complaint (the per-card figure), so I've left the Total untouched. Happy to revisit #2 separately if you want it.

## Verification
`./init.sh app` green. Compile-only — an on-device check needs a seeded credit-card account.