### PR TITLE
fix(transactions): keep "Last Month" tiled with the budget cycle (#740)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/presentation/common/Filters.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/common/Filters.kt
@@ -3,6 +3,7 @@ package com.pennywiseai.tracker.presentation.common
 import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.data.database.entity.ProfileEntity
 import com.pennywiseai.tracker.data.database.entity.TransactionEntity
+import com.pennywiseai.tracker.domain.model.BudgetCycle
 import java.time.LocalDate
 import java.time.YearMonth
 
@@ -11,7 +12,14 @@ enum class TimePeriod(val label: String) {
     LAST_MONTH("Last Month"),
     CURRENT_FY("Current FY"),
     ALL("All Time"),
-    CUSTOM("Custom Range")
+    CUSTOM("Custom Range");
+
+    /**
+     * True for the two "month" periods, which resolve against the user's budget
+     * cycle rather than the calendar month. See [getCycleAwareDateRange].
+     */
+    val followsBudgetCycle: Boolean
+        get() = this == THIS_MONTH || this == LAST_MONTH
 }
 
 enum class TransactionTypeFilter(val label: String) {
@@ -57,6 +65,32 @@ fun getDateRangeForPeriod(period: TimePeriod): Pair<LocalDate, LocalDate>? {
             null
         }
     }
+}
+
+/**
+ * The date range for [period], honouring the user's configured budget cycle
+ * start day (e.g. 25th → 24th) for the two "month" periods.
+ *
+ * "This Month" already followed the cycle everywhere; "Last Month" did not, so
+ * with any start day other than the 1st the two windows neither met nor
+ * overlapped and the days in between were unreachable from either chip (#740).
+ * Resolving both from [BudgetCycle] keeps them tiled: "Last Month" always ends
+ * the day before "This Month" starts.
+ *
+ * With the default start day of 1 this is identical to the calendar months
+ * [getDateRangeForPeriod] returns.
+ */
+fun getCycleAwareDateRange(
+    period: TimePeriod,
+    cycleStartDay: Int,
+    today: LocalDate = LocalDate.now()
+): Pair<LocalDate, LocalDate>? = when (period) {
+    TimePeriod.THIS_MONTH -> BudgetCycle.currentCycle(today, cycleStartDay)
+    TimePeriod.LAST_MONTH -> BudgetCycle.previousCycle(
+        BudgetCycle.currentCycle(today, cycleStartDay),
+        cycleStartDay
+    )
+    else -> getDateRangeForPeriod(period)
 }
 
 /**

--- a/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/presentation/transactions/TransactionsViewModel.kt
@@ -11,9 +11,9 @@ import com.pennywiseai.tracker.data.repository.CategoryRepository
 import com.pennywiseai.tracker.data.repository.MerchantAliasRepository
 import com.pennywiseai.tracker.data.repository.TagRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
-import com.pennywiseai.tracker.domain.model.BudgetCycle
 import com.pennywiseai.tracker.presentation.common.TimePeriod
 import com.pennywiseai.tracker.presentation.common.TransactionTypeFilter
+import com.pennywiseai.tracker.presentation.common.getCycleAwareDateRange
 import com.pennywiseai.tracker.presentation.common.getDateRangeForPeriod
 import com.pennywiseai.tracker.presentation.common.CurrencyGroupedTotals
 import com.pennywiseai.tracker.presentation.common.CurrencyTotals
@@ -169,8 +169,8 @@ class TransactionsViewModel @Inject constructor(
             val startDateTime = startDate.atStartOfDay()
             val endDateTime = endDate.atTime(23, 59, 59)
             transactionRepository.getCurrenciesForPeriod(startDateTime, endDateTime)
-        } else if (period == TimePeriod.THIS_MONTH) {
-            val (startDate, endDate) = getThisCycleRange()
+        } else if (period.followsBudgetCycle) {
+            val (startDate, endDate) = getCycleRange(period)
             val startDateTime = startDate.atStartOfDay()
             val endDateTime = endDate.atTime(23, 59, 59)
             transactionRepository.getCurrenciesForPeriod(startDateTime, endDateTime)
@@ -729,13 +729,13 @@ class TransactionsViewModel @Inject constructor(
             .transformLatest { _ ->
                 val period = selectedPeriod.value
                 val categories = categoriesFilter.value
-                // Always resolve a cycle range up-front; only THIS_MONTH consumes it
-                // today, but keeping a real Pair avoids nullable plumbing in the
-                // (non-suspend) filter helper.
-                val cycleRange = if (period == TimePeriod.THIS_MONTH) {
-                    getThisCycleRange()
+                // Always resolve a cycle range up-front; only the cycle-following
+                // periods consume it, but keeping a real Pair avoids nullable
+                // plumbing in the (non-suspend) filter helper.
+                val cycleRange = if (period.followsBudgetCycle) {
+                    getCycleRange(period)
                 } else {
-                    // Use a sentinel range — never read for non-THIS_MONTH branches.
+                    // Use a sentinel range — never read for other periods.
                     LocalDate.now() to LocalDate.now()
                 }
                 // Get all transactions without category filter applied
@@ -787,11 +787,11 @@ class TransactionsViewModel @Inject constructor(
                 val tag = _tagFilter.value
 
                 // Resolve the cycle window up-front so the inner (non-suspend)
-                // filter helper can reuse it for THIS_MONTH. Non-THIS_MONTH
-                // branches never read this — pass a sentinel pair to keep
+                // filter helper can reuse it for the cycle-following periods.
+                // Other periods never read this — pass a sentinel pair to keep
                 // the helper signature non-nullable.
-                val cycleRange = if (period == TimePeriod.THIS_MONTH) {
-                    getThisCycleRange()
+                val cycleRange = if (period.followsBudgetCycle) {
+                    getCycleRange(period)
                 } else {
                     LocalDate.now() to LocalDate.now()
                 }
@@ -975,14 +975,17 @@ class TransactionsViewModel @Inject constructor(
     }
 
     /**
-     * The "This Month" range for the Transactions tab. Honours the user's
-     * configured budget cycle start day (e.g. 25th → 24th) so the transactions
-     * list, totals, and analytics agree on the same window.
+     * The "This Month" / "Last Month" range for the Transactions tab. Honours
+     * the user's configured budget cycle start day (e.g. 25th → 24th) so the
+     * transactions list, totals, and analytics agree on the same window — and
+     * so the two chips stay tiled with no unreachable days between them.
+     *
+     * Only ever called for a period where [TimePeriod.followsBudgetCycle] is
+     * true, so the non-null assertion cannot fire.
      */
-    private suspend fun getThisCycleRange(): Pair<LocalDate, LocalDate> {
+    private suspend fun getCycleRange(period: TimePeriod): Pair<LocalDate, LocalDate> {
         val startDay = userPreferencesRepository.getBudgetCycleStartDay()
-        val (start, end) = BudgetCycle.currentCycle(LocalDate.now(), startDay)
-        return start to end
+        return getCycleAwareDateRange(period, startDay)!!
     }
 
     fun deleteTransaction(transaction: TransactionEntity) {
@@ -1308,7 +1311,7 @@ class TransactionsViewModel @Inject constructor(
                     }
                 }
             }
-            TimePeriod.THIS_MONTH -> {
+            TimePeriod.THIS_MONTH, TimePeriod.LAST_MONTH -> {
                 val (startDate, endDate) = cycleRange
                 val startDateTime = startDate.atStartOfDay()
                 val endDateTime = endDate.atTime(23, 59, 59)

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/analytics/AnalyticsViewModel.kt
@@ -19,9 +19,9 @@ import com.pennywiseai.tracker.presentation.common.AccountOption
 import com.pennywiseai.tracker.presentation.common.accountOptions
 import com.pennywiseai.tracker.presentation.common.buildProfileAccountKeys
 import com.pennywiseai.tracker.presentation.common.filterTransactionsByProfile
+import com.pennywiseai.tracker.presentation.common.getCycleAwareDateRange
 import com.pennywiseai.tracker.presentation.common.getDateRangeForPeriod
 import com.pennywiseai.tracker.utils.CurrencyUtils
-import com.pennywiseai.tracker.domain.model.BudgetCycle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -176,10 +176,10 @@ class AnalyticsViewModel @Inject constructor(
         triple to tagMap
     }.flatMapLatest { (triple, tagMap) ->
         val (filterState, balances, categoryColorMap) = triple
-        // Determine date range based on selected period. THIS_MONTH is special:
-        // it follows the user's custom budget cycle (e.g. 25th → 24th) instead
-        // of the calendar month, so the analytics range lines up with the
-        // home/cycle everywhere else in the app.
+        // Determine date range based on selected period. The two "month"
+        // periods are special: they follow the user's custom budget cycle
+        // (e.g. 25th → 24th) instead of the calendar month, so the analytics
+        // range lines up with the home/cycle everywhere else in the app.
         val dateRange = if (filterState.period == TimePeriod.CUSTOM) {
             val customRange = filterState.customRange
             // Guard against invalid state: CUSTOM period must have a date range
@@ -188,12 +188,12 @@ class AnalyticsViewModel @Inject constructor(
                     "CUSTOM period selected but no date range set - falling back to THIS_MONTH")
                 // Auto-correct the invalid state
                 _selectedPeriod.value = TimePeriod.THIS_MONTH
-                getThisCycleRange()
+                getCycleRange(TimePeriod.THIS_MONTH)
             } else {
                 customRange
             }
-        } else if (filterState.period == TimePeriod.THIS_MONTH) {
-            getThisCycleRange()
+        } else if (filterState.period.followsBudgetCycle) {
+            getCycleRange(filterState.period)
         } else {
             getDateRangeForPeriod(filterState.period)
         }
@@ -635,15 +635,17 @@ class AnalyticsViewModel @Inject constructor(
     }
 
     /**
-     * The "This Month" range for the Analytics tab. Honours the user's
-     * configured budget cycle start day (e.g. 25th → 24th) instead of the
-     * calendar month, so the chart and stats line up with the cycle used
+     * The "This Month" / "Last Month" range for the Analytics tab. Honours the
+     * user's configured budget cycle start day (e.g. 25th → 24th) instead of
+     * the calendar month, so the chart and stats line up with the cycle used
      * everywhere else in the app.
+     *
+     * Only ever called for a period where [TimePeriod.followsBudgetCycle] is
+     * true, so the non-null assertion cannot fire.
      */
-    private suspend fun getThisCycleRange(): Pair<LocalDate, LocalDate> {
+    private suspend fun getCycleRange(period: TimePeriod): Pair<LocalDate, LocalDate> {
         val startDay = userPreferencesRepository.getBudgetCycleStartDay()
-        val (start, end) = BudgetCycle.currentCycle(LocalDate.now(), startDay)
-        return start to end
+        return getCycleAwareDateRange(period, startDay)!!
     }
 
     private suspend fun calculateSpendingTrend(

--- a/app/src/test/java/com/pennywiseai/tracker/presentation/common/CycleAwareDateRangeTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/presentation/common/CycleAwareDateRangeTest.kt
@@ -1,0 +1,80 @@
+package com.pennywiseai.tracker.presentation.common
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * "This Month" has always resolved against the user's budget cycle while
+ * "Last Month" resolved against the calendar month. With any cycle start day
+ * other than the 1st the two windows stopped meeting, and the days in between
+ * were unreachable from either chip — the Aug-31 report in #740, where "This
+ * Month" was empty and "Last Month" showed July while August's transactions
+ * were only visible under "Current FY".
+ *
+ * These tests pin the property that actually matters: the two windows tile.
+ */
+class CycleAwareDateRangeTest {
+
+    @Test
+    fun `issue 740 - on Aug 31 with a 31st cycle August stays reachable`() {
+        val today = LocalDate.of(2026, 8, 31)
+
+        val thisMonth = getCycleAwareDateRange(TimePeriod.THIS_MONTH, cycleStartDay = 31, today = today)!!
+        val lastMonth = getCycleAwareDateRange(TimePeriod.LAST_MONTH, cycleStartDay = 31, today = today)!!
+
+        // The current cycle only just started, so it holds a single day.
+        assertEquals(LocalDate.of(2026, 8, 31), thisMonth.first)
+        // "Last Month" now covers the rest of August instead of jumping to July.
+        assertEquals(LocalDate.of(2026, 7, 31), lastMonth.first)
+        assertEquals(LocalDate.of(2026, 8, 30), lastMonth.second)
+
+        val aug15 = LocalDate.of(2026, 8, 15)
+        assertTrue(
+            "A mid-August transaction must be visible under one of the two month chips",
+            aug15 in lastMonth.first..lastMonth.second || aug15 in thisMonth.first..thisMonth.second
+        )
+    }
+
+    @Test
+    fun `last month ends the day before this month starts, for every start day`() {
+        val today = LocalDate.of(2026, 3, 10)
+        for (startDay in 1..31) {
+            val thisMonth = getCycleAwareDateRange(TimePeriod.THIS_MONTH, startDay, today)!!
+            val lastMonth = getCycleAwareDateRange(TimePeriod.LAST_MONTH, startDay, today)!!
+
+            assertEquals(
+                "start day $startDay leaves a gap or an overlap between the two chips",
+                thisMonth.first.minusDays(1),
+                lastMonth.second
+            )
+        }
+    }
+
+    @Test
+    fun `the default start day still yields the calendar months`() {
+        val today = LocalDate.of(2026, 8, 31)
+
+        val thisMonth = getCycleAwareDateRange(TimePeriod.THIS_MONTH, cycleStartDay = 1, today = today)!!
+        val lastMonth = getCycleAwareDateRange(TimePeriod.LAST_MONTH, cycleStartDay = 1, today = today)!!
+
+        assertEquals(LocalDate.of(2026, 8, 1) to LocalDate.of(2026, 8, 31), thisMonth)
+        assertEquals(LocalDate.of(2026, 7, 1) to LocalDate.of(2026, 7, 31), lastMonth)
+    }
+
+    @Test
+    fun `periods that do not follow the cycle are unchanged`() {
+        assertEquals(false, TimePeriod.ALL.followsBudgetCycle)
+        assertEquals(false, TimePeriod.CURRENT_FY.followsBudgetCycle)
+        assertEquals(false, TimePeriod.CUSTOM.followsBudgetCycle)
+        assertEquals(true, TimePeriod.THIS_MONTH.followsBudgetCycle)
+        assertEquals(true, TimePeriod.LAST_MONTH.followsBudgetCycle)
+
+        assertEquals(
+            getDateRangeForPeriod(TimePeriod.CURRENT_FY),
+            getCycleAwareDateRange(TimePeriod.CURRENT_FY, cycleStartDay = 25)
+        )
+        assertEquals(null, getCycleAwareDateRange(TimePeriod.CUSTOM, cycleStartDay = 25))
+    }
+}


### PR DESCRIPTION
Closes part of #740.

## The bug

"This Month" has always resolved against the user's **budget cycle start day**; "Last Month" resolved against the **calendar month**. With any start day other than the 1st the two windows stop meeting, and the days in between are unreachable from either chip.

The reporter's case, on Aug 31: "This Month" was empty, "Last Month" showed July, and their August transactions were only visible under "Current FY".

## The fix

Both month periods now resolve through `BudgetCycle`, via a shared `getCycleAwareDateRange(period, cycleStartDay)`:

- `THIS_MONTH` → `BudgetCycle.currentCycle(...)` (unchanged)
- `LAST_MONTH` → `BudgetCycle.previousCycle(...)` (was the calendar month)

So "Last Month" always ends the day before "This Month" starts. **With the default start day of 1 this is byte-for-byte the calendar months it produced before**, so users who never touched the setting see no change.

Applied on both surfaces that had the split: the Transactions list (rows, totals, currency chips, category chips) and Analytics.

## Not included

Items 2 and 3 of the issue ("clicking Home does nothing from the Transactions tab") don't reproduce on the emulator — see my comment on the issue asking the reporter for their nav-bar style and Android version. Keeping this PR to the part that's root-caused.

## Verification

`./init.sh app` green, plus 4 new tests in `CycleAwareDateRangeTest` — including the property that the two windows tile for **every** start day 1..31, and the exact Aug-31 scenario from the issue.

On the emulator, with cycle start day = 15 and today = Sep 1:

| Chip | Window | Shows |
|---|---|---|
| This Month | Aug 15 – Sep 14 | the three Sep-1 transactions (₹645) |
| Last Month | Jul 15 – Aug 14 | a Jul-20 transaction (₹999) |

Before the fix, "Last Month" was Aug 1–31 and that Jul-20 transaction was reachable from neither chip.