### PR TITLE
fix(parser): harden Al Rajhi Saudi transaction parsing

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/AlRajhiBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/AlRajhiBankParser.kt
@@ -38,8 +38,14 @@ class AlRajhiBankParser : BankParser() {
 
     private companion object {
         // English PoS format patterns, compiled once.
-        val POS_DETECT = Regex("""Amount:\s*SR\s""", RegexOption.IGNORE_CASE)
-        val POS_AMOUNT = Regex("""Amount:\s*SR\s+([0-9,]+(?:\.\d{1,2})?)""", RegexOption.IGNORE_CASE)
+        val POS_DETECT = Regex(
+            """Amount\s*:\s*(?:(?:SAR|SR)\s|[0-9])""",
+            RegexOption.IGNORE_CASE
+        )
+        val POS_AMOUNT = Regex(
+            """Amount\s*:\s*(?:(?:SAR|SR)\s*([0-9,]+(?:\.\d{1,2})?)|([0-9,]+(?:\.\d{1,2})?)\s*(?:SAR|SR))""",
+            RegexOption.IGNORE_CASE
+        )
         val POS_CARD = Regex("""By:\s*(\d+)\s*;""")
         val POS_MERCHANT = Regex("""At:\s*([^\n]+)""")
     }
@@ -57,25 +63,41 @@ class AlRajhiBankParser : BankParser() {
         // SMS that happens to contain the same substring.
         if (isEnglishPosFormat(message)) {
             POS_AMOUNT.find(message)?.let { match ->
-                return parseSarAmount(match.groupValues[1])
+                return parseSarAmount(match.groupValues[1].ifBlank { match.groupValues[2] })
             }
         }
 
-        // Pattern 1: "بـSAR 5.75" or "بـSAR 140"
+        // Historical English refund/cashback alerts use an explicit Amount field
+        // without the PoS title. Keep the field and title gates narrow so a fee or
+        // balance line cannot become the transaction amount.
+        if (isRefundOrReversalMessage(message) || isCashbackMessage(message)) {
+            labelledSarAmount(message)?.let { return it }
+        }
+
+        // Pattern 1: "بـSAR 5.75" / "بـSR 5.75" (optional spacing)
         val bPattern = Regex(
-            """بـSAR\s+([0-9,]+(?:\.\d{1,2})?)""",
+            """بـ?\s*:?[ \t]*(?:SAR|SR)\s*:?[ \t]*([0-9,]+(?:\.\d{1,2})?)\b""",
             RegexOption.IGNORE_CASE
         )
         bPattern.find(message)?.let { match ->
             return parseSarAmount(match.groupValues[1])
         }
 
-        // Pattern 2: "مبلغ:SAR 100" or "مبلغ: SAR 100"
+        // Pattern 2: "مبلغ:SAR 100" / "مبلغ:SR 100" (optional spacing)
         val amountPattern = Regex(
-            """مبلغ:\s*SAR\s+([0-9,]+(?:\.\d{1,2})?)""",
+            """مبلغ\s*:?[ \t]*(?:SAR|SR)\s*:?[ \t]*([0-9,]+(?:\.\d{1,2})?)\b""",
             RegexOption.IGNORE_CASE
         )
         amountPattern.find(message)?.let { match ->
+            return parseSarAmount(match.groupValues[1])
+        }
+
+        // Historical Arabic layouts may put the number before the currency.
+        val numberFirstPattern = Regex(
+            """(?im)^\s*(?:بـ?|مبلغ)\s*:?[ \t]*([0-9,]+(?:\.\d{1,2})?)\s*(?:SAR|SR)\s*$""",
+            RegexOption.IGNORE_CASE
+        )
+        numberFirstPattern.find(message)?.let { match ->
             return parseSarAmount(match.groupValues[1])
         }
 
@@ -101,17 +123,23 @@ class AlRajhiBankParser : BankParser() {
     }
 
     override fun extractTransactionType(message: String): TransactionType? {
-        // English PoS purchase is always an expense
-        if (isEnglishPosFormat(message)) {
-            return TransactionType.EXPENSE
-        }
-
         return when {
+            // Return/reversal wording takes precedence over the original purchase
+            // term commonly repeated in successful return notifications.
+            isCashbackReversalMessage(message) -> TransactionType.EXPENSE
+            isCashbackMessage(message) -> TransactionType.INCOME
+            isRefundOrReversalMessage(message) -> TransactionType.INCOME
+
+            // English PoS purchase is an expense unless an explicit return title
+            // above has already classified it as income.
+            isEnglishPosFormat(message) -> TransactionType.EXPENSE
+
             // Incoming (واردة = incoming)
             message.contains("واردة") -> TransactionType.INCOME
 
+            isPurchaseMessage(message) -> TransactionType.EXPENSE
+
             // Expense types
-            message.contains("شراء") -> TransactionType.EXPENSE           // purchase
             message.contains("سحب") -> TransactionType.EXPENSE            // withdrawal
             message.contains("صادرة") -> TransactionType.EXPENSE          // outgoing
             message.contains("خصم") -> TransactionType.EXPENSE            // deduction
@@ -122,6 +150,14 @@ class AlRajhiBankParser : BankParser() {
     }
 
     override fun extractMerchant(message: String, sender: String): String? {
+        // Historical purchase and return alerts use labelled merchant fields.
+        // Keep this restricted to transaction families with explicit grammar.
+        if (!isEnglishPosFormat(message) &&
+            (isPurchaseMessage(message) || isRefundOrReversalMessage(message) ||
+                isCashbackMessage(message))) {
+            labelledMerchant(message)?.let { return it }
+        }
+
         // English PoS: merchant is the value after "At:" up to end of line
         if (isEnglishPosFormat(message)) {
             POS_MERCHANT.find(message)?.let { match ->
@@ -233,10 +269,19 @@ class AlRajhiBankParser : BankParser() {
     override fun extractBalance(message: String): BigDecimal? {
         // Pattern: "المبلغ المتبقي: SAR 13827.48" (remaining amount)
         val remainingPattern = Regex(
-            """المبلغ المتبقي:\s*SAR\s+([0-9,]+(?:\.\d{1,2})?)""",
+            """المبلغ المتبقي\s*:\s*(?:SAR|SR)\s*([0-9,]+(?:\.\d{1,2})?)""",
             RegexOption.IGNORE_CASE
         )
         remainingPattern.find(message)?.let { match ->
+            return parseSarAmount(match.groupValues[1])
+        }
+
+        // Current balance form: "رصيد: 1.55 SR".
+        val balancePattern = Regex(
+            """رصيد\s*:\s*([0-9,]+(?:\.\d{1,2})?)\s*(?:SAR|SR)""",
+            RegexOption.IGNORE_CASE
+        )
+        balancePattern.find(message)?.let { match ->
             return parseSarAmount(match.groupValues[1])
         }
 
@@ -257,10 +302,13 @@ class AlRajhiBankParser : BankParser() {
     }
 
     override fun isTransactionMessage(message: String): Boolean {
+        if (isDeclinedOrFailedMessage(message)) return false
+
         // Skip OTP / verification (Arabic + English)
         if (message.contains("رمز") || message.contains("OTP", ignoreCase = true) ||
             message.contains("كلمة المرور") ||
-            message.contains("verification code", ignoreCase = true)
+            message.contains("verification code", ignoreCase = true) ||
+            message.contains("one time password", ignoreCase = true)
         ) {
             return false
         }
@@ -276,8 +324,71 @@ class AlRajhiBankParser : BankParser() {
             "حوالة",     // transfer
             "خصم",       // deduction
             "سداد",      // payment/settlement
-            "SAR"        // currency marker
+            "استرجاع",   // refund/return
+            "مرتجع",     // returned purchase
+            "عكس",       // reversal
+            "refund",
+            "reversal",
+            "cashback",
+            "كاش باك",
+            "SAR",       // currency marker
+            "SR"
         )
-        return keywords.any { message.contains(it) }
+        return keywords.any { message.contains(it, ignoreCase = true) }
+    }
+
+    private fun isPurchaseMessage(message: String): Boolean =
+        message.contains("purchase", ignoreCase = true) ||
+            message.contains("PoS", ignoreCase = true) ||
+            message.contains("شراء")
+
+    private fun isRefundOrReversalMessage(message: String): Boolean {
+        val explicitTitle = Regex(
+            """(?im)^\s*(?:(?:pos\s+)?purchase\s+|card\s+purchase\s+)?(?:refund|reversal)\b""",
+            RegexOption.IGNORE_CASE
+        )
+        val explicitArabicTitle = Regex(
+            """(?m)^\s*(?:استرجاع|إرجاع|مرتجع|عكس\s+العملية)\b"""
+        )
+        return explicitTitle.containsMatchIn(message) || explicitArabicTitle.containsMatchIn(message)
+    }
+
+    private fun isCashbackMessage(message: String): Boolean =
+        message.contains("cashback", ignoreCase = true) || message.contains("كاش باك")
+
+    private fun isCashbackReversalMessage(message: String): Boolean =
+        isCashbackMessage(message) &&
+            (message.contains("reversal", ignoreCase = true) ||
+                Regex("""(?m)^\s*كاش\s+باك\s+عكس(?:\s|$)""").containsMatchIn(message))
+
+    private fun labelledSarAmount(message: String): BigDecimal? {
+        val pattern = Regex(
+            """(?im)^\s*Amount\s*:\s*(?:(?:SAR|SR)\s*([0-9,]+(?:\.\d{1,2})?)|([0-9,]+(?:\.\d{1,2})?)\s*(?:SAR|SR))\s*$""",
+            RegexOption.IGNORE_CASE
+        )
+        return pattern.find(message)?.let { match ->
+            parseSarAmount(match.groupValues[1].ifBlank { match.groupValues[2] })
+        }
+    }
+
+    private fun labelledMerchant(message: String): String? {
+        val pattern = Regex("""(?im)^\s*(?:At|لدى|التاجر)\s*:?\s*([^\n]+?)\s*$""")
+        return pattern.find(message)?.let { match ->
+            val merchant = cleanMerchantName(match.groupValues[1].trim())
+            merchant.takeIf { isValidMerchantName(it) }
+        }
+    }
+
+    private fun isDeclinedOrFailedMessage(message: String): Boolean {
+        val lower = message.lowercase()
+        val english = listOf(
+            "declined", "failed", "not successful", "rejected",
+            "could not be completed", "was not completed"
+        )
+        val arabic = listOf(
+            "عملية مرفوضة", "تم رفض العملية", "فشل العملية",
+            "عملية فاشلة", "تعذر إتمام العملية", "عملية غير ناجحة"
+        )
+        return english.any { lower.contains(it) } || arabic.any { message.contains(it) }
     }
 }

--- a/parser-core/src/test/kotlin/TestAlRajhiBankParser.kt
+++ b/parser-core/src/test/kotlin/TestAlRajhiBankParser.kt
@@ -9,6 +9,126 @@ import java.math.BigDecimal
 class AlRajhiBankParserTest {
 
     @TestFactory
+    fun `al rajhi parser covers historical and safety variants`(): List<DynamicTest> {
+        val parser = AlRajhiBankParser()
+
+        val testCases = listOf(
+            ParserTestCase(
+                name = "Historical English purchase with number-first SAR amount",
+                message = "PoS Purchase\nBy:0007;mada\nAmount: 12.34 SAR\nAt: SYNTHETIC STORE\n01/01/2030 10:20",
+                sender = "AlRajhiBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("12.34"),
+                    currency = "SAR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "SYNTHETIC STORE",
+                    accountLast4 = "0007",
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "Arabic purchase accepts number-first SR and labelled merchant",
+                message = "شراء\nبـ5.75 SR\nالتاجر: SYNTHETIC MERCHANT\nرصيد: 88.88 SR\n01/01/2030 10:20",
+                sender = "AlRajhiBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("5.75"),
+                    currency = "SAR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "SYNTHETIC MERCHANT",
+                    balance = BigDecimal("88.88")
+                )
+            ),
+            ParserTestCase(
+                name = "Refund is classified as income",
+                message = "Purchase Refund\nAmount: 7.89 SAR\nAt: SYNTHETIC REFUND STORE\n01/01/2030 10:20",
+                sender = "AlRajhiBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("7.89"),
+                    currency = "SAR",
+                    type = TransactionType.INCOME,
+                    merchant = "SYNTHETIC REFUND STORE"
+                )
+            ),
+            ParserTestCase(
+                name = "Cashback credit is classified as income",
+                message = "Cashback\nAmount: 2.50 SAR\nAt: SYNTHETIC CASHBACK\n01/01/2030 10:20",
+                sender = "AlRajhiBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2.50"),
+                    currency = "SAR",
+                    type = TransactionType.INCOME,
+                    merchant = "SYNTHETIC CASHBACK"
+                )
+            ),
+            ParserTestCase(
+                name = "Cashback reversal is classified as expense",
+                message = "Cashback Reversal\nAmount: 2.50 SAR\nAt: SYNTHETIC CASHBACK\n01/01/2030 10:20",
+                sender = "AlRajhiBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2.50"),
+                    currency = "SAR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "SYNTHETIC CASHBACK"
+                )
+            ),
+            ParserTestCase(
+                name = "PoS refund overrides purchase wording",
+                message = "PoS Purchase Refund\nBy:0008;mada\nAmount: 3.25 SAR\nAt: SYNTHETIC POS REFUND\n01/01/2030 10:20",
+                sender = "AlRajhiBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("3.25"),
+                    currency = "SAR",
+                    type = TransactionType.INCOME,
+                    merchant = "SYNTHETIC POS REFUND",
+                    accountLast4 = "0008",
+                    isFromCard = true
+                )
+            ),
+            ParserTestCase(
+                name = "Arabic cashback reversal is an expense",
+                message = "كاش باك عكس\nمبلغ: SAR 2.50\nالتاجر: SYNTHETIC CASHBACK\n01/01/2030 10:20",
+                sender = "AlRajhiBank",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("2.50"),
+                    currency = "SAR",
+                    type = TransactionType.EXPENSE,
+                    merchant = "SYNTHETIC CASHBACK"
+                )
+            ),
+            ParserTestCase(
+                name = "Operational refund wording is not a transaction",
+                message = "Help: refunds are processed within 5 days.\nAmount: SAR 9.99\nAt: SYNTHETIC HELP DESK",
+                sender = "AlRajhiBank",
+                shouldParse = false
+            ),
+            ParserTestCase(
+                name = "Incidental number-first SAR text is not an amount field",
+                message = "شراء\nمعلومة: ب 99.99 SR هو الحد المتاح\nالتاجر: SYNTHETIC INFORMATION\n01/01/2030 10:20",
+                sender = "AlRajhiBank",
+                shouldParse = false
+            ),
+            ParserTestCase(
+                name = "Declined historical purchase is ignored",
+                message = "PoS Purchase Declined\nBy:0007;mada\nAmount: 12.34 SAR\nAt: SYNTHETIC STORE\n01/01/2030 10:20",
+                sender = "AlRajhiBank",
+                shouldParse = false
+            ),
+            ParserTestCase(
+                name = "Fee-only notice is not a transaction",
+                message = "Fee Notice\nFee: SAR 0.50\nAt: SYNTHETIC SERVICE\n01/01/2030 10:20",
+                sender = "AlRajhiBank",
+                shouldParse = false
+            )
+        )
+
+        return ParserTestUtils.runTestSuite(
+            parser = parser,
+            testCases = testCases,
+            suiteName = "Al Rajhi Historical and Safety Suite"
+        )
+    }
+
+    @TestFactory
     fun `al rajhi parser covers representative scenarios`(): List<DynamicTest> {
         val parser = AlRajhiBankParser()
 


### PR DESCRIPTION
## Summary

Improve Al Rajhi transaction notification parsing for additional historical Saudi SAR/SR formats.

This change:

- adds support for additional SAR/SR amount layouts
- classifies refunds, reversals, and cashback corrections correctly
- rejects declined, failed, and non-transaction notifications
- improves merchant extraction from supported Arabic and English fields
- improves current-balance extraction without treating balances as transaction amounts
- adds synthetic positive and negative regression coverage

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Code improvement (no behavior change)
- [ ] perf: Performance improvement
- [ ] style: Formatting (no behavior change)
- [ ] test: Add/update tests
- [ ] chore/ci: Build or CI changes

## Screenshots/Recordings

Not applicable — parser-only change.

## How to test

Run the focused Al Rajhi parser tests:

```bash
./gradlew :parser-core:jvmTest --tests AlRajhiBankParserTest