### PR TITLE
fix(parser): handle HDFC credit-card transaction reversals (#698)

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/HDFCBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/HDFCBankParser.kt
@@ -37,6 +37,21 @@ class HDFCBankParser : BaseIndianBankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
+        // Reversal/refund format: "... By AMAZON        000 On 2026-08-21:..." —
+        // HDFC right-pads the merchant name with spaces before a trailing code,
+        // so capture up to that run of spaces (or " On "). (#698)
+        if (message.contains("reversed", ignoreCase = true) ||
+            message.contains("reversal", ignoreCase = true)
+        ) {
+            Regex("""\bBy\s+(.+?)(?:\s{2,}|\s+On\s)""", RegexOption.IGNORE_CASE)
+                .find(message)?.let { match ->
+                    val merchant = cleanMerchantName(match.groupValues[1].trim())
+                    if (merchant.isNotEmpty()) {
+                        return merchant
+                    }
+                }
+        }
+
         // Check for HDFC Bank Card debit transactions - "Spent Rs.xxx From HDFC Bank Card xxxx At [MERCHANT] On xxx"
         if (message.contains("From HDFC Bank Card", ignoreCase = true) &&
             message.contains(" At ", ignoreCase = true) &&
@@ -277,6 +292,11 @@ class HDFCBankParser : BaseIndianBankParser() {
         }
 
         return when {
+            // Reversals return money to the account — on a credit card this pays
+            // down the outstanding balance (INCOME semantics in BalanceCalculator),
+            // so classify it before the debit/expense keywords below. (#698)
+            lowerMessage.contains("reversed") || lowerMessage.contains("reversal") -> TransactionType.INCOME
+
             // Credit card transactions - ONLY if message contains CC or PCC indicators
             // Any transaction with BLOCK CC or BLOCK PCC is a credit card transaction
             lowerMessage.contains("block cc") || lowerMessage.contains("block pcc") -> TransactionType.CREDIT
@@ -509,7 +529,9 @@ class HDFCBankParser : BaseIndianBankParser() {
             "sent", // HDFC uses "Sent Rs.X From HDFC Bank"
             "deducted", // Add support for "deducted from" pattern
             "txn", // HDFC uses "Txn Rs.X" for card transactions
-            "refund" // "Refund initiated: Amt: Rs.X on HDFC Bank Credit Card ####"
+            "refund", // "Refund initiated: Amt: Rs.X on HDFC Bank Credit Card ####"
+            "reversed", // "Transaction Reversed!On HDFC Bank CREDIT Card ####" (#698)
+            "reversal"
         )
 
         return hdfcTransactionKeywords.any { lowerMessage.contains(it) }

--- a/parser-core/src/test/kotlin/TestHDFCBankParser.kt
+++ b/parser-core/src/test/kotlin/TestHDFCBankParser.kt
@@ -91,6 +91,22 @@ T&C. Ignore if paid""",
                     type = com.pennywiseai.parser.core.TransactionType.INCOME,
                     accountLast4 = "1111"
                 )
+            ),
+
+            // Credit-card transaction reversal — money returns to the card, so it
+            // reduces outstanding (INCOME). Like the refund above, the message has
+            // none of the standard debit/credit keywords. (#698)
+            ParserTestCase(
+                name = "Credit Card Transaction Reversed - Income",
+                message = "Transaction Reversed!On HDFC Bank CREDIT Card xx5555 Amt: Rs.862.16 By AMAZON                000 On 2026-08-21:05:20:26",
+                sender = "VM-HDFCBK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("862.16"),
+                    currency = "INR",
+                    type = com.pennywiseai.parser.core.TransactionType.INCOME,
+                    merchant = "AMAZON",
+                    accountLast4 = "5555"
+                )
             )
         )
 


### PR DESCRIPTION
Closes #698.

## Bug
This HDFC credit-card **reversal** SMS produced **no transaction** at all:
```
Transaction Reversed!On HDFC Bank CREDIT Card xx5555 Amt: Rs.862.16 By AMAZON                000 On 2026-08-21:05:20:26
```
It failed two gates: `isTransactionMessage` (its keyword list has debited/credited/spent/refund… but not *reversed*) rejected it outright, and even past that `extractTransactionType` returned `null` (no reversal branch).

## Fix (HDFC parser only)
- Add `reversed` / `reversal` to HDFC's transaction-keyword list (mirrors the existing `refund` handling right above it).
- Map reversed/reversal → **`TransactionType.INCOME`**, classified *before* the debit/expense keywords. On a credit card `INCOME` pays down the outstanding balance (`BalanceCalculator`: "Refunds or repayments reduce outstanding debt"), which is exactly what a reversal is.
- Add a `By <merchant>` extractor for this format — HDFC right-pads the merchant before a trailing code (`By AMAZON        000 On …`), so it captures up to the run of spaces / `" On "`.
- Amount (`Rs.862.16`) and card last-4 (`xx5555` → `5555`) already resolve via existing patterns.

## Result → `INCOME` ₹862.16 · merchant `AMAZON` · card ••5555 (reduces outstanding)

## Tests
Added a reversal regression case next to the existing "Refund Initiated" case; `./init.sh parser` green. Pure `parser-core` change — no catalogue/app changes.