### PR TITLE
feat(recurring): scheduled manual/cash transactions that auto-add (#706)

### DIFF
--- a/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/59.json
+++ b/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/59.json
@@ -1,0 +1,2040 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 59,
+    "identityHash": "ca3a1823a465639a0204e825aa640a20",
+    "entities": [
+      {
+        "tableName": "transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` TEXT NOT NULL, `merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `transaction_type` TEXT NOT NULL, `date_time` TEXT NOT NULL, `description` TEXT, `sms_body` TEXT, `bank_name` TEXT, `sms_sender` TEXT, `account_number` TEXT, `balance_after` TEXT, `transaction_hash` TEXT NOT NULL DEFAULT '', `is_recurring` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `excluded_from_analytics` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `from_account` TEXT, `to_account` TEXT, `reference` TEXT, `loan_id` INTEGER DEFAULT NULL, `loan_contribution` TEXT DEFAULT NULL, `receipt_path` TEXT DEFAULT NULL, `budget_category` TEXT DEFAULT NULL, `budget_impact_type` TEXT DEFAULT NULL, `group_id` INTEGER DEFAULT NULL, `profile_id` INTEGER DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionType",
+            "columnName": "transaction_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateTime",
+            "columnName": "date_time",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsSender",
+            "columnName": "sms_sender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountNumber",
+            "columnName": "account_number",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "balanceAfter",
+            "columnName": "balance_after",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "transactionHash",
+            "columnName": "transaction_hash",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isRecurring",
+            "columnName": "is_recurring",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "excludedFromAnalytics",
+            "columnName": "excluded_from_analytics",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "fromAccount",
+            "columnName": "from_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toAccount",
+            "columnName": "to_account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "loanId",
+            "columnName": "loan_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "loanContribution",
+            "columnName": "loan_contribution",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "receiptPath",
+            "columnName": "receipt_path",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetCategory",
+            "columnName": "budget_category",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "budgetImpactType",
+            "columnName": "budget_impact_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "group_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transactions_transaction_hash",
+            "unique": true,
+            "columnNames": [
+              "transaction_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_transactions_transaction_hash` ON `${TABLE_NAME}` (`transaction_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `merchant_name` TEXT NOT NULL, `amount` TEXT NOT NULL, `next_payment_date` TEXT, `state` TEXT NOT NULL, `bank_name` TEXT, `account_last4` TEXT, `umn` TEXT, `category` TEXT, `sms_body` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `direction` TEXT NOT NULL DEFAULT 'EXPENSE', `billing_cycle` TEXT NOT NULL DEFAULT 'Monthly', `last_paid_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextPaymentDate",
+            "columnName": "next_payment_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "umn",
+            "columnName": "umn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'EXPENSE'"
+          },
+          {
+            "fieldPath": "billingCycle",
+            "columnName": "billing_cycle",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Monthly'"
+          },
+          {
+            "fieldPath": "lastPaidAt",
+            "columnName": "last_paid_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `message` TEXT NOT NULL, `isUser` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `isSystemPrompt` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUser",
+            "columnName": "isUser",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemPrompt",
+            "columnName": "isSystemPrompt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "merchant_mappings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`merchant_name` TEXT NOT NULL, `category` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`merchant_name`))",
+        "fields": [
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "merchant_name"
+          ]
+        }
+      },
+      {
+        "tableName": "merchant_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`merchant_name` TEXT NOT NULL, `alias` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`merchant_name`))",
+        "fields": [
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "merchant_name"
+          ]
+        }
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `color` TEXT NOT NULL, `is_system` INTEGER NOT NULL, `is_income` INTEGER NOT NULL, `display_order` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIncome",
+            "columnName": "is_income",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_categories_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_categories_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "account_balances",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT NOT NULL, `balance` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `transaction_id` INTEGER, `credit_limit` TEXT, `is_credit_card` INTEGER NOT NULL DEFAULT 0, `sms_source` TEXT, `source_type` TEXT, `account_type` TEXT, `created_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `statement_day` INTEGER DEFAULT NULL, `profile_id` INTEGER NOT NULL DEFAULT 1, `alias` TEXT, `lowBalanceThreshold` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "creditLimit",
+            "columnName": "credit_limit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isCreditCard",
+            "columnName": "is_credit_card",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "smsSource",
+            "columnName": "sms_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "source_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountType",
+            "columnName": "account_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "statementDay",
+            "columnName": "statement_day",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lowBalanceThreshold",
+            "columnName": "lowBalanceThreshold",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_account_balances_bank_name_account_last4_timestamp",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "account_last4",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4_timestamp` ON `${TABLE_NAME}` (`bank_name`, `account_last4`, `timestamp`)"
+          },
+          {
+            "name": "index_account_balances_bank_name_account_last4",
+            "unique": false,
+            "columnNames": [
+              "bank_name",
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_bank_name_account_last4` ON `${TABLE_NAME}` (`bank_name`, `account_last4`)"
+          },
+          {
+            "name": "index_account_balances_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_balances_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "unrecognized_sms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sender` TEXT NOT NULL, `sms_body` TEXT NOT NULL, `received_at` TEXT NOT NULL, `reported` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "smsBody",
+            "columnName": "sms_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receivedAt",
+            "columnName": "received_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reported",
+            "columnName": "reported",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_unrecognized_sms_sender_sms_body",
+            "unique": true,
+            "columnNames": [
+              "sender",
+              "sms_body"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_unrecognized_sms_sender_sms_body` ON `${TABLE_NAME}` (`sender`, `sms_body`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `card_last4` TEXT NOT NULL, `card_type` TEXT NOT NULL, `bank_name` TEXT NOT NULL, `account_last4` TEXT, `nickname` TEXT, `is_active` INTEGER NOT NULL DEFAULT 1, `last_balance` TEXT, `last_balance_source` TEXT, `last_balance_date` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardLast4",
+            "columnName": "card_last4",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardType",
+            "columnName": "card_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastBalance",
+            "columnName": "last_balance",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceSource",
+            "columnName": "last_balance_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastBalanceDate",
+            "columnName": "last_balance_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cards_bank_name_card_last4",
+            "unique": true,
+            "columnNames": [
+              "bank_name",
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cards_bank_name_card_last4` ON `${TABLE_NAME}` (`bank_name`, `card_last4`)"
+          },
+          {
+            "name": "index_cards_card_last4",
+            "unique": false,
+            "columnNames": [
+              "card_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_card_last4` ON `${TABLE_NAME}` (`card_last4`)"
+          },
+          {
+            "name": "index_cards_account_last4",
+            "unique": false,
+            "columnNames": [
+              "account_last4"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_account_last4` ON `${TABLE_NAME}` (`account_last4`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `conditions` TEXT NOT NULL, `actions` TEXT NOT NULL, `is_active` INTEGER NOT NULL, `is_system_template` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conditions",
+            "columnName": "conditions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actions",
+            "columnName": "actions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystemTemplate",
+            "columnName": "is_system_template",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_rules_priority_is_active",
+            "unique": false,
+            "columnNames": [
+              "priority",
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_priority_is_active` ON `${TABLE_NAME}` (`priority`, `is_active`)"
+          },
+          {
+            "name": "index_transaction_rules_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_rules_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "rule_applications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `rule_id` TEXT NOT NULL, `rule_name` TEXT NOT NULL, `transaction_id` TEXT NOT NULL, `fields_modified` TEXT NOT NULL, `applied_at` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`rule_id`) REFERENCES `transaction_rules`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "rule_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleName",
+            "columnName": "rule_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fieldsModified",
+            "columnName": "fields_modified",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedAt",
+            "columnName": "applied_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rule_applications_rule_id",
+            "unique": false,
+            "columnNames": [
+              "rule_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_rule_id` ON `${TABLE_NAME}` (`rule_id`)"
+          },
+          {
+            "name": "index_rule_applications_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          },
+          {
+            "name": "index_rule_applications_applied_at",
+            "unique": false,
+            "columnNames": [
+              "applied_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rule_applications_applied_at` ON `${TABLE_NAME}` (`applied_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transaction_rules",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "rule_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "exchange_rates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `from_currency` TEXT NOT NULL, `to_currency` TEXT NOT NULL, `rate` TEXT NOT NULL, `provider` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `updated_at_unix` INTEGER NOT NULL DEFAULT 0, `expires_at` TEXT NOT NULL, `expires_at_unix` INTEGER NOT NULL DEFAULT 0, `is_custom_rate` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCurrency",
+            "columnName": "from_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCurrency",
+            "columnName": "to_currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtUnix",
+            "columnName": "updated_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expires_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAtUnix",
+            "columnName": "expires_at_unix",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isCustomRate",
+            "columnName": "is_custom_rate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_exchange_rates_from_currency_to_currency",
+            "unique": true,
+            "columnNames": [
+              "from_currency",
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_exchange_rates_from_currency_to_currency` ON `${TABLE_NAME}` (`from_currency`, `to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_from_currency",
+            "unique": false,
+            "columnNames": [
+              "from_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_from_currency` ON `${TABLE_NAME}` (`from_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_to_currency",
+            "unique": false,
+            "columnNames": [
+              "to_currency"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_to_currency` ON `${TABLE_NAME}` (`to_currency`)"
+          },
+          {
+            "name": "index_exchange_rates_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          },
+          {
+            "name": "index_exchange_rates_expires_at_unix",
+            "unique": false,
+            "columnNames": [
+              "expires_at_unix"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exchange_rates_expires_at_unix` ON `${TABLE_NAME}` (`expires_at_unix`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `period_type` TEXT NOT NULL, `start_date` TEXT NOT NULL, `end_date` TEXT NOT NULL, `weekday_anchor` INTEGER, `month_anchor` INTEGER, `currency` TEXT NOT NULL DEFAULT 'INR', `is_active` INTEGER NOT NULL DEFAULT 1, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "periodType",
+            "columnName": "period_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weekStartDay",
+            "columnName": "weekday_anchor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "monthStartDay",
+            "columnName": "month_anchor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budgets_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_budgets_is_active",
+            "unique": false,
+            "columnNames": [
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budgets_is_active` ON `${TABLE_NAME}` (`is_active`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budget_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL DEFAULT '0', `match_type` TEXT DEFAULT NULL, FOREIGN KEY(`budget_id`) REFERENCES `budgets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          },
+          {
+            "fieldPath": "matchType",
+            "columnName": "match_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budget_categories_budget_id",
+            "unique": false,
+            "columnNames": [
+              "budget_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_budget_categories_budget_id` ON `${TABLE_NAME}` (`budget_id`)"
+          },
+          {
+            "name": "index_budget_categories_budget_id_category_name",
+            "unique": true,
+            "columnNames": [
+              "budget_id",
+              "category_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_budget_categories_budget_id_category_name` ON `${TABLE_NAME}` (`budget_id`, `category_name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "budgets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "budget_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "budget_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `budget_name` TEXT NOT NULL, `limit_amount` TEXT NOT NULL, `include_all_categories` INTEGER NOT NULL DEFAULT 0, `color` TEXT NOT NULL DEFAULT '#1565C0', `group_type` TEXT NOT NULL DEFAULT 'LIMIT', `display_order` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetName",
+            "columnName": "budget_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limitAmount",
+            "columnName": "limit_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includeAllCategories",
+            "columnName": "include_all_categories",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#1565C0'"
+          },
+          {
+            "fieldPath": "groupType",
+            "columnName": "group_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LIMIT'"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "budget_category_month_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budget_id` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `category_name` TEXT NOT NULL, `budget_amount` TEXT NOT NULL, `match_type` TEXT DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budget_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetAmount",
+            "columnName": "budget_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchType",
+            "columnName": "match_type",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "transaction_splits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `transaction_id` INTEGER NOT NULL, `category` TEXT NOT NULL, `amount` TEXT NOT NULL, `created_at` TEXT NOT NULL, FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_splits_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_splits_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bank_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `package_name` TEXT NOT NULL, `sender_alias` TEXT NOT NULL, `message_body` TEXT NOT NULL, `message_hash` TEXT NOT NULL, `posted_at` TEXT NOT NULL, `processed` INTEGER NOT NULL, `transaction_id` INTEGER, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderAlias",
+            "columnName": "sender_alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageBody",
+            "columnName": "message_body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageHash",
+            "columnName": "message_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postedAt",
+            "columnName": "posted_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "processed",
+            "columnName": "processed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bank_notifications_package_name_message_hash",
+            "unique": true,
+            "columnNames": [
+              "package_name",
+              "message_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_bank_notifications_package_name_message_hash` ON `${TABLE_NAME}` (`package_name`, `message_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "loans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `person_name` TEXT NOT NULL, `direction` TEXT NOT NULL, `original_amount` TEXT NOT NULL, `remaining_amount` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `status` TEXT NOT NULL DEFAULT 'ACTIVE', `note` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `settled_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personName",
+            "columnName": "person_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalAmount",
+            "columnName": "original_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remainingAmount",
+            "columnName": "remaining_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'ACTIVE'"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settledAt",
+            "columnName": "settled_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_loans_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_loans_person_name",
+            "unique": false,
+            "columnNames": [
+              "person_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_person_name` ON `${TABLE_NAME}` (`person_name`)"
+          },
+          {
+            "name": "index_loans_created_at",
+            "unique": false,
+            "columnNames": [
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_loans_created_at` ON `${TABLE_NAME}` (`created_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `note` TEXT DEFAULT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_groups_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_groups_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `color_hex` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorHex",
+            "columnName": "color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `created_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tags_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tags_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transaction_tag_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transaction_id` INTEGER NOT NULL, `tag_id` INTEGER NOT NULL, PRIMARY KEY(`transaction_id`, `tag_id`), FOREIGN KEY(`transaction_id`) REFERENCES `transactions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tag_id`) REFERENCES `tags`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transaction_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tag_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transaction_id",
+            "tag_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_tag_cross_ref_transaction_id",
+            "unique": false,
+            "columnNames": [
+              "transaction_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_tag_cross_ref_transaction_id` ON `${TABLE_NAME}` (`transaction_id`)"
+          },
+          {
+            "name": "index_transaction_tag_cross_ref_tag_id",
+            "unique": false,
+            "columnNames": [
+              "tag_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_tag_cross_ref_tag_id` ON `${TABLE_NAME}` (`tag_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "transactions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transaction_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "tags",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tag_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recurring_transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `merchant_name` TEXT NOT NULL, `amount` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `category` TEXT NOT NULL DEFAULT 'Others', `transaction_type` TEXT NOT NULL DEFAULT 'EXPENSE', `frequency` TEXT NOT NULL DEFAULT 'MONTHLY', `day_of_month` INTEGER, `day_of_week` INTEGER, `next_due_date` TEXT NOT NULL, `is_active` INTEGER NOT NULL DEFAULT 1, `account_last4` TEXT, `bank_name` TEXT, `note` TEXT, `profile_id` INTEGER NOT NULL DEFAULT 1, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchant_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INR'"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Others'"
+          },
+          {
+            "fieldPath": "transactionType",
+            "columnName": "transaction_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'EXPENSE'"
+          },
+          {
+            "fieldPath": "frequency",
+            "columnName": "frequency",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'MONTHLY'"
+          },
+          {
+            "fieldPath": "dayOfMonth",
+            "columnName": "day_of_month",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dayOfWeek",
+            "columnName": "day_of_week",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "nextDueDate",
+            "columnName": "next_due_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "accountLast4",
+            "columnName": "account_last4",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bank_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profile_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ca3a1823a465639a0204e825aa640a20')"
+    ]
+  }
+}

--- a/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/59.json
+++ b/app/schemas/com.pennywiseai.tracker.data.database.PennyWiseDatabase/59.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 59,
-    "identityHash": "ca3a1823a465639a0204e825aa640a20",
+    "identityHash": "e545ff87f15ab20d71be747d330aeb4a",
     "entities": [
       {
         "tableName": "transactions",
@@ -1918,13 +1918,20 @@
       },
       {
         "tableName": "recurring_transactions",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `merchant_name` TEXT NOT NULL, `amount` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `category` TEXT NOT NULL DEFAULT 'Others', `transaction_type` TEXT NOT NULL DEFAULT 'EXPENSE', `frequency` TEXT NOT NULL DEFAULT 'MONTHLY', `day_of_month` INTEGER, `day_of_week` INTEGER, `next_due_date` TEXT NOT NULL, `is_active` INTEGER NOT NULL DEFAULT 1, `account_last4` TEXT, `bank_name` TEXT, `note` TEXT, `profile_id` INTEGER NOT NULL DEFAULT 1, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `uid` TEXT NOT NULL DEFAULT '', `merchant_name` TEXT NOT NULL, `amount` TEXT NOT NULL, `currency` TEXT NOT NULL DEFAULT 'INR', `category` TEXT NOT NULL DEFAULT 'Others', `transaction_type` TEXT NOT NULL DEFAULT 'EXPENSE', `frequency` TEXT NOT NULL DEFAULT 'MONTHLY', `day_of_month` INTEGER, `day_of_week` INTEGER, `next_due_date` TEXT NOT NULL, `is_active` INTEGER NOT NULL DEFAULT 1, `account_last4` TEXT, `bank_name` TEXT, `note` TEXT, `profile_id` INTEGER NOT NULL DEFAULT 1, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
         "fields": [
           {
             "fieldPath": "id",
             "columnName": "id",
             "affinity": "INTEGER",
             "notNull": true
+          },
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
           },
           {
             "fieldPath": "merchantName",
@@ -2034,7 +2041,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ca3a1823a465639a0204e825aa640a20')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e545ff87f15ab20d71be747d330aeb4a')"
     ]
   }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/PennyWiseApplication.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/PennyWiseApplication.kt
@@ -75,6 +75,12 @@ class PennyWiseApplication : Application(), Configuration.Provider {
             }
         }
 
+        // Materialise recurring / scheduled manual (cash) transactions (#706):
+        // a daily periodic run plus a one-shot catch-up now, so a device that was
+        // off still creates anything that came due while it was down.
+        com.pennywiseai.tracker.worker.RecurringTransactionWorker.enqueuePeriodic(this)
+        com.pennywiseai.tracker.worker.RecurringTransactionWorker.enqueueOneShotCatchUp(this)
+
         // Keep CurrencyFormatter's number-format style in sync with the user's
         // preference. CurrencyFormatter is a stateless object used from non-Compose
         // contexts (widgets, workers) too, so we push the value into its @Volatile

--- a/app/src/main/java/com/pennywiseai/tracker/billing/FreeTierLimits.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/billing/FreeTierLimits.kt
@@ -19,4 +19,7 @@ object FreeTierLimits {
 
     /** Max rows a free user can export to CSV per calendar month. Pro = unlimited. */
     const val MAX_CSV_EXPORT_ROWS_PER_MONTH = 100
+
+    /** Max recurring transaction templates a free user can create. Pro = unlimited. (#706) */
+    const val MAX_RECURRING_TEMPLATES = 1
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupExporter.kt
@@ -83,6 +83,7 @@ class BackupExporter @Inject constructor(
         val budgetCategoryMonthSnapshots = database.budgetSnapshotDao().getAllCategorySnapshots()
         val tags = database.tagDao().getAllTagsSync()
         val transactionTagCrossRefs = database.tagDao().getAllCrossRefs()
+        val recurringTransactions = database.recurringTransactionDao().getAll().first()
         
         // Get preferences from repository
         val prefs = userPreferencesRepository.userPreferences.first()
@@ -144,6 +145,9 @@ class BackupExporter @Inject constructor(
         // the cross-refs point at transaction ids that only survive a FULL export.
         val exportedTags = tags
         val exportedTransactionTagCrossRefs = if (privacy == ExportPrivacy.FULL) transactionTagCrossRefs else emptyList()
+        // Recurring templates carry raw merchant names + notes, so they're kept
+        // on FULL only — same treatment as loans / other relational tables.
+        val exportedRecurringTransactions = if (privacy == ExportPrivacy.FULL) recurringTransactions else emptyList()
 
         return PennyWiseBackup(
             metadata = BackupMetadata(
@@ -170,6 +174,7 @@ class BackupExporter @Inject constructor(
                     totalBudgetMonthSnapshots = exportedBudgetMonthSnapshots.size,
                     totalBudgetCategoryMonthSnapshots = exportedBudgetCategoryMonthSnapshots.size,
                     totalMerchantAliases = merchantAliases.size,
+                    totalRecurringTransactions = exportedRecurringTransactions.size,
                     dateRange = dateRange
                 )
             ),
@@ -196,7 +201,8 @@ class BackupExporter @Inject constructor(
                 budgetMonthSnapshots = exportedBudgetMonthSnapshots,
                 budgetCategoryMonthSnapshots = exportedBudgetCategoryMonthSnapshots,
                 tags = exportedTags,
-                transactionTagCrossRefs = exportedTransactionTagCrossRefs
+                transactionTagCrossRefs = exportedTransactionTagCrossRefs,
+                recurringTransactions = exportedRecurringTransactions
             ),
             preferences = PreferencesSnapshot(
                 theme = ThemePreferences(

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
@@ -268,8 +268,10 @@ class BackupImporter @Inject constructor(
                 // profile_id is remapped so materialized transactions land under
                 // the right local profile. (Greptile)
                 backup.database.recurringTransactions.insertEachCounting({ skippedRows++ }) { recurring ->
+                    // Fall back to the default Personal profile (1) when the source
+                    // profile can't be mapped, rather than keeping a stale/invalid id.
                     database.recurringTransactionDao().insert(
-                        recurring.copy(profileId = resolveProfileId(recurring.profileId) ?: recurring.profileId)
+                        recurring.copy(profileId = resolveProfileId(recurring.profileId) ?: 1L)
                     )
                 }
 
@@ -636,7 +638,9 @@ class BackupImporter @Inject constructor(
             .toMutableSet()
 
         recurring.insertEachCounting(onSkip) { template ->
-            val mappedProfileId = resolveProfileId(template.profileId) ?: template.profileId
+            // Fall back to the default Personal profile (1) when unmapped, so a
+            // template never restores under a stale/invalid profile id.
+            val mappedProfileId = resolveProfileId(template.profileId) ?: 1L
             val key = keyOf(template, mappedProfileId)
             if (seenKeys.add(key)) {
                 database.recurringTransactionDao().insert(template.copy(id = 0, profileId = mappedProfileId))

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
@@ -264,9 +264,13 @@ class BackupImporter @Inject constructor(
 
                 // Recurring / scheduled manual transaction templates (#706).
                 // Standalone table (no foreign keys); ids are preserved in
-                // REPLACE_ALL like every other cleared table.
+                // REPLACE_ALL like every other cleared table, but the source
+                // profile_id is remapped so materialized transactions land under
+                // the right local profile. (Greptile)
                 backup.database.recurringTransactions.insertEachCounting({ skippedRows++ }) { recurring ->
-                    database.recurringTransactionDao().insert(recurring)
+                    database.recurringTransactionDao().insert(
+                        recurring.copy(profileId = resolveProfileId(recurring.profileId) ?: recurring.profileId)
+                    )
                 }
 
                 // Profiles were already imported earlier (before transactions /
@@ -419,7 +423,7 @@ class BackupImporter @Inject constructor(
                 importCardsWithMerge(backup.database.cards) { skippedRows++ }
                 importAccountBalancesWithMerge(backup.database.accountBalances, { resolveProfileId(it) }) { skippedRows++ }
                 importSubscriptionsWithMerge(backup.database.subscriptions) { skippedRows++ }
-                importRecurringTransactionsWithMerge(backup.database.recurringTransactions) { skippedRows++ }
+                importRecurringTransactionsWithMerge(backup.database.recurringTransactions, { resolveProfileId(it) }) { skippedRows++ }
                 importMerchantMappingsWithMerge(backup.database.merchantMappings) { skippedRows++ }
                 importMerchantAliasesWithMerge(backup.database.merchantAliases) { skippedRows++ }
 
@@ -601,22 +605,39 @@ class BackupImporter @Inject constructor(
     
     /**
      * Import recurring / scheduled manual transaction templates with duplicate
-     * checking (#706). Dedup by (merchant, amount, frequency) so a repeat MERGE
-     * of the same backup doesn't stack duplicate templates; a fresh id is
-     * assigned so imported rows never collide with local ones.
+     * checking (#706). The dedup key covers every schedule-distinguishing field
+     * (merchant, amount, currency, category, type, frequency, day-of-month/week,
+     * profile), so a repeat MERGE of the same backup doesn't stack duplicates
+     * while genuinely distinct templates are never collapsed (Greptile). The
+     * source profile_id is remapped so materialized transactions land under the
+     * right local profile, and a fresh id avoids colliding with local rows.
      */
     private suspend fun importRecurringTransactionsWithMerge(
         recurring: List<RecurringTransactionEntity>,
+        resolveProfileId: (Long?) -> Long?,
         onSkip: () -> Unit
     ) {
-        val existingKeys = database.recurringTransactionDao().getAll().first()
-            .map { "${it.merchantName}_${it.amount}_${it.frequency}" }
-            .toSet()
+        fun keyOf(t: RecurringTransactionEntity, profileId: Long) = listOf(
+            t.merchantName,
+            t.amount.stripTrailingZeros().toPlainString(),
+            t.currency,
+            t.category,
+            t.transactionType,
+            t.frequency,
+            t.dayOfMonth,
+            t.dayOfWeek,
+            profileId
+        ).joinToString("|")
+
+        val seenKeys = database.recurringTransactionDao().getAll().first()
+            .map { keyOf(it, it.profileId) }
+            .toMutableSet()
 
         recurring.insertEachCounting(onSkip) { template ->
-            val key = "${template.merchantName}_${template.amount}_${template.frequency}"
-            if (!existingKeys.contains(key)) {
-                database.recurringTransactionDao().insert(template.copy(id = 0))
+            val mappedProfileId = resolveProfileId(template.profileId) ?: template.profileId
+            val key = keyOf(template, mappedProfileId)
+            if (seenKeys.add(key)) {
+                database.recurringTransactionDao().insert(template.copy(id = 0, profileId = mappedProfileId))
             }
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
@@ -631,6 +631,8 @@ class BackupImporter @Inject constructor(
             t.bankName,
             t.accountLast4,
             t.note,
+            t.nextDueDate,
+            t.isActive,
             profileId
         ).joinToString("|")
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
@@ -269,9 +269,13 @@ class BackupImporter @Inject constructor(
                 // the right local profile. (Greptile)
                 backup.database.recurringTransactions.insertEachCounting({ skippedRows++ }) { recurring ->
                     // Fall back to the default Personal profile (1) when the source
-                    // profile can't be mapped, rather than keeping a stale/invalid id.
+                    // profile can't be mapped, rather than keeping a stale/invalid id;
+                    // give a fresh uid to any blank/legacy one.
                     database.recurringTransactionDao().insert(
-                        recurring.copy(profileId = resolveProfileId(recurring.profileId) ?: 1L)
+                        recurring.copy(
+                            uid = recurring.uid.ifEmpty { java.util.UUID.randomUUID().toString() },
+                            profileId = resolveProfileId(recurring.profileId) ?: 1L
+                        )
                     )
                 }
 
@@ -619,34 +623,26 @@ class BackupImporter @Inject constructor(
         resolveProfileId: (Long?) -> Long?,
         onSkip: () -> Unit
     ) {
-        fun keyOf(t: RecurringTransactionEntity, profileId: Long) = listOf(
-            t.merchantName,
-            t.amount.stripTrailingZeros().toPlainString(),
-            t.currency,
-            t.category,
-            t.transactionType,
-            t.frequency,
-            t.dayOfMonth,
-            t.dayOfWeek,
-            t.bankName,
-            t.accountLast4,
-            t.note,
-            t.nextDueDate,
-            t.isActive,
-            profileId
-        ).joinToString("|")
-
-        val seenKeys = database.recurringTransactionDao().getAll().first()
-            .map { keyOf(it, it.profileId) }
-            .toMutableSet()
+        // Dedup on the stable [RecurringTransactionEntity.uid], not on mutable
+        // content: a repeated restore of the same backup can't duplicate a
+        // template (same uid), while genuinely distinct templates always have
+        // distinct uids and are always kept. A blank/legacy uid gets a fresh one
+        // so it still inserts.
+        val seenUids = database.recurringTransactionDao().getAll().first()
+            .map { it.uid }.filter { it.isNotEmpty() }.toMutableSet()
 
         recurring.insertEachCounting(onSkip) { template ->
-            // Fall back to the default Personal profile (1) when unmapped, so a
-            // template never restores under a stale/invalid profile id.
-            val mappedProfileId = resolveProfileId(template.profileId) ?: 1L
-            val key = keyOf(template, mappedProfileId)
-            if (seenKeys.add(key)) {
-                database.recurringTransactionDao().insert(template.copy(id = 0, profileId = mappedProfileId))
+            val uid = template.uid.ifEmpty { java.util.UUID.randomUUID().toString() }
+            if (seenUids.add(uid)) {
+                database.recurringTransactionDao().insert(
+                    template.copy(
+                        id = 0,
+                        uid = uid,
+                        // Fall back to the default Personal profile (1) when unmapped,
+                        // so a template never restores under a stale/invalid id.
+                        profileId = resolveProfileId(template.profileId) ?: 1L
+                    )
+                )
             }
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
@@ -273,7 +273,7 @@ class BackupImporter @Inject constructor(
                     // give a fresh uid to any blank/legacy one.
                     database.recurringTransactionDao().insert(
                         recurring.copy(
-                            uid = recurring.uid.ifEmpty { java.util.UUID.randomUUID().toString() },
+                            uid = stableUid(recurring),
                             profileId = resolveProfileId(recurring.profileId) ?: 1L
                         )
                     )
@@ -618,6 +618,29 @@ class BackupImporter @Inject constructor(
      * source profile_id is remapped so materialized transactions land under the
      * right local profile, and a fresh id avoids colliding with local rows.
      */
+    /**
+     * A stable uid for a template: the real one, or — for a blank/legacy uid —
+     * a deterministic content-derived id so re-importing the same legacy row is
+     * idempotent (same content → same uid → deduped), while distinct legacy rows
+     * still get distinct uids. New templates always carry a real uid.
+     */
+    private fun stableUid(t: RecurringTransactionEntity): String = t.uid.ifEmpty {
+        "legacy:" + listOf(
+            t.merchantName,
+            t.amount.stripTrailingZeros().toPlainString(),
+            t.currency,
+            t.category,
+            t.transactionType,
+            t.frequency,
+            t.dayOfMonth,
+            t.dayOfWeek,
+            t.bankName,
+            t.accountLast4,
+            t.note,
+            t.profileId
+        ).joinToString("|")
+    }
+
     private suspend fun importRecurringTransactionsWithMerge(
         recurring: List<RecurringTransactionEntity>,
         resolveProfileId: (Long?) -> Long?,
@@ -632,7 +655,7 @@ class BackupImporter @Inject constructor(
             .map { it.uid }.filter { it.isNotEmpty() }.toMutableSet()
 
         recurring.insertEachCounting(onSkip) { template ->
-            val uid = template.uid.ifEmpty { java.util.UUID.randomUUID().toString() }
+            val uid = stableUid(template)
             if (seenUids.add(uid)) {
                 database.recurringTransactionDao().insert(
                     template.copy(

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
@@ -134,6 +134,7 @@ class BackupImporter @Inject constructor(
                 // but tags live in their own table — clear both explicitly.
                 database.tagDao().deleteAllCrossRefs()
                 database.tagDao().deleteAllTags()
+                database.recurringTransactionDao().deleteAll()
                 // Note: budget categories and transaction splits are deleted via cascade (budget categories via budget deletion, transaction splits via transaction deletion)
                 // Profiles deliberately preserved — defaults (Personal=1, Business=2)
                 // are seeded on first launch and we don't want to wipe them.
@@ -259,6 +260,13 @@ class BackupImporter @Inject constructor(
                 }
                 backup.database.transactionTagCrossRefs.insertEachCounting({ skippedRows++ }) { ref ->
                     database.tagDao().insertCrossRef(ref)
+                }
+
+                // Recurring / scheduled manual transaction templates (#706).
+                // Standalone table (no foreign keys); ids are preserved in
+                // REPLACE_ALL like every other cleared table.
+                backup.database.recurringTransactions.insertEachCounting({ skippedRows++ }) { recurring ->
+                    database.recurringTransactionDao().insert(recurring)
                 }
 
                 // Profiles were already imported earlier (before transactions /
@@ -411,6 +419,7 @@ class BackupImporter @Inject constructor(
                 importCardsWithMerge(backup.database.cards) { skippedRows++ }
                 importAccountBalancesWithMerge(backup.database.accountBalances, { resolveProfileId(it) }) { skippedRows++ }
                 importSubscriptionsWithMerge(backup.database.subscriptions) { skippedRows++ }
+                importRecurringTransactionsWithMerge(backup.database.recurringTransactions) { skippedRows++ }
                 importMerchantMappingsWithMerge(backup.database.merchantMappings) { skippedRows++ }
                 importMerchantAliasesWithMerge(backup.database.merchantAliases) { skippedRows++ }
 
@@ -590,6 +599,28 @@ class BackupImporter @Inject constructor(
         }
     }
     
+    /**
+     * Import recurring / scheduled manual transaction templates with duplicate
+     * checking (#706). Dedup by (merchant, amount, frequency) so a repeat MERGE
+     * of the same backup doesn't stack duplicate templates; a fresh id is
+     * assigned so imported rows never collide with local ones.
+     */
+    private suspend fun importRecurringTransactionsWithMerge(
+        recurring: List<RecurringTransactionEntity>,
+        onSkip: () -> Unit
+    ) {
+        val existingKeys = database.recurringTransactionDao().getAll().first()
+            .map { "${it.merchantName}_${it.amount}_${it.frequency}" }
+            .toSet()
+
+        recurring.insertEachCounting(onSkip) { template ->
+            val key = "${template.merchantName}_${template.amount}_${template.frequency}"
+            if (!existingKeys.contains(key)) {
+                database.recurringTransactionDao().insert(template.copy(id = 0))
+            }
+        }
+    }
+
     /**
      * Import merchant mappings with merge
      */

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
@@ -630,6 +630,7 @@ class BackupImporter @Inject constructor(
             t.dayOfWeek,
             t.bankName,
             t.accountLast4,
+            t.note,
             profileId
         ).joinToString("|")
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupImporter.kt
@@ -626,6 +626,8 @@ class BackupImporter @Inject constructor(
             t.frequency,
             t.dayOfMonth,
             t.dayOfWeek,
+            t.bankName,
+            t.accountLast4,
             profileId
         ).joinToString("|")
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/backup/BackupModels.kt
@@ -135,6 +135,9 @@ data class BackupStatistics(
     @SerialName("total_merchant_aliases")
     val totalMerchantAliases: Int = 0,
 
+    @SerialName("total_recurring_transactions")
+    val totalRecurringTransactions: Int = 0,
+
     @SerialName("date_range")
     val dateRange: DateRange? = null
 )
@@ -227,7 +230,10 @@ data class DatabaseSnapshot(
     val tags: List<TagEntity> = emptyList(),
 
     @SerialName("transaction_tag_cross_refs")
-    val transactionTagCrossRefs: List<TransactionTagCrossRef> = emptyList()
+    val transactionTagCrossRefs: List<TransactionTagCrossRef> = emptyList(),
+
+    @SerialName("recurring_transactions")
+    val recurringTransactions: List<RecurringTransactionEntity> = emptyList()
 )
 
 /**

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
@@ -26,6 +26,7 @@ import com.pennywiseai.tracker.data.database.dao.MerchantAliasDao
 import com.pennywiseai.tracker.data.database.dao.BudgetSnapshotDao
 import com.pennywiseai.tracker.data.database.dao.TransactionGroupDao
 import com.pennywiseai.tracker.data.database.dao.RuleApplicationDao
+import com.pennywiseai.tracker.data.database.dao.RecurringTransactionDao
 import com.pennywiseai.tracker.data.database.dao.RuleDao
 import com.pennywiseai.tracker.data.database.dao.SubscriptionDao
 import com.pennywiseai.tracker.data.database.dao.TransactionDao
@@ -48,6 +49,7 @@ import com.pennywiseai.tracker.data.database.entity.LoanEntity
 import com.pennywiseai.tracker.data.database.entity.MerchantMappingEntity
 import com.pennywiseai.tracker.data.database.entity.MerchantAliasEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionGroupEntity
+import com.pennywiseai.tracker.data.database.entity.RecurringTransactionEntity
 import com.pennywiseai.tracker.data.database.entity.RuleApplicationEntity
 import com.pennywiseai.tracker.data.database.entity.RuleEntity
 import com.pennywiseai.tracker.data.database.entity.SubscriptionEntity
@@ -62,7 +64,7 @@ import com.pennywiseai.tracker.data.database.entity.UnrecognizedSmsEntity
  * that needs to record the version it was exported against. Bump this in lock-
  * step with any schema change.
  */
-const val SCHEMA_VERSION = 58
+const val SCHEMA_VERSION = 59
 
 /**
  * The PennyWise Room database.
@@ -75,7 +77,7 @@ const val SCHEMA_VERSION = 58
  * @property autoMigrations List of automatic migrations between versions.
  */
 @Database(
-    entities = [TransactionEntity::class, SubscriptionEntity::class, ChatMessage::class, MerchantMappingEntity::class, MerchantAliasEntity::class, CategoryEntity::class, AccountBalanceEntity::class, UnrecognizedSmsEntity::class, CardEntity::class, RuleEntity::class, RuleApplicationEntity::class, ExchangeRateEntity::class, BudgetEntity::class, BudgetCategoryEntity::class, BudgetMonthSnapshotEntity::class, BudgetCategoryMonthSnapshotEntity::class, TransactionSplitEntity::class, BankNotificationEntity::class, LoanEntity::class, TransactionGroupEntity::class, ProfileEntity::class, TagEntity::class, TransactionTagCrossRef::class],
+    entities = [TransactionEntity::class, SubscriptionEntity::class, ChatMessage::class, MerchantMappingEntity::class, MerchantAliasEntity::class, CategoryEntity::class, AccountBalanceEntity::class, UnrecognizedSmsEntity::class, CardEntity::class, RuleEntity::class, RuleApplicationEntity::class, ExchangeRateEntity::class, BudgetEntity::class, BudgetCategoryEntity::class, BudgetMonthSnapshotEntity::class, BudgetCategoryMonthSnapshotEntity::class, TransactionSplitEntity::class, BankNotificationEntity::class, LoanEntity::class, TransactionGroupEntity::class, ProfileEntity::class, TagEntity::class, TransactionTagCrossRef::class, RecurringTransactionEntity::class],
     version = SCHEMA_VERSION,
     exportSchema = true,
     autoMigrations = [
@@ -152,6 +154,7 @@ abstract class PennyWiseDatabase : RoomDatabase() {
     abstract fun budgetSnapshotDao(): BudgetSnapshotDao
     abstract fun profileDao(): ProfileDao
     abstract fun tagDao(): TagDao
+    abstract fun recurringTransactionDao(): RecurringTransactionDao
 
     companion object {
         const val DATABASE_NAME = "pennywise_database"
@@ -598,6 +601,40 @@ abstract class PennyWiseDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Adds the `recurring_transactions` table for user-defined recurring /
+         * scheduled manual (cash) transaction templates (#706). Purely additive
+         * — a new standalone table — but written as a manual migration so the
+         * exact column types / defaults match Room's generated identity for v59
+         * (schemas/.../59.json). Enums, dates and BigDecimal are TEXT; booleans
+         * and ints are INTEGER; nullable funding-account / day columns omit NOT
+         * NULL.
+         */
+        val MIGRATION_58_59 = object : Migration(58, 59) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `recurring_transactions` (" +
+                        "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                        "`merchant_name` TEXT NOT NULL, " +
+                        "`amount` TEXT NOT NULL, " +
+                        "`currency` TEXT NOT NULL DEFAULT 'INR', " +
+                        "`category` TEXT NOT NULL DEFAULT 'Others', " +
+                        "`transaction_type` TEXT NOT NULL DEFAULT 'EXPENSE', " +
+                        "`frequency` TEXT NOT NULL DEFAULT 'MONTHLY', " +
+                        "`day_of_month` INTEGER, " +
+                        "`day_of_week` INTEGER, " +
+                        "`next_due_date` TEXT NOT NULL, " +
+                        "`is_active` INTEGER NOT NULL DEFAULT 1, " +
+                        "`account_last4` TEXT, " +
+                        "`bank_name` TEXT, " +
+                        "`note` TEXT, " +
+                        "`profile_id` INTEGER NOT NULL DEFAULT 1, " +
+                        "`created_at` TEXT NOT NULL, " +
+                        "`updated_at` TEXT NOT NULL)"
+                )
+            }
+        }
+
         val MIGRATION_38_39 = object : Migration(38, 39) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 // Add receipt_path to transactions if missing
@@ -654,6 +691,7 @@ abstract class PennyWiseDatabase : RoomDatabase() {
             MIGRATION_53_54,
             MIGRATION_54_55,
             MIGRATION_57_58,
+            MIGRATION_58_59,
         )
     }
     

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/PennyWiseDatabase.kt
@@ -615,6 +615,7 @@ abstract class PennyWiseDatabase : RoomDatabase() {
                 db.execSQL(
                     "CREATE TABLE IF NOT EXISTS `recurring_transactions` (" +
                         "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                        "`uid` TEXT NOT NULL DEFAULT '', " +
                         "`merchant_name` TEXT NOT NULL, " +
                         "`amount` TEXT NOT NULL, " +
                         "`currency` TEXT NOT NULL DEFAULT 'INR', " +

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/RecurringTransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/RecurringTransactionDao.kt
@@ -1,0 +1,45 @@
+package com.pennywiseai.tracker.data.database.dao
+
+import androidx.room.*
+import com.pennywiseai.tracker.data.database.entity.RecurringTransactionEntity
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
+
+@Dao
+interface RecurringTransactionDao {
+
+    @Query("SELECT * FROM recurring_transactions ORDER BY next_due_date ASC")
+    fun getAll(): Flow<List<RecurringTransactionEntity>>
+
+    @Query("SELECT * FROM recurring_transactions WHERE is_active = 1 ORDER BY next_due_date ASC")
+    fun getActive(): Flow<List<RecurringTransactionEntity>>
+
+    @Query("SELECT * FROM recurring_transactions WHERE id = :id")
+    suspend fun getById(id: Long): RecurringTransactionEntity?
+
+    /**
+     * Active templates whose next due date is today or earlier — the daily
+     * worker materialises one transaction per row returned here, then advances
+     * each row's next_due_date past today.
+     */
+    @Query("SELECT * FROM recurring_transactions WHERE is_active = 1 AND next_due_date <= :today ORDER BY next_due_date ASC")
+    suspend fun getDue(today: LocalDate): List<RecurringTransactionEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(recurring: RecurringTransactionEntity): Long
+
+    @Update
+    suspend fun update(recurring: RecurringTransactionEntity)
+
+    @Delete
+    suspend fun delete(recurring: RecurringTransactionEntity)
+
+    @Query("DELETE FROM recurring_transactions WHERE id = :id")
+    suspend fun deleteById(id: Long)
+
+    @Query("UPDATE recurring_transactions SET next_due_date = :nextDueDate, updated_at = datetime('now') WHERE id = :id")
+    suspend fun updateNextDueDate(id: Long, nextDueDate: LocalDate)
+
+    @Query("DELETE FROM recurring_transactions")
+    suspend fun deleteAll()
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/RecurringTransactionEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/RecurringTransactionEntity.kt
@@ -32,6 +32,15 @@ data class RecurringTransactionEntity(
     @ColumnInfo(name = "id")
     val id: Long = 0,
 
+    /**
+     * Stable synthetic identity assigned at creation and carried through
+     * backups. Backup restore dedups on this (not on mutable content), so a
+     * repeated restore of the same backup never duplicates a template, while
+     * genuinely distinct templates always have distinct uids. (#706)
+     */
+    @ColumnInfo(name = "uid", defaultValue = "")
+    val uid: String = java.util.UUID.randomUUID().toString(),
+
     @ColumnInfo(name = "merchant_name")
     val merchantName: String = "",
 

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/RecurringTransactionEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/RecurringTransactionEntity.kt
@@ -1,0 +1,140 @@
+package com.pennywiseai.tracker.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+/**
+ * A user-defined recurring / scheduled MANUAL transaction template (#706).
+ *
+ * Unlike [SubscriptionEntity] — which is derived from bank SMS mandates and is
+ * matched against incoming debit SMS — a recurring transaction template has no
+ * SMS behind it. It exists for cash / manual spend (rent paid in cash, a weekly
+ * allowance, a monthly cleaner) that the user wants materialised automatically
+ * on a schedule. A daily worker ([com.pennywiseai.tracker.worker.RecurringTransactionWorker])
+ * calls the repository's `materializeDue`, which inserts a real
+ * [TransactionEntity] for every template whose [nextDueDate] has arrived and
+ * advances [nextDueDate] by the template's [frequency].
+ *
+ * ## Backup contract (#414)
+ * Every field has a Kotlin default so an older backup that omits any key still
+ * restores (see docs/backup-format.md, enforced by `BackupSchemaGuardTest`).
+ */
+@Entity(tableName = "recurring_transactions")
+@Serializable
+data class RecurringTransactionEntity(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "id")
+    val id: Long = 0,
+
+    @ColumnInfo(name = "merchant_name")
+    val merchantName: String = "",
+
+    @ColumnInfo(name = "amount")
+    @Contextual
+    val amount: BigDecimal = BigDecimal.ZERO,
+
+    @ColumnInfo(name = "currency", defaultValue = "INR")
+    val currency: String = "INR",
+
+    @ColumnInfo(name = "category", defaultValue = "Others")
+    val category: String = "Others",
+
+    @ColumnInfo(name = "transaction_type", defaultValue = "EXPENSE")
+    val transactionType: TransactionType = TransactionType.EXPENSE,
+
+    @ColumnInfo(name = "frequency", defaultValue = "MONTHLY")
+    val frequency: RecurringFrequency = RecurringFrequency.MONTHLY,
+
+    /** Day-of-month (1..31) the charge lands on, for MONTHLY / YEARLY. */
+    @ColumnInfo(name = "day_of_month")
+    val dayOfMonth: Int? = null,
+
+    /** ISO day-of-week (1=Mon .. 7=Sun) the charge lands on, for WEEKLY. */
+    @ColumnInfo(name = "day_of_week")
+    val dayOfWeek: Int? = null,
+
+    @ColumnInfo(name = "next_due_date")
+    @Contextual
+    val nextDueDate: LocalDate = LocalDate.now(),
+
+    @ColumnInfo(name = "is_active", defaultValue = "1")
+    val isActive: Boolean = true,
+
+    /**
+     * Optional funding account. When both are null the template is treated as
+     * cash (no account balance is moved when it materialises). When set they
+     * pair to identify the exact account, matching how the rest of the app
+     * keys accounts by (bank_name + account_last4).
+     */
+    @ColumnInfo(name = "account_last4")
+    val accountLast4: String? = null,
+
+    @ColumnInfo(name = "bank_name")
+    val bankName: String? = null,
+
+    @ColumnInfo(name = "note")
+    val note: String? = null,
+
+    @ColumnInfo(name = "profile_id", defaultValue = "1")
+    val profileId: Long = 1,
+
+    @ColumnInfo(name = "created_at")
+    @Contextual
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @ColumnInfo(name = "updated_at")
+    @Contextual
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
+    /**
+     * The next due date strictly after [from], **re-anchored** to this
+     * template's [dayOfMonth] / [dayOfWeek]. Stepping off the previous
+     * (possibly day-clamped) date would let a day-31 monthly template drift to
+     * the 28th permanently after February; anchoring to [dayOfMonth] each step
+     * keeps it on the 31st (clamped only for that short month). #706
+     */
+    fun nextDueAfter(from: LocalDate): LocalDate = when (frequency) {
+        RecurringFrequency.DAILY -> from.plusDays(1)
+        RecurringFrequency.WEEKLY -> from.plusWeeks(1) // +7d preserves the weekday
+        RecurringFrequency.MONTHLY -> {
+            val ym = java.time.YearMonth.from(from).plusMonths(1)
+            ym.atDay((dayOfMonth ?: from.dayOfMonth).coerceIn(1, ym.lengthOfMonth()))
+        }
+        RecurringFrequency.YEARLY -> {
+            val ym = java.time.YearMonth.from(from).plusYears(1)
+            ym.atDay((dayOfMonth ?: from.dayOfMonth).coerceIn(1, ym.lengthOfMonth()))
+        }
+    }
+}
+
+/**
+ * Cadence for a [RecurringTransactionEntity]. Stored as its enum name (TEXT) by
+ * Room's built-in enum support (no converter needed) and as a string by
+ * kotlinx.serialization for the backup.
+ */
+@Serializable
+enum class RecurringFrequency {
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+    YEARLY;
+
+    /**
+     * The next occurrence strictly after [from]. Month/year cadences use real
+     * calendar arithmetic (`plusMonths` / `plusYears` already clamp to the last
+     * valid day of a shorter target month, so a day-31 template lands on Feb 28
+     * / 29 rather than throwing).
+     */
+    fun advance(from: LocalDate): LocalDate = when (this) {
+        DAILY -> from.plusDays(1)
+        WEEKLY -> from.plusWeeks(1)
+        MONTHLY -> from.plusMonths(1)
+        YEARLY -> from.plusYears(1)
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/entity/RecurringTransactionEntity.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/entity/RecurringTransactionEntity.kt
@@ -51,7 +51,7 @@ data class RecurringTransactionEntity(
     @ColumnInfo(name = "frequency", defaultValue = "MONTHLY")
     val frequency: RecurringFrequency = RecurringFrequency.MONTHLY,
 
-    /** Day-of-month (1..31) the charge lands on, for MONTHLY / YEARLY. */
+    /** Day-of-month (1..31) the charge lands on, for MONTHLY. */
     @ColumnInfo(name = "day_of_month")
     val dayOfMonth: Int? = null,
 
@@ -106,10 +106,6 @@ data class RecurringTransactionEntity(
             val ym = java.time.YearMonth.from(from).plusMonths(1)
             ym.atDay((dayOfMonth ?: from.dayOfMonth).coerceIn(1, ym.lengthOfMonth()))
         }
-        RecurringFrequency.YEARLY -> {
-            val ym = java.time.YearMonth.from(from).plusYears(1)
-            ym.atDay((dayOfMonth ?: from.dayOfMonth).coerceIn(1, ym.lengthOfMonth()))
-        }
     }
 }
 
@@ -122,19 +118,20 @@ data class RecurringTransactionEntity(
 enum class RecurringFrequency {
     DAILY,
     WEEKLY,
-    MONTHLY,
-    YEARLY;
+    MONTHLY;
+
+    // Note: a yearly cadence needs a month anchor we don't model yet, so it's
+    // intentionally not offered. Add it back with a month field when supported.
 
     /**
-     * The next occurrence strictly after [from]. Month/year cadences use real
-     * calendar arithmetic (`plusMonths` / `plusYears` already clamp to the last
-     * valid day of a shorter target month, so a day-31 template lands on Feb 28
-     * / 29 rather than throwing).
+     * The next occurrence strictly after [from]. The monthly cadence uses real
+     * calendar arithmetic (`plusMonths` already clamps to the last valid day of
+     * a shorter target month, so a day-31 template lands on Feb 28/29 rather
+     * than throwing). [nextDueAfter] re-anchors monthly to dayOfMonth.
      */
     fun advance(from: LocalDate): LocalDate = when (this) {
         DAILY -> from.plusDays(1)
         WEEKLY -> from.plusWeeks(1)
         MONTHLY -> from.plusMonths(1)
-        YEARLY -> from.plusYears(1)
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/RecurringTransactionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/RecurringTransactionRepository.kt
@@ -1,0 +1,158 @@
+package com.pennywiseai.tracker.data.repository
+
+import android.util.Log
+import androidx.room.withTransaction
+import com.pennywiseai.tracker.data.database.PennyWiseDatabase
+import com.pennywiseai.tracker.data.database.dao.RecurringTransactionDao
+import com.pennywiseai.tracker.data.database.entity.RecurringTransactionEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionEntity
+import kotlinx.coroutines.flow.Flow
+import java.math.BigDecimal
+import java.security.MessageDigest
+import java.time.LocalDate
+import java.time.LocalDateTime
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * CRUD + scheduled materialisation for recurring / scheduled manual (cash)
+ * transaction templates (#706).
+ *
+ * A template has no SMS behind it — it exists so a user can schedule cash /
+ * manual spend (rent, allowance, a weekly cleaner) to be created automatically.
+ * [materializeDue] is the scheduler entry point: the daily
+ * [com.pennywiseai.tracker.worker.RecurringTransactionWorker] calls it, and it
+ * inserts a real [TransactionEntity] for every due active template — reusing
+ * [AccountBalanceRepository] so a linked funding account's balance moves the
+ * same way a hand-entered transaction's would — then advances each template's
+ * `nextDueDate` past today.
+ */
+@Singleton
+class RecurringTransactionRepository @Inject constructor(
+    private val dao: RecurringTransactionDao,
+    private val database: PennyWiseDatabase,
+    private val accountBalanceRepository: AccountBalanceRepository
+) {
+
+    companion object {
+        private const val TAG = "RecurringTxnRepository"
+    }
+
+    fun getAll(): Flow<List<RecurringTransactionEntity>> = dao.getAll()
+
+    fun getActive(): Flow<List<RecurringTransactionEntity>> = dao.getActive()
+
+    suspend fun getById(id: Long): RecurringTransactionEntity? = dao.getById(id)
+
+    suspend fun insert(recurring: RecurringTransactionEntity): Long = dao.insert(recurring)
+
+    suspend fun update(recurring: RecurringTransactionEntity) =
+        dao.update(recurring.copy(updatedAt = LocalDateTime.now()))
+
+    suspend fun delete(recurring: RecurringTransactionEntity) = dao.delete(recurring)
+
+    suspend fun deleteById(id: Long) = dao.deleteById(id)
+
+    /**
+     * Materialise every due active template into a real transaction and advance
+     * its schedule. Returns the number of transactions actually created.
+     *
+     * Double-insertion is guarded two ways, both belt-and-suspenders:
+     *  1. Each template's insert + date-advance run inside ONE Room transaction,
+     *     so a template whose `nextDueDate` we advance past today can't be
+     *     returned by `getDue` again on a later run the same day.
+     *  2. The created transaction gets a deterministic hash derived from the
+     *     template id + the due date, so even if the worker runs twice before
+     *     the advance commits, the second insert collides on the unique
+     *     `transaction_hash` index and no-ops (insert returns -1).
+     *
+     * A template that missed several cycles (device off) materialises ONCE and
+     * its schedule is fast-forwarded past today, rather than back-filling a
+     * burst of historical transactions.
+     */
+    suspend fun materializeDue(today: LocalDate = LocalDate.now()): Int {
+        val due = dao.getDue(today)
+        var created = 0
+        for (template in due) {
+            try {
+                database.withTransaction {
+                    val transaction = template.toTransaction()
+                    val rowId = accountBalanceRepository.insertTransactionWithBalance(
+                        transaction = transaction,
+                        bankName = template.bankName,
+                        accountLast4 = template.accountLast4
+                    )
+                    // Advance the schedule regardless of whether the insert was a
+                    // fresh row or a dedup no-op (-1): the intent is "this due
+                    // date has been handled, move on".
+                    dao.updateNextDueDate(template.id, nextDueDateAfter(template, today))
+                    if (rowId != -1L) created++
+                }
+            } catch (e: Exception) {
+                // One bad template must not abort the rest of the batch.
+                Log.w(TAG, "Failed to materialize recurring template ${template.id}: ${e.message}", e)
+            }
+        }
+        return created
+    }
+
+    /**
+     * The first occurrence strictly after [today], stepping by the template's
+     * cadence from its current [RecurringTransactionEntity.nextDueDate]. Loops
+     * so a template that missed several cycles lands on the next real future
+     * date instead of re-firing immediately.
+     */
+    private fun nextDueDateAfter(
+        template: RecurringTransactionEntity,
+        today: LocalDate
+    ): LocalDate {
+        var next = template.nextDueAfter(template.nextDueDate)
+        while (!next.isAfter(today)) {
+            next = template.nextDueAfter(next)
+        }
+        return next
+    }
+
+    /**
+     * Build the manual transaction for this template, mirroring how
+     * `AddTransactionUseCase` constructs a hand-entered one: null SMS fields
+     * mark it manual, and a null funding account falls back to "Manual Entry".
+     * The date is pinned to the scheduled due date (start of day) so the
+     * deterministic hash stays stable across worker re-runs.
+     */
+    private fun RecurringTransactionEntity.toTransaction(): TransactionEntity {
+        val now = LocalDateTime.now()
+        return TransactionEntity(
+            amount = amount,
+            merchantName = merchantName,
+            category = category,
+            transactionType = transactionType,
+            dateTime = nextDueDate.atStartOfDay(),
+            description = note,
+            smsBody = null,
+            bankName = bankName ?: "Manual Entry",
+            smsSender = null,
+            accountNumber = accountLast4,
+            balanceAfter = null,
+            transactionHash = recurringTransactionHash(id, amount, merchantName, nextDueDate),
+            currency = currency,
+            createdAt = now,
+            updatedAt = now,
+            profileId = profileId
+        )
+    }
+
+    private fun recurringTransactionHash(
+        templateId: Long,
+        amount: BigDecimal,
+        merchant: String,
+        dueDate: LocalDate
+    ): String {
+        // Template id + due date make this deterministic per (template, cycle),
+        // so a repeated run before the date advances collides on the unique hash.
+        val data = "RECURRING_${templateId}_${amount}_${merchant}_${dueDate}"
+        return MessageDigest.getInstance("MD5")
+            .digest(data.toByteArray())
+            .joinToString("") { "%02x".format(it) }
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/di/DatabaseModule.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/di/DatabaseModule.kt
@@ -20,6 +20,7 @@ import com.pennywiseai.tracker.data.database.dao.TransactionGroupDao
 import com.pennywiseai.tracker.data.database.dao.MerchantMappingDao
 import com.pennywiseai.tracker.data.database.dao.MerchantAliasDao
 import com.pennywiseai.tracker.data.database.dao.RuleApplicationDao
+import com.pennywiseai.tracker.data.database.dao.RecurringTransactionDao
 import com.pennywiseai.tracker.data.database.dao.RuleDao
 import com.pennywiseai.tracker.data.database.dao.SubscriptionDao
 import com.pennywiseai.tracker.data.database.dao.TagDao
@@ -279,6 +280,12 @@ object DatabaseModule {
     @Singleton
     fun provideTagDao(database: PennyWiseDatabase): TagDao {
         return database.tagDao()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRecurringTransactionDao(database: PennyWiseDatabase): RecurringTransactionDao {
+        return database.recurringTransactionDao()
     }
 }
 

--- a/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseDestinations.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseDestinations.kt
@@ -76,6 +76,9 @@ data class BudgetHistory(
 object Loans
 
 @Serializable
+object RecurringTransactions
+
+@Serializable
 data class LoanDetail(val loanId: Long)
 
 @Serializable

--- a/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseNavHost.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/navigation/PennyWiseNavHost.kt
@@ -384,6 +384,19 @@ fun PennyWiseNavHost(
             )
         }
 
+        composable<RecurringTransactions>(
+            enterTransition = { fadeIn(tween(300)) + slideInVertically { it / 4 } },
+            exitTransition = { fadeOut(tween(200)) },
+            popEnterTransition = { fadeIn(tween(300)) },
+            popExitTransition = { fadeOut(tween(200)) + slideOutVertically { it / 4 } }
+        ) {
+            com.pennywiseai.tracker.presentation.recurring.RecurringTransactionsScreen(
+                onNavigateBack = {
+                    navController.safePopBackStack()
+                }
+            )
+        }
+
         composable<LoanDetail>(
             enterTransition = { fadeIn(tween(300)) + slideInVertically { it / 4 } },
             exitTransition = { fadeOut(tween(200)) },

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.filled.EventRepeat
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -42,9 +43,12 @@ fun RecurringTransactionsScreen(
     val templates by viewModel.templates.collectAsStateWithLifecycle()
     val categories by viewModel.categories.collectAsStateWithLifecycle()
     val baseCurrency by viewModel.baseCurrency.collectAsStateWithLifecycle()
+    val canAddMore by viewModel.canAddMore.collectAsStateWithLifecycle()
 
     // Null = editor closed. Non-null = editing this form (id 0 for a fresh add).
     var editing by remember { mutableStateOf<RecurringFormState?>(null) }
+    // Free tier allows a limited number of templates; adding beyond it opens the paywall (#706).
+    var showUpgradeSheet by rememberSaveable { mutableStateOf(false) }
 
     val active = templates.filter { it.isActive }
     val paused = templates.filterNot { it.isActive }
@@ -58,7 +62,10 @@ fun RecurringTransactionsScreen(
         },
         floatingActionButton = {
             FloatingActionButton(
-                onClick = { editing = RecurringFormState(currency = baseCurrency) },
+                onClick = {
+                    if (canAddMore) editing = RecurringFormState(currency = baseCurrency)
+                    else showUpgradeSheet = true
+                },
                 containerColor = MaterialTheme.colorScheme.primaryContainer,
                 contentColor = MaterialTheme.colorScheme.onPrimaryContainer
             ) {
@@ -128,6 +135,12 @@ fun RecurringTransactionsScreen(
             categoryNames = categories.map { it.name },
             onDismiss = { editing = null },
             onSave = { viewModel.save(it); editing = null }
+        )
+    }
+
+    if (showUpgradeSheet) {
+        com.pennywiseai.tracker.presentation.paywall.UpgradeSheet(
+            onDismiss = { showUpgradeSheet = false },
         )
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsScreen.kt
@@ -1,0 +1,448 @@
+package com.pennywiseai.tracker.presentation.recurring
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.EventRepeat
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.pennywiseai.tracker.data.database.entity.RecurringFrequency
+import com.pennywiseai.tracker.data.database.entity.RecurringTransactionEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionType
+import com.pennywiseai.tracker.ui.components.PennyWiseEmptyState
+import com.pennywiseai.tracker.ui.components.PennyWiseScaffold
+import com.pennywiseai.tracker.ui.components.cards.PennyWiseCardV2
+import com.pennywiseai.tracker.ui.components.cards.SectionHeaderV2
+import com.pennywiseai.tracker.ui.theme.Dimensions
+import com.pennywiseai.tracker.ui.theme.Spacing
+import com.pennywiseai.tracker.utils.CurrencyFormatter
+import java.time.format.DateTimeFormatter
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RecurringTransactionsScreen(
+    onNavigateBack: () -> Unit = {},
+    viewModel: RecurringTransactionsViewModel = hiltViewModel()
+) {
+    val templates by viewModel.templates.collectAsStateWithLifecycle()
+    val categories by viewModel.categories.collectAsStateWithLifecycle()
+    val baseCurrency by viewModel.baseCurrency.collectAsStateWithLifecycle()
+
+    // Null = editor closed. Non-null = editing this form (id 0 for a fresh add).
+    var editing by remember { mutableStateOf<RecurringFormState?>(null) }
+
+    val active = templates.filter { it.isActive }
+    val paused = templates.filterNot { it.isActive }
+
+    PennyWiseScaffold(
+        title = "Recurring",
+        navigationIcon = {
+            IconButton(onClick = onNavigateBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { editing = RecurringFormState(currency = baseCurrency) },
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+            ) {
+                Icon(Icons.Default.Add, contentDescription = "Add recurring transaction")
+            }
+        }
+    ) { padding ->
+        if (templates.isEmpty()) {
+            Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+                PennyWiseEmptyState(
+                    icon = Icons.Default.EventRepeat,
+                    headline = "No recurring transactions",
+                    description = "Schedule cash or manual spend to be added automatically — rent, an allowance, a weekly cleaner."
+                )
+            }
+            editing?.let { form ->
+                RecurringEditorDialog(
+                    form = form,
+                    categoryNames = categories.map { it.name },
+                    onDismiss = { editing = null },
+                    onSave = { viewModel.save(it); editing = null }
+                )
+            }
+            return@PennyWiseScaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background),
+            contentPadding = PaddingValues(
+                start = Dimensions.Padding.content,
+                end = Dimensions.Padding.content,
+                top = Dimensions.Padding.content + padding.calculateTopPadding(),
+                bottom = padding.calculateBottomPadding() + 88.dp
+            ),
+            verticalArrangement = Arrangement.spacedBy(Spacing.md)
+        ) {
+            if (active.isNotEmpty()) {
+                item { SectionHeaderV2(title = "Active") }
+                items(active, key = { it.id }) { template ->
+                    RecurringItem(
+                        template = template,
+                        onEdit = { editing = RecurringFormState.from(template) },
+                        onToggleActive = { viewModel.setActive(template, it) },
+                        onDelete = { viewModel.delete(template) }
+                    )
+                }
+            }
+            if (paused.isNotEmpty()) {
+                item { SectionHeaderV2(title = "Paused") }
+                items(paused, key = { it.id }) { template ->
+                    RecurringItem(
+                        template = template,
+                        onEdit = { editing = RecurringFormState.from(template) },
+                        onToggleActive = { viewModel.setActive(template, it) },
+                        onDelete = { viewModel.delete(template) }
+                    )
+                }
+            }
+        }
+    }
+
+    editing?.let { form ->
+        RecurringEditorDialog(
+            form = form,
+            categoryNames = categories.map { it.name },
+            onDismiss = { editing = null },
+            onSave = { viewModel.save(it); editing = null }
+        )
+    }
+}
+
+private fun RecurringFrequency.label(): String = when (this) {
+    RecurringFrequency.DAILY -> "Daily"
+    RecurringFrequency.WEEKLY -> "Weekly"
+    RecurringFrequency.MONTHLY -> "Monthly"
+    RecurringFrequency.YEARLY -> "Yearly"
+}
+
+@Composable
+private fun RecurringItem(
+    template: RecurringTransactionEntity,
+    onEdit: () -> Unit,
+    onToggleActive: (Boolean) -> Unit,
+    onDelete: () -> Unit
+) {
+    var showMenu by remember { mutableStateOf(false) }
+    var showDeleteConfirm by remember { mutableStateOf(false) }
+
+    PennyWiseCardV2(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onEdit)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.md)
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = template.merchantName.ifBlank { "Untitled" },
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    text = buildString {
+                        append(template.frequency.label())
+                        append(" · Next ")
+                        append(template.nextDueDate.format(DateTimeFormatter.ofPattern("MMM d")))
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                template.category.takeIf { it.isNotBlank() }?.let {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            Text(
+                text = CurrencyFormatter.formatCurrency(template.amount, template.currency),
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+
+            Box {
+                IconButton(onClick = { showMenu = true }) {
+                    Icon(Icons.Default.MoreVert, contentDescription = "More options")
+                }
+                DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
+                    DropdownMenuItem(
+                        text = { Text(if (template.isActive) "Pause" else "Resume") },
+                        onClick = {
+                            showMenu = false
+                            onToggleActive(!template.isActive)
+                        }
+                    )
+                    DropdownMenuItem(
+                        text = { Text("Edit") },
+                        onClick = {
+                            showMenu = false
+                            onEdit()
+                        }
+                    )
+                    DropdownMenuItem(
+                        text = { Text("Delete", color = MaterialTheme.colorScheme.error) },
+                        leadingIcon = {
+                            Icon(
+                                Icons.Default.Delete,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.error
+                            )
+                        },
+                        onClick = {
+                            showMenu = false
+                            showDeleteConfirm = true
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    if (showDeleteConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirm = false },
+            title = { Text("Delete recurring transaction?") },
+            text = { Text("\"${template.merchantName}\" will stop being added automatically. This cannot be undone.") },
+            confirmButton = {
+                TextButton(onClick = { showDeleteConfirm = false; onDelete() }) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirm = false }) { Text("Cancel") }
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RecurringEditorDialog(
+    form: RecurringFormState,
+    categoryNames: List<String>,
+    onDismiss: () -> Unit,
+    onSave: (RecurringFormState) -> Unit
+) {
+    var state by remember { mutableStateOf(form) }
+    var freqExpanded by remember { mutableStateOf(false) }
+    var categoryExpanded by remember { mutableStateOf(false) }
+    var dowExpanded by remember { mutableStateOf(false) }
+
+    val dayOfWeekNames = listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(if (form.id == 0L) "New recurring" else "Edit recurring") },
+        text = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(Spacing.sm)
+            ) {
+                OutlinedTextField(
+                    value = state.merchantName,
+                    onValueChange = { state = state.copy(merchantName = it) },
+                    label = { Text("Name") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                    OutlinedTextField(
+                        value = state.amount,
+                        onValueChange = { input ->
+                            val filtered = input.filter { it.isDigit() || it == '.' }
+                            if (filtered.count { it == '.' } <= 1) state = state.copy(amount = filtered)
+                        },
+                        label = { Text("Amount") },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                        modifier = Modifier.weight(1f)
+                    )
+                    OutlinedTextField(
+                        value = state.currency,
+                        onValueChange = { state = state.copy(currency = it.uppercase().take(3)) },
+                        label = { Text("Currency") },
+                        singleLine = true,
+                        modifier = Modifier.width(110.dp)
+                    )
+                }
+
+                // Type: Expense / Income
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.sm)
+                ) {
+                    FilterChip(
+                        selected = state.transactionType == TransactionType.EXPENSE,
+                        onClick = { state = state.copy(transactionType = TransactionType.EXPENSE) },
+                        label = { Text("Expense") }
+                    )
+                    FilterChip(
+                        selected = state.transactionType == TransactionType.INCOME,
+                        onClick = { state = state.copy(transactionType = TransactionType.INCOME) },
+                        label = { Text("Income") }
+                    )
+                }
+
+                // Category dropdown
+                ExposedDropdownMenuBox(
+                    expanded = categoryExpanded,
+                    onExpandedChange = { categoryExpanded = it }
+                ) {
+                    OutlinedTextField(
+                        value = state.category,
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text("Category") },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(categoryExpanded) },
+                        modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable).fillMaxWidth()
+                    )
+                    ExposedDropdownMenu(
+                        expanded = categoryExpanded,
+                        onDismissRequest = { categoryExpanded = false }
+                    ) {
+                        categoryNames.forEach { name ->
+                            DropdownMenuItem(
+                                text = { Text(name) },
+                                onClick = {
+                                    state = state.copy(category = name)
+                                    categoryExpanded = false
+                                }
+                            )
+                        }
+                    }
+                }
+
+                // Frequency dropdown
+                ExposedDropdownMenuBox(
+                    expanded = freqExpanded,
+                    onExpandedChange = { freqExpanded = it }
+                ) {
+                    OutlinedTextField(
+                        value = state.frequency.label(),
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text("Frequency") },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(freqExpanded) },
+                        modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable).fillMaxWidth()
+                    )
+                    ExposedDropdownMenu(
+                        expanded = freqExpanded,
+                        onDismissRequest = { freqExpanded = false }
+                    ) {
+                        RecurringFrequency.entries.forEach { freq ->
+                            DropdownMenuItem(
+                                text = { Text(freq.label()) },
+                                onClick = {
+                                    state = state.copy(frequency = freq)
+                                    freqExpanded = false
+                                }
+                            )
+                        }
+                    }
+                }
+
+                // Day selector — depends on cadence
+                when (state.frequency) {
+                    RecurringFrequency.MONTHLY, RecurringFrequency.YEARLY -> {
+                        OutlinedTextField(
+                            value = state.dayOfMonth?.toString() ?: "",
+                            onValueChange = { input ->
+                                val n = input.filter { it.isDigit() }.toIntOrNull()
+                                state = state.copy(dayOfMonth = n?.coerceIn(1, 31))
+                            },
+                            label = { Text("Day of month (1-31)") },
+                            singleLine = true,
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                    RecurringFrequency.WEEKLY -> {
+                        ExposedDropdownMenuBox(
+                            expanded = dowExpanded,
+                            onExpandedChange = { dowExpanded = it }
+                        ) {
+                            OutlinedTextField(
+                                value = state.dayOfWeek?.let { dayOfWeekNames[it - 1] } ?: "Any",
+                                onValueChange = {},
+                                readOnly = true,
+                                label = { Text("Day of week") },
+                                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(dowExpanded) },
+                                modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable).fillMaxWidth()
+                            )
+                            ExposedDropdownMenu(
+                                expanded = dowExpanded,
+                                onDismissRequest = { dowExpanded = false }
+                            ) {
+                                dayOfWeekNames.forEachIndexed { index, name ->
+                                    DropdownMenuItem(
+                                        text = { Text(name) },
+                                        onClick = {
+                                            state = state.copy(dayOfWeek = index + 1)
+                                            dowExpanded = false
+                                        }
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    RecurringFrequency.DAILY -> { /* no day selector */ }
+                }
+
+                OutlinedTextField(
+                    value = state.note,
+                    onValueChange = { state = state.copy(note = it) },
+                    label = { Text("Note (optional)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text("Active", style = MaterialTheme.typography.bodyLarge)
+                    Switch(
+                        checked = state.isActive,
+                        onCheckedChange = { state = state.copy(isActive = it) }
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(enabled = state.isValid, onClick = { onSave(state) }) { Text("Save") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
+}

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsScreen.kt
@@ -149,7 +149,6 @@ private fun RecurringFrequency.label(): String = when (this) {
     RecurringFrequency.DAILY -> "Daily"
     RecurringFrequency.WEEKLY -> "Weekly"
     RecurringFrequency.MONTHLY -> "Monthly"
-    RecurringFrequency.YEARLY -> "Yearly"
 }
 
 @Composable
@@ -371,12 +370,7 @@ private fun RecurringEditorDialog(
                         expanded = freqExpanded,
                         onDismissRequest = { freqExpanded = false }
                     ) {
-                        // Yearly needs a month anchor we don't model yet, so it's
-                        // left out of the picker for now (the enum stays for backup
-                        // compatibility). (#706 Greptile)
-                        RecurringFrequency.entries
-                            .filter { it != RecurringFrequency.YEARLY }
-                            .forEach { freq ->
+                        RecurringFrequency.entries.forEach { freq ->
                             DropdownMenuItem(
                                 text = { Text(freq.label()) },
                                 onClick = {
@@ -390,7 +384,7 @@ private fun RecurringEditorDialog(
 
                 // Day selector — depends on cadence
                 when (state.frequency) {
-                    RecurringFrequency.MONTHLY, RecurringFrequency.YEARLY -> {
+                    RecurringFrequency.MONTHLY -> {
                         OutlinedTextField(
                             value = state.dayOfMonth?.toString() ?: "",
                             onValueChange = { input ->

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsScreen.kt
@@ -100,7 +100,7 @@ fun RecurringTransactionsScreen(
                 start = Dimensions.Padding.content,
                 end = Dimensions.Padding.content,
                 top = Dimensions.Padding.content + padding.calculateTopPadding(),
-                bottom = padding.calculateBottomPadding() + 88.dp
+                bottom = padding.calculateBottomPadding() + Dimensions.Component.fabBottomInset
             ),
             verticalArrangement = Arrangement.spacedBy(Spacing.md)
         ) {
@@ -371,7 +371,12 @@ private fun RecurringEditorDialog(
                         expanded = freqExpanded,
                         onDismissRequest = { freqExpanded = false }
                     ) {
-                        RecurringFrequency.entries.forEach { freq ->
+                        // Yearly needs a month anchor we don't model yet, so it's
+                        // left out of the picker for now (the enum stays for backup
+                        // compatibility). (#706 Greptile)
+                        RecurringFrequency.entries
+                            .filter { it != RecurringFrequency.YEARLY }
+                            .forEach { freq ->
                             DropdownMenuItem(
                                 text = { Text(freq.label()) },
                                 onClick = {

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsViewModel.kt
@@ -6,12 +6,15 @@ import com.pennywiseai.tracker.data.database.entity.CategoryEntity
 import com.pennywiseai.tracker.data.database.entity.RecurringFrequency
 import com.pennywiseai.tracker.data.database.entity.RecurringTransactionEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionType
+import com.pennywiseai.tracker.billing.EntitlementGate
+import com.pennywiseai.tracker.billing.FreeTierLimits
 import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
 import com.pennywiseai.tracker.data.repository.RecurringTransactionRepository
 import com.pennywiseai.tracker.domain.usecase.GetCategoriesUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -24,12 +27,26 @@ import javax.inject.Inject
 class RecurringTransactionsViewModel @Inject constructor(
     private val repository: RecurringTransactionRepository,
     getCategoriesUseCase: GetCategoriesUseCase,
-    userPreferencesRepository: UserPreferencesRepository
+    userPreferencesRepository: UserPreferencesRepository,
+    entitlementGate: EntitlementGate
 ) : ViewModel() {
 
     val templates: StateFlow<List<RecurringTransactionEntity>> =
         repository.getAll()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val isProEntitled: StateFlow<Boolean> = entitlementGate.isProEntitled
+
+    /**
+     * True when the user may create another template — Pro (unlimited) or under
+     * [FreeTierLimits.MAX_RECURRING_TEMPLATES]. The screen's Add FAB checks this
+     * to decide between opening the editor and showing the paywall (#706).
+     * Editing existing templates is always allowed.
+     */
+    val canAddMore: StateFlow<Boolean> =
+        combine(templates, isProEntitled) { list, pro ->
+            pro || list.size < FreeTierLimits.MAX_RECURRING_TEMPLATES
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
 
     val categories: StateFlow<List<CategoryEntity>> =
         getCategoriesUseCase.execute()

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsViewModel.kt
@@ -1,0 +1,160 @@
+package com.pennywiseai.tracker.presentation.recurring
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.pennywiseai.tracker.data.database.entity.CategoryEntity
+import com.pennywiseai.tracker.data.database.entity.RecurringFrequency
+import com.pennywiseai.tracker.data.database.entity.RecurringTransactionEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionType
+import com.pennywiseai.tracker.data.preferences.UserPreferencesRepository
+import com.pennywiseai.tracker.data.repository.RecurringTransactionRepository
+import com.pennywiseai.tracker.domain.usecase.GetCategoriesUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import javax.inject.Inject
+
+@HiltViewModel
+class RecurringTransactionsViewModel @Inject constructor(
+    private val repository: RecurringTransactionRepository,
+    getCategoriesUseCase: GetCategoriesUseCase,
+    userPreferencesRepository: UserPreferencesRepository
+) : ViewModel() {
+
+    val templates: StateFlow<List<RecurringTransactionEntity>> =
+        repository.getAll()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val categories: StateFlow<List<CategoryEntity>> =
+        getCategoriesUseCase.execute()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val baseCurrency: StateFlow<String> =
+        userPreferencesRepository.baseCurrency
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "INR")
+
+    /**
+     * Insert a new template ([id] == 0) or update an existing one. The next due
+     * date is resolved from the chosen cadence + day-of-month / day-of-week so
+     * the first materialisation lands on the user's intended day.
+     */
+    fun save(form: RecurringFormState) {
+        viewModelScope.launch {
+            val amount = form.amount.toBigDecimalOrNull() ?: return@launch
+            val nextDue = resolveNextDueDate(form)
+            if (form.id == 0L) {
+                repository.insert(
+                    RecurringTransactionEntity(
+                        merchantName = form.merchantName.trim(),
+                        amount = amount,
+                        currency = form.currency,
+                        category = form.category,
+                        transactionType = form.transactionType,
+                        frequency = form.frequency,
+                        dayOfMonth = form.dayOfMonth,
+                        dayOfWeek = form.dayOfWeek,
+                        nextDueDate = nextDue,
+                        isActive = form.isActive,
+                        note = form.note.trim().ifBlank { null }
+                    )
+                )
+            } else {
+                val existing = repository.getById(form.id) ?: return@launch
+                repository.update(
+                    existing.copy(
+                        merchantName = form.merchantName.trim(),
+                        amount = amount,
+                        currency = form.currency,
+                        category = form.category,
+                        transactionType = form.transactionType,
+                        frequency = form.frequency,
+                        dayOfMonth = form.dayOfMonth,
+                        dayOfWeek = form.dayOfWeek,
+                        nextDueDate = nextDue,
+                        isActive = form.isActive,
+                        note = form.note.trim().ifBlank { null },
+                        updatedAt = LocalDateTime.now()
+                    )
+                )
+            }
+        }
+    }
+
+    fun setActive(template: RecurringTransactionEntity, active: Boolean) {
+        viewModelScope.launch {
+            repository.update(template.copy(isActive = active))
+        }
+    }
+
+    fun delete(template: RecurringTransactionEntity) {
+        viewModelScope.launch { repository.delete(template) }
+    }
+
+    /**
+     * Pick the first upcoming date matching the cadence + selected day. Today
+     * counts as valid so a template created on its due day still fires today.
+     */
+    private fun resolveNextDueDate(form: RecurringFormState): LocalDate {
+        val today = LocalDate.now()
+        return when (form.frequency) {
+            RecurringFrequency.DAILY -> today
+            RecurringFrequency.WEEKLY -> {
+                val target = form.dayOfWeek ?: today.dayOfWeek.value
+                var d = today
+                while (d.dayOfWeek.value != target) d = d.plusDays(1)
+                d
+            }
+            RecurringFrequency.MONTHLY, RecurringFrequency.YEARLY -> {
+                val dom = (form.dayOfMonth ?: today.dayOfMonth)
+                    .coerceIn(1, today.lengthOfMonth())
+                val candidate = today.withDayOfMonth(dom)
+                if (candidate.isBefore(today)) form.frequency.advance(candidate) else candidate
+            }
+        }
+    }
+}
+
+/**
+ * Editable form state for the add/edit sheet. Kept in the presentation layer so
+ * the ViewModel only deals in validated primitives.
+ */
+data class RecurringFormState(
+    val id: Long = 0L,
+    val merchantName: String = "",
+    val amount: String = "",
+    val currency: String = "INR",
+    val category: String = "Others",
+    val transactionType: TransactionType = TransactionType.EXPENSE,
+    val frequency: RecurringFrequency = RecurringFrequency.MONTHLY,
+    val dayOfMonth: Int? = null,
+    val dayOfWeek: Int? = null,
+    val isActive: Boolean = true,
+    val note: String = ""
+) {
+    val isValid: Boolean
+        get() = merchantName.isNotBlank() &&
+            (amount.toBigDecimalOrNull()?.let { it > BigDecimal.ZERO } == true) &&
+            category.isNotBlank()
+
+    companion object {
+        fun from(template: RecurringTransactionEntity): RecurringFormState = RecurringFormState(
+            id = template.id,
+            merchantName = template.merchantName,
+            amount = template.amount.stripTrailingZeros().toPlainString(),
+            currency = template.currency,
+            category = template.category,
+            transactionType = template.transactionType,
+            frequency = template.frequency,
+            dayOfMonth = template.dayOfMonth,
+            dayOfWeek = template.dayOfWeek,
+            isActive = template.isActive,
+            note = template.note.orEmpty()
+        )
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsViewModel.kt
@@ -85,9 +85,14 @@ class RecurringTransactionsViewModel @Inject constructor(
                 // Only recompute the schedule when a cadence field actually changed;
                 // a metadata-only edit (amount, merchant, category, note, active) must
                 // keep the existing next due date rather than jumping it to today. (#706 Greptile)
-                val scheduleChanged = existing.frequency != form.frequency ||
-                    existing.dayOfMonth != form.dayOfMonth ||
-                    existing.dayOfWeek != form.dayOfWeek
+                // Yearly is never recomputed here: it's not offered in the picker, its
+                // month lives only in the existing nextDueDate, and resolveNextDueDate
+                // (today-anchored) would move it to the wrong month. Preserve it and
+                // let nextDueAfter advance it correctly. (Greptile)
+                val scheduleChanged = form.frequency != RecurringFrequency.YEARLY &&
+                    (existing.frequency != form.frequency ||
+                        existing.dayOfMonth != form.dayOfMonth ||
+                        existing.dayOfWeek != form.dayOfWeek)
                 val nextDue = if (scheduleChanged) resolveNextDueDate(form) else existing.nextDueDate
                 repository.update(
                     existing.copy(

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsViewModel.kt
@@ -64,7 +64,6 @@ class RecurringTransactionsViewModel @Inject constructor(
     fun save(form: RecurringFormState) {
         viewModelScope.launch {
             val amount = form.amount.toBigDecimalOrNull() ?: return@launch
-            val nextDue = resolveNextDueDate(form)
             if (form.id == 0L) {
                 repository.insert(
                     RecurringTransactionEntity(
@@ -76,13 +75,20 @@ class RecurringTransactionsViewModel @Inject constructor(
                         frequency = form.frequency,
                         dayOfMonth = form.dayOfMonth,
                         dayOfWeek = form.dayOfWeek,
-                        nextDueDate = nextDue,
+                        nextDueDate = resolveNextDueDate(form),
                         isActive = form.isActive,
                         note = form.note.trim().ifBlank { null }
                     )
                 )
             } else {
                 val existing = repository.getById(form.id) ?: return@launch
+                // Only recompute the schedule when a cadence field actually changed;
+                // a metadata-only edit (amount, merchant, category, note, active) must
+                // keep the existing next due date rather than jumping it to today. (#706 Greptile)
+                val scheduleChanged = existing.frequency != form.frequency ||
+                    existing.dayOfMonth != form.dayOfMonth ||
+                    existing.dayOfWeek != form.dayOfWeek
+                val nextDue = if (scheduleChanged) resolveNextDueDate(form) else existing.nextDueDate
                 repository.update(
                     existing.copy(
                         merchantName = form.merchantName.trim(),

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsViewModel.kt
@@ -85,14 +85,9 @@ class RecurringTransactionsViewModel @Inject constructor(
                 // Only recompute the schedule when a cadence field actually changed;
                 // a metadata-only edit (amount, merchant, category, note, active) must
                 // keep the existing next due date rather than jumping it to today. (#706 Greptile)
-                // Yearly is never recomputed here: it's not offered in the picker, its
-                // month lives only in the existing nextDueDate, and resolveNextDueDate
-                // (today-anchored) would move it to the wrong month. Preserve it and
-                // let nextDueAfter advance it correctly. (Greptile)
-                val scheduleChanged = form.frequency != RecurringFrequency.YEARLY &&
-                    (existing.frequency != form.frequency ||
-                        existing.dayOfMonth != form.dayOfMonth ||
-                        existing.dayOfWeek != form.dayOfWeek)
+                val scheduleChanged = existing.frequency != form.frequency ||
+                    existing.dayOfMonth != form.dayOfMonth ||
+                    existing.dayOfWeek != form.dayOfWeek
                 val nextDue = if (scheduleChanged) resolveNextDueDate(form) else existing.nextDueDate
                 repository.update(
                     existing.copy(
@@ -138,7 +133,7 @@ class RecurringTransactionsViewModel @Inject constructor(
                 while (d.dayOfWeek.value != target) d = d.plusDays(1)
                 d
             }
-            RecurringFrequency.MONTHLY, RecurringFrequency.YEARLY -> {
+            RecurringFrequency.MONTHLY -> {
                 val dom = (form.dayOfMonth ?: today.dayOfMonth)
                     .coerceIn(1, today.lengthOfMonth())
                 val candidate = today.withDayOfMonth(dom)

--- a/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/MainScreen.kt
@@ -464,6 +464,11 @@ fun MainScreen(
                                     com.pennywiseai.tracker.navigation.Loans
                                 ) { launchSingleTop = true }
                             },
+                            onNavigateToRecurring = {
+                                rootNavController?.navigate(
+                                    com.pennywiseai.tracker.navigation.RecurringTransactions
+                                ) { launchSingleTop = true }
+                            },
                             onNavigateToExchangeRates = {
                                 rootNavController?.navigate(
                                     com.pennywiseai.tracker.navigation.ExchangeRates

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -98,6 +98,7 @@ fun SettingsScreen(
     onNavigateToRules: () -> Unit = {},
     onNavigateToBudgets: () -> Unit = {},
     onNavigateToLoans: () -> Unit = {},
+    onNavigateToRecurring: () -> Unit = {},
     onNavigateToTransactionGroups: () -> Unit = {},
     onNavigateToExchangeRates: () -> Unit = {},
     onNavigateToAppearance: () -> Unit = {},
@@ -544,6 +545,15 @@ fun SettingsScreen(
                     title = "Loans",
                     subtitle = "Track money lent and borrowed",
                     onClick = onNavigateToLoans,
+                    position = ListItemPosition.Middle
+                )
+                SettingsNavItem(
+                    icon = Icons.Default.EventRepeat,
+                    iconBgColor = green_light,
+                    iconTint = green_dark,
+                    title = "Recurring",
+                    subtitle = "Auto-add scheduled cash & manual transactions",
+                    onClick = onNavigateToRecurring,
                     position = ListItemPosition.Middle
                 )
                 SettingsNavItem(

--- a/app/src/main/java/com/pennywiseai/tracker/worker/RecurringTransactionWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/worker/RecurringTransactionWorker.kt
@@ -1,0 +1,77 @@
+package com.pennywiseai.tracker.worker
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.pennywiseai.tracker.data.repository.RecurringTransactionRepository
+import com.pennywiseai.tracker.widget.WidgetRefresher
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import java.time.LocalDate
+import java.util.concurrent.TimeUnit
+
+/**
+ * Materialises due recurring / scheduled manual transaction templates (#706).
+ *
+ * Runs daily (periodic) plus a one-shot catch-up at app start so a device that
+ * was off still materialises anything that came due while it was down. All the
+ * double-insertion safety lives in
+ * [RecurringTransactionRepository.materializeDue].
+ */
+@HiltWorker
+class RecurringTransactionWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val recurringTransactionRepository: RecurringTransactionRepository
+) : CoroutineWorker(appContext, workerParams) {
+
+    companion object {
+        private const val WORK_NAME_PERIODIC = "recurring_transactions_materialize_periodic"
+        private const val WORK_NAME_ONE_SHOT = "recurring_transactions_materialize_one_shot"
+
+        /**
+         * Daily periodic materialisation. KEEP so re-enqueuing on every app
+         * start doesn't reset the schedule.
+         */
+        fun enqueuePeriodic(context: Context) {
+            val request = PeriodicWorkRequestBuilder<RecurringTransactionWorker>(
+                1, TimeUnit.DAYS
+            ).build()
+            WorkManager.getInstance(context)
+                .enqueueUniquePeriodicWork(
+                    WORK_NAME_PERIODIC,
+                    ExistingPeriodicWorkPolicy.KEEP,
+                    request
+                )
+        }
+
+        /**
+         * One-shot catch-up run — used at app start so due templates materialise
+         * immediately rather than waiting up to a day for the periodic run.
+         */
+        fun enqueueOneShotCatchUp(context: Context) {
+            val request = OneTimeWorkRequestBuilder<RecurringTransactionWorker>().build()
+            WorkManager.getInstance(context)
+                .enqueueUniqueWork(WORK_NAME_ONE_SHOT, ExistingWorkPolicy.REPLACE, request)
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        return try {
+            val created = recurringTransactionRepository.materializeDue(LocalDate.now())
+            if (created > 0) {
+                // New transactions landed — keep the home/transactions widgets fresh.
+                WidgetRefresher.refreshTransactionWidgets(applicationContext)
+            }
+            Result.success()
+        } catch (e: Exception) {
+            Result.retry()
+        }
+    }
+}

--- a/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupModelsTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupModelsTest.kt
@@ -650,6 +650,87 @@ class BackupModelsTest {
     }
 
     /**
+     * #706 regression. An older backup predates the `recurring_transactions`
+     * table, so the key is absent — it must default to an empty list, not crash.
+     */
+    @Test
+    fun oldBackupMissingRecurringTransactions_defaultsToEmptyList() {
+        val json = """
+        {
+          "database": {
+            "merchant_mappings": [
+              { "merchantName": "xyz@upi", "category": "Food" }
+            ]
+          }
+        }
+        """.trimIndent()
+
+        val db = backupJson.decodeFromString<PennyWiseBackup>(json).database
+
+        assertTrue(db.recurringTransactions.isEmpty())
+    }
+
+    /**
+     * #706. A backup carrying recurring templates must round-trip every field,
+     * and a row missing newer keys must fall back to defaults rather than throw.
+     */
+    @Test
+    fun recurringTransactions_roundTripAndTolerateMissingFields() {
+        val json = """
+        {
+          "database": {
+            "recurring_transactions": [
+              {
+                "id": 5,
+                "merchantName": "Rent",
+                "amount": "1200.00",
+                "currency": "USD",
+                "category": "Bills",
+                "transactionType": "EXPENSE",
+                "frequency": "MONTHLY",
+                "dayOfMonth": 1,
+                "nextDueDate": "2026-09-01",
+                "isActive": true,
+                "note": "Landlord",
+                "profileId": 1,
+                "createdAt": "2026-08-01T10:00:00",
+                "updatedAt": "2026-08-01T10:00:00"
+              },
+              {
+                "merchantName": "Allowance"
+              }
+            ]
+          }
+        }
+        """.trimIndent()
+
+        val recurring = backupJson.decodeFromString<PennyWiseBackup>(json)
+            .database.recurringTransactions
+
+        assertEquals(2, recurring.size)
+
+        val full = recurring.first { it.merchantName == "Rent" }
+        assertEquals(java.math.BigDecimal("1200.00"), full.amount)
+        assertEquals("USD", full.currency)
+        assertEquals(
+            com.pennywiseai.tracker.data.database.entity.RecurringFrequency.MONTHLY,
+            full.frequency
+        )
+        assertEquals(1, full.dayOfMonth)
+        assertEquals(LocalDate.of(2026, 9, 1), full.nextDueDate)
+
+        // Minimal row: only the name provided → every other field defaults, no crash.
+        val minimal = recurring.first { it.merchantName == "Allowance" }
+        assertEquals("INR", minimal.currency)
+        assertEquals(
+            com.pennywiseai.tracker.data.database.entity.RecurringFrequency.MONTHLY,
+            minimal.frequency
+        )
+        assertTrue(minimal.isActive)
+        assertNotNull(minimal.nextDueDate)
+    }
+
+    /**
      * Forward compatibility (#415). A backup from a *newer* app carries keys
      * this version has never heard of — both unknown object keys and a whole
      * unknown table. They must be ignored, not rejected.

--- a/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupSchemaGuardTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/backup/BackupSchemaGuardTest.kt
@@ -71,6 +71,7 @@ class BackupSchemaGuardTest {
         serializer<BudgetCategoryMonthSnapshotEntity>().descriptor,
         serializer<TagEntity>().descriptor,
         serializer<TransactionTagCrossRef>().descriptor,
+        serializer<RecurringTransactionEntity>().descriptor,
     )
 
     private fun SerialDescriptor.requiredFields(): List<String> =

--- a/app/src/test/java/com/pennywiseai/tracker/data/database/entity/RecurringTransactionEntityTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/database/entity/RecurringTransactionEntityTest.kt
@@ -51,11 +51,4 @@ class RecurringTransactionEntityTest {
         val t = template(RecurringFrequency.DAILY)
         assertEquals(LocalDate.of(2026, 3, 1), t.nextDueAfter(LocalDate.of(2026, 2, 28)))
     }
-
-    @Test
-    fun `yearly on Feb 29 clamps to Feb 28 in a non-leap year`() {
-        val t = template(RecurringFrequency.YEARLY, dayOfMonth = 29)
-        // 2028 is a leap year; the next year is not.
-        assertEquals(LocalDate.of(2029, 2, 28), t.nextDueAfter(LocalDate.of(2028, 2, 29)))
-    }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/data/database/entity/RecurringTransactionEntityTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/database/entity/RecurringTransactionEntityTest.kt
@@ -1,0 +1,61 @@
+package com.pennywiseai.tracker.data.database.entity
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * Locks in [RecurringTransactionEntity.nextDueAfter] — specifically that a
+ * monthly template anchored to a high day-of-month does NOT drift after a short
+ * month (the bug the re-anchoring fix addresses, #706).
+ */
+class RecurringTransactionEntityTest {
+
+    private fun template(
+        frequency: RecurringFrequency,
+        dayOfMonth: Int? = null,
+        dayOfWeek: Int? = null,
+    ) = RecurringTransactionEntity(
+        merchantName = "Rent",
+        frequency = frequency,
+        dayOfMonth = dayOfMonth,
+        dayOfWeek = dayOfWeek,
+    )
+
+    @Test
+    fun `monthly day-31 clamps for a short month but does not drift afterward`() {
+        val t = template(RecurringFrequency.MONTHLY, dayOfMonth = 31)
+
+        val feb = t.nextDueAfter(LocalDate.of(2026, 1, 31))
+        assertEquals("Jan 31 -> Feb 28 (clamped)", LocalDate.of(2026, 2, 28), feb)
+
+        // Re-anchored to the 31st, NOT Mar 28 (which plain plusMonths would give).
+        val mar = t.nextDueAfter(feb)
+        assertEquals("Feb 28 -> Mar 31 (re-anchored, no drift)", LocalDate.of(2026, 3, 31), mar)
+
+        val apr = t.nextDueAfter(mar)
+        assertEquals("Mar 31 -> Apr 30 (clamped)", LocalDate.of(2026, 4, 30), apr)
+    }
+
+    @Test
+    fun `weekly preserves the weekday`() {
+        val t = template(RecurringFrequency.WEEKLY, dayOfWeek = 3)
+        val start = LocalDate.of(2026, 1, 7) // a Wednesday
+        val next = t.nextDueAfter(start)
+        assertEquals(LocalDate.of(2026, 1, 14), next)
+        assertEquals(start.dayOfWeek, next.dayOfWeek)
+    }
+
+    @Test
+    fun `daily steps by one day`() {
+        val t = template(RecurringFrequency.DAILY)
+        assertEquals(LocalDate.of(2026, 3, 1), t.nextDueAfter(LocalDate.of(2026, 2, 28)))
+    }
+
+    @Test
+    fun `yearly on Feb 29 clamps to Feb 28 in a non-leap year`() {
+        val t = template(RecurringFrequency.YEARLY, dayOfMonth = 29)
+        // 2028 is a leap year; the next year is not.
+        assertEquals(LocalDate.of(2029, 2, 28), t.nextDueAfter(LocalDate.of(2028, 2, 29)))
+    }
+}

--- a/app/src/test/java/com/pennywiseai/tracker/domain/usecase/DeleteTransactionUseCaseTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/domain/usecase/DeleteTransactionUseCaseTest.kt
@@ -65,6 +65,7 @@ class DeleteTransactionUseCaseTest {
         override fun transactionGroupDao(): TransactionGroupDao = error("unused")
         override fun profileDao(): ProfileDao = error("unused")
         override fun tagDao(): TagDao = error("unused")
+        override fun recurringTransactionDao(): RecurringTransactionDao = error("unused")
         override fun createOpenHelper(config: DatabaseConfiguration): SupportSQLiteOpenHelper = error("unused")
         override fun createInvalidationTracker(): InvalidationTracker = error("unused")
         override fun clearAllTables() {}

--- a/app/src/test/java/com/pennywiseai/tracker/domain/usecase/RestoreTransactionUseCaseTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/domain/usecase/RestoreTransactionUseCaseTest.kt
@@ -64,6 +64,7 @@ class RestoreTransactionUseCaseTest {
         override fun transactionGroupDao(): TransactionGroupDao = error("unused")
         override fun profileDao(): ProfileDao = error("unused")
         override fun tagDao(): TagDao = error("unused")
+        override fun recurringTransactionDao(): RecurringTransactionDao = error("unused")
         override fun createOpenHelper(config: DatabaseConfiguration): SupportSQLiteOpenHelper = error("unused")
         override fun createInvalidationTracker(): InvalidationTracker = error("unused")
         override fun clearAllTables() {}

--- a/app/src/test/java/com/pennywiseai/tracker/receiver/NotificationActionReceiverTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/receiver/NotificationActionReceiverTest.kt
@@ -83,6 +83,7 @@ class NotificationActionReceiverTest {
         override fun transactionGroupDao(): TransactionGroupDao = error("unused")
         override fun profileDao(): ProfileDao = error("unused")
         override fun tagDao(): TagDao = error("unused")
+        override fun recurringTransactionDao(): RecurringTransactionDao = error("unused")
         override fun createOpenHelper(config: DatabaseConfiguration): SupportSQLiteOpenHelper = error("unused")
         override fun createInvalidationTracker(): InvalidationTracker = error("unused")
         override fun clearAllTables() {}


### PR DESCRIPTION
Closes #706.

## Request
Users can't schedule a **cash/manual** transaction to be added automatically — with no SMS to detect, they re-enter the same rent/allowance/cleaner spend by hand every period.

## What this adds
A recurring **template** (amount, currency, merchant, category, type, cadence) that a daily worker turns into real transactions on schedule. Distinct from `SubscriptionEntity` (SMS mandates) — this is a brand-new entity for manual/cash spend.

Full stack, mirroring existing patterns:
- **Entity** `RecurringTransactionEntity` + `RecurringFrequency` (DAILY/WEEKLY/MONTHLY/YEARLY), all fields defaulted (backup-safe). **DAO**, **Repository**, **DI**.
- **DB migration 58→59** — manual `MIGRATION_58_59` registered in `ALL_MIGRATIONS`; the CREATE TABLE SQL matches Room's generated `59.json` exactly.
- **Worker** `RecurringTransactionWorker` — daily periodic + one-shot catch-up on app start (so an off device still materializes). `materializeDue()` inserts via `AccountBalanceRepository.insertTransactionWithBalance` (funding-account balance moves; null account = cash), advancing the schedule.
- **UI** — a Recurring list (empty state + Active/Paused) and add/edit dialog, reached from **Settings → Recurring**. Amounts are currency-tagged.
- **Backup** — new list round-trips in exporter/importer (FULL export, conservative like loans), backward/forward compatible; guard + round-trip tests added.

## Correctness details
- **No double-insert:** each occurrence gets a deterministic hash (`RECURRING_<id>_<amount>_<merchant>_<dueDate>`); insert + `nextDueDate` advance run in one `withTransaction`, so a re-run the same day no-ops.
- **No calendar drift:** `nextDueAfter()` re-anchors monthly/yearly to `dayOfMonth`, so a day-31 template clamps to Feb 28 that month but returns to the 31st afterward (not stuck on the 28th). Regression test: `RecurringTransactionEntityTest`.

## Verification
`./init.sh app` green (incl. `BackupSchemaGuardTest`, `CurrencyFormatterTest`, new entity + backup round-trip tests). **On-device:** installed over existing data — migration 58→59 ran with no crash; Settings → Recurring opens (clean empty state) and the add dialog renders all controls (screenshots below in review). Materialization itself is unit-covered; the worker fires daily.

Built with an agent for the scaffolding; I reviewed the migration SQL against `59.json`, fixed the day-of-month drift, added the regression test, and did the on-device migration + UI smoke.