### PR TITLE
feat(settings): add a 'Delete All Transactions' action (#737)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/AccountBalanceDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/AccountBalanceDao.kt
@@ -57,6 +57,39 @@ interface AccountBalanceDao {
         ORDER BY ab1.balance DESC
     """)
     fun getAllLatestBalances(): Flow<List<AccountBalanceEntity>>
+
+    /**
+     * One-shot form of [getAllLatestBalances], for callers that need the account
+     * list *inside* a database transaction — collecting a Flow there would
+     * observe the very writes the transaction is making.
+     */
+    @Query("""
+        SELECT ab1.* FROM account_balances ab1
+        INNER JOIN (
+            SELECT bank_name, account_last4, MAX(timestamp) as max_timestamp
+            FROM account_balances
+            GROUP BY bank_name, account_last4
+        ) ab2
+        ON ab1.bank_name = ab2.bank_name
+        AND ab1.account_last4 = ab2.account_last4
+        AND ab1.timestamp = ab2.max_timestamp
+        ORDER BY ab1.balance DESC
+    """)
+    suspend fun getAllLatestBalancesOnce(): List<AccountBalanceEntity>
+
+    /**
+     * Removes balance rows the app derived from a transaction — the signed delta
+     * snapshots written by `insertBalanceDelta`, which carry a `transaction_id`
+     * and no `sms_source`.
+     *
+     * Deliberately spares anything with an `sms_source`: a bank-reported balance
+     * is the bank's own word even though it arrived alongside a transaction, so a
+     * wipe of local history must not rewrite it.
+     *
+     * @return the number of rows removed.
+     */
+    @Query("DELETE FROM account_balances WHERE transaction_id IS NOT NULL AND sms_source IS NULL")
+    suspend fun deleteTransactionDerivedBalances(): Int
     
     @Query("SELECT * FROM account_balances ORDER BY timestamp DESC")
     fun getAllBalances(): Flow<List<AccountBalanceEntity>>

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
@@ -125,6 +125,14 @@ interface TransactionDao {
     suspend fun deleteAllTransactions()
 
     /**
+     * Every row in the table, soft-deleted ones included, so the "delete all"
+     * confirmation reports the same number of rows [deleteAllTransactions]
+     * will actually remove.
+     */
+    @Query("SELECT COUNT(*) FROM transactions")
+    suspend fun countAllTransactions(): Int
+
+    /**
      * Deletes only transactions that don't carry user-curated annotations
      * (no loan link, no group membership). Used by the full-rescan path so
      * rebuilding the SMS-derived view doesn't blow away loans + their

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
@@ -135,6 +135,14 @@ interface TransactionDao {
     @Query("SELECT COUNT(*) FROM transactions")
     fun observeAllTransactionCount(): Flow<Int>
 
+    /**
+     * One-shot row count, read *inside* the delete-all transaction to check that
+     * the table still holds exactly what the user confirmed before anything is
+     * removed.
+     */
+    @Query("SELECT COUNT(*) FROM transactions")
+    suspend fun countAllTransactions(): Int
+
 
     /**
      * Deletes only transactions that don't carry user-curated annotations

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
@@ -126,13 +126,14 @@ interface TransactionDao {
     suspend fun deleteAllTransactions(): Int
 
     /**
-     * Every row in the table, soft-deleted ones included, so the "delete all"
-     * confirmation can preview how many rows it is about to remove. The result
-     * message uses [deleteAllTransactions]'s own return value instead, so a row
-     * written while the dialog was open is still reported accurately.
+     * Every row in the table, soft-deleted ones included, observed so the
+     * "delete all" confirmation keeps showing what it is actually about to
+     * remove — a background SMS scan writing a row while the dialog is open
+     * moves the number the user is consenting to, rather than leaving them
+     * looking at a stale one.
      */
     @Query("SELECT COUNT(*) FROM transactions")
-    suspend fun countAllTransactions(): Int
+    fun observeAllTransactionCount(): Flow<Int>
 
 
     /**

--- a/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/database/dao/TransactionDao.kt
@@ -121,16 +121,19 @@ interface TransactionDao {
     @Query("DELETE FROM transactions WHERE id = :transactionId")
     suspend fun deleteTransactionById(transactionId: Long)
     
+    /** @return the number of rows actually removed. */
     @Query("DELETE FROM transactions")
-    suspend fun deleteAllTransactions()
+    suspend fun deleteAllTransactions(): Int
 
     /**
      * Every row in the table, soft-deleted ones included, so the "delete all"
-     * confirmation reports the same number of rows [deleteAllTransactions]
-     * will actually remove.
+     * confirmation can preview how many rows it is about to remove. The result
+     * message uses [deleteAllTransactions]'s own return value instead, so a row
+     * written while the dialog was open is still reported accurately.
      */
     @Query("SELECT COUNT(*) FROM transactions")
     suspend fun countAllTransactions(): Int
+
 
     /**
      * Deletes only transactions that don't carry user-curated annotations

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/AccountBalanceRepository.kt
@@ -628,6 +628,31 @@ open class AccountBalanceRepository @Inject constructor(
         return sum
     }
 
+    /** One-shot account list; see [AccountBalanceDao.getAllLatestBalancesOnce]. */
+    suspend fun getAllLatestBalancesOnce(): List<AccountBalanceEntity> =
+        accountBalanceDao.getAllLatestBalancesOnce()
+
+    /**
+     * Drops the balance rows the app *derived* from transactions, after those
+     * transactions have been deleted wholesale.
+     *
+     * [insertBalanceDelta] snapshots a signed delta row (`sourceType`
+     * "TRANSACTION", `smsSource` null) every time a transaction lands on an
+     * SMS-tracked account — and on a manual credit card, which
+     * [recomputeManualBalance] can't own because its sum is income-positive and
+     * would invert a card's outstanding figure. Once the transactions are gone
+     * those rows are orphans that still hold the account's displayed balance at
+     * a total for history that no longer exists.
+     *
+     * Rows carrying an `sms_source` are left alone: those are balances the bank
+     * itself reported, not something computed from the local history, so
+     * clearing the history shouldn't rewrite them.
+     *
+     * @return the number of orphaned rows removed.
+     */
+    suspend fun deleteTransactionDerivedBalances(): Int =
+        accountBalanceDao.deleteTransactionDerivedBalances()
+
     /**
      * Ensures a manual account has an OPENING anchor, deriving it once so the
      * currently-displayed balance is preserved: opening = currentBalance − Σtxns.

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
@@ -142,6 +142,10 @@ open class TransactionRepository @Inject constructor(
     fun observeAllTransactionCount(): Flow<Int> =
         transactionDao.observeAllTransactionCount()
 
+    /** See [TransactionDao.countAllTransactions]. */
+    suspend fun countAllTransactions(): Int =
+        transactionDao.countAllTransactions()
+
     /** See [TransactionDao.deleteUncuratedTransactions]. */
     suspend fun deleteUncuratedTransactions() =
         transactionDao.deleteUncuratedTransactions()

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
@@ -138,9 +138,9 @@ open class TransactionRepository @Inject constructor(
     suspend fun deleteAllTransactions(): Int =
         transactionDao.deleteAllTransactions()
 
-    /** See [TransactionDao.countAllTransactions]. */
-    suspend fun countAllTransactions(): Int =
-        transactionDao.countAllTransactions()
+    /** See [TransactionDao.observeAllTransactionCount]. */
+    fun observeAllTransactionCount(): Flow<Int> =
+        transactionDao.observeAllTransactionCount()
 
     /** See [TransactionDao.deleteUncuratedTransactions]. */
     suspend fun deleteUncuratedTransactions() =

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
@@ -137,6 +137,10 @@ open class TransactionRepository @Inject constructor(
     suspend fun deleteAllTransactions() =
         transactionDao.deleteAllTransactions()
 
+    /** See [TransactionDao.countAllTransactions]. */
+    suspend fun countAllTransactions(): Int =
+        transactionDao.countAllTransactions()
+
     /** See [TransactionDao.deleteUncuratedTransactions]. */
     suspend fun deleteUncuratedTransactions() =
         transactionDao.deleteUncuratedTransactions()

--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/TransactionRepository.kt
@@ -134,7 +134,8 @@ open class TransactionRepository @Inject constructor(
         }
     }
 
-    suspend fun deleteAllTransactions() =
+    /** @return the number of rows actually removed. */
+    suspend fun deleteAllTransactions(): Int =
         transactionDao.deleteAllTransactions()
 
     /** See [TransactionDao.countAllTransactions]. */

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/DeleteAllTransactionsUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/DeleteAllTransactionsUseCase.kt
@@ -4,7 +4,6 @@ import androidx.room.withTransaction
 import com.pennywiseai.tracker.data.database.PennyWiseDatabase
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
-import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -23,9 +22,16 @@ import javax.inject.Singleton
  *    Replaying that for every row would unwind every expense at once and leave
  *    the user staring at an inflated balance right after asking to clear their
  *    history.)
+ *  - **Rows the app derived from a transaction are dropped.** Every delta
+ *    snapshot written when a transaction landed is an orphan once that
+ *    transaction is gone, and would otherwise keep the account displaying a
+ *    total for history that no longer exists. This is what settles a manual
+ *    *credit card*, which [AccountBalanceRepository.recomputeManualBalance]
+ *    cannot own — its sum is income-positive and would invert a card's
+ *    outstanding figure.
  *  - **Manual / cash accounts are recomputed.** Their balance *is defined* as
- *    opening + Σ(transactions), so leaving it untouched would keep showing a
- *    total for transactions that no longer exist.
+ *    opening + Σ(transactions); with the transactions gone that lands them back
+ *    on their opening balance.
  *
  * Everything else a transaction hangs off — splits, tags, rule applications —
  * goes with it through the cascading foreign keys. Accounts, budgets, loans,
@@ -46,7 +52,7 @@ open class DeleteAllTransactionsUseCase @Inject constructor(
      *   its preview count is still reported accurately.
      */
     suspend operator fun invoke(): Int = runInTransaction {
-        val accounts = accountBalanceRepository.getAllLatestBalances().first()
+        val accounts = accountBalanceRepository.getAllLatestBalancesOnce()
 
         // Must run before the delete: a manual account's opening balance is
         // back-solved from the transaction sum that is about to disappear.
@@ -56,7 +62,11 @@ open class DeleteAllTransactionsUseCase @Inject constructor(
 
         val deleted = transactionRepository.deleteAllTransactions()
 
-        // No-ops for SMS-tracked accounts; lands a manual one back on its opening.
+        // Clears the now-orphaned delta rows. Bank-reported balances survive.
+        accountBalanceRepository.deleteTransactionDerivedBalances()
+
+        // No-op for SMS-tracked accounts and for credit cards (handled above by
+        // dropping their deltas); lands a manual account back on its opening.
         accounts.forEach { account ->
             accountBalanceRepository.recomputeManualBalance(account.bankName, account.accountLast4)
         }

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/DeleteAllTransactionsUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/DeleteAllTransactionsUseCase.kt
@@ -1,0 +1,66 @@
+package com.pennywiseai.tracker.domain.usecase
+
+import androidx.room.withTransaction
+import com.pennywiseai.tracker.data.database.PennyWiseDatabase
+import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
+import com.pennywiseai.tracker.data.repository.TransactionRepository
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Clears the user's whole transaction history and settles the account-balance
+ * ledger behind it, as one database transaction — a crash or cancellation
+ * part-way through can't leave the transactions gone but a manual account still
+ * displaying a total for them.
+ *
+ * Balances get different treatment per account kind, on purpose:
+ *
+ *  - **SMS-tracked accounts keep their last reported figure.** That number is
+ *    the bank's own word, not something derived from the local history, so
+ *    clearing the history shouldn't rewrite it. (Deleting a *single* transaction
+ *    does shift it, via [AccountBalanceRepository.applyDeleteBalanceShift].
+ *    Replaying that for every row would unwind every expense at once and leave
+ *    the user staring at an inflated balance right after asking to clear their
+ *    history.)
+ *  - **Manual / cash accounts are recomputed.** Their balance *is defined* as
+ *    opening + Σ(transactions), so leaving it untouched would keep showing a
+ *    total for transactions that no longer exist.
+ *
+ * Everything else a transaction hangs off — splits, tags, rule applications —
+ * goes with it through the cascading foreign keys. Accounts, budgets, loans,
+ * categories and rules are kept.
+ */
+@Singleton
+open class DeleteAllTransactionsUseCase @Inject constructor(
+    private val database: PennyWiseDatabase,
+    private val transactionRepository: TransactionRepository,
+    private val accountBalanceRepository: AccountBalanceRepository
+) {
+    internal open suspend fun <R> runInTransaction(block: suspend () -> R): R =
+        database.withTransaction(block)
+
+    /**
+     * @return the number of transaction rows actually removed — the DELETE's own
+     *   affected-row count, so a row written after the confirmation dialog read
+     *   its preview count is still reported accurately.
+     */
+    suspend operator fun invoke(): Int = runInTransaction {
+        val accounts = accountBalanceRepository.getAllLatestBalances().first()
+
+        // Must run before the delete: a manual account's opening balance is
+        // back-solved from the transaction sum that is about to disappear.
+        accounts.forEach { account ->
+            accountBalanceRepository.ensureManualOpening(account.bankName, account.accountLast4)
+        }
+
+        val deleted = transactionRepository.deleteAllTransactions()
+
+        // No-ops for SMS-tracked accounts; lands a manual one back on its opening.
+        accounts.forEach { account ->
+            accountBalanceRepository.recomputeManualBalance(account.bankName, account.accountLast4)
+        }
+
+        deleted
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/domain/usecase/DeleteAllTransactionsUseCase.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/usecase/DeleteAllTransactionsUseCase.kt
@@ -46,12 +46,31 @@ open class DeleteAllTransactionsUseCase @Inject constructor(
     internal open suspend fun <R> runInTransaction(block: suspend () -> R): R =
         database.withTransaction(block)
 
+    /** Outcome of a delete-all attempt. */
+    sealed interface Result {
+        /** [deleted] rows were removed. */
+        data class Deleted(val deleted: Int) : Result
+
+        /**
+         * Nothing was removed because the table no longer held [expected] rows.
+         * A background SMS scan committed while the confirmation was open, so the
+         * user would have been authorising a bigger delete than the one they were
+         * shown. They get to look at the new number and decide again.
+         */
+        data class CountChanged(val expected: Int, val actual: Int) : Result
+    }
+
     /**
-     * @return the number of transaction rows actually removed — the DELETE's own
-     *   affected-row count, so a row written after the confirmation dialog read
-     *   its preview count is still reported accurately.
+     * @param expectedCount the row count the confirmation dialog was showing when
+     *   the user confirmed. Re-checked inside the transaction so the delete either
+     *   removes exactly what was authorised or removes nothing at all.
      */
-    suspend operator fun invoke(): Int = runInTransaction {
+    suspend operator fun invoke(expectedCount: Int): Result = runInTransaction {
+        val actual = transactionRepository.countAllTransactions()
+        if (actual != expectedCount) {
+            return@runInTransaction Result.CountChanged(expectedCount, actual)
+        }
+
         val accounts = accountBalanceRepository.getAllLatestBalancesOnce()
 
         // Must run before the delete: a manual account's opening balance is
@@ -71,6 +90,6 @@ open class DeleteAllTransactionsUseCase @Inject constructor(
             accountBalanceRepository.recomputeManualBalance(account.bankName, account.accountLast4)
         }
 
-        deleted
+        Result.Deleted(deleted)
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.material3.SelectableDates
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.ui.Alignment
@@ -123,6 +124,9 @@ fun SettingsScreen(
     val budgetCycleStartDay by settingsViewModel.budgetCycleStartDay.collectAsStateWithLifecycle(initialValue = 1)
     val importExportMessage by settingsViewModel.importExportMessage.collectAsStateWithLifecycle()
     val exportedBackupFile by settingsViewModel.exportedBackupFile.collectAsStateWithLifecycle()
+    val deleteAllTransactionsCount by settingsViewModel.deleteAllTransactionsCount.collectAsStateWithLifecycle()
+    val isDeletingAllTransactions by settingsViewModel.isDeletingAllTransactions.collectAsStateWithLifecycle()
+    val deleteAllTransactionsResult by settingsViewModel.deleteAllTransactionsResult.collectAsStateWithLifecycle()
     val unifiedCurrencyMode by settingsViewModel.unifiedCurrencyMode.collectAsStateWithLifecycle(initialValue = false)
     val countCreditCardAsExpense by settingsViewModel.countCreditCardAsExpense.collectAsStateWithLifecycle(initialValue = false)
     val displayCurrency by settingsViewModel.displayCurrency.collectAsStateWithLifecycle(initialValue = "")
@@ -689,12 +693,21 @@ fun SettingsScreen(
                         else -> "Scan last $smsScanMonths months"
                     },
                     onClick = { showSmsScanDialog = true },
-                    position = ListItemPosition.Bottom,
+                    position = ListItemPosition.Middle,
                     trailingText = when {
                         smsScanAllTime -> "All Time"
                         smsScanUseCustomDate -> smsScanCustomDate?.let { formatSmsScanCustomDateShort(it) } ?: "Custom"
                         else -> "$smsScanMonths mo"
                     }
+                )
+                SettingsNavItem(
+                    icon = Icons.Default.DeleteForever,
+                    iconBgColor = red_light,
+                    iconTint = red_dark,
+                    title = "Delete All Transactions",
+                    subtitle = "Clear your transaction history — accounts and budgets stay",
+                    onClick = { settingsViewModel.requestDeleteAllTransactions() },
+                    position = ListItemPosition.Bottom
                 )
             }
 
@@ -1082,6 +1095,85 @@ fun SettingsScreen(
         ) {
             DatePicker(state = datePickerState)
         }
+    }
+
+    // Delete-all-transactions confirmation. Irreversible and unbatched, so it
+    // asks for the word DELETE rather than a single tap, names the exact number
+    // of rows, and points at Export Data first.
+    deleteAllTransactionsCount?.let { count ->
+        var confirmationText by rememberSaveable(count) { mutableStateOf("") }
+        val confirmed = confirmationText.trim().equals("DELETE", ignoreCase = false)
+
+        AlertDialog(
+            onDismissRequest = {
+                if (!isDeletingAllTransactions) settingsViewModel.cancelDeleteAllTransactions()
+            },
+            icon = {
+                Icon(
+                    Icons.Default.DeleteForever,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error
+                )
+            },
+            title = { Text("Delete all transactions?") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(Spacing.md)) {
+                    Text(
+                        if (count == 1) {
+                            "This permanently deletes your 1 transaction, along with its splits and tags. It cannot be undone."
+                        } else {
+                            "This permanently deletes all $count transactions, along with their splits and tags. It cannot be undone."
+                        }
+                    )
+                    Text(
+                        "Your accounts, budgets, loans, categories and rules are kept. " +
+                            "Export Data first if you might want this history back.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    OutlinedTextField(
+                        value = confirmationText,
+                        onValueChange = { confirmationText = it },
+                        singleLine = true,
+                        enabled = !isDeletingAllTransactions,
+                        label = { Text("Type DELETE to confirm") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = { settingsViewModel.deleteAllTransactions() },
+                    enabled = confirmed && !isDeletingAllTransactions,
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error
+                    )
+                ) {
+                    Text(if (isDeletingAllTransactions) "Deleting…" else "Delete All")
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { settingsViewModel.cancelDeleteAllTransactions() },
+                    enabled = !isDeletingAllTransactions
+                ) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
+    deleteAllTransactionsResult?.let { message ->
+        AlertDialog(
+            onDismissRequest = { settingsViewModel.clearDeleteAllTransactionsResult() },
+            title = { Text("Transactions") },
+            text = { Text(message) },
+            confirmButton = {
+                TextButton(onClick = { settingsViewModel.clearDeleteAllTransactionsResult() }) {
+                    Text("OK")
+                }
+            }
+        )
     }
 
     // Show import/export message

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsScreen.kt
@@ -1143,7 +1143,7 @@ fun SettingsScreen(
             },
             confirmButton = {
                 TextButton(
-                    onClick = { settingsViewModel.deleteAllTransactions() },
+                    onClick = { settingsViewModel.deleteAllTransactions(count) },
                     enabled = confirmed && !isDeletingAllTransactions,
                     colors = ButtonDefaults.textButtonColors(
                         contentColor = MaterialTheme.colorScheme.error

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -56,6 +56,7 @@ class SettingsViewModel @Inject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val unrecognizedSmsRepository: UnrecognizedSmsRepository,
     private val transactionRepository: TransactionRepository,
+    private val deleteAllTransactionsUseCase: com.pennywiseai.tracker.domain.usecase.DeleteAllTransactionsUseCase,
     private val accountBalanceRepository: AccountBalanceRepository,
     private val backupExporter: BackupExporter,
     private val backupImporter: BackupImporter,
@@ -514,46 +515,16 @@ class SettingsViewModel @Inject constructor(
     }
 
     /**
-     * Deletes every transaction, then settles the account-balance ledger.
-     *
-     * Balances get different treatment per account kind, on purpose:
-     *
-     *  - **SMS-tracked accounts keep their last reported figure.** That number is
-     *    the bank's own word, not something derived from the local history, so
-     *    clearing the history shouldn't rewrite it. (Deleting a *single*
-     *    transaction does shift it, via
-     *    [AccountBalanceRepository.applyDeleteBalanceShift]. Replaying that for
-     *    every row would unwind every expense at once and leave the user staring
-     *    at an inflated balance right after asking to clear their history.)
-     *  - **Manual / cash accounts are recomputed.** Their balance *is defined* as
-     *    opening + Σ(transactions), so leaving it untouched would keep showing a
-     *    total for transactions that no longer exist. The opening row is
-     *    established *before* the delete — it is back-solved from the current
-     *    balance minus the transaction sum, which only works while those rows are
-     *    still there — and the recompute afterwards lands the account back on its
-     *    opening balance.
-     *
-     * The result message uses the delete's own affected-row count rather than
-     * the dialog's preview, so a row a background SMS scan wrote while the
-     * dialog was open is both deleted and reported.
+     * Clears the transaction history. The delete and the balance settlement that
+     * follows it are one database transaction inside
+     * [DeleteAllTransactionsUseCase] — see there for what happens to each kind of
+     * account's balance and why.
      */
     fun deleteAllTransactions() {
         viewModelScope.launch {
             _isDeletingAllTransactions.value = true
             try {
-                val accounts = accountBalanceRepository.getAllLatestBalances().first()
-                // Must run before the delete: the opening balance is back-solved
-                // from the transactions that are about to disappear.
-                accounts.forEach { account ->
-                    accountBalanceRepository.ensureManualOpening(account.bankName, account.accountLast4)
-                }
-
-                val deleted = transactionRepository.deleteAllTransactions()
-
-                accounts.forEach { account ->
-                    accountBalanceRepository.recomputeManualBalance(account.bankName, account.accountLast4)
-                }
-
+                val deleted = deleteAllTransactionsUseCase()
                 com.pennywiseai.tracker.widget.WidgetRefresher.refreshTransactionWidgets(context)
                 com.pennywiseai.tracker.widget.RecentTransactionsWidgetDataStore.clear(context)
                 _deleteAllTransactionsResult.value = when (deleted) {

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -36,6 +36,7 @@ import com.pennywiseai.tracker.backup.folder.FolderBackupWriter
 import com.pennywiseai.tracker.backup.folder.ScheduledFolderBackupScheduler
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
 import com.pennywiseai.tracker.data.repository.TransactionRepository
+import com.pennywiseai.tracker.domain.usecase.DeleteAllTransactionsUseCase
 import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.utils.CurrencyFormatter
 import com.pennywiseai.tracker.utils.CurrencyUtils
@@ -60,7 +61,7 @@ class SettingsViewModel @Inject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val unrecognizedSmsRepository: UnrecognizedSmsRepository,
     private val transactionRepository: TransactionRepository,
-    private val deleteAllTransactionsUseCase: com.pennywiseai.tracker.domain.usecase.DeleteAllTransactionsUseCase,
+    private val deleteAllTransactionsUseCase: DeleteAllTransactionsUseCase,
     private val accountBalanceRepository: AccountBalanceRepository,
     private val backupExporter: BackupExporter,
     private val backupImporter: BackupImporter,
@@ -528,32 +529,47 @@ class SettingsViewModel @Inject constructor(
      * [DeleteAllTransactionsUseCase] — see there for what happens to each kind of
      * account's balance and why.
      */
-    fun deleteAllTransactions() {
+    private suspend fun onDeleteAllSucceeded(deleted: Int) {
+        com.pennywiseai.tracker.widget.WidgetRefresher.refreshTransactionWidgets(context)
+        com.pennywiseai.tracker.widget.RecentTransactionsWidgetDataStore.clear(context)
+
+        // SMS ingestion runs independently and can commit a row straight after
+        // the delete's transaction commits. That isn't the delete failing — the
+        // authorised history did go — but reporting a clean sweep while rows
+        // exist would be a lie, so say what actually happened.
+        val arrived = transactionRepository.observeAllTransactionCount().first()
+        _deleteAllTransactionsResult.value = buildString {
+            append(
+                when (deleted) {
+                    0 -> "There were no transactions to delete."
+                    1 -> "1 transaction deleted."
+                    else -> "$deleted transactions deleted."
+                }
+            )
+            if (arrived > 0) {
+                append(
+                    if (arrived == 1) " 1 new transaction arrived while it ran."
+                    else " $arrived new transactions arrived while it ran."
+                )
+            }
+        }
+    }
+
+    fun deleteAllTransactions(expectedCount: Int) {
         viewModelScope.launch {
             _isDeletingAllTransactions.value = true
             try {
-                val deleted = deleteAllTransactionsUseCase()
-                com.pennywiseai.tracker.widget.WidgetRefresher.refreshTransactionWidgets(context)
-                com.pennywiseai.tracker.widget.RecentTransactionsWidgetDataStore.clear(context)
-
-                // SMS ingestion runs independently and can commit a row straight
-                // after the delete's transaction. That isn't the delete failing —
-                // the history did go — but reporting a clean sweep while rows
-                // exist would be a lie, so say what actually happened.
-                val arrived = transactionRepository.observeAllTransactionCount().first()
-                _deleteAllTransactionsResult.value = buildString {
-                    append(
-                        when (deleted) {
-                            0 -> "There were no transactions to delete."
-                            1 -> "1 transaction deleted."
-                            else -> "$deleted transactions deleted."
-                        }
-                    )
-                    if (arrived > 0) {
-                        append(
-                            if (arrived == 1) " 1 new transaction arrived while it ran."
-                            else " $arrived new transactions arrived while it ran."
-                        )
+                when (val result = deleteAllTransactionsUseCase(expectedCount)) {
+                    is DeleteAllTransactionsUseCase.Result.CountChanged -> {
+                        // Nothing was removed; the dialog stays open showing the
+                        // new (observed) figure so the user re-authorises it.
+                        _deleteAllTransactionsResult.value =
+                            "New transactions arrived while you were confirming, so nothing was deleted. " +
+                                "There are now ${result.actual}. Check the number and try again."
+                        return@launch
+                    }
+                    is DeleteAllTransactionsUseCase.Result.Deleted -> {
+                        onDeleteAllSucceeded(result.deleted)
                     }
                 }
             } catch (e: Exception) {

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -513,17 +513,54 @@ class SettingsViewModel @Inject constructor(
         _deleteAllTransactionsCount.value = null
     }
 
+    /**
+     * Deletes every transaction, then settles the account-balance ledger.
+     *
+     * Balances get different treatment per account kind, on purpose:
+     *
+     *  - **SMS-tracked accounts keep their last reported figure.** That number is
+     *    the bank's own word, not something derived from the local history, so
+     *    clearing the history shouldn't rewrite it. (Deleting a *single*
+     *    transaction does shift it, via
+     *    [AccountBalanceRepository.applyDeleteBalanceShift]. Replaying that for
+     *    every row would unwind every expense at once and leave the user staring
+     *    at an inflated balance right after asking to clear their history.)
+     *  - **Manual / cash accounts are recomputed.** Their balance *is defined* as
+     *    opening + Σ(transactions), so leaving it untouched would keep showing a
+     *    total for transactions that no longer exist. The opening row is
+     *    established *before* the delete — it is back-solved from the current
+     *    balance minus the transaction sum, which only works while those rows are
+     *    still there — and the recompute afterwards lands the account back on its
+     *    opening balance.
+     *
+     * The result message uses the delete's own affected-row count rather than
+     * the dialog's preview, so a row a background SMS scan wrote while the
+     * dialog was open is both deleted and reported.
+     */
     fun deleteAllTransactions() {
         viewModelScope.launch {
             _isDeletingAllTransactions.value = true
-            val deleted = _deleteAllTransactionsCount.value ?: 0
             try {
-                transactionRepository.deleteAllTransactions()
+                val accounts = accountBalanceRepository.getAllLatestBalances().first()
+                // Must run before the delete: the opening balance is back-solved
+                // from the transactions that are about to disappear.
+                accounts.forEach { account ->
+                    accountBalanceRepository.ensureManualOpening(account.bankName, account.accountLast4)
+                }
+
+                val deleted = transactionRepository.deleteAllTransactions()
+
+                accounts.forEach { account ->
+                    accountBalanceRepository.recomputeManualBalance(account.bankName, account.accountLast4)
+                }
+
                 com.pennywiseai.tracker.widget.WidgetRefresher.refreshTransactionWidgets(context)
                 com.pennywiseai.tracker.widget.RecentTransactionsWidgetDataStore.clear(context)
-                _deleteAllTransactionsResult.value =
-                    if (deleted == 1) "1 transaction deleted."
-                    else "$deleted transactions deleted."
+                _deleteAllTransactionsResult.value = when (deleted) {
+                    0 -> "There were no transactions to delete."
+                    1 -> "1 transaction deleted."
+                    else -> "$deleted transactions deleted."
+                }
             } catch (e: Exception) {
                 Log.e("SettingsViewModel", "Delete all transactions failed", e)
                 _deleteAllTransactionsResult.value = "Couldn't delete transactions: ${e.message}"

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -91,6 +91,24 @@ class SettingsViewModel @Inject constructor(
     private val _exportedBackupFile = MutableStateFlow<File?>(null)
     val exportedBackupFile: StateFlow<File?> = _exportedBackupFile.asStateFlow()
 
+    // "Delete all transactions": null while the confirmation isn't open, else the
+    // number of rows the delete would remove. Loaded when the dialog opens so the
+    // irreversible action states its real blast radius rather than a guess.
+    private val _deleteAllTransactionsCount = MutableStateFlow<Int?>(null)
+    val deleteAllTransactionsCount: StateFlow<Int?> = _deleteAllTransactionsCount.asStateFlow()
+
+    private val _isDeletingAllTransactions = MutableStateFlow(false)
+    val isDeletingAllTransactions: StateFlow<Boolean> = _isDeletingAllTransactions.asStateFlow()
+
+    // Kept separate from [importExportMessage] so the outcome isn't reported
+    // under that flow's "Backup Status" dialog.
+    private val _deleteAllTransactionsResult = MutableStateFlow<String?>(null)
+    val deleteAllTransactionsResult: StateFlow<String?> = _deleteAllTransactionsResult.asStateFlow()
+
+    fun clearDeleteAllTransactionsResult() {
+        _deleteAllTransactionsResult.value = null
+    }
+
     val scheduledFolderBackupEnabled = userPreferencesRepository.scheduledFolderBackupEnabled
     val scheduledFolderBackupLastTimestamp = userPreferencesRepository.scheduledFolderBackupLastTimestamp
 
@@ -476,6 +494,43 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             userPreferencesRepository.setUnifiedCurrencyMode(enabled)
             com.pennywiseai.tracker.widget.WidgetRefresher.refreshTransactionWidgets(context)
+        }
+    }
+
+    /**
+     * Opens the "delete all transactions" confirmation, loading the row count
+     * it will report. Transactions only: accounts, budgets, loans, categories
+     * and rules are left alone, and the cascading foreign keys clear the
+     * splits / tags / rule-applications that hang off the deleted rows.
+     */
+    fun requestDeleteAllTransactions() {
+        viewModelScope.launch {
+            _deleteAllTransactionsCount.value = transactionRepository.countAllTransactions()
+        }
+    }
+
+    fun cancelDeleteAllTransactions() {
+        _deleteAllTransactionsCount.value = null
+    }
+
+    fun deleteAllTransactions() {
+        viewModelScope.launch {
+            _isDeletingAllTransactions.value = true
+            val deleted = _deleteAllTransactionsCount.value ?: 0
+            try {
+                transactionRepository.deleteAllTransactions()
+                com.pennywiseai.tracker.widget.WidgetRefresher.refreshTransactionWidgets(context)
+                com.pennywiseai.tracker.widget.RecentTransactionsWidgetDataStore.clear(context)
+                _deleteAllTransactionsResult.value =
+                    if (deleted == 1) "1 transaction deleted."
+                    else "$deleted transactions deleted."
+            } catch (e: Exception) {
+                Log.e("SettingsViewModel", "Delete all transactions failed", e)
+                _deleteAllTransactionsResult.value = "Couldn't delete transactions: ${e.message}"
+            } finally {
+                _isDeletingAllTransactions.value = false
+                _deleteAllTransactionsCount.value = null
+            }
         }
     }
 

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/settings/SettingsViewModel.kt
@@ -10,7 +10,10 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
@@ -49,6 +52,7 @@ import java.net.URLEncoder
 import java.io.File
 import javax.inject.Inject
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     @param:ApplicationContext private val context: Context,
@@ -93,10 +97,16 @@ class SettingsViewModel @Inject constructor(
     val exportedBackupFile: StateFlow<File?> = _exportedBackupFile.asStateFlow()
 
     // "Delete all transactions": null while the confirmation isn't open, else the
-    // number of rows the delete would remove. Loaded when the dialog opens so the
-    // irreversible action states its real blast radius rather than a guess.
-    private val _deleteAllTransactionsCount = MutableStateFlow<Int?>(null)
-    val deleteAllTransactionsCount: StateFlow<Int?> = _deleteAllTransactionsCount.asStateFlow()
+    // number of rows the delete would remove — observed, not snapshotted, so the
+    // figure the user is consenting to stays the one the delete will act on even
+    // if a background scan writes a row while the dialog is up.
+    private val _deleteAllTransactionsRequested = MutableStateFlow(false)
+    val deleteAllTransactionsCount: StateFlow<Int?> = _deleteAllTransactionsRequested
+        .flatMapLatest { requested ->
+            if (requested) transactionRepository.observeAllTransactionCount().map { it as Int? }
+            else flowOf(null)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
     private val _isDeletingAllTransactions = MutableStateFlow(false)
     val isDeletingAllTransactions: StateFlow<Boolean> = _isDeletingAllTransactions.asStateFlow()
@@ -505,13 +515,11 @@ class SettingsViewModel @Inject constructor(
      * splits / tags / rule-applications that hang off the deleted rows.
      */
     fun requestDeleteAllTransactions() {
-        viewModelScope.launch {
-            _deleteAllTransactionsCount.value = transactionRepository.countAllTransactions()
-        }
+        _deleteAllTransactionsRequested.value = true
     }
 
     fun cancelDeleteAllTransactions() {
-        _deleteAllTransactionsCount.value = null
+        _deleteAllTransactionsRequested.value = false
     }
 
     /**
@@ -527,17 +535,33 @@ class SettingsViewModel @Inject constructor(
                 val deleted = deleteAllTransactionsUseCase()
                 com.pennywiseai.tracker.widget.WidgetRefresher.refreshTransactionWidgets(context)
                 com.pennywiseai.tracker.widget.RecentTransactionsWidgetDataStore.clear(context)
-                _deleteAllTransactionsResult.value = when (deleted) {
-                    0 -> "There were no transactions to delete."
-                    1 -> "1 transaction deleted."
-                    else -> "$deleted transactions deleted."
+
+                // SMS ingestion runs independently and can commit a row straight
+                // after the delete's transaction. That isn't the delete failing —
+                // the history did go — but reporting a clean sweep while rows
+                // exist would be a lie, so say what actually happened.
+                val arrived = transactionRepository.observeAllTransactionCount().first()
+                _deleteAllTransactionsResult.value = buildString {
+                    append(
+                        when (deleted) {
+                            0 -> "There were no transactions to delete."
+                            1 -> "1 transaction deleted."
+                            else -> "$deleted transactions deleted."
+                        }
+                    )
+                    if (arrived > 0) {
+                        append(
+                            if (arrived == 1) " 1 new transaction arrived while it ran."
+                            else " $arrived new transactions arrived while it ran."
+                        )
+                    }
                 }
             } catch (e: Exception) {
                 Log.e("SettingsViewModel", "Delete all transactions failed", e)
                 _deleteAllTransactionsResult.value = "Couldn't delete transactions: ${e.message}"
             } finally {
                 _isDeletingAllTransactions.value = false
-                _deleteAllTransactionsCount.value = null
+                _deleteAllTransactionsRequested.value = false
             }
         }
     }


### PR DESCRIPTION
Closes #737.

## What

A one-tap way to clear transaction history, in **Settings → Data Management → Delete All Transactions**.

`TransactionRepository.deleteAllTransactions()` already existed but was only reachable from backup import, so users had to clear the app's data or delete rows one at a time.

## Scope decisions

The issue left two open questions:

- **Transactions only.** Accounts, budgets, loans, categories and rules are kept — the ask was to clear *history*, not to factory-reset. The dialog says so.
- **No loan/group preservation.** Unlike the full-resync path (`deleteUncuratedTransactions`), "delete all" means all. The cascading foreign keys on splits, tags and rule applications clear what hangs off the deleted rows; loans and groups survive as empty containers.

Widgets are refreshed afterwards, and the recent-transactions widget cache is cleared.

## The confirmation

Irreversible and unbatched, so a single tap isn't enough:

- names the exact row count, read from a new `countAllTransactions()` (soft-deleted rows included, so it matches what the delete actually removes)
- requires the word `DELETE`, case-sensitive
- points at Export Data first

## Verification

`./init.sh app` green.

On the emulator with 4 transactions:

1. The dialog reads "This permanently deletes all 4 transactions…" — the real count.
2. Typing `delete` (lowercase) leaves **Delete All** disabled; `DELETE` enables it.
3. Confirming reports "4 transactions deleted."; the Transactions tab under **All Time** is empty.
4. Home still shows the bank account and its balance — accounts survived.