### PR TITLE
fix(parser): parse HDFC "Payment Successful!" NetBanking messages

### DIFF
--- a/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/HDFCBankParser.kt
+++ b/parser-core/src/main/kotlin/com/pennywiseai/parser/core/bank/HDFCBankParser.kt
@@ -137,6 +137,16 @@ class HDFCBankParser : BaseIndianBankParser() {
             }
         }
 
+        if (message.contains("NetBanking", ignoreCase = true)) {
+            Regex("""to\s+(.+?)\s+via\s+HDFC\s+Bank\s+NetBanking""", RegexOption.IGNORE_CASE)
+                .find(message)?.let { match ->
+                    val merchant = cleanMerchantName(match.groupValues[1].trim())
+                    if (merchant.isNotEmpty()) {
+                        return merchant
+                    }
+                }
+        }
+
         // Try HDFC specific patterns
 
         // Pattern 0: NEFT/RTGS credit - "for NEFT Cr-IFSCCODE-COMPANY NAME-BENEFICIARY-REF"
@@ -307,6 +317,8 @@ class HDFCBankParser : BaseIndianBankParser() {
             // Credit card bill payments (these are regular expenses from bank account)
             lowerMessage.contains("payment") && lowerMessage.contains("credit card") -> TransactionType.EXPENSE
             lowerMessage.contains("towards") && lowerMessage.contains("credit card") -> TransactionType.EXPENSE
+
+            lowerMessage.contains("payment successful") -> TransactionType.EXPENSE
 
             // HDFC specific: "Sent Rs.X From HDFC Bank"
             lowerMessage.contains("sent") && lowerMessage.contains("from hdfc") -> TransactionType.EXPENSE
@@ -531,7 +543,8 @@ class HDFCBankParser : BaseIndianBankParser() {
             "txn", // HDFC uses "Txn Rs.X" for card transactions
             "refund", // "Refund initiated: Amt: Rs.X on HDFC Bank Credit Card ####"
             "reversed", // "Transaction Reversed!On HDFC Bank CREDIT Card ####" (#698)
-            "reversal"
+            "reversal",
+            "payment successful"
         )
 
         return hdfcTransactionKeywords.any { lowerMessage.contains(it) }

--- a/parser-core/src/test/kotlin/TestHDFCBankParser.kt
+++ b/parser-core/src/test/kotlin/TestHDFCBankParser.kt
@@ -107,6 +107,19 @@ T&C. Ignore if paid""",
                     merchant = "AMAZON",
                     accountLast4 = "5555"
                 )
+            ),
+
+            ParserTestCase(
+                name = "NetBanking Payment Successful - Expense",
+                message = "Payment Successful! Rs. 12345.67 from A/c ****4321 to ACMEPAYMENTS via HDFC Bank NetBanking. Not you?Call 18002586161",
+                sender = "VM-HDFCBK-S",
+                expected = ExpectedTransaction(
+                    amount = BigDecimal("12345.67"),
+                    currency = "INR",
+                    type = com.pennywiseai.parser.core.TransactionType.EXPENSE,
+                    accountLast4 = "4321",
+                    merchant = "ACMEPAYMENTS"
+                )
             )
         )
 


### PR DESCRIPTION
## Problem

HDFC's NetBanking payment SMS is dropped silently:

> Payment Successful! Rs. 12345.67 from A/c ****4321 to ACMEPAYMENTS via HDFC Bank NetBanking. Not you?Call 18002586161

This format lacks the standard debit/credit keywords, so it fails at three points in `HDFCBankParser`.

## Fix

| Method | Problem | Fix |
|---|---|---|
| `isTransactionMessage` | No keyword matched → SMS dropped | Add `"payment successful"` to keyword list |
| `extractTransactionType` | No branch matched → `null` → parse bails | Map `"payment successful"` → `EXPENSE` (outgoing payment) |
| `extractMerchant` | Base `TO_PATTERN` needs a trailing `on/at/Ref/UPI` absent here | Add branch capturing payee between `to` and `via HDFC Bank NetBanking` |

Amount (`Rs. …`) and account (`A/c ****NNNN`) already resolve via base patterns.

## Test

Added a `NetBanking Payment Successful - Expense` case to `TestHDFCBankParser` (fake account/payee/amount, no PII).

`./gradlew :parser-core:test` passes, including the new case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)