### PR TITLE
Minor fixes

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/preferences/UserPreferencesRepository.kt
@@ -229,7 +229,7 @@ open class UserPreferencesRepository @Inject constructor(
 
     /**
      * When true, credit-card spend (TransactionType.CREDIT) is folded into the
-     * fixed "expenses / spent" totals (Home card, Transactions summary) instead
+     * fixed "expenses / spent" totals (Home card) instead
      * of being kept as a separate figure. Default off. The filter-driven
      * Analytics screen is unaffected — it already lets users select the Credit
      * type to view card spend. (#705)

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/BalanceHistoryScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/accounts/BalanceHistoryScreen.kt
@@ -98,7 +98,7 @@ fun BalanceHistoryScreen(
                         modifier = Modifier.weight(1f),
                         verticalArrangement = Arrangement.spacedBy(Spacing.sm)
                     ) {
-                        items(balanceHistory) { balance ->
+                        items(balanceHistory, key = { it.id }) { balance ->
                             val isLatest = balance == balanceHistory.first()
                             val isOnlyRecord = balanceHistory.size == 1
                             val isExpanded = expandedSources.contains(balance.id)

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/recurring/RecurringTransactionsScreen.kt
@@ -81,14 +81,6 @@ fun RecurringTransactionsScreen(
                     description = "Schedule cash or manual spend to be added automatically — rent, an allowance, a weekly cleaner."
                 )
             }
-            editing?.let { form ->
-                RecurringEditorDialog(
-                    form = form,
-                    categoryNames = categories.map { it.name },
-                    onDismiss = { editing = null },
-                    onSave = { viewModel.save(it); editing = null }
-                )
-            }
             return@PennyWiseScaffold
         }
 

--- a/app/src/main/java/com/pennywiseai/tracker/ui/components/QuickCategoryPickerSheet.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/components/QuickCategoryPickerSheet.kt
@@ -63,7 +63,7 @@ fun QuickCategoryPickerSheet(
         sheetState = sheetState
     ) {
         if (onTagsChanged != null) {
-            var tags by remember { mutableStateOf(initialTags) }
+            var tags by remember(initialTags) { mutableStateOf(initialTags) }
             TagInputField(
                 selectedTags = tags,
                 allTags = tagSuggestions,

--- a/parser-core/src/test/kotlin/TestBancolombiaParser.kt
+++ b/parser-core/src/test/kotlin/TestBancolombiaParser.kt
@@ -14,6 +14,7 @@ import java.math.BigDecimal
 class TestBancolombiaParser {
 
     private val parser = BancolombiaParser()
+    private val fixedTimestamp = 1735689600000L // 2025-01-01T00:00:00Z
 
     @Test
     fun `test bank name`() {
@@ -40,10 +41,10 @@ class TestBancolombiaParser {
         val paymentMessage = "Pagaste $2.000.000 de tu tarjeta"
         val receiveMessage = "Recibiste $100.000,25 de Maria"
 
-        val transfer = parser.parse(transferMessage, "87400", System.currentTimeMillis())
-        val purchase = parser.parse(purchaseMessage, "87400", System.currentTimeMillis())
-        val payment = parser.parse(paymentMessage, "87400", System.currentTimeMillis())
-        val receive = parser.parse(receiveMessage, "87400", System.currentTimeMillis())
+        val transfer = parser.parse(transferMessage, "87400", fixedTimestamp)
+        val purchase = parser.parse(purchaseMessage, "87400", fixedTimestamp)
+        val payment = parser.parse(paymentMessage, "87400", fixedTimestamp)
+        val receive = parser.parse(receiveMessage, "87400", fixedTimestamp)
 
         assertEquals(TransactionType.EXPENSE, transfer?.type)
         assertEquals(TransactionType.EXPENSE, purchase?.type)
@@ -55,7 +56,7 @@ class TestBancolombiaParser {
     fun `test Colombian currency format parsing with thousand separators`() {
         // Test with dots as thousand separators
         val message1 = "Transferiste $1.000.000 a cuenta"
-        val parsed1 = parser.parse(message1, "87400", System.currentTimeMillis())
+        val parsed1 = parser.parse(message1, "87400", fixedTimestamp)
 
         assertNotNull(parsed1)
         assertEquals(BigDecimal("1000000"), parsed1?.amount)
@@ -66,7 +67,7 @@ class TestBancolombiaParser {
     fun `test Colombian currency format parsing with decimals`() {
         // Test with comma as decimal separator
         val message2 = "Compraste $500,50 en tienda"
-        val parsed2 = parser.parse(message2, "87400", System.currentTimeMillis())
+        val parsed2 = parser.parse(message2, "87400", fixedTimestamp)
 
         assertNotNull(parsed2)
         assertEquals(BigDecimal("500.50"), parsed2?.amount)
@@ -77,7 +78,7 @@ class TestBancolombiaParser {
     fun `test Colombian currency format parsing with both separators`() {
         // Test with both thousand separator (dot) and decimal separator (comma)
         val message3 = "Pagaste $1.000.000,75 de tarjeta credito"
-        val parsed3 = parser.parse(message3, "85540", System.currentTimeMillis())
+        val parsed3 = parser.parse(message3, "85540", fixedTimestamp)
 
         assertNotNull(parsed3)
         assertEquals(BigDecimal("1000000.75"), parsed3?.amount)
@@ -88,7 +89,7 @@ class TestBancolombiaParser {
     fun `test Colombian currency format parsing income transaction`() {
         // Test income with Colombian format
         val message4 = "Recibiste $2.500.000,00 transferencia de empresa"
-        val parsed4 = parser.parse(message4, "87400", System.currentTimeMillis())
+        val parsed4 = parser.parse(message4, "87400", fixedTimestamp)
 
         assertNotNull(parsed4)
         assertEquals(BigDecimal("2500000.00"), parsed4?.amount)
@@ -98,7 +99,7 @@ class TestBancolombiaParser {
     @Test
     fun `test amount without decimals`() {
         val message = "Transferiste $5000 a Pedro"
-        val parsed = parser.parse(message, "87400", System.currentTimeMillis())
+        val parsed = parser.parse(message, "87400", fixedTimestamp)
 
         assertNotNull(parsed)
         assertEquals(BigDecimal("5000"), parsed?.amount)
@@ -107,7 +108,7 @@ class TestBancolombiaParser {
     @Test
     fun `test small amounts with decimals`() {
         val message = "Compraste $25,99 en cafeteria"
-        val parsed = parser.parse(message, "85540", System.currentTimeMillis())
+        val parsed = parser.parse(message, "85540", fixedTimestamp)
 
         assertNotNull(parsed)
         assertEquals(BigDecimal("25.99"), parsed?.amount)
@@ -120,10 +121,10 @@ class TestBancolombiaParser {
         val payment = "Pagaste $2.000 tarjeta"
         val receive = "Recibiste $100.000 de empresa"
 
-        val parsedTransfer = parser.parse(transfer, "87400", System.currentTimeMillis())
-        val parsedPurchase = parser.parse(purchase, "87400", System.currentTimeMillis())
-        val parsedPayment = parser.parse(payment, "87400", System.currentTimeMillis())
-        val parsedReceive = parser.parse(receive, "87400", System.currentTimeMillis())
+        val parsedTransfer = parser.parse(transfer, "87400", fixedTimestamp)
+        val parsedPurchase = parser.parse(purchase, "87400", fixedTimestamp)
+        val parsedPayment = parser.parse(payment, "87400", fixedTimestamp)
+        val parsedReceive = parser.parse(receive, "87400", fixedTimestamp)
 
         assertEquals("Transferencia", parsedTransfer?.merchant)
         assertEquals("Compra", parsedPurchase?.merchant)
@@ -136,7 +137,7 @@ class TestBancolombiaParser {
         val balanceMessage = "Tu saldo es $50.000,00"
         val promoMessage = "Aprovecha nuestras ofertas"
 
-        assertNull(parser.parse(balanceMessage, "87400", System.currentTimeMillis()))
-        assertNull(parser.parse(promoMessage, "87400", System.currentTimeMillis()))
+        assertNull(parser.parse(balanceMessage, "87400", fixedTimestamp))
+        assertNull(parser.parse(promoMessage, "87400", fixedTimestamp))
     }
 }


### PR DESCRIPTION
## Summary

1. Balance history list renders without item keys. `items(balanceHistory)` now passes `key = { it.id }`, so rows keep positional identity when new balances prepend/reorder and expanded-row state stays on the right row.
2. `QuickCategoryPickerSheet`'s tag state was an unkeyed `remember`; rotation between enqueue and commit could drop the last chip from the next replace-all. Now keyed on `initialTags`.
3. On the recurring screen's empty state, `RecurringEditorDialog` was composed twice (inside the empty branch and again post-scaffold), so tapping FAB on an empty list stacked two dialogs over each other. The in-empty-state copy is deleted; only the outer one remains.
4. `countCreditCardAsExpense` KDoc claimed the fold reaches "Transactions summary"; only the Home card consumes the pref. Comment corrected.
5. `TestBancolombiaParser` used wall-clock `System.currentTimeMillis()` for parse timestamps, making tests nondeterministic; all 16 call sites now use a fixed epoch (`1735689600000L`, 2025-01-01Z). Other parser test files still do this and are left for follow-up.

No behavior changes beyond 1–3; no data or money-path changes.

## Type of change

- [x] fix: Bug fix
- [x] docs: Documentation update
- [x] test: Add/update tests

## Screenshots/Recordings (optional)

N/A — no visual change.

## How to test

1. `./init.sh parser` — green; Bancolombia tests pass unchanged with fixed timestamps.
2. `./init.sh app` — green.
3. Optional on-device: open an account's balance history, expand a row, trigger a new balance entry — expansion stays on the correct row.
4. Optional on-device: Recurring screen on an empty list — FAB opens exactly one editor dialog; saving inserts one template.

## Breaking changes

- [x] No breaking changes

## Related issues

No GitHub issues.

## Checklist

- [x] Focused PR (single purpose — small audit fixes)
- [x] Tests added/updated (if applicable) — TestBancolombiaParser timestamps fixed
- [x] Docs updated (if applicable) — UserPreferencesRepository KDoc corrected
- [x] `./gradlew test` passes locally (`./init.sh parser` + `./init.sh app`)
- [x] `./gradlew lint` passes locally
- [x] Follows existing code style and patterns