### PR TITLE
fix(analytics): explain why category bars can exceed the total (#704)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsScreen.kt
@@ -442,6 +442,17 @@ fun AnalyticsScreen(
                             )
                         }
                     }
+
+                    // Explain why the bars can sum above the headline total: refunds are
+                    // netted in full off the total, but a category bar can't go negative (#704).
+                    if (uiState.refundNettedFromTotal > BigDecimal.ZERO) {
+                        Text(
+                            text = "Total is net of ${CurrencyFormatter.formatCurrency(uiState.refundNettedFromTotal, selectedCurrency)} in refunds. Category bars can't go below zero, so they may add up to more than the total shown.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = Spacing.sm)
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -363,6 +363,9 @@ class AnalyticsViewModel @Inject constructor(
                 val refundByAccount = mutableMapOf<String, BigDecimal>()
                 val refundByMerchant = mutableMapOf<String, BigDecimal>()
                 val refundByDay = mutableMapOf<LocalDate, BigDecimal>()
+                // Total refund value netted off the headline total. Used to explain the
+                // gap when the per-category floor leaves the bars summing above the total (#704).
+                var refundNettedTotal = BigDecimal.ZERO
                 if (filterState.typeFilter == TransactionTypeFilter.EXPENSE) {
                     for (tw in allTransactionsWithSplits) {
                         val tx = tw.transaction
@@ -389,6 +392,7 @@ class AnalyticsViewModel @Inject constructor(
                         val existing = categoryAmounts[category] ?: BigDecimal.ZERO
                         categoryAmounts[category] = (existing - converted).coerceAtLeast(BigDecimal.ZERO)
                         totalSpending -= converted
+                        refundNettedTotal += converted
                         val accountKey = "${tx.bankName}_${tx.accountNumber}"
                         refundByAccount[accountKey] = (refundByAccount[accountKey] ?: BigDecimal.ZERO) + converted
                         refundByMerchant[tx.merchantName] = (refundByMerchant[tx.merchantName] ?: BigDecimal.ZERO) + converted
@@ -412,6 +416,15 @@ class AnalyticsViewModel @Inject constructor(
                         color = categoryColorMap[categoryName]
                     )
                 }.sortedByDescending { it.amount }
+
+                // When refunds over-net a category, its bar floors at zero while the full
+                // refund still comes off the total — so the bars can sum above the headline
+                // total. Surface the netted refund only when that actually happens, so the
+                // UI can explain why the "Spending by category" bars don't add up (#704).
+                val categorySum = categoryBreakdown.fold(BigDecimal.ZERO) { acc, c -> acc + c.amount }
+                val refundNettedFromTotal =
+                    if (refundNettedTotal > BigDecimal.ZERO && categorySum > totalSpending) refundNettedTotal
+                    else BigDecimal.ZERO
 
                 // Build tag breakdown from the many-to-many tag map. A
                 // transaction can carry several tags, and its full amount
@@ -548,6 +561,7 @@ class AnalyticsViewModel @Inject constructor(
                         filteredTransactions, dateRange.first, dateRange.second, isUnified, displayCurrency, refundByDay
                     ),
                     availableCategories = allCategoryNames,
+                    refundNettedFromTotal = refundNettedFromTotal,
                     accountBreakdown = accountBreakdown,
                     tagBreakdown = tagBreakdown
                 )
@@ -768,6 +782,10 @@ data class AnalyticsUiState(
     val isLoading: Boolean = true,
     val spendingTrend: List<BalancePoint> = emptyList(),
     val availableCategories: List<String> = emptyList(),
+    // Refund value netted off the total when the per-category floor makes the
+    // "Spending by category" bars sum above the headline total (#704). Zero when
+    // the bars reconcile; the UI shows an explainer only when this is positive.
+    val refundNettedFromTotal: BigDecimal = BigDecimal.ZERO,
     val accountBreakdown: List<AccountBreakdownData> = emptyList(),
     val tagBreakdown: List<TagData> = emptyList()
 )


### PR DESCRIPTION
## Problem (#704, Play Store feedback)
> "Spending by category — the chart shows a different total from the actual transactions."

The category bars can sum **above** the headline total. This is by design and documented in `AnalyticsViewModel`: a refund (INCOME + `DEDUCT_SPENT`) is netted **in full** off the total (to stay consistent with the Home card, widget, and Transactions page), while each per-category bar **floors at zero** (a bar can't show negative spend). So an over-refund leaves the bars summing higher than the total. The figures are correct — the gap just wasn't explained.

## Fix
Surface a subtle caption under the "Top Categories" chart, shown **only** when the floor actually makes the bars exceed the total:

> *Total is net of ₹X in refunds. Category bars can't go below zero, so they may add up to more than the total shown.*

- `AnalyticsViewModel` accumulates the netted refund value and exposes it (`refundNettedFromTotal`) **only** when `sum(categoryBars) > totalSpending`; zero otherwise.
- The screen formats it with `CurrencyFormatter` (currency-tagged) and renders the caption. **No figures change.**

## Verification
`./init.sh app` green. On the emulator (screenshot in the issue/PR thread):
- Seeded Shopping ₹100 + Food ₹200 expenses and a Shopping refund ₹150 → Shopping bar floors to ₹0, **TOTAL ₹150** while **Food reads ₹200 (100%)**; the caption appears reading "net of ₹150 in refunds".
- Removing the refund → **TOTAL ₹300**, caption gone. So it's shown only when the divergence is real.

Closes #704

https://claude.ai/code/session_017JdBDF1AncNhc76a4EnTuZ