### PR TITLE
 docs: sync guides with current architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,10 @@ complaint.
    see `docs/adding-bank-parsers.md`.
 
 ## Verification — Definition of Done
-Run **`./init.sh`** before claiming a change is done — it runs exactly what CI
-(`.github/workflows/test.yml`) gates on, so "green here" means "green in CI".
-Scope it to what you touched:
+Run **`./init.sh`** before claiming a change is done — it runs the same
+compile/test gate CI applies (CI's App Compile job additionally assembles a
+debug APK, so a change that compiles but breaks assembly will still surface
+there). Scope it to what you touched:
 
 | Change | Command |
 |---|---|
@@ -55,15 +56,15 @@ Scope it to what you touched:
 | Everything | `./init.sh` (default) |
 | Runtime / UI | plus an on-device check (use the **emulator-verify** skill) |
 
-`init.sh` sets `JAVA_HOME` to a JDK 21 (Android Studio's JBR by default). Run
-the raw `./gradlew` tasks it wraps only if you need finer control. `./gradlew
-build` and `lint` are heavier and **not** part of the gate — don't use them to
-verify.
+`init.sh` sets `JAVA_HOME` to a JDK 21 (it tries `JAVA_HOME`, macOS `java_home`,
+Android Studio's JBR, then SDKMAN). Run the raw `./gradlew` tasks it wraps only
+if you need finer control. `./gradlew build` and `lint` are heavier and **not**
+part of the gate — don't use them to verify.
 
 ## Architecture at a glance
 - **Stack:** Kotlin · Jetpack Compose + Material 3 · MVVM + Clean Architecture ·
   StateFlow (unidirectional data flow) · Hilt DI · Room · WorkManager (background
-  SMS scanning) · MediaPipe LLM (Qwen 2.5) for on-device AI.
+  SMS scanning) · Google AI Edge LiteRT-LM (Qwen 2.5) for on-device AI.
 - **Modules:** `app` (Android) · `parser-core` (pure-Kotlin bank SMS parsers, no
   Android deps) · `shared` (KMP) · `iosApp` · `pennywise-web`.
 - **UI:** Material You dynamic color (Android 12+), full light/dark with semantic
@@ -83,7 +84,7 @@ verify.
 | Adding a bank parser | `docs/adding-bank-parsers.md` | New/changed parser in `parser-core` |
 | Parser tests | `docs/parser-test-standards.md` | Writing parser tests |
 | DB migrations | `docs/database-migrations.md` | Room schema changes |
-| Supported banks | `docs/BANK_SUPPORT.md`, `docs/supported-banks.json` | Which banks/patterns are covered (139 banks, 23 countries) |
+| Supported banks | `docs/BANK_SUPPORT.md`, `docs/supported-banks.json` | Which banks/patterns are covered (144 banks, 23 countries) |
 | Roadmap / requirements | `docs/planned-features.md`, `docs/prd-unified-currency.md` | Feature scope / intent |
 
 **Subagents:** `backup-maintainer` (backup-serialized changes) ·
@@ -96,5 +97,6 @@ clean tree — run `./scripts/release.sh patch|minor|major --yes` (preview first
 with `--dry-run`). It commits/tags the current branch and pushes `main`, so the
 branch state matters.
 `scripts/release.sh` is the single source of truth — it bumps the version,
-generates changelogs + release notes, builds/signs the APKs, tags, pushes, and
-cuts the GitHub release. Full flag reference in `docs/RELEASE.md`.
+generates changelogs + release notes, builds the APKs (standard flavor signed;
+the F-Droid APK stays unsigned for IzzyOnDroid), tags, pushes, and cuts the
+GitHub release. Full flag reference in `docs/RELEASE.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,16 +25,18 @@ Thank you for your interest in contributing to PennyWise AI! We welcome contribu
 
 To add support for a new bank:
 
-1. Create a new parser class in `/app/src/main/java/com/pennywiseai/tracker/data/parser/bank/`
-2. Extend the `BankParser` abstract class
-3. Implement required methods:
+1. Create a new parser class in `parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/`
+2. Extend the right base class: `BaseIndianBankParser` for Indian banks, `UAEBankParser` for UAE banks, `BaseIranianBankParser` / `BaseThailandBankParser` for those markets, plain `BankParser` otherwise
+3. Implement the required methods (`parse()` has a default implementation you only override when the bank needs custom parsing):
    ```kotlin
    override fun getBankName(): String
    override fun canHandle(sender: String): Boolean
-   override fun parse(smsBody: String, sender: String, timestamp: Long): ParsedTransaction?
    ```
-4. Add your parser to `BankParserFactory.parsers` list
-5. Test with real SMS samples
+4. Register your parser in `BankParserFactory` — registration order matters, so place it **above** any broader parser whose `canHandle()` could also match your sender IDs
+5. Test with real SMS samples ([parser test conventions](docs/parser-test-standards.md))
+6. Run `./scripts/update-supported-banks.sh` so the generated bank list stays in sync (CI fails otherwise)
+
+Full walkthrough: [docs/adding-bank-parsers.md](docs/adding-bank-parsers.md)
 
 ### 💻 Code Contributions
 
@@ -68,8 +70,8 @@ To add support for a new bank:
 ### Prerequisites
 
 - Android Studio Ladybug or newer
-- JDK 11+
-- Android SDK (API 31+)
+- JDK 21
+- Android SDK (installed through Android Studio; compileSdk/targetSdk come from Gradle)
 
 ### Building the Project
 
@@ -90,16 +92,22 @@ cd pennywiseai-tracker
 
 ### Project Structure
 
+PennyWise is a multi-module project (`settings.gradle.kts` includes `:app`, `:parser-core`, `:shared`, and `:iosApp`; the tree below also shows non-module directories):
+
 ```
-app/
-├── src/main/java/com/pennywiseai/tracker/
-│   ├── data/
-│   │   ├── database/      # Room database
-│   │   ├── parser/        # SMS parsers
-│   │   └── repository/    # Data repositories
-│   ├── domain/            # Business logic
-│   └── ui/               # Compose UI
-└── build.gradle.kts
+app/                  # Android app (Compose UI, Room, Hilt)
+└── src/main/java/com/pennywiseai/tracker/
+    ├── data/             # Database, repositories, managers
+    ├── domain/           # Use cases and services
+    ├── presentation/     # Feature screens + ViewModels
+    ├── ui/               # Shared UI components, theme, remaining screens
+    ├── navigation/       # Navigation graph
+    ├── widget/ worker/ receiver/   # Widgets, WorkManager jobs, SMS receiver
+    └── billing/ backup/ core/ utils/
+parser-core/          # Kotlin Multiplatform bank parsers (shared with iOS)
+shared/               # Shared Kotlin code for the iOS app
+iosApp/               # Swift iOS app
+pennywise-web/        # Web deployment (Cloudflare Worker + Ktor server)
 ```
 
 ## Testing

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,17 +1,17 @@
 # Privacy Policy
 
-**Last Updated: August 2025**
+**Last Updated: August 2026**
 
 ## Our Commitment to Privacy
 
 PennyWise AI is built with privacy as the core principle. We believe your financial data should remain yours alone.
 
-## 100% On-Device Processing
+## On-Device Processing
 
-**All data processing happens locally on your device.** We use MediaPipe's on-device LLM (Qwen 2.5) for AI features, ensuring:
+**Transaction processing and AI run locally on your device.** AI features use an on-device LLM (Qwen 2.5, via Google AI Edge LiteRT-LM). The only data that ever leaves your device goes through the explicit outbound requests listed under Internet Permission below:
 
-- ✅ **No cloud servers** - Your data never leaves your phone
-- ✅ **No data collection** - We don't collect, store, or transmit any user data
+- ✅ **On-device AI** - Parsing and AI processing run locally; your transaction database never uploads anywhere
+- ✅ **No data collection** - No analytics, telemetry, or accounts; the one exception is the parse-report flow (see Internet Permission)
 - ✅ **No tracking** - No analytics, no telemetry, no user tracking
 - ✅ **No ads** - No advertising networks or tracking pixels
 - ✅ **Offline AI** - Once downloaded, AI works completely offline
@@ -35,28 +35,35 @@ PennyWise AI is built with privacy as the core principle. We believe your financ
 
 ## Permissions
 
-### SMS Permission (Read-Only)
-- **Purpose**: To read bank transaction SMS messages
+### SMS Permissions (Read-Only)
+- **`READ_SMS` / `RECEIVE_SMS`**: to read bank transaction SMS as they arrive
 - **Scope**: Read-only access, we cannot send or modify messages
 - **Processing**: SMS parsing happens entirely on-device
-- **Storage**: Only transaction data is extracted and stored, not full messages
+- **Storage**: Only extracted transaction fields are stored, not full messages
+
+### Notifications (`POST_NOTIFICATIONS`)
+- Subscription due-date reminders and budget alerts
+
+### Biometrics (`USE_BIOMETRIC`)
+- Optional app lock via fingerprint or face unlock
+
+### Contacts (`READ_CONTACTS`, off by default)
+- PennyWise ships this permission for one opt-in feature: contact lookup, which can resolve a UPI VPA like `merchant@ybl` into a name from your address book so merchant lists read naturally
+- The lookup runs on-device and the feature stays dormant until you enable it in Settings
 
 ### Internet Permission
-- **Primary Purpose**: To download the AI model (Qwen 2.5) on first use
-- **Model Download**: One-time download of ~1.5GB model file from CloudFront CDN
+- **Model Download**: One-time download of the ~1.5GB Qwen 2.5 model from a public Cloudflare R2 bucket, verified against a SHA-256 checksum before use
+- **Exchange Rates**: Multi-currency features fetch current rates from open.er-api.com; only the currency code is sent
+- **Parse Reports**: The "report a parsing problem" action opens pennywise.zynth.dev with the SMS text and sender ID pre-filled. The link also carries an encrypted device identifier — your Android device ID plus a timestamp, RSA-encrypted on-device before it leaves. Opening the page sends these details to the server right away to generate a parsed preview; submitting the report itself remains a separate user action
 - **App Updates**: Google Play Store variant uses Play Services for app updates (F-Droid variant does not)
 - **After Model Download**: AI works completely offline, no internet required for core features
-- **Your Data**: Never transmitted over the internet, all processing remains on-device
 
-### No Other Permissions Required
-- No location tracking
-- No contact access
-- No camera or microphone access
+No location, camera, or microphone permission is requested.
 
 ## Third-Party Services
 
 PennyWise AI does **NOT** use:
-- ❌ Cloud services or APIs (except CDN for model download)
+- ❌ Cloud storage, backup, or sync of your transaction data
 - ❌ Analytics services (Google Analytics, Firebase, etc.)
 - ❌ Crash reporting services
 - ❌ Advertising networks
@@ -68,10 +75,10 @@ PennyWise AI does **NOT** use:
 ## AI Features
 
 ### On-Device AI Assistant
-- Uses MediaPipe's Qwen 2.5 model (1.5GB download)
-- Model runs entirely on your device using MediaPipe LLM Inference
+- Uses the Qwen 2.5 model (1.5GB download) via Google AI Edge LiteRT-LM
+- Model runs entirely on your device; inference needs no network
 - After initial download, no internet connection required
-- Conversations are not stored or transmitted
+- Chat history is saved locally in the app's database so conversations survive restarts; it's never transmitted
 - AI insights are generated locally from your local transaction data
 - Model file stored in app's private storage
 
@@ -108,13 +115,7 @@ For privacy concerns or questions:
 
 ## Summary
 
-**Your financial data stays on your phone. Period.**
-
-- No servers
-- No uploads
-- No tracking
-- No ads
-- Complete privacy
+**Your financial data lives on your phone.** Transactions, balances, budgets, and chat history all sit in a local database inside the app sandbox, and uninstalling removes everything. PennyWise has no analytics or cloud-sync backend; the outbound requests listed under Internet Permission are the complete list.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![PennyWise AI Banner](banner.png)](https://github.com/sarim2000/pennywiseai-tracker)
 [![GitHub stars](https://img.shields.io/github/stars/sarim2000/pennywiseai-tracker?style=social)](https://github.com/sarim2000/pennywiseai-tracker)
 [![License](https://img.shields.io/badge/license-AGPL%20v3-blue)](LICENSE)
-[![Android](https://img.shields.io/badge/Android-12+-3DDC84)](https://developer.android.com/about/versions/12)
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.0.21-7F52FF)](https://kotlinlang.org/)
-[![Privacy](https://img.shields.io/badge/AI-100%25_On--Device-FF6B6B)](https://developers.google.com/mediapipe)
+[![Android](https://img.shields.io/badge/Android-8.0%2B-3DDC84)](https://developer.android.com/about/versions/oreo/android-8.0)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.21-7F52FF)](https://kotlinlang.org/)
+[![Privacy](https://img.shields.io/badge/AI-100%25_On--Device-FF6B6B)](https://ai.google.dev/edge)
 [![Downloads](https://img.shields.io/badge/Downloads-100+-green)](https://play.google.com/store/apps/details?id=com.pennywiseai.tracker)
 [![F-Droid](https://img.shields.io/f-droid/v/com.pennywiseai.tracker?color=1976d2)](https://f-droid.org/packages/com.pennywiseai.tracker/)
 [![GitHub release](https://img.shields.io/github/v/release/sarim2000/pennywiseai-tracker)](https://github.com/sarim2000/pennywiseai-tracker/releases)
@@ -14,7 +14,7 @@
 
 ## PennyWise AI — Free & Open‑Source, private SMS‑powered expense tracker
 
-Turn bank SMS into a clean, searchable money timeline with on-device AI assistance. 100% private, no cloud processing.
+Turn bank SMS into a clean, searchable money timeline with on-device AI assistance. Parsing, storage, and AI all run on your phone.
 
 
 ⭐ **Star us on GitHub — join 300+ supporters!**
@@ -26,7 +26,7 @@ Turn bank SMS into a clean, searchable money timeline with on-device AI assistan
 
 ## Overview
 
-Your bank already texts you every transaction — PennyWise turns those SMS into a private, zero-setup expense tracker with on-device AI. No accounts, no cloud, no effort.
+Your bank already texts you every transaction — PennyWise turns those SMS into a private, zero-setup expense tracker with on-device AI. No accounts, no sign-ups, no effort.
 
 <a href="https://play.google.com/store/apps/details?id=com.pennywiseai.tracker">
   <img src="https://img.shields.io/badge/GET_IT_ON-Google_Play-00875F?style=for-the-badge&logo=google-play&logoColor=white" alt="Get it on Google Play" />
@@ -48,7 +48,7 @@ Your bank already texts you every transaction — PennyWise turns those SMS into
 
 **Key Differentiators**
 
-- **🔒 100% On-Device & Private** — All AI processing runs locally, no cloud, no servers, no tracking
+- **🔒 Private by Design** — All AI processing and transaction storage happen on your phone; no accounts, no analytics, no servers collecting your data
 - **⚡ Zero Setup** — Just grant SMS permission, no accounts to create, works instantly
 - **🆓 Free & Open Source** — AGPL v3 licensed, no ads, no trackers; an optional **PennyWise Pro** upgrade (unlimited rules, PDF statement imports, CSV export, account merge) supports the solo developer
 
@@ -197,7 +197,7 @@ More banks being added regularly! [Request your bank →](https://github.com/sar
 
 ## Privacy First
 
-All AI processing happens on your device using MediaPipe's Qwen 2.5 model — no cloud, no API calls, no data leaving your phone. There are no accounts to create, no sign-ups, no servers collecting your data. Your SMS and financial information stay entirely on your device. The entire codebase is open source (AGPL v3) so anyone can verify exactly what the app does.
+All AI processing happens on your device, powered by Google AI Edge LiteRT-LM running Qwen 2.5. Your transactions are parsed, stored, and analyzed locally; there are no accounts, no analytics SDKs, and no servers collecting your data. Two things do touch the network, both easy to verify in the source: multi-currency features can fetch exchange rates from `open.er-api.com`, and the "report a parsing problem" flow opens `pennywise.zynth.dev`, which immediately parses the pre-filled SMS text and sender ID server-side to generate a preview before you submit anything. Everything else stays on your phone. The entire codebase is open source (AGPL v3) so anyone can check each of these claims.
 
 ## Screenshots
 
@@ -262,18 +262,21 @@ All AI processing happens on your device using MediaPipe's Qwen 2.5 model — no
 git clone https://github.com/sarim2000/pennywiseai-tracker.git
 cd pennywiseai-tracker
 
+# Environment check + fast test gate (same compile/test tasks CI runs)
+./init.sh
+
 # Build APK
 ./gradlew assembleDebug
 
 # Install
-adb install app/build/outputs/apk/debug/app-debug.apk
+adb install app/build/outputs/apk/standard/debug/app-standard-universal-debug.apk
 ```
 
 ### Requirements
 
-- Android 12+ (API 31)
+- Android 8.0+ (API 26)
 - Android Studio Ladybug or newer
-- JDK 11
+- JDK 21
 
 ## Tech Stack
 
@@ -282,7 +285,7 @@ adb install app/build/outputs/apk/debug/app-debug.apk
   <img src="https://skillicons.dev/icons?i=hilt,room,coroutines" />
 </p>
 
-**Architecture**: MVVM • Jetpack Compose • Room • Coroutines • Hilt • MediaPipe AI • Material Design 3
+**Architecture**: MVVM • Jetpack Compose • Room • Coroutines • Hilt • Google AI Edge (on-device LLM) • Material Design 3
 
 ## Community & Support
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,16 +1,7 @@
-- Transfer transaction type should let us specify source and target bank and update balances automatically
-- Like how we can split transactions into categories, we should be able to split it to contacts using phone numbers, and maybe send everyone an SMS with QR code link to pay the exact amount
-- A feature where we can change cards that have been identified incorrectly and mark a subscription as 'ended'
-- Another FR: if the UPI ID of the user paid to/from contains the phone number, maybe lookup and rename the merchant using contacts?
+# Ideas & Open Requests
 
+- Split a transaction across contacts by phone number (the way category splits work today), optionally sending each person an SMS with a QR code that links their exact share
+- Add refund amounts from credit card SMS to the card's available balance (`Refund initiated: Amt: Rs.XXX on HDFC Bank Credit Card...`)
+- Custom date ranges exist already (`CustomDateRangePicker` in Analytics and Transactions); still open: letting a custom range like "25th of last month to 25th of this month" become the default monthly view
 
-JX-CSHfre-S
-
-Payment INR 50.00 (ID:5448114171) confirmed for order #735571_428_1777162938185 on AuraGold.
-Powered by Cashfree
-
-
-- Please add refund amount of credit card to the credit balance
-Refund initiated: Amt: Rs.34274.66 on HDFC Bank Credit Card 1111. To receive your Refund,please update your Bank details: TnC.
-
-- Great app but could you please give option to create custom date charts and make that custom date as default for every month? for eg : 25th of last month to 25th of current month. This would be good for anyone who uses credit cards and would like to track their monthly credit card expenses.
+*Pruned August 2026: transfer source/target editing, marking subscriptions as ended, card detail correction, and contact-based UPI merchant lookup have all shipped.*

--- a/docs/BANK_SUPPORT.md
+++ b/docs/BANK_SUPPORT.md
@@ -1,207 +1,57 @@
-# Bank SMS Support Matrix
+# Bank SMS Support
 
-## Supported Banks & Transaction Patterns
+PennyWise parses bank SMS into transactions through a registry of dedicated parsers. As of August 2026 the registry holds **144 parsers covering 23 countries**.
 
-| Bank | Credit | Debit | UPI Send | UPI Receive | ATM | Card Payment | Balance | Reference |
-|------|--------|-------|----------|-------------|-----|--------------|---------|-----------|
-| **HDFC Bank** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅* | ✅ |
-| **SBI** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
-| **ICICI Bank** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅* | ✅ |
-| **Axis Bank** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅* | ✅ |
-| **Indian Bank** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
-| **Federal Bank** | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅* | ❌ |
-| **PNB** | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ |
-| **IDBI Bank** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
-| **Karnataka Bank** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
-| **Canara Bank** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
-| **Bank of Baroda** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
-| **Jio Payments** | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ |
-| **Jupiter** | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅* | ✅ |
-| **Amazon Pay** | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅* | ✅ |
-| **IDFC First** | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ |
+This page explains how support works and where to look things up. It deliberately doesn't repeat the full bank list — that list is machine-generated and would drift the moment someone adds a parser without updating prose.
 
-*Uses default balance patterns (may have limited support)
+## The authoritative bank list
 
----
+`docs/supported-banks.json` is generated directly from the `BankParserFactory` registry and guarded by CI (`SupportedBanksDocTest` fails when it goes stale). Per-country counts, bank names, and feature flags there are ground truth. If a bank appears in the JSON, a parser registered in `BankParserFactory` handles its senders today.
 
-## SMS Template Patterns by Bank
+After adding, removing, or renaming any parser, run:
 
-### HDFC Bank
-| Type | Template Pattern | Example |
-|------|-----------------|---------|
-| **Credit** | `Rs.XXX credited to a/c **XXXX` | Rs.5000 credited to a/c **3456 on 15-01 |
-| **Debit** | `Rs.XXX debited from a/c **XXXX` | Rs.2000 debited from a/c **3456 on 15-01 |
-| **UPI Send** | `Rs.XXX debited for UPI/` | Rs.500 debited for UPI/PhonePe/merchant@ybl |
-| **ATM** | `debited from a/c at ATM` | Rs.3000 debited from a/c **3456 at ATM |
-| **Card** | `Rs.XXX spent on Credit Card` | Rs.1500 spent on HDFC Credit Card XX1234 |
-
-### State Bank of India (SBI)
-| Type | Template Pattern | Example |
-|------|-----------------|---------|
-| **Credit** | `Rs.XXX credited to A/c` | Rs.5000 credited to A/c XX1234 |
-| **Credit** | `A/c XXXX-credited by Rs.XXX` | A/c X9338-credited by Rs.500 |
-| **Credit** | `has credit for MERCHANT of Rs XXX` | has credit for SHOP of Rs 10,000.00 |
-| **Credit** | `has a credit by Cheque of Rs XXX` | has a credit by Cheque of Rs 12,07,000.00 |
-| **Credit** | `Credited INR XXX` | Credited INR 9,000.00 |
-| **Debit** | `Rs.XXX debited from A/c` | Rs.2000 debited from A/c XX1234 |
-| **Debit** | `A/C XXXX debited by XXX` | A/C X9474 debited by 370.0 |
-| **UPI Send** | `trf to MERCHANT` | debited by 100 trf to SHOPKEEPER |
-| **UPI Receive** | `transfer from SENDER` | credited by Rs.500 transfer from PERSON |
-| **ATM** | `ATM withdrawal of Rs.XXX` | ATM withdrawal of Rs.2000 |
-| **YONO Cash** | `Yono Cash Rs.XXX w/d@` | Yono Cash Rs.3000 w/d@SBI ATM |
-
-### ICICI Bank
-| Type | Template Pattern | Example |
-|------|-----------------|---------|
-| **Credit** | `INR XXX credited to A/c` | INR 5000 credited to A/c XX456 |
-| **Debit** | `Acct XXXX debited with INR` | Acct XX456 debited with INR 2000 |
-| **UPI** | `linked to VPA` | Rs 500 debited from A/c linked to VPA merchant@icici |
-| **Card** | `Transaction of INR XXX on Card` | Transaction of INR 1500 on Credit Card XX1234 |
-
-### Axis Bank
-| Type | Template Pattern | Example |
-|------|-----------------|---------|
-| **Credit** | `A/c no. XXXX credited with Rs` | A/c no. XX789 credited with Rs 5000 |
-| **Debit** | `A/c no. XXXX debited for Rs` | A/c no. XX789 debited for Rs 2000 |
-| **UPI** | `transferred from A/c to UPI:` | Rs.500 transferred from A/c to UPI: merchant@axl |
-| **ATM** | `withdrawn using Debit Card` | Rs.3000 withdrawn using Debit Card XX1234 |
-
-### Indian Bank
-| Type | Template Pattern | Example |
-|------|-----------------|---------|
-| **Credit** | `Rs.XXX credited to a/c` | Rs.589.00 credited to a/c *3829 |
-| **Credit** | `credited Rs. XXX` | Your a/c credited Rs. 5000.00 |
-| **Debit** | `debited Rs. XXX` | Your a/c debited Rs. 2000.00 |
-| **UPI** | `linked to VPA XXX@XXX` | by a/c linked to VPA 7970282159-2@axl |
-| **ATM** | `withdrawn Rs. XXX` | Your a/c withdrawn Rs. 2000 at ATM |
-
-### Federal Bank
-| Type | Template Pattern | Example |
-|------|-----------------|---------|
-| **Credit** | `credited by Rs.XXX` | Federal Bank A/c credited by Rs.5000 |
-| **Debit** | `debited by Rs.XXX` | Federal Bank A/c debited by Rs.2000 |
-| **UPI** | `transferred via UPI` | Rs.500 transferred via UPI to merchant@federal |
-
-### Punjab National Bank (PNB)
-| Type | Template Pattern | Example |
-|------|-----------------|---------|
-| **Credit** | `credited by Rs XXX` | PNB A/c XX5678 credited by Rs 3000 |
-| **Debit** | `Ac XX1234 Debited with Rs.XXX` | Ac XX1234 Debited with Rs.5000.00 |
-| **Debit** | `initial amount of Rs. 2.00 has been debited` | auto pay facility... An initial amount of Rs. 2.00 has been debited |
-| **Mandate** | `UPI-Mandate is successfully created` | Your UPI-Mandate is successfully created towards Google |
-| **Debit** | `debited with Rs.XXX thru card XX1234` | debited with Rs.5000.00 thru card XX9239 |
-| **ATM** | `ATM withdrawal Rs XXX` | ATM withdrawal Rs 2000 from A/c XX5678 |
-
-### IDFC First Bank
-| Type | Template Pattern | Example |
-|------|-----------------|---------|
-| **Credit** | `Credited Rs XXX to A/c` | Credited Rs 5000 to A/c XX9876 |
-| **Debit** | `Debited Rs XXX from A/c` | Debited Rs 2500 from A/c XX9876 |
-| **UPI** | `UPI payment of Rs XXX` | UPI payment of Rs 500 from A/c XX9876 |
-
----
-
-## Sender ID Patterns
-
-| Bank | Common Sender IDs |
-|------|-------------------|
-| **HDFC** | `HDFC`, `HDFCBK`, `XX-HDFC-S`, `XX-HDFCBK-S` |
-| **SBI** | `SBI`, `SBIBK`, `SBIUPI`, `XX-SBIBK-S`, `XX-SBI-S` |
-| **ICICI** | `ICICI`, `ICICIB`, `XX-ICICI-S`, `XX-ICICIB-S` |
-| **Axis** | `AXIS`, `AXISBK`, `XX-AXIS-S`, `XX-AXISBK-S` |
-| **Indian Bank** | `INDBNK`, `INDIAN`, `XX-INDBNK-S` (e.g., `AD-INDBNK-S`) |
-| **Federal** | `FEDERA`, `FEDERALBNK`, `XX-FEDERA-S` |
-| **PNB** | `PNB`, `PNBSMS`, `XX-PNB-S`, `XX-PNBSMS-S` |
-| **IDBI** | `IDBI`, `IDBIBNK`, `XX-IDBI-S` |
-| **Karnataka** | `KARNBK`, `KARNATAKA`, `XX-KARNBK-S` |
-| **Canara** | `CANBNK`, `CANARA`, `XX-CANBNK-S` |
-| **BOB** | `BOB`, `BOBBNK`, `XX-BOB-S` |
-| **Jio** | `JIOBK`, `JIOPAY`, `XX-JIOBK-S` |
-| **Jupiter** | `JUSPAY`, `JUPITER`, `XX-JUSPAY-S` |
-| **Amazon Pay** | `AMZNPY`, `AMAZONPAY`, `XX-AMZNPY-S` |
-| **IDFC First** | `IDFCFB`, `IDFCFBANK`, `XX-IDFCFB-S` |
-
----
-
-## Balance Extraction Patterns
-
-### Banks with Custom Balance Patterns
-
-| Bank | Balance Pattern | Example |
-|------|----------------|---------|
-| **SBI** | `Avl Bal Rs XXX` | Avl Bal Rs 10000.00 |
-| **SBI** | `Available Balance: Rs XXX` | Available Balance: Rs 25000 |
-| **SBI** | `Bal: Rs XXX` | Bal: Rs 5000 |
-| **Indian Bank** | `Bal Rs. XXX` | Bal Rs. 50000.00 |
-| **Indian Bank** | `Available Balance: Rs. XXX` | Available Balance: Rs. 25000 |
-| **PNB** | `Aval Bal Rs.XX.XX CR` or `Bal XX.XX CR` | Aval Bal Rs.27000.00 CR |
-| **IDBI** | `Bal Rs XXX` | Bal Rs 3694.38 |
-| **IDFC First** | `New Bal :INR XXX` | New Bal :INR 15000.00 |
-| **Karnataka Bank** | `Balance is Rs.XXX` | Balance is Rs.705.92 |
-| **Canara Bank** | `Total Avail.bal INR XXX` | Total Avail.bal INR 1,092.62 |
-| **Bank of Baroda** | `AvlBal:RsXXX` | AvlBal:Rs10500.50 |
-| **Jio Payments** | `Avl. Bal: Rs. XXX` | Avl. Bal: Rs. 9095.5 |
-
-### Banks Using Default Patterns
-These banks rely on the base parser patterns which look for:
-- `Bal:`, `Balance:`, `Avl Bal`, `Available Balance` followed by amount
-
-| Bank | Status |
-|------|--------|
-| **HDFC Bank** | Uses default patterns |
-| **ICICI Bank** | Uses default patterns |
-| **Axis Bank** | Uses default patterns |
-| **Federal Bank** | Uses default patterns |
-| **Jupiter** | Uses default patterns |
-| **Amazon Pay** | Uses default patterns |
-
----
-
-## Data Extraction Capabilities
-
-| Field | Description | Banks Supporting |
-|-------|-------------|------------------|
-| **Amount** | Transaction amount | All banks ✅ |
-| **Type** | Credit/Debit/Income/Expense | All banks ✅ |
-| **Account** | Last 4 digits of account | All banks ✅ |
-| **Merchant** | Merchant/Sender name | All banks ✅ |
-| **Balance** | Available balance after transaction | Most banks (except ICICI) |
-| **Reference** | Transaction reference/ID | Most banks (except Federal) |
-| **UPI ID** | VPA for UPI transactions | HDFC, SBI, ICICI, Axis, Indian |
-| **Card Number** | Last 4 digits of card | HDFC, ICICI, PNB |
-| **ATM Location** | ATM withdrawal location | HDFC, SBI, Axis, Indian, PNB |
-| **Date/Time** | Transaction timestamp | Parsed from SMS timestamp |
-
----
-
-## Quick Implementation Guide
-
-To add a new bank:
-
-1. **Create Parser Class**
-```kotlin
-class NewBankParser : BankParser() {
-    override fun getBankName() = "New Bank"
-    override fun canHandle(sender: String): Boolean
-    override fun parse(smsBody: String, sender: String, timestamp: Long): ParsedTransaction?
-}
+```bash
+./scripts/update-supported-banks.sh
 ```
 
-2. **Register in Factory**
+It regenerates the JSON, the README bank table, the Play listing copy, and copies for pennywise-web. CI fails on the next push if you forget.
+
+## How an SMS becomes a transaction
+
+1. A notification or SMS arrives; `receiver/BankNotificationListenerService` routes the body into `data/manager/SmsTransactionProcessor`.
+2. `BankParserFactory.getParsers()` returns every parser whose `canHandle(sender)` matches the sender ID.
+3. Each candidate parser's `parse()` runs against the body in **registration order** until one returns a `ParsedTransaction`. Order matters — a broad matcher placed above a narrow one will swallow its messages.
+
+Parsers extend one of five base classes in `parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/`: `BankParser` (generic international), `BaseIndianBankParser`, `UAEBankParser`, `BaseIranianBankParser`, or `BaseThailandBankParser`. Pick the regional base when one exists; it carries currency handling and common patterns for that market.
+
+Full contributor walkthrough: [adding-bank-parsers.md](adding-bank-parsers.md). Test conventions: [parser-test-standards.md](parser-test-standards.md).
+
+## What gets extracted
+
+Every parser fills a `ParsedTransaction`: amount, credit/debit type, merchant, account last-4, timestamp, and where the message supports it — reference number, balance after the transaction, UPI VPA, card last-4. Which fields a given bank populates depends on what its SMS templates contain; the parser source is the honest answer per bank.
+
+## Balance extraction
+
+The base class ships default patterns (`Bal:`, `Balance:`, `Avl Bal`, `Available Balance`, each followed by an amount). Banks whose messages phrase balances differently override `extractBalance()`. Example: `ICICIBankParser` overrides it with its own `Avl`/`Avb` patterns rather than relying on defaults. When auditing a bank, check the parser file before assuming either way.
+
+## Worked example: HDFC Bank
+
+Two of the current card patterns in `HDFCBankParser.kt` show the flavor:
+
 ```kotlin
-// In BankParserFactory.kt
-val parsers = listOf(
-    // ... existing parsers
-    NewBankParser()
-)
+// Card purchase at a merchant
+"Spent Rs.X From HDFC Bank Card X At [MERCHANT]"
+
+// Card spend phrased without merchant
+"...spent on Card XX1234"
 ```
 
-3. **Test with Real SMS**
-- Test credit transactions
-- Test debit transactions
-- Test UPI transactions
-- Test edge cases
+Each pattern lives beside its siblings in the same parser file, so grepping a bank's name inside `parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/` shows every message shape it handles.
+
+## Adding a bank
+
+Short version: create a parser extending the right base class, implement `getBankName()` and `canHandle()`, register it in `BankParserFactory` **above any broader matcher that could claim the same senders**, add tests with real SMS samples, then run `./scripts/update-supported-banks.sh`. See [adding-bank-parsers.md](adding-bank-parsers.md) for the complete guide.
 
 ---
 
-*Last Updated: January 2025*
+*Last Updated: August 2026*

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -43,10 +43,11 @@ The bump keyword is the usual SemVer choice:
    the same structured notes it writes:
    - the store changelog `changelogs/<versionCode>.txt` + `default.txt`, and
    - `RELEASE_NOTES.md` for the GitHub release.
-3. Builds, renames, and (F-Droid) computes SHA256 for the standard + F-Droid
-   APKs.
+3. Builds, renames, and computes SHA256 for the standard + F-Droid APKs.
 4. Commits `chore(release): bump version to X [skip ci]`, tags `vX`, and pushes.
-5. Cuts the GitHub release with the APKs + `.sha256` attached.
+5. Cuts the GitHub release with the universal / arm64-v8a / armeabi-v7a / F-Droid
+   APKs + `.sha256` attached (x86 and x86_64 builds are produced and hashed but
+   kept local).
 
 If the script is interrupted, a trap reverts the version bump and changelog
 changes so you're left in a clean state.

--- a/docs/adding-bank-parsers.md
+++ b/docs/adding-bank-parsers.md
@@ -15,21 +15,34 @@ All parsers extend `BankParser`. But:
   mandate, subscription, and balance-update logic.
 - **UAE banks** MUST extend `UAEBankParser` for currency and transaction-type
   handling.
+- **Iranian banks** extend `BaseIranianBankParser` (Persian-digit amounts,
+  Iranian SMS shapes).
+- **Thai banks** extend `BaseThailandBankParser`.
 - Everything else extends `BankParser` directly.
 
 ## Key methods
 - `getBankName()` — the bank's display name.
 - `canHandle(sender: String)` — whether this parser handles SMS from a sender.
-- `parse(smsBody, sender, timestamp)` — returns `ParsedTransaction` or `null`.
+- `parse(smsBody, sender, timestamp)` — returns `ParsedTransaction` or `null`
+  (it's an `open fun` with a default implementation; override it only when the
+  bank needs custom parsing).
 
 ## Commonly overridden
 - `extractAmount()` — bank-specific amount patterns.
 - `extractMerchant()` — bank-specific merchant extraction.
 - `extractTransactionType()` — only for special cases.
+- `extractBalance()` — when the bank phrases balances differently from the
+  base-class defaults (`ICICIBankParser` is a worked example).
 
-## Registration
+## Registration — order matters
 Add the new parser to the `BankParserFactory.parsers` list in
 `parser-core/.../bank/BankParserFactory.kt`.
+
+The factory dispatches by content: for a matching sender, every candidate
+parser's `parse()` runs in list order until one returns a transaction. That
+makes registration order part of correctness — place your parser **above** any
+broader parser whose `canHandle()` could also claim your senders. The ordering
+comments inside the file explain existing precedence rules; keep them accurate.
 
 ## Return type & imports (parser-core)
 Use `ParsedTransaction` from parser-core:
@@ -55,3 +68,12 @@ The full list of supported banks and transaction patterns lives in
 [`docs/BANK_SUPPORT.md`](BANK_SUPPORT.md) and
 [`docs/supported-banks.json`](supported-banks.json) — the authoritative source,
 kept in sync with the parsers (do not maintain a hand-copied list elsewhere).
+
+After adding, removing, or renaming any parser, regenerate the docs:
+
+```bash
+./scripts/update-supported-banks.sh
+```
+
+`SupportedBanksDocTest` fails in CI when the generated files drift from the
+registry.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,10 +40,9 @@ PennyWise follows modern Android architecture guidelines with MVVM pattern, Clea
 
 **Key Classes:**
 ```kotlin
-- HomeScreen.kt
-- TransactionListScreen.kt
-- HomeViewModel.kt
-- TransactionViewModel.kt
+- presentation/home/HomeScreen.kt
+- presentation/home/HomeViewModel.kt
+- ui/viewmodel/ThemeViewModel.kt
 - UiState data classes
 ```
 
@@ -60,10 +59,11 @@ PennyWise follows modern Android architecture guidelines with MVVM pattern, Clea
 
 **Key Classes:**
 ```kotlin
-- ExtractTransactionUseCase.kt
-- CategorizeTransactionUseCase.kt
-- DetectSubscriptionUseCase.kt
-- Transaction domain model
+- AddTransactionUseCase.kt
+- DeleteTransactionUseCase.kt
+- ApplyRulesToPastTransactionsUseCase.kt
+- MarkSubscriptionPaidUseCase.kt
+- domain/service/LlmService.kt (on-device AI interface)
 ```
 
 ### Data Layer (Data Sources)
@@ -82,31 +82,55 @@ PennyWise follows modern Android architecture guidelines with MVVM pattern, Clea
 ```kotlin
 - TransactionRepository.kt
 - TransactionDao.kt
-- SmsDataSource.kt
-- AICategorizationService.kt
-- BankNotificationListenerService.kt (notification-to-SMS parser bridge for whitelisted bank apps)
+- data/manager/SmsTransactionProcessor.kt (orchestrates SMS → parser → database)
+- data/repository/LlmRepository.kt (backs LlmService with the on-device model)
+- receiver/BankNotificationListenerService.kt (notification-to-SMS parser bridge for whitelisted bank apps)
 ```
+
+SMS parsing itself lives in the `parser-core` module (pure Kotlin, no Android
+dependencies). Parsers register in `BankParserFactory`, which dispatches each
+message to every candidate parser by content — see
+[adding-bank-parsers.md](adding-bank-parsers.md).
 
 ## Module Structure
 ```
 app/
-├── src/main/java/com/pennywise/
-│   ├── ui/                    # UI Layer
-│   │   ├── screens/
-│   │   ├── components/
-│   │   ├── theme/
-│   │   └── navigation/
-│   ├── domain/                # Domain Layer
+├── src/main/java/com/pennywiseai/tracker/
+│   ├── presentation/            # Feature screens + ViewModels (home, accounts,
+│   │   │                        #   add, transactions, budgetgroups, categories,
+│   │   │                        #   subscriptions, loans, groups, paywall, share,
+│   │   │                        #   statement, exchangerates, common; also a
+│   │   │                        #   navigation/ subpackage for feature routes)
+│   ├── ui/                      # Shared components, theme, ViewModels
+│   │   ├── components/          # Reusable Compose components
+│   │   ├── theme/               # Design system tokens
+│   │   ├── viewmodel/           # App-level ViewModels (theme, app lock, ...)
+│   │   └── screens/             # analytics, chat, onboarding, rules,
+│   │                            #   settings, unrecognized
+│   ├── navigation/              # Navigation graph
+│   ├── domain/                  # Business logic
 │   │   ├── model/
 │   │   ├── usecase/
-│   │   └── repository/
-│   ├── data/                  # Data Layer
-│   │   ├── database/
-│   │   ├── repository/
-│   │   ├── source/
+│   │   ├── service/             # LlmService and friends
+│   │   └── repository/          # Repository interfaces
+│   ├── data/                    # Data Layer
+│   │   ├── database/            # Room database, DAOs, entities
+│   │   ├── repository/          # Repository implementations
+│   │   ├── manager/             # SmsTransactionProcessor, sync managers
+│   │   ├── preferences/         # DataStore-backed settings
+│   │   ├── currency/ backup/ contacts/
 │   │   └── mapper/
-│   └── di/                    # Dependency Injection
-│       └── modules/
+│   ├── di/                      # Hilt modules (DatabaseModule, etc.)
+│   ├── receiver/                # SMS / notification entry points
+│   ├── worker/                  # WorkManager jobs (SMS scan retry, scheduled backups)
+│   ├── widget/                  # Home-screen widgets
+│   ├── billing/                 # Play Billing + FreeTierLimits
+│   ├── backup/ core/ initializer/ utils/
+└── build.gradle.kts             # Flavors: standard, fdroid
+parser-core/                     # Bank SMS parsers (Kotlin Multiplatform)
+shared/                          # KMP code shared with iOS
+iosApp/                          # Swift iOS app
+pennywise-web/                   # Web deployment (Cloudflare Worker + server/)
 ```
 
 ## Data Flow Example
@@ -115,11 +139,9 @@ User opens app
     ↓
 HomeScreen observes HomeViewModel.uiState
     ↓
-HomeViewModel calls GetTransactionsUseCase
+HomeViewModel collects flows from TransactionRepository
     ↓
-UseCase queries TransactionRepository
-    ↓
-Repository fetches from TransactionDao
+Repository queries TransactionDao
     ↓
 Data flows back up as StateFlow
     ↓
@@ -142,18 +164,21 @@ UI recomposes with new state
 ```kotlin
 data class HomeUiState(
     val transactions: List<Transaction> = emptyList(),
-    val monthlyTotal: Double = 0.0,
     val isLoading: Boolean = false,
     val error: String? = null
 )
 
 class HomeViewModel @Inject constructor(
-    private val getTransactionsUseCase: GetTransactionsUseCase
+    private val transactionRepository: TransactionRepository
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 }
 ```
+
+The real `HomeUiState` in `presentation/home/HomeViewModel.kt` carries much more
+(filters, balances, budget summaries); this trimmed version shows the shape.
+[state-management.md](state-management.md) has the full patterns.
 
 ### Navigation
 - **Navigation Compose** for type-safe navigation
@@ -197,7 +222,7 @@ class HomeViewModel @Inject constructor(
 ## Security & Privacy
 
 ### Data Protection
-- On-device processing only
+- Transaction parsing and AI processing run on-device
 - No network calls without consent
 - Encrypted preferences with DataStore
 

--- a/docs/backup-format.md
+++ b/docs/backup-format.md
@@ -7,7 +7,9 @@ versions, and the rules you must follow when you change anything it touches.
 
 > TL;DR: every backup-serialized field **must have a Kotlin default value**.
 > That single rule is what makes old backups restorable forever. A CI test
-> (`BackupSchemaGuardTest`) enforces it for the wrapper models.
+> (`BackupSchemaGuardTest`) enforces it twice: once for the wrapper models, and
+> once against a pinned required-fields baseline for every Room entity — so an
+> entity that gains a new non-defaulted column fails CI too.
 
 ## Where it lives
 

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -1,238 +1,66 @@
 # Database Migrations Guide
 
-## Overview
-This guide explains how to handle database migrations in PennyWise using Room's migration features.
+PennyWise's Room database stands at version 58 (`SCHEMA_VERSION`, 23 entities). Every migration, auto or manual, is defined in one file: `app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt`. Start there when you touch the schema; this doc explains how that file is organized and which rules keep upgrades safe.
 
-## Migration Types
+## The one rule: ALL_MIGRATIONS
 
-### 1. Automatic Migrations
-Room can automatically generate migrations for simple schema changes:
-- Adding new columns with default values
-- Adding new tables
-- Removing columns (with caution)
+Manual migrations register in a single shared array at the bottom of `PennyWiseDatabase.kt`:
 
 ```kotlin
-@Database(
-    version = 2,
-    autoMigrations = [
-        AutoMigration(from = 1, to = 2)
-    ]
+val ALL_MIGRATIONS: Array<Migration> = arrayOf(
+    MIGRATION_12_14,
+    MIGRATION_13_14,
+    // ... through MIGRATION_57_58
 )
 ```
 
-### 2. Automatic Migrations with Spec
-For ambiguous changes, provide additional information:
+Two builders consume that array: the Hilt provider in `di/DatabaseModule.kt`, and the `getInstance(context)` fallback builder kept for non-Hilt callers. Register a migration once and both paths get it. The rule exists because of a real crash: the Hilt builder once carried its own list, missed `MIGRATION_47_48`, and v47 installs crashed on boot after updating to v48. Never pass a hand-picked list to `.addMigrations()` anywhere else.
 
-```kotlin
-@Database(
-    version = 2,
-    autoMigrations = [
-        AutoMigration(
-            from = 1, 
-            to = 2, 
-            spec = PennyWiseDatabase.Migration1To2::class
-        )
-    ]
-)
+## How a version bump ships here
 
-// Inside PennyWiseDatabase
-@RenameColumn(
-    tableName = "transactions",
-    fromColumnName = "merchant_name",
-    toColumnName = "vendor_name"
-)
-class Migration1To2 : AutoMigrationSpec
-```
+### Route 1: auto-migration
 
-### 3. Manual Migrations
-For complex schema changes:
+Purely additive changes need no migration code. Bump `SCHEMA_VERSION`, add `AutoMigration(from = N, to = N + 1)` to the `@Database` annotation, build once so KSP exports the schema JSON, commit it. Recent examples: v55→56 created the `merchant_aliases` table and v56→57 added a nullable `account_last4` column to subscriptions.
 
-```kotlin
-val MIGRATION_2_3 = object : Migration(2, 3) {
-    override fun migrate(db: SupportSQLiteDatabase) {
-        // Create new table
-        db.execSQL("""
-            CREATE TABLE categories (
-                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-                name TEXT NOT NULL,
-                icon TEXT,
-                color TEXT
-            )
-        """)
-        
-        // Add foreign key
-        db.execSQL("""
-            ALTER TABLE transactions 
-            ADD COLUMN category_id INTEGER 
-            REFERENCES categories(id)
-        """)
-    }
-}
-```
+When Room can't infer your intent, give the auto-migration a spec class next to the database class:
 
-## Common Migration Scenarios
+- `Migration4To5` removes `chat_messages.sessionId` through `@DeleteColumn.Entries`
+- `Migration35To36` drops the `category_budget_limits` table through `@DeleteTable.Entries`
+- `Migration7To8` seeds the default categories in `onPostMigrate` (this is where the categories feature shipped)
+- `Migration10To11` backfills `account_balances` from historical transaction rows
+- `Migration27To28` derives `account_type` from the old `is_credit_card` flag
+- `Migration43To44` inserts the Personal and Business profiles
 
-### Adding a Column
-```kotlin
-// Auto-migration works if column has default value
-@ColumnInfo(name = "notes", defaultValue = "")
-val notes: String = ""
-```
+### Route 2: manual migration
 
-### Renaming a Column
-```kotlin
-@RenameColumn(
-    tableName = "transactions",
-    fromColumnName = "amount",
-    toColumnName = "transaction_amount"
-)
-class MigrationSpec : AutoMigrationSpec
-```
+Reach for `Migration(from, to)` when data moves in ways Room can't generate: nullability flips, column guards on databases that may have drifted, backfills. The file holds 19 registered ones, `MIGRATION_12_14` through `MIGRATION_57_58`. Read two or three before writing your own — `MIGRATION_13_14` shows the house pattern of checking `PRAGMA table_info` before altering.
 
-### Adding an Index
-```kotlin
-override fun migrate(db: SupportSQLiteDatabase) {
-    db.execSQL("""
-        CREATE INDEX index_transactions_date 
-        ON transactions(date_time)
-    """)
-}
-```
+Two quirks worth knowing:
 
-### Data Transformation
-```kotlin
-override fun migrate(db: SupportSQLiteDatabase) {
-    // Add new column
-    db.execSQL("ALTER TABLE transactions ADD COLUMN amount_cents INTEGER")
-    
-    // Migrate data
-    db.execSQL("""
-        UPDATE transactions 
-        SET amount_cents = CAST(amount * 100 AS INTEGER)
-    """)
-    
-    // Drop old column (requires table recreation in SQLite)
-}
-```
+- `MIGRATION_1_2` sits in the file as a live but unregistered example. v1→2 runs as an auto-migration.
+- Some manual migrations skip intermediate versions (`MIGRATION_12_14`) so devices several releases behind can jump directly.
 
-## Best Practices
+## Adding a migration: checklist
 
-### 1. Always Test Migrations
-```kotlin
-@Test
-fun testMigration1To2() {
-    val db = Room.databaseBuilder(
-        context,
-        PennyWiseDatabase::class.java,
-        "test-db"
-    ).addMigrations(MIGRATION_1_2).build()
-    
-    // Verify migration
-    val cursor = db.query("SELECT * FROM sqlite_master WHERE type='table'")
-    // Assert expected schema
-}
-```
+1. Bump `SCHEMA_VERSION` at the top of `PennyWiseDatabase.kt`. It's a top-level constant so non-Room code like `BackupExporter` can stamp backups with the same number.
+2. Make your entity changes.
+3. Additive change: add an `AutoMigration` entry (plus spec if ambiguous). Anything else: write the `Migration` object **and** register it in `ALL_MIGRATIONS`.
+4. Build once. KSP exports `app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/<version>.json` automatically (the `room.schemaLocation` arg lives in `app/build.gradle.kts`). Commit the JSON.
+5. Test the upgrade against a real pre-change database if you touched existing rows.
+6. Verify a fresh install still works — migrations only run on existing database files.
 
-### 2. Export Schema
-Enable schema export in build.gradle:
-```kotlin
-ksp {
-    arg("room.schemaLocation", "$projectDir/schemas")
-}
-```
+## No destructive fallback
 
-### 3. Version Control Schema Files
-- Commit generated schema JSON files
-- Review changes in pull requests
-- Use for migration testing
+Neither builder calls `fallbackToDestructiveMigration()`. A missing migration fails loudly during development instead of silently wiping a user's transaction history in production. That's deliberate; don't add one "temporarily".
 
-### 4. Fallback Strategies
+## Schema files are contracts
 
-#### Development
-```kotlin
-.fallbackToDestructiveMigration()  // Recreates database
-```
-
-#### Production
-```kotlin
-.fallbackToDestructiveMigrationFrom(1, 2)  // Only for specific versions
-.fallbackToDestructiveMigrationOnDowngrade()  // For downgrades only
-```
-
-## Migration Checklist
-
-- [ ] Increment database version
-- [ ] Write migration (auto or manual)
-- [ ] Test migration with real data
-- [ ] Test fresh install
-- [ ] Update schema documentation
-- [ ] Consider data backup strategy
-- [ ] Plan rollback procedure
-
-## Example: Adding Transaction Tags
-
-### Step 1: Update Entity
-```kotlin
-@Entity(tableName = "transactions")
-data class TransactionEntity(
-    // ... existing fields ...
-    
-    @ColumnInfo(name = "tags")
-    val tags: List<String>? = null  // New field
-)
-```
-
-### Step 2: Add Converter
-```kotlin
-@TypeConverter
-fun fromStringList(value: List<String>?): String? {
-    return value?.joinToString(",")
-}
-
-@TypeConverter
-fun toStringList(value: String?): List<String>? {
-    return value?.split(",")?.filter { it.isNotEmpty() }
-}
-```
-
-### Step 3: Create Migration
-```kotlin
-@Database(
-    version = 2,
-    autoMigrations = [
-        AutoMigration(from = 1, to = 2)
-    ]
-)
-```
-
-### Step 4: Update Module
-```kotlin
-.addMigrations(/* add if manual */)
-```
+`app/schemas/` holds one generated JSON per shipped version. Review these diffs in PRs as carefully as code: they define exactly what Room expects on disk after each hop, and every future device will migrate through them. One known gap: `48.json` was never committed (history runs 47 → 49). Nothing migrates against it, but don't treat the gap as precedent.
 
 ## Troubleshooting
 
-### "Cannot find the schema file"
-- Enable `exportSchema = true`
-- Check schema location in build.gradle
+**"Migration didn't properly handle"** — Room compared the migrated schema against the exported JSON and found drift. Usually a missing default value or an index your SQL forgot to create. Diff your post-migration schema against the target version's JSON.
 
-### "Migration didn't properly handle"
-- Room detected schema mismatch
-- Compare expected vs actual schema
-- Write manual migration if needed
+**"Cannot find the schema file"** — confirm `exportSchema = true` on the `@Database` annotation and the `ksp { arg("room.schemaLocation", ...) }` block in `app/build.gradle.kts`.
 
-### "Cannot add a NOT NULL column"
-- Provide default value
-- Or make column nullable first, then migrate data
-
-## Future Migrations Plan
-
-### Version 2 (Planned)
-- Add categories table
-- Add transaction tags
-- Add recurring transaction support
-
-### Version 3 (Planned)
-- Add budgets table
-- Add financial goals
-- Add multi-currency support
+**"Cannot add a NOT NULL column"** — add it nullable first, backfill with `UPDATE`, then rebuild the table with the constraint if you truly need it.

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -1,5 +1,8 @@
 # Issue Tracker — Open Feature/Bug Backlog
 
+> **Scope note:** this file tracks the *forward-looking* backlog. Post-mortems
+> on fixed regressions live in [`../issues.md`](../issues.md).
+
 Ordered **easiest → hardest** by implementation effort, not priority. Effort is a
 rough estimate for this codebase (Compose + Room + Hilt + on-device LLM):
 **S** ≈ localized change, **M** ≈ schema + a few screens, **L** ≈ new sub-feature,

--- a/docs/parser-test-standards.md
+++ b/docs/parser-test-standards.md
@@ -4,7 +4,7 @@ This repository provides a shared Kotlin test harness for all SMS parser impleme
 
 ## 1. Organise tests with JUnit 5 Dynamic Tests
 
-* Each parser must expose a dedicated JUnit 5 test class (e.g. `class FabParserTest`).
+* Each parser must expose a dedicated JUnit 5 test class. Newer tests use `XxxParserTest.kt` under `src/test/kotlin/com/pennywiseai/parser/core/bank/`; many older tests sit at the test root with a `TestXxx` file prefix (the FAB suite is `TestFABParser.kt` containing `class FABParserTest`). Match whatever the file you're editing already uses.
 * Use `@TestFactory` instead of `@Test` for test suites that cover multiple scenarios.
 * Return `List<DynamicTest>` by leveraging `ParserTestUtils.runTestSuite` or `runFactoryTestSuite`.
 * This provides granular reporting where each test case appears as a separate result in the IDE and CI/CD logs.
@@ -17,6 +17,7 @@ This repository provides a shared Kotlin test harness for all SMS parser impleme
   * `SimpleTestCase`
   * `ParserTestUtils`
 * Use `ParserTestUtils.runTestSuite` for parser-specific assertions and `ParserTestUtils.runFactoryTestSuite` for sender lookups that delegate to `BankParserFactory`.
+* `runTestSuite` also accepts an optional `handleCases: List<Pair<String, Boolean>>` argument for asserting `canHandle()` outcomes next to the parsing assertions.
 
 ### Parser-specific tests
 
@@ -85,7 +86,7 @@ fun `factory resolves fab`(): List<DynamicTest> {
 1. Replace `@Test` with `@TestFactory`.
 2. Ensure the method returns `List<DynamicTest>`.
 3. Call `ParserTestUtils.runTestSuite` and return its result.
-4. Remove manual `println` or `printTestHeader` calls.
+4. Drop manual `println` reporting. `printTestHeader` survives as a no-op stub that many existing tests still call — it does nothing, so remove the calls only if you're already editing those lines.
 
 Following these standards keeps parser coverage consistent and guarantees that
 human-readable logs and JUnit tooling stay in sync.

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -7,11 +7,15 @@ PennyWise uses the modern Android state management approach with:
 - **Unidirectional Data Flow (UDF)** pattern
 - **State hoisting** for composable functions
 
+The snippets below are trimmed for reading. The real files are
+`data/preferences/UserPreferencesRepository.kt`, `ui/viewmodel/ThemeViewModel.kt`,
+and `PennyWiseApp.kt` — the patterns match, the field lists don't.
+
 ## Architecture
 
 ### 1. Data Layer (Repository)
 ```kotlin
-// UserPreferencesRepository.kt
+// data/preferences/UserPreferencesRepository.kt
 @Singleton
 class UserPreferencesRepository @Inject constructor(
     private val context: Context
@@ -36,7 +40,7 @@ class UserPreferencesRepository @Inject constructor(
 
 ### 2. ViewModel Layer
 ```kotlin
-// ThemeViewModel.kt
+// ui/viewmodel/ThemeViewModel.kt
 @HiltViewModel
 class ThemeViewModel @Inject constructor(
     private val repository: UserPreferencesRepository
@@ -64,6 +68,10 @@ class ThemeViewModel @Inject constructor(
     }
 }
 ```
+
+The production `ThemeUiState` carries more than theme flags — theme style,
+accent color, AMOLED mode, app font, blur effects. `PennyWiseApp` forwards all
+of it into the `PennyWiseTheme(...)` call.
 
 ### 3. UI Layer (Composables)
 ```kotlin
@@ -165,6 +173,10 @@ data class HomeUiState(
     val error: String? = null
 )
 ```
+
+The production `HomeUiState` in `presentation/home/HomeViewModel.kt` is far
+bigger (filters, account balances, budget summaries, currency state). Keep new
+fields defaulted so existing `copy()` calls stay valid.
 
 ### 4. Single Source of Truth
 - Database: Room for transactions

--- a/docs/store-localization.md
+++ b/docs/store-localization.md
@@ -27,8 +27,9 @@ Translations land in sibling locale folders, e.g.
 `fastlane/metadata/android/hi-IN/title.txt`, ready for `fastlane supply`.
 
 The English → Play-folder mapping lives in [`crowdin.yml`](../crowdin.yml)
-(`languages_mapping`). Only Play-supported locale codes are mapped; Hindi and
-Arabic are active, others are commented in until you enable them.
+(`languages_mapping`). Eleven locale codes are active today: Hindi, Arabic,
+Thai, Swahili, Nepali, Russian, Belarusian, Czech, Persian, Amharic, and
+Spanish. Add or comment out entries in `languages_mapping` to change that set.
 
 ## One-time setup
 


### PR DESCRIPTION
## Summary

The docs had drifted several releases behind the code and were giving wrong answers (stale bank lists, a migration log nobody maintained, module trees from before the KMP split). This syncs every contributor-facing doc with what ships today. Docs only, no code changes.

- **BANK_SUPPORT.md** stops hand-maintaining a bank table that broke with every parser addition. It now points to `docs/supported-banks.json` (generated from `BankParserFactory`, CI-checked by `SupportedBanksDocTest`) and explains the SMS-to-parser pipeline. Registry today: 144 parsers, 23 countries.
- **database-migrations.md** replaces the per-version migration log with what matters: all manual migrations live in `ALL_MIGRATIONS` in `PennyWiseDatabase.kt` so both the Hilt and fallback builders see them (a hand-picked list once missed `MIGRATION_47_48` and crashed v47 installs), plus auto-vs-manual bump workflows and fixes for the common Room errors.
- **architecture.md / CONTRIBUTING.md** show the real multi-module layout: `:app`, `:parser-core`, `:shared`, `:iosApp`, `pennywise-web` (Cloudflare Workers).
- **adding-bank-parsers.md** adds the registration-order warning and the required `./scripts/update-supported-banks.sh` step.
- **parser-test-standards.md** documents actual test naming (`XxxParserTest.kt` vs legacy `TestXxx` prefixes) and `runTestSuite`'s `handleCases` argument.
- **state-management.md** snippets now admit they're trimmed and link to the production sources instead of implying they're complete.
- **CLAUDE.md** corrects the verification gate: `./init.sh` runs the same compile/test gate as CI; CI additionally assembles a debug APK.
- Review-driven accuracy fixes: PRIVACY.md and README now disclose that opening a parse-report link immediately sends the SMS text and sender ID server-side to generate the parsed preview (the old "you choose when to send it" claim was wrong), and PRIVACY.md additionally discloses that the link carries an encrypted device identifier (Android device ID + timestamp, RSA-encrypted on-device) included with those details. The README and `selfdocs/AGENTS.md` install commands now point at the real flavor output (`app/build/outputs/apk/standard/debug/app-standard-universal-debug.apk`) instead of an unflavored `app-debug.apk` / `app-standard-debug.apk` that flavors + ABI splits never produce. Follow-up: PRIVACY.md's leftover absolute claims (the "no data collection — there is no backend; nothing you do in PennyWise reaches us" bullet, the "100% On-Device Processing" heading, and the Summary's "no backend") were rewritten to defer to the Internet Permission list, since they contradicted the parse-report disclosure above.
- Smaller refreshes: README badges (Android 8.0+, Kotlin 2.3.21), PRIVACY.md dated to August 2026 with the on-device LLM wording, TODO items pruned where features shipped, RELEASE/backup-format/issue-tracker/store-localization touch-ups.

## Type of change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [x] docs: Documentation update
- [ ] refactor: Code improvement (no behavior change)
- [ ] perf: Performance improvement
- [ ] style: Formatting (no behavior change)
- [ ] test: Add/update tests
- [ ] chore/ci: Build or CI changes

## Screenshots/Recordings (optional)

N/A (docs only).

## How to test

1. `git show ba336b09 --stat` and confirm only `.md` files changed.
2. Run `./scripts/update-supported-banks.sh` and confirm it produces no diff in `docs/supported-banks.json`.
3. Spot-check doc claims against code: `SCHEMA_VERSION` (58) and the `ALL_MIGRATIONS` array in `PennyWiseDatabase.kt`, module list in `settings.gradle.kts`.

## Breaking changes

- [x] No breaking changes
- [ ] Yes (describe):

## Related issues

None.

## Checklist

- [x] Focused PR (single purpose)
- [ ] Tests added/updated (if applicable) — N/A, no code changed
- [x] Docs updated (if applicable)
- [ ] `./gradlew test` passes locally — N/A for a docs-only diff
- [ ] `./gradlew lint` passes locally — N/A for a docs-only diff
- [x] Follows existing code style and patterns