### PR TITLE
 Fix four high-severity findings from the security audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ iosApp/fastlane/.env
 
 # fastlane run artifact (regenerated every run)
 iosApp/fastlane/report.xml
+
+# git worktrees (superpowers SDD)
+.worktrees/

--- a/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsTransactionProcessor.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsTransactionProcessor.kt
@@ -2,8 +2,10 @@ package com.pennywiseai.tracker.data.manager
 
 import android.content.Context
 import android.util.Log
+import androidx.room.withTransaction
 import com.pennywiseai.parser.core.ParsedTransaction
 import com.pennywiseai.parser.core.bank.BankParserFactory
+import com.pennywiseai.tracker.data.database.PennyWiseDatabase
 import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.data.database.entity.ProfileEntity
 import com.pennywiseai.tracker.data.database.entity.CardType
@@ -40,7 +42,8 @@ class SmsTransactionProcessor @Inject constructor(
     private val merchantMappingRepository: MerchantMappingRepository,
     private val subscriptionRepository: SubscriptionRepository,
     private val ruleRepository: RuleRepository,
-    private val ruleEngine: RuleEngine
+    private val ruleEngine: RuleEngine,
+    private val database: PennyWiseDatabase
 ) {
     companion object {
         private const val TAG = "SmsTransactionProcessor"
@@ -160,19 +163,31 @@ class SmsTransactionProcessor @Inject constructor(
                 entityWithRules.merchantName,
                 entityWithRules.amount
             )
-
             val finalEntity = if (matchedSubscription != null) {
-                Log.d(TAG, "Transaction matched to active subscription: ${matchedSubscription.merchantName}")
-                subscriptionRepository.updateNextPaymentDateAfterCharge(
-                    matchedSubscription.id,
-                    entityWithRules.dateTime.toLocalDate()
-                )
+                Log.d(TAG, "Matched subscription ${matchedSubscription.id}")
                 entityWithRules.copy(isRecurring = true)
             } else {
                 entityWithRules
             }
 
-            val rowId = transactionRepository.insertTransaction(finalEntity)
+            val rowId = if (matchedSubscription != null) {
+                // Atomicity: advance the billing cycle only if the charge row commits.
+                // Insert returning -1L (duplicate hash) or a throw must leave
+                // next_payment_date untouched. Reentrant: nested repository-level
+                // withTransaction calls join this outer transaction.
+                database.withTransaction {
+                    val id = transactionRepository.insertTransaction(finalEntity)
+                    if (id != -1L) {
+                        subscriptionRepository.updateNextPaymentDateAfterCharge(
+                            matchedSubscription.id,
+                            finalEntity.dateTime.toLocalDate()
+                        )
+                    }
+                    id
+                }
+            } else {
+                transactionRepository.insertTransaction(finalEntity)
+            }
             if (rowId != -1L) {
                 Log.d(TAG, "Saved new transaction with ID: $rowId${if (finalEntity.isRecurring) " (Recurring)" else ""}")
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsTransactionProcessor.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/manager/SmsTransactionProcessor.kt
@@ -173,8 +173,8 @@ class SmsTransactionProcessor @Inject constructor(
             val rowId = if (matchedSubscription != null) {
                 // Atomicity: advance the billing cycle only if the charge row commits.
                 // Insert returning -1L (duplicate hash) or a throw must leave
-                // next_payment_date untouched. Reentrant: nested repository-level
-                // withTransaction calls join this outer transaction.
+                // next_payment_date untouched. Callees are DAO passthroughs; no
+                // nested transactions.
                 database.withTransaction {
                     val id = transactionRepository.insertTransaction(finalEntity)
                     if (id != -1L) {

--- a/app/src/main/java/com/pennywiseai/tracker/data/manager/TransactionDeduplication.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/manager/TransactionDeduplication.kt
@@ -27,6 +27,19 @@ object TransactionDeduplication {
         return gap <= window
     }
 
+    // Notification-vs-SMS cross-channel check: the same charge can carry a
+    // different sender code and body text per channel, so content hashes
+    // diverge. Callers pre-filter candidates by amount and time window; bank
+    // and merchant identity decide. Merchant names are mapper-normalized on
+    // both sides, so raw vs title-case renders still compare equal.
+    fun isSameCharge(
+        existing: TransactionEntity,
+        incoming: TransactionEntity
+    ): Boolean {
+        if (existing.bankName != incoming.bankName) return false
+        return existing.merchantName.equals(incoming.merchantName, ignoreCase = true)
+    }
+
     fun shouldReplaceWithIncoming(
         existing: TransactionEntity,
         incoming: TransactionEntity

--- a/app/src/main/java/com/pennywiseai/tracker/receiver/BankNotificationListenerService.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/receiver/BankNotificationListenerService.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import com.pennywiseai.tracker.data.repository.BankNotificationRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import com.pennywiseai.tracker.data.manager.SmsTransactionProcessor
+import com.pennywiseai.tracker.data.manager.TransactionDeduplication
 import com.pennywiseai.parser.core.bank.BankParserFactory
 import com.pennywiseai.tracker.worker.BankNotificationRetryWorker
 import com.pennywiseai.tracker.data.mapper.toEntity
@@ -18,6 +19,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 /**
  * Notification listener that ingests bank app notifications and routes them
@@ -80,16 +84,27 @@ class BankNotificationListenerService : NotificationListenerService() {
             }
 
             try {
-                // Cross-dedup: check if SMS already created this transaction.
-                // Resolve parsers exactly like the SMS processor, then compare
-                // content hashes — identical to the processor's own dedup.
+                // Two-layer cross-channel dedup. Layer 1: exact transaction
+                // hash (the same value the SMS path stores) — identical bodies
+                // dedup here. Layer 2: same bank + merchant + amount within a
+                // ±2-minute window — catches the same charge whose sender code
+                // or body text differs between the SMS and the notification.
                 val parsed = BankParserFactory.getParsers(senderAlias)
                     .firstNotNullOfOrNull { it.parse(body, senderAlias, timestamp) }
                 if (parsed != null) {
-                    val incomingHash = parsed.toEntity().transactionHash
-                    val existing = incomingHash?.let { transactionRepository.getTransactionByHash(it) }
-                    if (existing != null) {
-                        Log.d(TAG, "Notification matches existing transaction (hash dedup)")
+                    val incoming = parsed.toEntity()
+                    val hashMatch = incoming.transactionHash
+                        ?.let { transactionRepository.getTransactionByHash(it) } != null
+                    val eventTime = LocalDateTime.ofInstant(
+                        Instant.ofEpochMilli(timestamp), ZoneId.systemDefault()
+                    )
+                    val nearby = transactionRepository.getTransactionByAmountAndDate(
+                        parsed.amount,
+                        eventTime.minusMinutes(2),
+                        eventTime.plusMinutes(2)
+                    )
+                    if (hashMatch || nearby.any { TransactionDeduplication.isSameCharge(it, incoming) }) {
+                        Log.d(TAG, "Notification matches existing transaction (dedup)")
                         notificationId?.let { notificationRepository.markProcessed(it, null) }
                         return@launch
                     }

--- a/app/src/main/java/com/pennywiseai/tracker/receiver/BankNotificationListenerService.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/receiver/BankNotificationListenerService.kt
@@ -8,6 +8,7 @@ import com.pennywiseai.tracker.data.repository.TransactionRepository
 import com.pennywiseai.tracker.data.manager.SmsTransactionProcessor
 import com.pennywiseai.parser.core.bank.BankParserFactory
 import com.pennywiseai.tracker.worker.BankNotificationRetryWorker
+import com.pennywiseai.tracker.data.mapper.toEntity
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
@@ -17,9 +18,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import java.time.Instant
-import java.time.LocalDateTime
-import java.time.ZoneId
 
 /**
  * Notification listener that ingests bank app notifications and routes them
@@ -83,24 +81,16 @@ class BankNotificationListenerService : NotificationListenerService() {
 
             try {
                 // Cross-dedup: check if SMS already created this transaction.
-                // Parse first to get amount, then look for an existing transaction
-                // with the same amount within a ±2-minute window.
-                val parser = BankParserFactory.getParser(senderAlias)
-                val parsed = parser?.parse(body, senderAlias, timestamp)
+                // Resolve parsers exactly like the SMS processor, then compare
+                // content hashes — identical to the processor's own dedup.
+                val parsed = BankParserFactory.getParsers(senderAlias)
+                    .firstNotNullOfOrNull { it.parse(body, senderAlias, timestamp) }
                 if (parsed != null) {
-                    val eventTime = LocalDateTime.ofInstant(
-                        Instant.ofEpochMilli(timestamp), ZoneId.systemDefault()
-                    )
-                    val windowStart = eventTime.minusMinutes(2)
-                    val windowEnd = eventTime.plusMinutes(2)
-                    val existing = transactionRepository.getTransactionByAmountAndDate(
-                        parsed.amount, windowStart, windowEnd
-                    )
-                    if (existing.any { it.bankName == parsed.bankName }) {
-                        Log.d(TAG, "Notification skipped: duplicate of SMS transaction")
-                        if (notificationId != null) {
-                            notificationRepository.markProcessed(notificationId, null)
-                        }
+                    val incomingHash = parsed.toEntity().transactionHash
+                    val existing = incomingHash?.let { transactionRepository.getTransactionByHash(it) }
+                    if (existing != null) {
+                        Log.d(TAG, "Notification matches existing transaction (hash dedup)")
+                        notificationId?.let { notificationRepository.markProcessed(it, null) }
                         return@launch
                     }
                 }

--- a/app/src/main/java/com/pennywiseai/tracker/receiver/SmsBroadcastReceiver.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/receiver/SmsBroadcastReceiver.kt
@@ -42,6 +42,21 @@ class SmsBroadcastReceiver : BroadcastReceiver() {
         const val EXTRA_TRANSACTION_ID = "transaction_id"
         const val CHANNEL_ID = "transaction_notifications"
         const val CHANNEL_NAME = "Transaction Notifications"
+
+        // Category actions occupy slots 0..1; picker reserves slot 9.
+        // Codes are unique per (transactionId, slot): txId*10+slot cannot alias across
+        // transactions because take(2) bounds slot < 10. This numbering is used ONLY by
+        // ACTION_CHANGE_CATEGORY broadcasts — one filterEquals space; activity intents
+        // (content → MainActivity, picker → QuickCategoryPickerActivity) are separate
+        // components and keep their own lanes.
+        private const val CATEGORY_SLOT_BASE = 10
+        private const val PICKER_SLOT = 9
+
+        internal fun categoryRequestCode(transactionId: Long, slotIndex: Int): Int =
+            (transactionId * CATEGORY_SLOT_BASE + slotIndex).toInt()
+
+        internal fun pickerRequestCode(transactionId: Long): Int =
+            (transactionId * CATEGORY_SLOT_BASE + PICKER_SLOT).toInt()
     }
 
     private val receiverScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -238,7 +253,7 @@ class SmsBroadcastReceiver : BroadcastReceiver() {
 
                 val categoryPendingIntent = PendingIntent.getBroadcast(
                     context,
-                    transactionId.toInt() + index + 1, // Unique request code
+                    categoryRequestCode(transactionId, index),
                     categoryIntent,
                     PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
                 )
@@ -259,7 +274,7 @@ class SmsBroadcastReceiver : BroadcastReceiver() {
             }
             val pickerPendingIntent = PendingIntent.getActivity(
                 context,
-                transactionId.toInt() + 100, // distinct request-code lane
+                pickerRequestCode(transactionId),
                 pickerIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )

--- a/app/src/test/java/com/pennywiseai/tracker/data/manager/TransactionDeduplicationTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/manager/TransactionDeduplicationTest.kt
@@ -164,6 +164,30 @@ class TransactionDeduplicationTest {
         assertEquals(listOf(1L), TransactionDeduplication.duplicateIdsToDelete(transactions))
     }
 
+    @Test
+    fun `isSameCharge matches same bank and merchant across channels`() {
+        val smsStored = transaction(id = 1, merchantName = "Sample Merchant")
+        val notificationStored = transaction(id = 2, merchantName = "sample merchant")
+
+        assertTrue(TransactionDeduplication.isSameCharge(smsStored, notificationStored))
+    }
+
+    @Test
+    fun `isSameCharge ignores distinct merchants sharing bank and amount`() {
+        val first = transaction(id = 1, merchantName = "Coffee Co")
+        val second = transaction(id = 2, merchantName = "Grocery Co")
+
+        assertFalse(TransactionDeduplication.isSameCharge(first, second))
+    }
+
+    @Test
+    fun `isSameCharge ignores other banks`() {
+        val first = transaction(id = 1)
+        val second = transaction(id = 2, bankName = "State Bank of India")
+
+        assertFalse(TransactionDeduplication.isSameCharge(first, second))
+    }
+
     private fun transaction(
         id: Long,
         amount: BigDecimal = BigDecimal("15000.00"),
@@ -171,11 +195,12 @@ class TransactionDeduplicationTest {
         bankName: String = "South Indian Bank",
         reference: String = "111222333444",
         dateTime: LocalDateTime = baseTime,
-        balanceAfter: BigDecimal? = BigDecimal("34567.67")
+        balanceAfter: BigDecimal? = BigDecimal("34567.67"),
+        merchantName: String = "Sample Merchant"
     ): TransactionEntity = TransactionEntity(
         id = id,
         amount = amount,
-        merchantName = "Sample Merchant",
+        merchantName = merchantName,
         category = "Others",
         transactionType = TransactionType.INCOME,
         dateTime = dateTime,

--- a/app/src/test/java/com/pennywiseai/tracker/receiver/BankNotificationDedupHashTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/receiver/BankNotificationDedupHashTest.kt
@@ -2,6 +2,7 @@ package com.pennywiseai.tracker.receiver
 
 import com.pennywiseai.parser.core.ParsedTransaction
 import com.pennywiseai.parser.core.TransactionType
+import com.pennywiseai.tracker.data.mapper.toEntity
 import java.math.BigDecimal
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -35,5 +36,14 @@ class BankNotificationDedupHashTest {
         val body = "Rs 500 spent at Coffee Co card x1234"
         assertEquals(tx(body, 1_700_000_000_000L).generateTransactionId(),
                      tx(body, 1_700_005_000_000L).generateTransactionId())
+    }
+
+    @Test
+    fun `toEntity mapper fills identical non-blank transactionHash for identical bodies`() {
+        val body = "Rs 500 spent at Coffee Co card x1234"
+        val first = tx(body, 1_700_000_000_000L).toEntity()
+        val second = tx(body, 1_700_005_000_000L).toEntity()
+        assertEquals(first.transactionHash, second.transactionHash)
+        kotlin.test.assertTrue(first.transactionHash.isNotBlank())
     }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/receiver/BankNotificationDedupHashTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/receiver/BankNotificationDedupHashTest.kt
@@ -1,0 +1,39 @@
+package com.pennywiseai.tracker.receiver
+
+import com.pennywiseai.parser.core.ParsedTransaction
+import com.pennywiseai.parser.core.TransactionType
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import org.junit.Test
+
+class BankNotificationDedupHashTest {
+
+    private fun tx(body: String, timestamp: Long) = ParsedTransaction(
+        amount = BigDecimal("500"),
+        type = TransactionType.EXPENSE,
+        merchant = "Store",
+        reference = null,
+        accountLast4 = null,
+        balance = null,
+        smsBody = body,
+        sender = "FaysalBank",
+        timestamp = timestamp,
+        bankName = "FaysalBank"
+    )
+
+    @Test
+    fun `two legit charges same amount different bodies produce distinct hashes`() {
+        val t0 = 1_700_000_000_000L
+        val first = tx("Rs 500 spent at Coffee Co card x1234", t0)
+        val second = tx("Rs 500 spent at Grocery Co card x5678", t0 + 60_000)
+        assertNotEquals(first.generateTransactionId(), second.generateTransactionId())
+    }
+
+    @Test
+    fun `carrier redelivery identical body produces identical hash`() {
+        val body = "Rs 500 spent at Coffee Co card x1234"
+        assertEquals(tx(body, 1_700_000_000_000L).generateTransactionId(),
+                     tx(body, 1_700_005_000_000L).generateTransactionId())
+    }
+}

--- a/app/src/test/java/com/pennywiseai/tracker/receiver/SmsBroadcastReceiverRequestCodeTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/receiver/SmsBroadcastReceiverRequestCodeTest.kt
@@ -1,0 +1,40 @@
+package com.pennywiseai.tracker.receiver
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class SmsBroadcastReceiverRequestCodeTest {
+
+    @Test
+    fun `codes unique across transactions and both category slots`() {
+        val ids = listOf(98L, 99L, 100L, 101L, 4095L, 123456L)
+        val codes = ids.flatMap { id -> (0..1).map { slot -> SmsBroadcastReceiver.categoryRequestCode(id, slot) } }
+        assertEquals(codes.size, codes.toSet().size)
+    }
+
+    @Test
+    fun `audited collision pair tx99-slot1_vs_tx100-slot0 now distinct`() {
+        // Old scheme: 99 + 1 + 1 == 100 + 0 + 1 == 101 → wrong-transaction recategorize
+        assertNotEquals(
+            SmsBroadcastReceiver.categoryRequestCode(99L, 1),
+            SmsBroadcastReceiver.categoryRequestCode(100L, 0)
+        )
+    }
+
+    @Test
+    fun `same transaction same slot is stable`() {
+        assertEquals(
+            SmsBroadcastReceiver.categoryRequestCode(100L, 0),
+            SmsBroadcastReceiver.categoryRequestCode(100L, 0)
+        )
+        assertEquals(1000L, SmsBroadcastReceiver.categoryRequestCode(100L, 0).toLong())
+    }
+
+    @Test
+    fun `picker code occupies reserved slot outside category slots`() {
+        val picker = SmsBroadcastReceiver.pickerRequestCode(100L)
+        assertNotEquals(picker, SmsBroadcastReceiver.categoryRequestCode(100L, 0))
+        assertNotEquals(picker, SmsBroadcastReceiver.categoryRequestCode(100L, 1))
+    }
+}

--- a/pennywise-web/server/src/main/kotlin/ui/ParseViews.kt
+++ b/pennywise-web/server/src/main/kotlin/ui/ParseViews.kt
@@ -281,8 +281,12 @@ object ParseViews {
                                     parsed.currency === 'INR' || !parsed.currency
                                         ? '₹' + parsed.amount.toLocaleString('en-IN')
                                         : parsed.currency + ' ' + parsed.amount.toLocaleString());
-                                addInfoRow('Type:', parsed.type);
-                                addInfoRow('Merchant:', parsed.merchant);
+                                if (parsed.type) {
+                                    addInfoRow('Type:', parsed.type);
+                                }
+                                if (parsed.merchant) {
+                                    addInfoRow('Merchant:', parsed.merchant);
+                                }
                             }
 
                             function hideReportModal() {
@@ -317,6 +321,21 @@ object ParseViews {
                                     userNote: userNote || null
                                 };
 
+                                // Same wrapper structure the old innerHTML strings
+                                // produced, rebuilt as text nodes (SEC-001).
+                                function showStatus(text, success) {
+                                    const status = document.getElementById('reportStatus');
+                                    status.textContent = '';
+                                    const el = document.createElement('div');
+                                    if (success) {
+                                        el.className = 'success-msg';
+                                    } else {
+                                        el.style.color = '#ef4444';
+                                    }
+                                    el.textContent = text;
+                                    status.appendChild(el);
+                                }
+
                                 try {
                                     const response = await fetch('/api/report', {
                                         method: 'POST',
@@ -327,16 +346,13 @@ object ParseViews {
                                     const result = await response.json();
 
                                     if (result.success) {
-                                        document.getElementById('reportStatus').textContent =
-                                            '<div class="success-msg">Report submitted successfully! Thank you for your feedback.</div>';
+                                        showStatus('Report submitted successfully! Thank you for your feedback.', true);
                                         setTimeout(hideReportModal, 2000);
                                     } else {
-                                        document.getElementById('reportStatus').textContent =
-                                            '<div style="color: #ef4444;">Error: ' + result.message + '</div>';
+                                        showStatus('Error: ' + result.message, false);
                                     }
                                 } catch (error) {
-                                    document.getElementById('reportStatus').textContent =
-                                        '<div style="color: #ef4444;">Failed to submit report. Please try again.</div>';
+                                    showStatus('Failed to submit report. Please try again.', false);
                                 }
                             }
                         """ }

--- a/pennywise-web/server/src/main/kotlin/ui/ParseViews.kt
+++ b/pennywise-web/server/src/main/kotlin/ui/ParseViews.kt
@@ -234,35 +234,55 @@ object ParseViews {
                                 document.getElementById('reportModal').classList.add('show');
 
                                 // Display parsed data in the modal
-                                const parsedResultStr = document.getElementById('parsed_result').value;
                                 const parsedDetails = document.getElementById('parsedDetails');
 
-                                if (parsedResultStr) {
-                                    try {
-                                        const parsed = JSON.parse(parsedResultStr);
-                                        let html = '';
-
-                                        if (parsed.amount !== undefined) {
-                                            html += '<div class="info-row"><span class="info-label">Amount:</span><span class="info-value">' + (parsed.currency === 'INR' || !parsed.currency ? '₹' + parsed.amount.toLocaleString('en-IN') : parsed.currency + ' ' + parsed.amount.toLocaleString()) + '</span></div>';
-                                        }
-                                        if (parsed.type) {
-                                            html += '<div class="info-row"><span class="info-label">Type:</span><span class="info-value">' + parsed.type + '</span></div>';
-                                        }
-                                        if (parsed.merchant) {
-                                            html += '<div class="info-row"><span class="info-label">Merchant:</span><span class="info-value">' + parsed.merchant + '</span></div>';
-                                        }
-
-                                        if (html === '') {
-                                            html = '<p class="no-transaction">No transaction details detected</p>';
-                                        }
-
-                                        parsedDetails.innerHTML = html;
-                                    } catch (e) {
-                                        parsedDetails.innerHTML = '<p class="no-transaction">No transaction detected</p>';
-                                    }
-                                } else {
-                                    parsedDetails.innerHTML = '<p class="no-transaction">No transaction detected</p>';
+                                const raw = document.getElementById('parsed_result').value;
+                                parsedDetails.textContent = '';
+                                if (!raw) {
+                                    const p = document.createElement('p');
+                                    p.className = 'no-transaction';
+                                    p.textContent = 'No transaction details detected';
+                                    parsedDetails.appendChild(p);
+                                    return;
                                 }
+                                let parsed;
+                                try {
+                                    parsed = JSON.parse(raw);
+                                } catch (e) {
+                                    const p = document.createElement('p');
+                                    p.className = 'no-transaction';
+                                    p.textContent = 'Error parsing transaction details';
+                                    parsedDetails.appendChild(p);
+                                    return;
+                                }
+                                if (!parsed || typeof parsed.amount !== 'number') {
+                                    const p = document.createElement('p');
+                                    p.className = 'no-transaction';
+                                    p.textContent = 'No transaction details detected';
+                                    parsedDetails.appendChild(p);
+                                    return;
+                                }
+
+                                function addInfoRow(label, value) {
+                                    const row = document.createElement('div');
+                                    row.className = 'info-row';
+                                    const labelEl = document.createElement('span');
+                                    labelEl.className = 'info-label';
+                                    labelEl.textContent = label;
+                                    const valueEl = document.createElement('span');
+                                    valueEl.className = 'info-value';
+                                    valueEl.textContent = value;
+                                    row.appendChild(labelEl);
+                                    row.appendChild(valueEl);
+                                    parsedDetails.appendChild(row);
+                                }
+
+                                addInfoRow('Amount:',
+                                    parsed.currency === 'INR' || !parsed.currency
+                                        ? '₹' + parsed.amount.toLocaleString('en-IN')
+                                        : parsed.currency + ' ' + parsed.amount.toLocaleString());
+                                addInfoRow('Type:', parsed.type);
+                                addInfoRow('Merchant:', parsed.merchant);
                             }
 
                             function hideReportModal() {
@@ -307,15 +327,15 @@ object ParseViews {
                                     const result = await response.json();
 
                                     if (result.success) {
-                                        document.getElementById('reportStatus').innerHTML =
+                                        document.getElementById('reportStatus').textContent =
                                             '<div class="success-msg">Report submitted successfully! Thank you for your feedback.</div>';
                                         setTimeout(hideReportModal, 2000);
                                     } else {
-                                        document.getElementById('reportStatus').innerHTML =
+                                        document.getElementById('reportStatus').textContent =
                                             '<div style="color: #ef4444;">Error: ' + result.message + '</div>';
                                     }
                                 } catch (error) {
-                                    document.getElementById('reportStatus').innerHTML =
+                                    document.getElementById('reportStatus').textContent =
                                         '<div style="color: #ef4444;">Failed to submit report. Please try again.</div>';
                                 }
                             }

--- a/pennywise-web/server/src/test/kotlin/com/example/ui/ParsePageSecurityTest.kt
+++ b/pennywise-web/server/src/test/kotlin/com/example/ui/ParsePageSecurityTest.kt
@@ -1,0 +1,65 @@
+package com.example.ui
+
+import com.example.module
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ParsePageSecurityTest {
+
+    // configureDatabases() opens its connection eagerly from config; point it at
+    // an in-memory H2 instance so the page-render tests stay hermetic.
+    private fun ApplicationTestBuilder.parsePageApp() {
+        environment {
+            config = MapApplicationConfig(
+                "postgres.url" to "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1",
+                "postgres.user" to "root",
+                "postgres.password" to ""
+            )
+        }
+        application { module() }
+    }
+
+    @Test
+    fun `report modal never assigns innerHTML from parsed fields`() = testApplication {
+        parsePageApp()
+        val response = client.get("/tools/parse")
+        assertEquals(HttpStatusCode.OK, response.status)
+        val html = response.bodyAsText()
+        // The only permitted innerHTML assignments are the literal empty-string
+        // clears in hideReportModal(); anything else is a DOM XSS sink.
+        val dynamicSinks = Regex("""innerHTML\s*=\s*([^;\r\n]+)""").findAll(html)
+            .map { it.groupValues[1].trim() }
+            .filterNot { it == "''" }
+            .toList()
+        assertTrue(
+            dynamicSinks.isEmpty(),
+            "innerHTML assignments beyond static clears found: $dynamicSinks"
+        )
+        assertTrue(
+            html.contains("parsedDetails.textContent"),
+            "dynamic fields must be written via textContent"
+        )
+    }
+
+    @Test
+    fun `submitReport error path writes status via textContent`() = testApplication {
+        parsePageApp()
+        val html = client.get("/tools/parse").bodyAsText()
+        assertFalse(
+            Regex("""innerHTML\s*=\s*[^;\n]*\+""").containsMatchIn(html),
+            "server-controlled result.message interpolated into innerHTML"
+        )
+        assertTrue(
+            html.contains("reportStatus').textContent"),
+            "status messages must be written via textContent"
+        )
+    }
+}

--- a/pennywise-web/server/src/test/kotlin/com/example/ui/ParsePageSecurityTest.kt
+++ b/pennywise-web/server/src/test/kotlin/com/example/ui/ParsePageSecurityTest.kt
@@ -47,6 +47,10 @@ class ParsePageSecurityTest {
             html.contains("parsedDetails.textContent"),
             "dynamic fields must be written via textContent"
         )
+        assertTrue(
+            html.contains("if (parsed.type)") && html.contains("if (parsed.merchant)"),
+            "Type/Merchant rows must be guarded against absent fields"
+        )
     }
 
     @Test
@@ -58,7 +62,7 @@ class ParsePageSecurityTest {
             "server-controlled result.message interpolated into innerHTML"
         )
         assertTrue(
-            html.contains("reportStatus').textContent"),
+            html.contains("function showStatus") && html.contains("el.textContent = text"),
             "status messages must be written via textContent"
         )
     }


### PR DESCRIPTION

## Summary

Four audit findings fixed, one commit each plus a test-hardening commit:

- **SEC-001** — the web report modal built rows by concatenating parsed SMS fields into `innerHTML`, so a merchant value like `<img src=x onerror=alert(1)>` executed instead of displaying. Rows are DOM nodes written through `textContent` now, including server error messages.
- **BUG-001** — category-action PendingIntents numbered themselves `transactionId + index + 1`, so transaction 99's second action and transaction 100's first both got code 101. `FLAG_UPDATE_CURRENT` keeps one PendingIntent per code, so tapping recategorized the wrong row. Codes are `transactionId * 10 + slot` now, picker lane at slot 9.
- **BUG-002** — subscription next-payment dates advanced before the charge was inserted. A duplicate-hash insert returned `-1` and left the cycle moved for a charge that never saved. Insert and advance run inside one `database.withTransaction` block now; the date moves only when the row commits.
- **BUG-003** — the notification listener dropped any charge matching an existing transaction on amount within ±2 minutes of the same bank, killing legitimate back-to-back charges, and resolved parsers through a single candidate while the SMS path tries all of them. Dedup now runs in two layers: the stored transaction hash first, then a bank + merchant match over amount/window-filtered candidates, so a charge that arrives as both an SMS and an app notification still collapses even though each channel hashes its own sender and body text. Parser resolution matches the processor exactly. The proximity predicate lives in `TransactionDeduplication` beside `isSameUpiTransaction`.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Code improvement (no behavior change)
- [ ] perf: Performance improvement
- [ ] style: Formatting (no behavior change)
- [x] test: Add/update tests
- [ ] chore/ci: Build or CI changes

## Screenshots/Recordings (optional)

None. Behavior is test-pinned; see How to test.

## How to test

1. `./gradlew test` — passes; includes three new test files: `ParsePageSecurityTest` (bans non-empty `innerHTML` assignments on the served page), `SmsBroadcastReceiverRequestCodeTest` (code uniqueness across transactions and slots), `BankNotificationDedupHashTest` (distinct charges get distinct hashes; identical bodies collapse), plus `isSameCharge` cases in `TransactionDeduplicationTest`.
2. Web modal: serve the pennywise-web app, parse an SMS whose merchant resolves to `<img src=x onerror=alert(1)>`, open the report modal. The tag renders as text, no script runs.
3. Request codes: `./gradlew :app:testStandardDebugUnitTest --tests "*SmsBroadcastReceiverRequestCodeTest*"` — green.
4. Notification dedup (device): send two same-amount charges from different merchants a minute apart, both persist. Send one charge that arrives as both an SMS and an app notification, one row saves. Re-deliver an identical notification body, nothing duplicates.

## Breaking changes

- [x] No breaking changes
- [ ] Yes (describe):

Old-scheme PendingIntents expire with their notifications; no migration needed.

## Related issues

None tracked.

## Checklist

- [x] Focused PR (single purpose)
- [x] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)
- [x] `./gradlew test` passes locally
- [x] `./gradlew lint` passes locally
- [x] Follows existing code style and patterns