### PR TITLE
fix(sms): keep deleted transactions deleted across re-scans (#703)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
@@ -169,6 +169,24 @@ interface TransactionDao {
     suspend fun getTransactionByHash(transactionHash: String): TransactionEntity?
 
     /**
+     * A SOFT-DELETED transaction from the exact same SMS (raw sender + body).
+     * Used to keep deletion durable across app updates: the transaction_hash
+     * includes the parsed amount, so a parser change can shift it and let a
+     * re-scan re-insert a previously-deleted row. The raw SMS never changes, so
+     * matching on it lets the scanner skip resurrecting a deleted txn even when
+     * its hash no longer matches. (#703)
+     */
+    @Query(
+        """
+        SELECT * FROM transactions
+        WHERE is_deleted = 1 AND sms_body = :smsBody
+          AND (sms_sender = :smsSender OR (:smsSender IS NULL AND sms_sender IS NULL))
+        LIMIT 1
+        """
+    )
+    suspend fun getDeletedBySms(smsBody: String, smsSender: String?): TransactionEntity?
+
+    /**
      * The subset of [hashes] that already exist (including soft-deleted rows).
      * One query for the whole batch — used by CSV import to dedup a whole file
      * without issuing a per-row lookup.

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
@@ -145,6 +145,10 @@ open class TransactionRepository @Inject constructor(
     suspend fun getTransactionByHash(transactionHash: String): TransactionEntity? =
         transactionDao.getTransactionByHash(transactionHash)
 
+    /** A soft-deleted transaction from the same raw SMS, if any (#703). */
+    suspend fun getDeletedBySms(smsBody: String, smsSender: String?): TransactionEntity? =
+        transactionDao.getDeletedBySms(smsBody, smsSender)
+
     /**
      * The subset of [hashes] already present. Chunked under SQLite's 999
      * bind-variable limit (Room does not auto-chunk `IN (:list)`), so a large

--- a/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/worker/OptimizedSmsReaderWorker.kt
@@ -687,6 +687,16 @@ class OptimizedSmsReaderWorker @AssistedInject constructor(
 
             if (hashDeferred.await() != null) return@coroutineScope SaveOutcome.SKIPPED
 
+            // Durable deletion: skip re-inserting a transaction the user deleted,
+            // even when its hash shifted across an app/parser update (the hash
+            // includes the parsed amount). The raw SMS is stable, so a matching
+            // soft-deleted row means "the user deleted this" — don't resurrect it. (#703)
+            entity.smsBody?.let { body ->
+                if (transactionRepository.getDeletedBySms(body, entity.smsSender) != null) {
+                    return@coroutineScope SaveOutcome.SKIPPED
+                }
+            }
+
             if (isBlocked) {
                 stats.blocked.incrementAndGet()
                 return@coroutineScope SaveOutcome.SKIPPED


### PR DESCRIPTION
Closes #703.

## Root cause (reproduced on-device)
Soft-delete **deliberately mangles the hash** — `TransactionDao.softDeleteTransaction` rewrites `transaction_hash` to `DELETED_<id>_<origHash>` ("so it doesn't block new inserts with same details"). The re-scan side still computes the **original** hash, so `getTransactionByHash(origHash)` no longer finds the deleted row → the transaction is **re-inserted**.

This fires on any scan that re-reads the deleted txn's SMS — i.e. a **normal scan re-reads the last 3 days**, so a recently-deleted transaction reappears on the next Sync (or background scan). (A full resync is a deliberate reset and is intentionally left as-is.)

Repro: created a txn, soft-deleted it (hash gets mangled), tapped Sync → a new live row appeared.

## Fix
On the scan path, after the hash check, also skip if a **soft-deleted row from the exact same raw SMS** (`sms_body` + `sms_sender`) exists. The raw SMS is stable and survives the hash mangling, so a deleted transaction stays deleted across re-scans.

- New `TransactionDao.getDeletedBySms` (matches `is_deleted = 1` only).
- Guarded by `smsBody != null` → manual/cash entries unaffected.
- Only affects the **SMS scan path**, so **manually re-adding** a deleted transaction still works (that was the point of the original hash-mangling).

**Trade-off:** a genuinely *new* SMS with a byte-identical body+sender after a delete would now also be skipped. In practice bank SMS differ (ref no / balance / timestamp), and identical bodies already collapse via the `UNIQUE(transaction_hash)` constraint even without deletion — so this is negligible.

## Verified on-device
- Before: normal scan → deleted row resurrected as a new `is_deleted=0` row.
- After: same scenario → only the deleted row remains, no re-insert. Unrelated new SMS still ingest normally.

`./init.sh app` green.