### PR TITLE
feat(home): option to count credit-card spend as expense (#705)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
@@ -61,6 +61,7 @@ open class UserPreferencesRepository @Inject constructor(
         val APP_FONT = stringPreferencesKey("app_font")
         val HAS_SKIPPED_SMS_PERMISSION = booleanPreferencesKey("has_skipped_sms_permission")
         val DEVELOPER_MODE_ENABLED = booleanPreferencesKey("developer_mode_enabled")
+        val COUNT_CREDIT_AS_EXPENSE = booleanPreferencesKey("count_credit_as_expense")
         val SYSTEM_PROMPT = stringPreferencesKey("system_prompt")
         val HAS_SHOWN_SCAN_TUTORIAL = booleanPreferencesKey("has_shown_scan_tutorial")
         val ACTIVE_DOWNLOAD_ID = longPreferencesKey("active_download_id")
@@ -226,6 +227,18 @@ open class UserPreferencesRepository @Inject constructor(
             preferences[PreferencesKeys.DEVELOPER_MODE_ENABLED] ?: false
         }
 
+    /**
+     * When true, credit-card spend (TransactionType.CREDIT) is folded into the
+     * fixed "expenses / spent" totals (Home card, Transactions summary) instead
+     * of being kept as a separate figure. Default off. The filter-driven
+     * Analytics screen is unaffected — it already lets users select the Credit
+     * type to view card spend. (#705)
+     */
+    val countCreditCardAsExpense: Flow<Boolean> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.COUNT_CREDIT_AS_EXPENSE] ?: false
+        }
+
     val numberFormatStyle: Flow<NumberFormatStyle> = context.dataStore.data
         .map { preferences ->
             preferences[PreferencesKeys.NUMBER_FORMAT_STYLE]?.let {
@@ -286,6 +299,12 @@ open class UserPreferencesRepository @Inject constructor(
     suspend fun setDeveloperModeEnabled(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[PreferencesKeys.DEVELOPER_MODE_ENABLED] = enabled
+        }
+    }
+
+    suspend fun setCountCreditCardAsExpense(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.COUNT_CREDIT_AS_EXPENSE] = enabled
         }
     }
     

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeScreen.kt
@@ -512,7 +512,10 @@ fun HomeScreen(
                 ) {
                     CashFlowCard(
                         currency = uiState.selectedCurrency,
-                        creditCardSpend = uiState.currentMonthCreditCard,
+                        // When card spend counts as expense (#705) it's already in
+                        // "Spent this month", so drop it from this "outside cash flow"
+                        // card (a zero channel is filtered out) to avoid double-showing.
+                        creditCardSpend = if (uiState.countCreditCardAsExpense) BigDecimal.ZERO else uiState.currentMonthCreditCard,
                         investments = uiState.currentMonthInvestment,
                         transfers = uiState.currentMonthTransfer,
                         isBalanceHidden = uiState.isBalanceHidden,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -163,6 +163,13 @@ class HomeViewModel @Inject constructor(
         loadUnifiedModePreferences()
         loadUserName()
         refreshSharePrompt()
+        // Mirror the "count card spend as expense" pref into UI state so the
+        // "Money in motion" card can hide its Credit chip when it's on (#705).
+        viewModelScope.launch {
+            userPreferencesRepository.countCreditCardAsExpense.collect { on ->
+                _uiState.value = _uiState.value.copy(countCreditCardAsExpense = on)
+            }
+        }
         // Load base currency FIRST so selectedCurrency is set before data loads
         viewModelScope.launch {
             val base = userPreferencesRepository.baseCurrency.first()
@@ -1610,6 +1617,10 @@ data class HomeUiState(
     val currentMonthExpenses: BigDecimal = BigDecimal.ZERO,
     val currentMonthLent: BigDecimal = BigDecimal.ZERO,
     val currentMonthCreditCard: BigDecimal = BigDecimal.ZERO,
+    // When true, credit-card spend is folded into "Spent this month" (#705), so
+    // the "Money in motion" card hides its Credit chip to avoid showing the same
+    // amount both inside and "outside" the cash flow.
+    val countCreditCardAsExpense: Boolean = false,
     val currentMonthTransfer: BigDecimal = BigDecimal.ZERO,
     val currentMonthInvestment: BigDecimal = BigDecimal.ZERO,
     val lastMonthTotal: BigDecimal = BigDecimal.ZERO,

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/home/HomeViewModel.kt
@@ -276,7 +276,8 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun computeBreakdownByCurrency(
-        transactions: List<TransactionEntity>
+        transactions: List<TransactionEntity>,
+        countCreditAsExpense: Boolean = false
     ): Map<String, TransactionRepository.MonthlyBreakdown> {
         // "Exclude from analytics" transactions stay in history & account balances
         // but must not count toward the home card's income/spend figures — same as
@@ -303,7 +304,11 @@ class HomeViewModel @Inject constructor(
                 }
                 .fold(BigDecimal.ZERO) { acc, tx -> acc + tx.amount }
             val rawExpenses = txs
-                .filter { it.transactionType == TransactionType.EXPENSE }
+                .filter {
+                    it.transactionType == TransactionType.EXPENSE ||
+                        // Fold credit-card spend into expenses when the user opted in (#705).
+                        (countCreditAsExpense && it.transactionType == TransactionType.CREDIT)
+                }
                 .fold(BigDecimal.ZERO) { acc, tx -> acc + tx.amount }
             val expenses = (rawExpenses - refundTotal).coerceAtLeast(BigDecimal.ZERO)
             TransactionRepository.MonthlyBreakdown(
@@ -392,9 +397,11 @@ class HomeViewModel @Inject constructor(
                     transactions to profileId
                 }
                 .combine(_cachedAccountBalances.filterNotNull()) { (transactions, profileId), balances ->
-                    val nonLoan = filterTransactionsByProfile(transactions, profileId, buildProfileAccountKeys(balances))
+                    filterTransactionsByProfile(transactions, profileId, buildProfileAccountKeys(balances))
                         .filter { it.loanId == null }
-                    computeBreakdownByCurrency(nonLoan)
+                }
+                .combine(userPreferencesRepository.countCreditCardAsExpense) { nonLoan, creditAsExpense ->
+                    computeBreakdownByCurrency(nonLoan, creditAsExpense)
                 }
                 .collect { breakdownByCurrency ->
                     updateBreakdownForSelectedCurrency(breakdownByCurrency, isCurrentMonth = true)
@@ -591,9 +598,11 @@ class HomeViewModel @Inject constructor(
                     transactions to profileId
                 }
                 .combine(_cachedAccountBalances.filterNotNull()) { (transactions, profileId), balances ->
-                    val nonLoan = filterTransactionsByProfile(transactions, profileId, buildProfileAccountKeys(balances))
+                    filterTransactionsByProfile(transactions, profileId, buildProfileAccountKeys(balances))
                         .filter { it.loanId == null }
-                    computeBreakdownByCurrency(nonLoan)
+                }
+                .combine(userPreferencesRepository.countCreditCardAsExpense) { nonLoan, creditAsExpense ->
+                    computeBreakdownByCurrency(nonLoan, creditAsExpense)
                 }
                 .collect { breakdownByCurrency ->
                     updateBreakdownForSelectedCurrency(breakdownByCurrency, isCurrentMonth = false)

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -123,6 +123,7 @@ fun SettingsScreen(
     val importExportMessage by settingsViewModel.importExportMessage.collectAsStateWithLifecycle()
     val exportedBackupFile by settingsViewModel.exportedBackupFile.collectAsStateWithLifecycle()
     val unifiedCurrencyMode by settingsViewModel.unifiedCurrencyMode.collectAsStateWithLifecycle(initialValue = false)
+    val countCreditCardAsExpense by settingsViewModel.countCreditCardAsExpense.collectAsStateWithLifecycle(initialValue = false)
     val displayCurrency by settingsViewModel.displayCurrency.collectAsStateWithLifecycle(initialValue = "")
     val availableCurrencies by settingsViewModel.availableCurrencies.collectAsStateWithLifecycle()
     val accounts by settingsViewModel.accounts.collectAsStateWithLifecycle()
@@ -324,6 +325,16 @@ fun SettingsScreen(
                     title = "Exchange Rates",
                     subtitle = "View and customize rates",
                     onClick = onNavigateToExchangeRates,
+                    position = ListItemPosition.Middle
+                )
+                SettingsSwitchRow(
+                    icon = Icons.Default.CreditCard,
+                    iconBgColor = indigo_light,
+                    iconTint = indigo_dark,
+                    title = "Count card spend as expense",
+                    subtitle = "Include credit-card spend in \"Spent this month\"",
+                    checked = countCreditCardAsExpense,
+                    onCheckedChange = { settingsViewModel.setCountCreditCardAsExpense(it) },
                     position = ListItemPosition.Middle
                 )
                 SettingsDropdownItem(

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -114,6 +114,9 @@ class SettingsViewModel @Inject constructor(
     val unifiedCurrencyMode = userPreferencesRepository.unifiedCurrencyMode
     val displayCurrency = userPreferencesRepository.displayCurrency
 
+    // Count credit-card spend toward the "Spent this month" total (#705)
+    val countCreditCardAsExpense = userPreferencesRepository.countCreditCardAsExpense
+
     // Replace UPI VPAs with contact names (gated by READ_CONTACTS).
     val useContactsForVpa = userPreferencesRepository.useContactsForVpa
 
@@ -472,6 +475,13 @@ class SettingsViewModel @Inject constructor(
     fun setUnifiedCurrencyMode(enabled: Boolean) {
         viewModelScope.launch {
             userPreferencesRepository.setUnifiedCurrencyMode(enabled)
+            com.pennywiseai.tracker.widget.WidgetRefresher.refreshTransactionWidgets(context)
+        }
+    }
+
+    fun setCountCreditCardAsExpense(enabled: Boolean) {
+        viewModelScope.launch {
+            userPreferencesRepository.setCountCreditCardAsExpense(enabled)
             com.pennywiseai.tracker.widget.WidgetRefresher.refreshTransactionWidgets(context)
         }
     }


### PR DESCRIPTION
Closes #705.

## Request
> Payments made by CC are added as *Credit*, but I want them in *Expense*. There should be an option for that.

## Change
New **default-off** preference **"Count card spend as expense"** (Settings → Currency). When enabled, `TransactionType.CREDIT` is folded into the Home **"Spent this month"** expense total (`computeBreakdownByCurrency`), threaded through the breakdown flows via `combine` so toggling refreshes live.

- **Default off** → no behavior change. Because CREDIT is currently *excluded* from that expense figure, including it when on **can't double-count**.
- **Scope:** the fixed Home spending figure. The **Transactions** and **Analytics** screens keep their explicit per-type breakdowns on purpose — Analytics already lets you select the **Credit** type filter to view card spend, so it doesn't need the toggle. This avoids a half-applied semantic that would make surfaces disagree.

Files: preference (`UserPreferencesRepository`), `HomeViewModel` (filter + reactive wiring), `SettingsViewModel` + `SettingsScreen` (toggle).

## Verification
`./init.sh app` green. **On-device toggle check pending** — the shared emulator was being actively driven by another session at the time, so I didn't contend it; the change is a default-off filter tweak on the standard Settings-toggle pattern. Worth a quick on-device confirm (toggle on → "Spent this month" includes a current-cycle CC charge) before merge.