### PR TITLE
feat(notification): inline tagging from the quick picker (#696)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TagRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TagRepository.kt
@@ -5,8 +5,13 @@ import com.pennywiseai.tracker.data.database.PennyWiseDatabase
 import com.pennywiseai.tracker.data.database.dao.TagDao
 import com.pennywiseai.tracker.data.database.entity.TagEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionTagCrossRef
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -20,6 +25,32 @@ class TagRepository @Inject constructor(
     private val database: PennyWiseDatabase,
     private val tagDao: TagDao
 ) {
+
+    // Ordered, single-consumer queue for tag writes (#710). setTagsForTransaction
+    // is a replace-all, so concurrent callers (e.g. rapid edits in the quick
+    // picker) could otherwise land out of order and persist a stale set, or lose
+    // one transaction's edits when the caller retargets to another. Enqueuing
+    // preserves send order and a single consumer applies them FIFO.
+    private val tagWriteScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val tagWriteQueue = Channel<Pair<Long, List<String>>>(Channel.UNLIMITED)
+
+    init {
+        tagWriteScope.launch {
+            for ((transactionId, tagNames) in tagWriteQueue) {
+                runCatching { setTagsForTransaction(transactionId, tagNames) }
+            }
+        }
+    }
+
+    /**
+     * Enqueue a replace-all tag write applied in FIFO order on a single
+     * consumer, so rapid or interleaved calls can't reorder or lose data.
+     * Prefer this over calling [setTagsForTransaction] directly from UI that
+     * fires many quick edits.
+     */
+    fun enqueueSetTags(transactionId: Long, tagNames: List<String>) {
+        tagWriteQueue.trySend(transactionId to tagNames)
+    }
 
     fun observeAllTags(): Flow<List<TagEntity>> = tagDao.getAllTags()
 

--- a/app/src/main/java/com/pennywiseai/tracker/receiver/QuickCategoryPickerActivity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/receiver/QuickCategoryPickerActivity.kt
@@ -24,7 +24,6 @@ import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.withLock
 
 /**
  * Translucent activity launched from the txn-alert notification's
@@ -56,6 +55,23 @@ class QuickCategoryPickerActivity : ComponentActivity() {
     // Holds the args from the latest intent (initial or via onNewIntent), so
     // a second notification tap re-targets the picker at the new transaction.
     private val currentArgs = mutableStateOf<PickerArgs?>(null)
+
+    // Latest (transactionId, tags) the user selected in the sheet. Written once
+    // in onPause rather than on every edit, so concurrent replace-all writes can
+    // never leave a stale set. (#710)
+    @Volatile private var pendingTagWrite: Pair<Long, List<String>>? = null
+
+    private fun flushPendingTags() {
+        val (txnId, tags) = pendingTagWrite ?: return
+        pendingTagWrite = null
+        appScope.launch { tagRepository.setTagsForTransaction(txnId, tags) }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        // Covers category-pick (finish), dismiss (finish), and backgrounding.
+        flushPendingTags()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -149,14 +165,12 @@ class QuickCategoryPickerActivity : ComponentActivity() {
                 tagSuggestions = tagSuggestions,
                 initialTags = initialTags,
                 onTagsChanged = { newTags ->
-                    // Persist immediately so tagging works even if the user
-                    // dismisses without picking a category (#696). Serialize under
-                    // the mutex so concurrent edits apply in order (#710).
-                    appScope.launch {
-                        tagWriteMutex.withLock {
-                            tagRepository.setTagsForTransaction(txn.id, newTags)
-                        }
-                    }
+                    // Record the latest selection only; the actual write happens
+                    // once in onPause (covers category-pick, dismiss, and
+                    // backgrounding). Writing on every edit raced — an earlier
+                    // replace-all could land after a later one and persist a stale
+                    // set. One write of the final set can't race. (#696 / #710)
+                    pendingTagWrite = txn.id to newTags
                 }
             )
         }
@@ -178,11 +192,5 @@ class QuickCategoryPickerActivity : ComponentActivity() {
         private const val TAG = "QuickCategoryPicker"
         const val EXTRA_TRANSACTION_ID = "transaction_id"
         const val EXTRA_NOTIFICATION_ID = "notification_id"
-
-        // Static so tag writes serialize even across an activity recreation
-        // (config change / process restart) — the app-scoped write from a
-        // previous instance can otherwise still race the new one and leave
-        // stale tags. kotlinx Mutex grants in suspension order (FIFO). (#710)
-        private val tagWriteMutex = kotlinx.coroutines.sync.Mutex()
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/receiver/QuickCategoryPickerActivity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/receiver/QuickCategoryPickerActivity.kt
@@ -14,6 +14,7 @@ import androidx.core.app.NotificationManagerCompat
 import com.pennywiseai.tracker.data.database.entity.CategoryEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
 import com.pennywiseai.tracker.data.repository.CategoryRepository
+import com.pennywiseai.tracker.data.repository.TagRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
 import com.pennywiseai.tracker.di.ApplicationScope
 import com.pennywiseai.tracker.ui.components.QuickCategoryPickerSheet
@@ -44,6 +45,7 @@ class QuickCategoryPickerActivity : ComponentActivity() {
 
     @Inject lateinit var transactionRepository: TransactionRepository
     @Inject lateinit var categoryRepository: CategoryRepository
+    @Inject lateinit var tagRepository: TagRepository
 
     // App-lifetime scope so the DB write survives finish() — the activity
     // closes immediately after the user picks.
@@ -89,14 +91,20 @@ class QuickCategoryPickerActivity : ComponentActivity() {
         var transactionLoaded by remember(args.transactionId) { mutableStateOf(false) }
         var categories by remember { mutableStateOf<List<CategoryEntity>>(emptyList()) }
         var categoriesLoaded by remember { mutableStateOf(false) }
+        // Tags for the inline tag section (#696): the txn's current tags seed
+        // the field, and every known tag name feeds autocomplete.
+        var initialTags by remember(args.transactionId) { mutableStateOf<List<String>>(emptyList()) }
+        var tagSuggestions by remember { mutableStateOf<List<String>>(emptyList()) }
 
         LaunchedEffect(args.transactionId) {
             transaction = transactionRepository.getTransactionById(args.transactionId)
             transactionLoaded = true
+            initialTags = tagRepository.getTagNamesForTransaction(args.transactionId)
         }
         LaunchedEffect(Unit) {
             categories = categoryRepository.getAllCategories().first()
             categoriesLoaded = true
+            tagSuggestions = tagRepository.observeAllTagNames().first()
         }
 
         // Finish silently when the load resolves to nothing renderable.
@@ -129,7 +137,16 @@ class QuickCategoryPickerActivity : ComponentActivity() {
                     }
                     finish()
                 },
-                onDismiss = { finish() }
+                onDismiss = { finish() },
+                tagSuggestions = tagSuggestions,
+                initialTags = initialTags,
+                onTagsChanged = { newTags ->
+                    // Persist immediately so tagging works even if the user
+                    // dismisses without picking a category (#696).
+                    appScope.launch {
+                        tagRepository.setTagsForTransaction(txn.id, newTags)
+                    }
+                }
             )
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/receiver/QuickCategoryPickerActivity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/receiver/QuickCategoryPickerActivity.kt
@@ -52,10 +52,6 @@ class QuickCategoryPickerActivity : ComponentActivity() {
     // closes immediately after the user picks.
     @Inject @ApplicationScope lateinit var appScope: CoroutineScope
 
-    // Serializes tag writes so rapid add/remove edits apply in order — otherwise
-    // an earlier replace-all could finish after a later one and leave stale tags
-    // (#710 Greptile). kotlinx Mutex grants in suspension order (FIFO).
-    private val tagWriteMutex = kotlinx.coroutines.sync.Mutex()
 
     // Holds the args from the latest intent (initial or via onNewIntent), so
     // a second notification tap re-targets the picker at the new transaction.
@@ -182,5 +178,11 @@ class QuickCategoryPickerActivity : ComponentActivity() {
         private const val TAG = "QuickCategoryPicker"
         const val EXTRA_TRANSACTION_ID = "transaction_id"
         const val EXTRA_NOTIFICATION_ID = "notification_id"
+
+        // Static so tag writes serialize even across an activity recreation
+        // (config change / process restart) — the app-scoped write from a
+        // previous instance can otherwise still race the new one and leave
+        // stale tags. kotlinx Mutex grants in suspension order (FIFO). (#710)
+        private val tagWriteMutex = kotlinx.coroutines.sync.Mutex()
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/receiver/QuickCategoryPickerActivity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/receiver/QuickCategoryPickerActivity.kt
@@ -94,12 +94,18 @@ class QuickCategoryPickerActivity : ComponentActivity() {
         // Tags for the inline tag section (#696): the txn's current tags seed
         // the field, and every known tag name feeds autocomplete.
         var initialTags by remember(args.transactionId) { mutableStateOf<List<String>>(emptyList()) }
+        var tagsLoaded by remember(args.transactionId) { mutableStateOf(false) }
         var tagSuggestions by remember { mutableStateOf<List<String>>(emptyList()) }
 
         LaunchedEffect(args.transactionId) {
             transaction = transactionRepository.getTransactionById(args.transactionId)
             transactionLoaded = true
+            // Load existing tags BEFORE the sheet renders (gated by tagsLoaded below).
+            // Otherwise the sheet's remember{} captures an empty list, and the first
+            // add/remove would replace-all with an incomplete set, deleting existing
+            // tag associations. (#710 Greptile)
             initialTags = tagRepository.getTagNamesForTransaction(args.transactionId)
+            tagsLoaded = true
         }
         LaunchedEffect(Unit) {
             categories = categoryRepository.getAllCategories().first()
@@ -118,7 +124,7 @@ class QuickCategoryPickerActivity : ComponentActivity() {
         }
 
         val txn = transaction
-        if (txn != null && categories.isNotEmpty()) {
+        if (txn != null && categories.isNotEmpty() && tagsLoaded) {
             // Snapshot the args this composition is targeting so the callback
             // doesn't accidentally see an args update from onNewIntent mid-flight.
             val activeNotificationId = args.notificationId

--- a/app/src/main/java/com/pennywiseai/tracker/receiver/QuickCategoryPickerActivity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/receiver/QuickCategoryPickerActivity.kt
@@ -24,6 +24,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.withLock
 
 /**
  * Translucent activity launched from the txn-alert notification's
@@ -50,6 +51,11 @@ class QuickCategoryPickerActivity : ComponentActivity() {
     // App-lifetime scope so the DB write survives finish() — the activity
     // closes immediately after the user picks.
     @Inject @ApplicationScope lateinit var appScope: CoroutineScope
+
+    // Serializes tag writes so rapid add/remove edits apply in order — otherwise
+    // an earlier replace-all could finish after a later one and leave stale tags
+    // (#710 Greptile). kotlinx Mutex grants in suspension order (FIFO).
+    private val tagWriteMutex = kotlinx.coroutines.sync.Mutex()
 
     // Holds the args from the latest intent (initial or via onNewIntent), so
     // a second notification tap re-targets the picker at the new transaction.
@@ -148,9 +154,12 @@ class QuickCategoryPickerActivity : ComponentActivity() {
                 initialTags = initialTags,
                 onTagsChanged = { newTags ->
                     // Persist immediately so tagging works even if the user
-                    // dismisses without picking a category (#696).
+                    // dismisses without picking a category (#696). Serialize under
+                    // the mutex so concurrent edits apply in order (#710).
                     appScope.launch {
-                        tagRepository.setTagsForTransaction(txn.id, newTags)
+                        tagWriteMutex.withLock {
+                            tagRepository.setTagsForTransaction(txn.id, newTags)
+                        }
                     }
                 }
             )

--- a/app/src/main/java/com/pennywiseai/tracker/receiver/QuickCategoryPickerActivity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/receiver/QuickCategoryPickerActivity.kt
@@ -56,23 +56,6 @@ class QuickCategoryPickerActivity : ComponentActivity() {
     // a second notification tap re-targets the picker at the new transaction.
     private val currentArgs = mutableStateOf<PickerArgs?>(null)
 
-    // Latest (transactionId, tags) the user selected in the sheet. Written once
-    // in onPause rather than on every edit, so concurrent replace-all writes can
-    // never leave a stale set. (#710)
-    @Volatile private var pendingTagWrite: Pair<Long, List<String>>? = null
-
-    private fun flushPendingTags() {
-        val (txnId, tags) = pendingTagWrite ?: return
-        pendingTagWrite = null
-        appScope.launch { tagRepository.setTagsForTransaction(txnId, tags) }
-    }
-
-    override fun onPause() {
-        super.onPause()
-        // Covers category-pick (finish), dismiss (finish), and backgrounding.
-        flushPendingTags()
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -165,12 +148,12 @@ class QuickCategoryPickerActivity : ComponentActivity() {
                 tagSuggestions = tagSuggestions,
                 initialTags = initialTags,
                 onTagsChanged = { newTags ->
-                    // Record the latest selection only; the actual write happens
-                    // once in onPause (covers category-pick, dismiss, and
-                    // backgrounding). Writing on every edit raced — an earlier
-                    // replace-all could land after a later one and persist a stale
-                    // set. One write of the final set can't race. (#696 / #710)
-                    pendingTagWrite = txn.id to newTags
+                    // Persist immediately so tagging works even if the user
+                    // dismisses without picking a category (#696). Enqueue rather
+                    // than write directly so rapid edits apply FIFO on a single
+                    // consumer — no reorder, and no loss when the picker retargets
+                    // to another transaction via onNewIntent. (#710)
+                    tagRepository.enqueueSetTags(txn.id, newTags)
                 }
             )
         }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/QuickCategoryPickerSheet.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/QuickCategoryPickerSheet.kt
@@ -10,12 +10,17 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -43,13 +48,48 @@ fun QuickCategoryPickerSheet(
     currentCategory: String,
     categories: List<CategoryEntity>,
     onCategorySelected: (String) -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    // Optional inline tagging (notification "More…" flow, #696). When
+    // [onTagsChanged] is non-null a Tags section is shown above the category
+    // list; each add/remove commits immediately, so the user can tag without
+    // also picking a category. In-app call sites omit these and see no change.
+    tagSuggestions: List<String> = emptyList(),
+    initialTags: List<String> = emptyList(),
+    onTagsChanged: ((List<String>) -> Unit)? = null
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState
     ) {
+        if (onTagsChanged != null) {
+            var tags by remember { mutableStateOf(initialTags) }
+            TagInputField(
+                selectedTags = tags,
+                allTags = tagSuggestions,
+                onAddTag = { name ->
+                    if (name !in tags) {
+                        tags = tags + name
+                        onTagsChanged(tags)
+                    }
+                },
+                onRemoveTag = { name ->
+                    tags = tags - name
+                    onTagsChanged(tags)
+                },
+                modifier = Modifier.padding(
+                    start = Dimensions.Padding.content,
+                    end = Dimensions.Padding.content,
+                    bottom = Spacing.sm
+                )
+            )
+            HorizontalDivider(
+                modifier = Modifier.padding(
+                    horizontal = Dimensions.Padding.content,
+                    vertical = Spacing.xs
+                )
+            )
+        }
         Text(
             text = "Change category",
             style = MaterialTheme.typography.titleMedium,


### PR DESCRIPTION
Closes #696.

## Request
Let users add a **custom tag** at capture time — "in the notification itself" — to differentiate spending within a category (e.g. Food & Dining → necessary vs pleasure), without opening the app.

## What already existed
Custom tags are a full in-app feature (create/apply/filter, `TagInputField`, `TagRepository`), and the txn-alert notification (#303) already has a **More…** action opening `QuickCategoryPickerSheet`. This PR brings tagging to that sheet — the notification's action bar is already full (2 category quick-picks + More…), so a new affordance there wasn't an option.

## Change (UI-only)
- `QuickCategoryPickerSheet` gains optional `tagSuggestions` / `initialTags` / `onTagsChanged`. When `onTagsChanged` is non-null, a **Tags** section (reusing `TagInputField`) renders above the category list. Each add/remove **commits immediately**, so tagging works even if the user dismisses without picking a category. In-app call sites omit these params → unchanged.
- `QuickCategoryPickerActivity` injects `TagRepository`, seeds the field from the txn's current tags + all tag names for autocomplete, and persists via `setTagsForTransaction`.

## Verification
`./init.sh app` green. UI change — worth an on-device look at the More… sheet from a transaction notification before merge.