### PR TITLE
feat(rules): export and import smart rules as JSON (#741)

### DIFF
--- a/app/src/main/java/com/pennywiseai/tracker/data/repository/RuleRepositoryImpl.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/repository/RuleRepositoryImpl.kt
@@ -61,6 +61,10 @@ class RuleRepositoryImpl @Inject constructor(
         ruleDao.insertRule(ruleToEntity(rule))
     }
 
+    override suspend fun insertRules(rules: List<TransactionRule>) {
+        ruleDao.insertRules(rules.map { ruleToEntity(it) })
+    }
+
     override suspend fun updateRule(rule: TransactionRule) {
         ruleDao.updateRule(ruleToEntity(rule))
     }

--- a/app/src/main/java/com/pennywiseai/tracker/data/rules/RuleSharing.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/rules/RuleSharing.kt
@@ -1,6 +1,7 @@
 package com.pennywiseai.tracker.data.rules
 
 import com.pennywiseai.tracker.domain.model.rule.RuleAction
+import com.pennywiseai.tracker.domain.model.rule.isExecutable
 import com.pennywiseai.tracker.domain.model.rule.RuleCondition
 import com.pennywiseai.tracker.domain.model.rule.supportedOperators
 import com.pennywiseai.tracker.domain.model.rule.TransactionRule
@@ -130,12 +131,13 @@ object RuleSharingCodec {
      * GREATER_THAN, would sail through the shape check and be persisted as a
      * rule that can never match. So each part is validated too, and each
      * condition's operator is checked against [supportedOperators] — the same
-     * list the rule editor builds its picker from.
+     * list the rule editor builds its picker from — and each action against
+     * [isExecutable], so a rule the engine would silently no-op never lands.
      */
     private fun TransactionRule.isFullyValid(): Boolean =
         validate() &&
             conditions.all { it.validate() && it.operator in supportedOperators(it.field) } &&
-            actions.all { it.validate() }
+            actions.all { it.validate() && it.isExecutable() }
 
     fun decode(text: String): DecodedRuleSet {
         require(text.length <= MAX_FILE_BYTES) {

--- a/app/src/main/java/com/pennywiseai/tracker/data/rules/RuleSharing.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/rules/RuleSharing.kt
@@ -59,6 +59,15 @@ object RuleSharingCodec {
     const val FILE_EXTENSION = "json"
 
     /**
+     * Largest file [decode] will look at. An exported rule set runs to a few
+     * hundred bytes per rule, so this holds thousands of them — while stopping
+     * a mis-picked video from being pulled into memory whole by a picker that
+     * has to accept every MIME type (see RulesScreen). A heap blow-up here would be an
+     * OutOfMemoryError, which the import's `catch (Exception)` would not catch.
+     */
+    const val MAX_FILE_BYTES = 1L * 1024 * 1024
+
+    /**
      * The exportable subset of [rules]: the user's own rules. Built-in
      * templates are excluded — every install already ships them, so sharing
      * them would only create duplicates on the other side.
@@ -82,14 +91,34 @@ object RuleSharingCodec {
     )
 
     /**
-     * Parses [text] into the rules it holds, keeping only entries that would
-     * pass [TransactionRule.validate] — a hand-edited or truncated file
-     * shouldn't be able to insert a rule the create screen would reject.
-     *
-     * @throws IllegalArgumentException if the file isn't a rule set, is empty,
-     *   or was written by a newer format version.
+     * What a file yielded: the rules worth importing, plus what was thrown away
+     * getting there. The counts are reported back to the user — a file that
+     * silently loses half its rules is worse than one that says so.
      */
-    fun decode(text: String): List<TransactionRule> {
+    data class DecodedRuleSet(
+        val rules: List<TransactionRule>,
+        /** Entries that wouldn't pass [TransactionRule.validate]. */
+        val invalid: Int,
+        /** Entries dropped because an earlier entry in the same file had that name. */
+        val duplicatedInFile: Int
+    )
+
+    /**
+     * Parses [text] into the rules it holds.
+     *
+     * Entries that wouldn't pass [TransactionRule.validate] are dropped rather
+     * than inserted — the create screen would reject them too — and so are
+     * repeats of a name that already appeared earlier in the same file, which
+     * would otherwise land as two rules the user can't tell apart. Both are
+     * counted so the caller can say what happened.
+     *
+     * @throws IllegalArgumentException if the file isn't a rule set, holds no
+     *   usable rule, or was written by a newer format version.
+     */
+    fun decode(text: String): DecodedRuleSet {
+        require(text.length <= MAX_FILE_BYTES) {
+            "That file is too large to be a rules file."
+        }
         val parsed = try {
             json.decodeFromString<SharedRuleSet>(text)
         } catch (e: Exception) {
@@ -98,20 +127,26 @@ object RuleSharingCodec {
         require(parsed.version <= SharedRuleSet.CURRENT_VERSION) {
             "This rules file was made by a newer version of PennyWise."
         }
-        val rules = parsed.rules
-            .map { shared ->
-                TransactionRule(
-                    name = shared.name.trim(),
-                    description = shared.description?.trim()?.takeIf { it.isNotBlank() },
-                    priority = shared.priority,
-                    conditions = shared.conditions,
-                    actions = shared.actions,
-                    isActive = shared.isActive,
-                    isSystemTemplate = false
-                )
-            }
-            .filter { it.validate() }
-        require(rules.isNotEmpty()) { "No usable rules found in this file." }
-        return rules
+
+        val mapped = parsed.rules.map { shared ->
+            TransactionRule(
+                name = shared.name.trim(),
+                description = shared.description?.trim()?.takeIf { it.isNotBlank() },
+                priority = shared.priority,
+                conditions = shared.conditions,
+                actions = shared.actions,
+                isActive = shared.isActive,
+                isSystemTemplate = false
+            )
+        }
+        val valid = mapped.filter { it.validate() }
+        val deduped = valid.distinctBy { it.name.lowercase() }
+
+        require(deduped.isNotEmpty()) { "No usable rules found in this file." }
+        return DecodedRuleSet(
+            rules = deduped,
+            invalid = mapped.size - valid.size,
+            duplicatedInFile = valid.size - deduped.size
+        )
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/rules/RuleSharing.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/rules/RuleSharing.kt
@@ -91,29 +91,33 @@ object RuleSharingCodec {
     )
 
     /**
-     * What a file yielded: the rules worth importing, plus what was thrown away
-     * getting there. The counts are reported back to the user — a file that
-     * silently loses half its rules is worse than one that says so.
+     * What a file yielded: the rules to import, plus the repeats collapsed on the
+     * way. The count is reported back to the user — quietly importing fewer rules
+     * than the file listed is worse than saying so.
      */
     data class DecodedRuleSet(
         val rules: List<TransactionRule>,
-        /** Entries that wouldn't pass [TransactionRule.validate]. */
-        val invalid: Int,
         /** Entries dropped because an earlier entry in the same file had that name. */
         val duplicatedInFile: Int
     )
 
     /**
-     * Parses [text] into the rules it holds.
+     * Parses [text] into the rules it holds, all or nothing.
      *
-     * Entries that wouldn't pass [TransactionRule.validate] are dropped rather
-     * than inserted — the create screen would reject them too — and so are
-     * repeats of a name that already appeared earlier in the same file, which
-     * would otherwise land as two rules the user can't tell apart. Both are
-     * counted so the caller can say what happened.
+     * An entry that wouldn't pass [TransactionRule.validate] fails the whole
+     * file rather than being skipped: importing "most of" a shared rule set
+     * leaves the user with a half-applied config they didn't ask for and can't
+     * easily tell apart from the real thing. Better to reject it and let whoever
+     * exported it send a good file.
      *
-     * @throws IllegalArgumentException if the file isn't a rule set, holds no
-     *   usable rule, or was written by a newer format version.
+     * Repeats of a name that already appeared earlier in the same file are the
+     * one thing still collapsed rather than refused — the file is unambiguous
+     * about what the rule should be (the first one wins), and the count is
+     * reported.
+     *
+     * @throws IllegalArgumentException if the file isn't a rule set, holds an
+     *   unusable entry, holds no rule at all, or was written by a newer format
+     *   version.
      */
     fun decode(text: String): DecodedRuleSet {
         require(text.length <= MAX_FILE_BYTES) {
@@ -139,14 +143,17 @@ object RuleSharingCodec {
                 isSystemTemplate = false
             )
         }
-        val valid = mapped.filter { it.validate() }
-        val deduped = valid.distinctBy { it.name.lowercase() }
+        val invalid = mapped.count { !it.validate() }
+        require(invalid == 0) {
+            if (invalid == 1) "1 rule in this file is incomplete, so nothing was imported."
+            else "$invalid rules in this file are incomplete, so nothing was imported."
+        }
 
-        require(deduped.isNotEmpty()) { "No usable rules found in this file." }
+        val deduped = mapped.distinctBy { it.name.lowercase() }
+        require(deduped.isNotEmpty()) { "No rules found in this file." }
         return DecodedRuleSet(
             rules = deduped,
-            invalid = mapped.size - valid.size,
-            duplicatedInFile = valid.size - deduped.size
+            duplicatedInFile = mapped.size - deduped.size
         )
     }
 }

--- a/app/src/main/java/com/pennywiseai/tracker/data/rules/RuleSharing.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/rules/RuleSharing.kt
@@ -104,11 +104,10 @@ object RuleSharingCodec {
     /**
      * Parses [text] into the rules it holds, all or nothing.
      *
-     * An entry that wouldn't pass [TransactionRule.validate] fails the whole
-     * file rather than being skipped: importing "most of" a shared rule set
-     * leaves the user with a half-applied config they didn't ask for and can't
-     * easily tell apart from the real thing. Better to reject it and let whoever
-     * exported it send a good file.
+     * An unusable entry fails the whole file rather than being skipped:
+     * importing "most of" a shared rule set leaves the user with a half-applied
+     * config they didn't ask for and can't easily tell apart from the real
+     * thing. Better to reject it and let whoever exported it send a good file.
      *
      * Repeats of a name that already appeared earlier in the same file are the
      * one thing still collapsed rather than refused — the file is unambiguous
@@ -119,6 +118,21 @@ object RuleSharingCodec {
      *   unusable entry, holds no rule at all, or was written by a newer format
      *   version.
      */
+    /**
+     * Whether a rule is usable in full.
+     *
+     * [TransactionRule.validate] only checks that the name, conditions and
+     * actions are present — it never asks the conditions and actions whether
+     * *they* are well-formed. That's fine for the create screen, which builds
+     * them from pickers, but an imported file is arbitrary text: a condition
+     * like AMOUNT / LESS_THAN / "abc" would sail through the shape check and be
+     * persisted as a rule that can never match. So each part is validated too.
+     */
+    private fun TransactionRule.isFullyValid(): Boolean =
+        validate() &&
+            conditions.all { it.validate() } &&
+            actions.all { it.validate() }
+
     fun decode(text: String): DecodedRuleSet {
         require(text.length <= MAX_FILE_BYTES) {
             "That file is too large to be a rules file."
@@ -143,7 +157,7 @@ object RuleSharingCodec {
                 isSystemTemplate = false
             )
         }
-        val invalid = mapped.count { !it.validate() }
+        val invalid = mapped.count { !it.isFullyValid() }
         require(invalid == 0) {
             if (invalid == 1) "1 rule in this file is incomplete, so nothing was imported."
             else "$invalid rules in this file are incomplete, so nothing was imported."

--- a/app/src/main/java/com/pennywiseai/tracker/data/rules/RuleSharing.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/rules/RuleSharing.kt
@@ -2,6 +2,7 @@ package com.pennywiseai.tracker.data.rules
 
 import com.pennywiseai.tracker.domain.model.rule.RuleAction
 import com.pennywiseai.tracker.domain.model.rule.RuleCondition
+import com.pennywiseai.tracker.domain.model.rule.supportedOperators
 import com.pennywiseai.tracker.domain.model.rule.TransactionRule
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -125,12 +126,15 @@ object RuleSharingCodec {
      * actions are present — it never asks the conditions and actions whether
      * *they* are well-formed. That's fine for the create screen, which builds
      * them from pickers, but an imported file is arbitrary text: a condition
-     * like AMOUNT / LESS_THAN / "abc" would sail through the shape check and be
-     * persisted as a rule that can never match. So each part is validated too.
+     * like AMOUNT / LESS_THAN / "abc", or a nonsensical pairing like MERCHANT /
+     * GREATER_THAN, would sail through the shape check and be persisted as a
+     * rule that can never match. So each part is validated too, and each
+     * condition's operator is checked against [supportedOperators] — the same
+     * list the rule editor builds its picker from.
      */
     private fun TransactionRule.isFullyValid(): Boolean =
         validate() &&
-            conditions.all { it.validate() } &&
+            conditions.all { it.validate() && it.operator in supportedOperators(it.field) } &&
             actions.all { it.validate() }
 
     fun decode(text: String): DecodedRuleSet {

--- a/app/src/main/java/com/pennywiseai/tracker/data/rules/RuleSharing.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/data/rules/RuleSharing.kt
@@ -1,0 +1,117 @@
+package com.pennywiseai.tracker.data.rules
+
+import com.pennywiseai.tracker.domain.model.rule.RuleAction
+import com.pennywiseai.tracker.domain.model.rule.RuleCondition
+import com.pennywiseai.tracker.domain.model.rule.TransactionRule
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * A single smart rule in the portable, shareable form (#741).
+ *
+ * Deliberately narrower than [TransactionRule]: ids, timestamps and the
+ * system-template flag are all local facts about *this* install, so they are
+ * dropped on export and regenerated on import. What travels is the part a
+ * peer actually wants — the name, what the rule matches, and what it does.
+ *
+ * Every field carries a default so a file written by an older or newer build
+ * still decodes.
+ */
+@Serializable
+data class SharedRule(
+    val name: String = "",
+    val description: String? = null,
+    val priority: Int = 100,
+    val conditions: List<RuleCondition> = emptyList(),
+    val actions: List<RuleAction> = emptyList(),
+    val isActive: Boolean = true
+)
+
+/**
+ * The exported file's envelope. [version] lets a future format change be
+ * detected rather than silently mis-read.
+ */
+@Serializable
+data class SharedRuleSet(
+    val version: Int = CURRENT_VERSION,
+    val rules: List<SharedRule> = emptyList()
+) {
+    companion object {
+        const val CURRENT_VERSION = 1
+    }
+}
+
+/**
+ * Encodes and decodes [SharedRuleSet] files. Kept separate from `RuleEngine`'s
+ * internal column serialization: that one persists conditions/actions inside a
+ * Room row, this one is a user-facing file that other people's installs read.
+ */
+object RuleSharingCodec {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        prettyPrint = true
+        encodeDefaults = true
+    }
+
+    const val MIME_TYPE = "application/json"
+    const val FILE_EXTENSION = "json"
+
+    /**
+     * The exportable subset of [rules]: the user's own rules. Built-in
+     * templates are excluded — every install already ships them, so sharing
+     * them would only create duplicates on the other side.
+     */
+    fun exportable(rules: List<TransactionRule>): List<TransactionRule> =
+        rules.filterNot { it.isSystemTemplate }
+
+    fun encode(rules: List<TransactionRule>): String = json.encodeToString(
+        SharedRuleSet(
+            rules = exportable(rules).map { rule ->
+                SharedRule(
+                    name = rule.name,
+                    description = rule.description,
+                    priority = rule.priority,
+                    conditions = rule.conditions,
+                    actions = rule.actions,
+                    isActive = rule.isActive
+                )
+            }
+        )
+    )
+
+    /**
+     * Parses [text] into the rules it holds, keeping only entries that would
+     * pass [TransactionRule.validate] — a hand-edited or truncated file
+     * shouldn't be able to insert a rule the create screen would reject.
+     *
+     * @throws IllegalArgumentException if the file isn't a rule set, is empty,
+     *   or was written by a newer format version.
+     */
+    fun decode(text: String): List<TransactionRule> {
+        val parsed = try {
+            json.decodeFromString<SharedRuleSet>(text)
+        } catch (e: Exception) {
+            throw IllegalArgumentException("This doesn't look like a PennyWise rules file.", e)
+        }
+        require(parsed.version <= SharedRuleSet.CURRENT_VERSION) {
+            "This rules file was made by a newer version of PennyWise."
+        }
+        val rules = parsed.rules
+            .map { shared ->
+                TransactionRule(
+                    name = shared.name.trim(),
+                    description = shared.description?.trim()?.takeIf { it.isNotBlank() },
+                    priority = shared.priority,
+                    conditions = shared.conditions,
+                    actions = shared.actions,
+                    isActive = shared.isActive,
+                    isSystemTemplate = false
+                )
+            }
+            .filter { it.validate() }
+        require(rules.isNotEmpty()) { "No usable rules found in this file." }
+        return rules
+    }
+}

--- a/app/src/main/java/com/pennywiseai/tracker/domain/model/rule/RuleAction.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/model/rule/RuleAction.kt
@@ -47,7 +47,12 @@ data class RuleAction(
 ) {
     fun validate(): Boolean {
         return when (actionType) {
-            ActionType.SET -> value.isNotBlank()
+            // Setting TYPE needs a value the engine can parse back into a
+            // TransactionType: applyAction falls back to the transaction's
+            // existing type otherwise, so the rule silently does nothing.
+            ActionType.SET ->
+                if (field == TransactionField.TYPE) parseRuleTransactionType(value) != null
+                else value.isNotBlank()
             ActionType.APPEND, ActionType.PREPEND -> value.isNotBlank()
             ActionType.CLEAR -> true
             ActionType.ADD_TAG -> value.isNotBlank()

--- a/app/src/main/java/com/pennywiseai/tracker/domain/model/rule/RuleAction.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/model/rule/RuleAction.kt
@@ -2,6 +2,43 @@ package com.pennywiseai.tracker.domain.model.rule
 
 import kotlinx.serialization.Serializable
 
+/**
+ * The action types [com.pennywiseai.tracker.domain.service.RuleEngine] can
+ * actually carry out on [field].
+ *
+ * Mirrors that engine's `applyAction` exactly — anything outside these sets
+ * falls into its `else` branch, leaves the transaction untouched, and records no
+ * modification, so a rule built from one is silently dead. The rule importer
+ * checks arbitrary file content against this; `RuleActionExecutabilityTest`
+ * pins the two together so they can't drift.
+ *
+ * [ActionType.BLOCK] is absent on purpose: it never modifies a transaction (the
+ * engine skips it in `applyActions` and handles it in `shouldBlockTransaction`),
+ * so it is valid regardless of field and is checked separately.
+ *
+ * [ActionType.ADD_TAG] / [ActionType.REMOVE_TAG] are absent because nothing in
+ * the app implements them — they exist only as labels in the rule editor.
+ */
+fun supportedActionTypes(field: TransactionField): Set<ActionType> = when (field) {
+    TransactionField.CATEGORY -> setOf(ActionType.SET, ActionType.CLEAR)
+    TransactionField.MERCHANT,
+    TransactionField.NARRATION -> setOf(
+        ActionType.SET,
+        ActionType.APPEND,
+        ActionType.PREPEND,
+        ActionType.CLEAR
+    )
+    TransactionField.TYPE -> setOf(ActionType.SET)
+    TransactionField.BANK_NAME -> setOf(ActionType.SET, ActionType.CLEAR)
+    else -> emptySet()
+}
+
+/**
+ * Whether the engine can carry this action out at all. See [supportedActionTypes].
+ */
+fun RuleAction.isExecutable(): Boolean =
+    actionType == ActionType.BLOCK || actionType in supportedActionTypes(field)
+
 @Serializable
 data class RuleAction(
     val field: TransactionField,

--- a/app/src/main/java/com/pennywiseai/tracker/domain/model/rule/RuleCondition.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/model/rule/RuleCondition.kt
@@ -55,6 +55,65 @@ fun isRuleApplicableToTransactionType(rule: TransactionRule, type: TransactionTy
     return typeConditions.any { matchesTransactionTypeCondition(it, type.name) }
 }
 
+/**
+ * The operators that mean anything for [field], in the order the rule editor
+ * offers them (the first is the field's default).
+ *
+ * This is the single source of truth for the pairing: the create screen builds
+ * its picker from it, and the rule importer checks arbitrary file content
+ * against it. A comparison like MERCHANT / GREATER_THAN can't be produced by the
+ * pickers, but a hand-written or hand-edited import file can carry one, and it
+ * would persist as a rule that never fires.
+ */
+fun supportedOperators(field: TransactionField): List<ConditionOperator> = when (field) {
+    TransactionField.AMOUNT -> listOf(
+        ConditionOperator.LESS_THAN,
+        ConditionOperator.GREATER_THAN,
+        ConditionOperator.EQUALS
+    )
+    TransactionField.TYPE -> listOf(
+        ConditionOperator.EQUALS,
+        ConditionOperator.NOT_EQUALS
+    )
+    TransactionField.TRANSACTION_TIME -> listOf(
+        ConditionOperator.LESS_THAN,
+        ConditionOperator.GREATER_THAN,
+        ConditionOperator.GREATER_THAN_OR_EQUAL,
+        ConditionOperator.LESS_THAN_OR_EQUAL,
+        ConditionOperator.EQUALS
+    )
+    TransactionField.TRANSACTION_HOUR -> listOf(
+        ConditionOperator.EQUALS,
+        ConditionOperator.LESS_THAN,
+        ConditionOperator.GREATER_THAN
+    )
+    TransactionField.TRANSACTION_DAY_OF_WEEK -> listOf(
+        ConditionOperator.EQUALS,
+        ConditionOperator.IN,
+        ConditionOperator.NOT_EQUALS
+    )
+    TransactionField.TRANSACTION_DAY_OF_MONTH -> listOf(
+        ConditionOperator.EQUALS,
+        ConditionOperator.IN,
+        ConditionOperator.LESS_THAN,
+        ConditionOperator.GREATER_THAN
+    )
+    TransactionField.TRANSACTION_DATE -> listOf(
+        ConditionOperator.EQUALS,
+        ConditionOperator.LESS_THAN,
+        ConditionOperator.GREATER_THAN
+    )
+    TransactionField.ACCOUNT -> listOf(
+        ConditionOperator.EQUALS,
+        ConditionOperator.NOT_EQUALS
+    )
+    else -> listOf(
+        ConditionOperator.CONTAINS,
+        ConditionOperator.EQUALS,
+        ConditionOperator.STARTS_WITH
+    )
+}
+
 @Serializable
 data class RuleCondition(
     val field: TransactionField,

--- a/app/src/main/java/com/pennywiseai/tracker/domain/model/rule/RuleCondition.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/model/rule/RuleCondition.kt
@@ -1,6 +1,7 @@
 package com.pennywiseai.tracker.domain.model.rule
 
 import com.pennywiseai.tracker.data.database.entity.TransactionType
+import java.time.LocalDate
 import kotlinx.serialization.Serializable
 
 /**
@@ -124,12 +125,13 @@ data class RuleCondition(
     fun validate(): Boolean {
         return value.isNotBlank() && when (field) {
             TransactionField.AMOUNT -> {
+                // Every amount comparison is numeric — EQUALS included, which the
+                // editor offers as "=". It used to fall through to `true`, so an
+                // imported `AMOUNT = abc` was stored as a rule that never fires.
                 when (operator) {
-                    ConditionOperator.LESS_THAN,
-                    ConditionOperator.GREATER_THAN,
-                    ConditionOperator.LESS_THAN_OR_EQUAL,
-                    ConditionOperator.GREATER_THAN_OR_EQUAL -> value.toBigDecimalOrNull() != null
-                    else -> true
+                    ConditionOperator.IN, ConditionOperator.NOT_IN ->
+                        value.split(",").all { it.trim().toBigDecimalOrNull() != null }
+                    else -> value.toBigDecimalOrNull() != null
                 }
             }
             TransactionField.TRANSACTION_HOUR -> {
@@ -158,6 +160,10 @@ data class RuleCondition(
                 parts.size == 2 && parts[0].isNotBlank() && parts[1].isNotBlank()
             }
             TransactionField.TYPE -> parseRuleTransactionType(value) != null
+            // Compared against LocalDate.toString() at evaluation time, so the
+            // value has to be an ISO date; anything else can never match.
+            TransactionField.TRANSACTION_DATE ->
+                runCatching { LocalDate.parse(value.trim()) }.isSuccess
             else -> true
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/domain/repository/RuleRepository.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/repository/RuleRepository.kt
@@ -12,6 +12,13 @@ interface RuleRepository {
     suspend fun getActiveRulesByTypes(types: List<TransactionType>): List<TransactionRule>
     suspend fun getRuleById(ruleId: String): TransactionRule?
     suspend fun insertRule(rule: TransactionRule)
+
+    /**
+     * Inserts [rules] as one unit. Room runs a list insert in a single
+     * transaction, so a failure part-way through can't leave an imported rule
+     * set half-persisted.
+     */
+    suspend fun insertRules(rules: List<TransactionRule>)
     suspend fun updateRule(rule: TransactionRule)
     suspend fun deleteRule(ruleId: String)
     suspend fun deleteAllRules()

--- a/app/src/main/java/com/pennywiseai/tracker/domain/service/RuleEngine.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/domain/service/RuleEngine.kt
@@ -131,10 +131,21 @@ class RuleEngine @Inject constructor() {
     ): Boolean {
         val fieldValue = getFieldValue(transaction, smsText, condition.field)
 
+        // AMOUNT is compared as a number, not as text. The field value is
+        // BigDecimal.toString(), so "100" or "100.0" would never string-match an
+        // amount stored as 100.00 — the editor offers "=" for amounts, so those
+        // rules simply never fired.
+        val amountEquality = condition.field == TransactionField.AMOUNT &&
+            condition.value.toBigDecimalOrNull() != null &&
+            fieldValue.toBigDecimalOrNull() != null
+
         return when (condition.operator) {
-            ConditionOperator.EQUALS -> fieldValue.equals(condition.value, ignoreCase = true)
+            ConditionOperator.EQUALS ->
+                if (amountEquality) compareNumeric(fieldValue, condition.value) == 0
+                else fieldValue.equals(condition.value, ignoreCase = true)
             ConditionOperator.NOT_EQUALS -> {
                 if (condition.field == TransactionField.ACCOUNT && fieldValue.isBlank()) false
+                else if (amountEquality) compareNumeric(fieldValue, condition.value) != 0
                 else !fieldValue.equals(condition.value, ignoreCase = true)
             }
             ConditionOperator.CONTAINS -> fieldValue.contains(condition.value, ignoreCase = true)

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/CreateRuleScreen.kt
@@ -60,58 +60,50 @@ private fun TransactionField.defaultConditionOperator(): ConditionOperator = whe
 }
 
 /**
- * Operators offered for a condition field, paired with their display label. The first entry is
- * the field's default (see [defaultConditionOperator]); every default must appear in its list.
+ * Operators offered for a condition field, paired with their display label.
+ *
+ * The set and its order come from [supportedOperators] so the picker and the
+ * rule importer can't drift apart; only the wording lives here, since the same
+ * operator reads differently per field ("<" for an amount, "before" for a time).
  */
 private fun conditionOperatorsForField(
     field: TransactionField
-): List<Pair<ConditionOperator, String>> = when (field) {
-    TransactionField.AMOUNT -> listOf(
-        ConditionOperator.LESS_THAN to "<",
-        ConditionOperator.GREATER_THAN to ">",
-        ConditionOperator.EQUALS to "="
-    )
-    TransactionField.TYPE -> listOf(
-        ConditionOperator.EQUALS to "is",
-        ConditionOperator.NOT_EQUALS to "is not"
-    )
-    TransactionField.TRANSACTION_TIME -> listOf(
-        ConditionOperator.LESS_THAN to "before",
-        ConditionOperator.GREATER_THAN to "after",
-        ConditionOperator.GREATER_THAN_OR_EQUAL to "at or after",
-        ConditionOperator.LESS_THAN_OR_EQUAL to "at or before",
-        ConditionOperator.EQUALS to "exactly at"
-    )
-    TransactionField.TRANSACTION_HOUR -> listOf(
-        ConditionOperator.EQUALS to "is",
-        ConditionOperator.LESS_THAN to "before",
-        ConditionOperator.GREATER_THAN to "after"
-    )
-    TransactionField.TRANSACTION_DAY_OF_WEEK -> listOf(
-        ConditionOperator.EQUALS to "is",
-        ConditionOperator.IN to "is any of",
-        ConditionOperator.NOT_EQUALS to "is not"
-    )
-    TransactionField.TRANSACTION_DAY_OF_MONTH -> listOf(
-        ConditionOperator.EQUALS to "is",
-        ConditionOperator.IN to "is any of",
-        ConditionOperator.LESS_THAN to "before",
-        ConditionOperator.GREATER_THAN to "after"
-    )
-    TransactionField.TRANSACTION_DATE -> listOf(
-        ConditionOperator.EQUALS to "is",
-        ConditionOperator.LESS_THAN to "before",
-        ConditionOperator.GREATER_THAN to "after"
-    )
-    TransactionField.ACCOUNT -> listOf(
-        ConditionOperator.EQUALS to "is",
-        ConditionOperator.NOT_EQUALS to "is not"
-    )
-    else -> listOf(
-        ConditionOperator.CONTAINS to "contains",
-        ConditionOperator.EQUALS to "equals",
-        ConditionOperator.STARTS_WITH to "starts with"
-    )
+): List<Pair<ConditionOperator, String>> =
+    supportedOperators(field).map { operator -> operator to operator.labelFor(field) }
+
+private fun ConditionOperator.labelFor(field: TransactionField): String = when (field) {
+    TransactionField.AMOUNT -> when (this) {
+        ConditionOperator.LESS_THAN -> "<"
+        ConditionOperator.GREATER_THAN -> ">"
+        else -> "="
+    }
+    TransactionField.TRANSACTION_TIME -> when (this) {
+        ConditionOperator.LESS_THAN -> "before"
+        ConditionOperator.GREATER_THAN -> "after"
+        ConditionOperator.GREATER_THAN_OR_EQUAL -> "at or after"
+        ConditionOperator.LESS_THAN_OR_EQUAL -> "at or before"
+        else -> "exactly at"
+    }
+    TransactionField.TRANSACTION_HOUR,
+    TransactionField.TRANSACTION_DAY_OF_MONTH,
+    TransactionField.TRANSACTION_DATE -> when (this) {
+        ConditionOperator.LESS_THAN -> "before"
+        ConditionOperator.GREATER_THAN -> "after"
+        ConditionOperator.IN -> "is any of"
+        else -> "is"
+    }
+    TransactionField.TYPE,
+    TransactionField.TRANSACTION_DAY_OF_WEEK,
+    TransactionField.ACCOUNT -> when (this) {
+        ConditionOperator.NOT_EQUALS -> "is not"
+        ConditionOperator.IN -> "is any of"
+        else -> "is"
+    }
+    else -> when (this) {
+        ConditionOperator.EQUALS -> "equals"
+        ConditionOperator.STARTS_WITH -> "starts with"
+        else -> "contains"
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/RulesScreen.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/screens/rules/RulesScreen.kt
@@ -1,5 +1,7 @@
 package com.pennywiseai.tracker.ui.screens.rules
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -21,6 +23,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.pennywiseai.tracker.data.rules.RuleSharingCodec
 import com.pennywiseai.tracker.domain.usecase.BatchApplyResult
 import com.pennywiseai.tracker.domain.usecase.DryRunResult
 import com.pennywiseai.tracker.ui.components.CustomTitleTopAppBar
@@ -47,7 +50,18 @@ fun RulesScreen(
     val batchApplyResult by viewModel.batchApplyResult.collectAsStateWithLifecycle()
     val dryRunResult by viewModel.dryRunResult.collectAsStateWithLifecycle()
     val canCreateMoreRules by viewModel.canCreateMoreRules.collectAsStateWithLifecycle()
+    val sharingMessage by viewModel.sharingMessage.collectAsStateWithLifecycle()
     var showUpgradeSheet by remember { mutableStateOf(false) }
+    var showOverflowMenu by remember { mutableStateOf(false) }
+
+    // Rule sharing (#741). CreateDocument/OpenDocument keep the file in the
+    // user's own storage — nothing leaves the device unless they share it.
+    val exportRulesLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument(RuleSharingCodec.MIME_TYPE)
+    ) { uri -> uri?.let { viewModel.exportRules(it) } }
+    val importRulesLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri -> uri?.let { viewModel.importRules(it) } }
 
     var showBatchApplyDialog by remember { mutableStateOf(false) }
     var selectedRuleForBatch by remember { mutableStateOf<com.pennywiseai.tracker.domain.model.rule.TransactionRule?>(null) }
@@ -78,13 +92,51 @@ fun RulesScreen(
                     }
                 },
                 actionContent = {
-                    IconButton(
-                        onClick = { showResetDialog = true }
-                    ) {
-                        Icon(
-                            Icons.Default.Refresh,
-                            contentDescription = "Reset to defaults"
-                        )
+                    Box {
+                        IconButton(onClick = { showOverflowMenu = true }) {
+                            Icon(
+                                Icons.Default.MoreVert,
+                                contentDescription = "More options"
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = showOverflowMenu,
+                            onDismissRequest = { showOverflowMenu = false }
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text("Export rules") },
+                                leadingIcon = { Icon(Icons.Default.Upload, contentDescription = null) },
+                                onClick = {
+                                    showOverflowMenu = false
+                                    if (RuleSharingCodec.exportable(rules).isEmpty()) {
+                                        viewModel.reportNothingToExport()
+                                    } else {
+                                        exportRulesLauncher.launch(
+                                            "pennywise-rules.${RuleSharingCodec.FILE_EXTENSION}"
+                                        )
+                                    }
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Import rules") },
+                                leadingIcon = { Icon(Icons.Default.Download, contentDescription = null) },
+                                onClick = {
+                                    showOverflowMenu = false
+                                    // Some file pickers don't offer JSON files under the
+                                    // strict MIME type, so accept anything and let the
+                                    // decoder reject what isn't a rule set.
+                                    importRulesLauncher.launch(arrayOf("*/*"))
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Reset to defaults") },
+                                leadingIcon = { Icon(Icons.Default.Refresh, contentDescription = null) },
+                                onClick = {
+                                    showOverflowMenu = false
+                                    showResetDialog = true
+                                }
+                            )
+                        }
                     }
                 },
                 hazeState = hazeState
@@ -102,6 +154,19 @@ fun RulesScreen(
             }
         }
     ) { paddingValues ->
+
+        sharingMessage?.let { message ->
+            AlertDialog(
+                onDismissRequest = { viewModel.clearSharingMessage() },
+                title = { Text("Smart Rules") },
+                text = { Text(message) },
+                confirmButton = {
+                    TextButton(onClick = { viewModel.clearSharingMessage() }) {
+                        Text("OK")
+                    }
+                }
+            )
+        }
 
         if (showResetDialog) {
             AlertDialog(

--- a/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/RulesViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/RulesViewModel.kt
@@ -1,12 +1,14 @@
 package com.pennywiseai.tracker.ui.viewmodel
 
 import android.content.Context
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.billing.EntitlementGate
 import com.pennywiseai.tracker.data.database.entity.AccountBalanceEntity
 import com.pennywiseai.tracker.billing.FreeTierLimits
 import com.pennywiseai.tracker.data.repository.AccountBalanceRepository
+import com.pennywiseai.tracker.data.rules.RuleSharingCodec
 import com.pennywiseai.tracker.domain.model.rule.TransactionRule
 import com.pennywiseai.tracker.domain.repository.RuleRepository
 import com.pennywiseai.tracker.domain.service.RuleTemplateService
@@ -16,8 +18,10 @@ import com.pennywiseai.tracker.domain.usecase.DryRunResult
 import com.pennywiseai.tracker.domain.usecase.InitializeRuleTemplatesUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
@@ -50,6 +54,22 @@ class RulesViewModel @Inject constructor(
 
     private val _dryRunResult = MutableStateFlow<DryRunResult?>(null)
     val dryRunResult: StateFlow<DryRunResult?> = _dryRunResult.asStateFlow()
+
+    // Outcome of the last export/import, shown once and then cleared (#741).
+    private val _sharingMessage = MutableStateFlow<String?>(null)
+    val sharingMessage: StateFlow<String?> = _sharingMessage.asStateFlow()
+
+    fun clearSharingMessage() {
+        _sharingMessage.value = null
+    }
+
+    /**
+     * Says so up-front when there is nothing to export, so the file picker
+     * never opens just to leave an empty file behind.
+     */
+    fun reportNothingToExport() {
+        _sharingMessage.value = "You don't have any custom rules to export yet."
+    }
 
     val rules: StateFlow<List<TransactionRule>> = ruleRepository.getAllRules()
         .stateIn(
@@ -156,6 +176,87 @@ class RulesViewModel @Inject constructor(
                 ruleRepository.updateRule(rule)
             } catch (e: Exception) {
                 e.printStackTrace()
+            }
+        }
+    }
+
+    /**
+     * Writes the user's own rules to [uri] as a shareable JSON file. Built-in
+     * templates are left out — see [RuleSharingCodec.exportable].
+     */
+    fun exportRules(uri: Uri) {
+        viewModelScope.launch {
+            try {
+                val all = ruleRepository.getAllRules().first()
+                val exportable = RuleSharingCodec.exportable(all)
+                if (exportable.isEmpty()) {
+                    _sharingMessage.value = "You don't have any custom rules to export yet."
+                    return@launch
+                }
+                val text = RuleSharingCodec.encode(all)
+                withContext(Dispatchers.IO) {
+                    context.contentResolver.openOutputStream(uri)?.use { out ->
+                        out.write(text.toByteArray())
+                    } ?: throw IllegalStateException("Couldn't open the file for writing.")
+                }
+                _sharingMessage.value = if (exportable.size == 1) {
+                    "Exported 1 rule."
+                } else {
+                    "Exported ${exportable.size} rules."
+                }
+            } catch (e: Exception) {
+                _sharingMessage.value = "Export failed: ${e.message}"
+            }
+        }
+    }
+
+    /**
+     * Adds the rules in [uri] to this install. Imported rules get fresh ids, so
+     * a file can be applied more than once without colliding; a rule whose name
+     * already exists is skipped rather than duplicated.
+     *
+     * The free-tier rule cap still applies — importing must not be a way around
+     * the paywall the create screen enforces.
+     */
+    fun importRules(uri: Uri) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            try {
+                val text = withContext(Dispatchers.IO) {
+                    context.contentResolver.openInputStream(uri)?.use { input ->
+                        input.readBytes().toString(Charsets.UTF_8)
+                    } ?: throw IllegalStateException("Couldn't open the file.")
+                }
+                val incoming = RuleSharingCodec.decode(text)
+
+                val existing = ruleRepository.getAllRules().first()
+                val existingNames = existing.map { it.name.trim().lowercase() }.toSet()
+                val fresh = incoming.filterNot { it.name.trim().lowercase() in existingNames }
+                val duplicates = incoming.size - fresh.size
+
+                val allowance = if (isProEntitled.value) {
+                    fresh.size
+                } else {
+                    (FreeTierLimits.MAX_RULES - existing.size).coerceAtLeast(0)
+                }
+                val toImport = fresh.take(allowance)
+                toImport.forEach { ruleRepository.insertRule(it) }
+
+                val blocked = fresh.size - toImport.size
+                _sharingMessage.value = buildString {
+                    append(
+                        if (toImport.size == 1) "Imported 1 rule."
+                        else "Imported ${toImport.size} rules."
+                    )
+                    if (duplicates > 0) append(" $duplicates already existed.")
+                    if (blocked > 0) {
+                        append(" $blocked more need Pro — you're at the free limit of ${FreeTierLimits.MAX_RULES}.")
+                    }
+                }
+            } catch (e: Exception) {
+                _sharingMessage.value = e.message ?: "Import failed."
+            } finally {
+                _isLoading.value = false
             }
         }
     }

--- a/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/RulesViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/RulesViewModel.kt
@@ -277,7 +277,7 @@ class RulesViewModel @Inject constructor(
                 toImport.forEach { ruleRepository.insertRule(it) }
 
                 val blocked = fresh.size - toImport.size
-                val skipped = decoded.invalid + decoded.duplicatedInFile
+                val skipped = decoded.duplicatedInFile
                 _sharingMessage.value = buildString {
                     append(
                         if (toImport.size == 1) "Imported 1 rule."
@@ -286,8 +286,8 @@ class RulesViewModel @Inject constructor(
                     if (duplicates > 0) append(" $duplicates already existed.")
                     if (skipped > 0) {
                         append(
-                            if (skipped == 1) " 1 entry in the file was unusable and was skipped."
-                            else " $skipped entries in the file were unusable and were skipped."
+                            if (skipped == 1) " 1 repeated name in the file was collapsed."
+                            else " $skipped repeated names in the file were collapsed."
                         )
                     }
                     if (blocked > 0) {

--- a/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/RulesViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/RulesViewModel.kt
@@ -274,7 +274,8 @@ class RulesViewModel @Inject constructor(
                     (FreeTierLimits.MAX_RULES - existing.size).coerceAtLeast(0)
                 }
                 val toImport = fresh.take(allowance)
-                toImport.forEach { ruleRepository.insertRule(it) }
+                // One insert, so a failure can't leave the set half-applied.
+                ruleRepository.insertRules(toImport)
 
                 val blocked = fresh.size - toImport.size
                 val skipped = decoded.duplicatedInFile

--- a/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/RulesViewModel.kt
+++ b/app/src/main/java/com/pennywiseai/tracker/ui/viewmodel/RulesViewModel.kt
@@ -2,6 +2,7 @@ package com.pennywiseai.tracker.ui.viewmodel
 
 import android.content.Context
 import android.net.Uri
+import android.provider.OpenableColumns
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pennywiseai.tracker.billing.EntitlementGate
@@ -181,6 +182,43 @@ class RulesViewModel @Inject constructor(
     }
 
     /**
+     * Reads [uri] as text, refusing anything past [RuleSharingCodec.MAX_FILE_BYTES].
+     *
+     * The import picker has to accept every MIME type (some file managers
+     * won't surface JSON under the strict one), so a mis-picked video could otherwise be
+     * pulled into memory whole. The size is checked up-front where the provider
+     * reports one, and the read is capped regardless for providers that don't.
+     */
+    private fun readBoundedText(uri: Uri): String {
+        val limit = RuleSharingCodec.MAX_FILE_BYTES
+        context.contentResolver.query(uri, arrayOf(OpenableColumns.SIZE), null, null, null)
+            ?.use { cursor ->
+                val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
+                if (cursor.moveToFirst() && sizeIndex >= 0 && !cursor.isNull(sizeIndex)) {
+                    require(cursor.getLong(sizeIndex) <= limit) {
+                        "That file is too large to be a rules file."
+                    }
+                }
+            }
+
+        val input = context.contentResolver.openInputStream(uri)
+            ?: throw IllegalStateException("Couldn't open the file.")
+        return input.use { stream ->
+            // One byte past the limit so an over-long stream is detected rather
+            // than silently truncated into an unparseable fragment.
+            val bytes = ByteArray((limit + 1).toInt())
+            var read = 0
+            while (read < bytes.size) {
+                val n = stream.read(bytes, read, bytes.size - read)
+                if (n < 0) break
+                read += n
+            }
+            require(read <= limit) { "That file is too large to be a rules file." }
+            String(bytes, 0, read, Charsets.UTF_8)
+        }
+    }
+
+    /**
      * Writes the user's own rules to [uri] as a shareable JSON file. Built-in
      * templates are left out — see [RuleSharingCodec.exportable].
      */
@@ -222,17 +260,13 @@ class RulesViewModel @Inject constructor(
         viewModelScope.launch {
             _isLoading.value = true
             try {
-                val text = withContext(Dispatchers.IO) {
-                    context.contentResolver.openInputStream(uri)?.use { input ->
-                        input.readBytes().toString(Charsets.UTF_8)
-                    } ?: throw IllegalStateException("Couldn't open the file.")
-                }
-                val incoming = RuleSharingCodec.decode(text)
+                val text = withContext(Dispatchers.IO) { readBoundedText(uri) }
+                val decoded = RuleSharingCodec.decode(text)
 
                 val existing = ruleRepository.getAllRules().first()
                 val existingNames = existing.map { it.name.trim().lowercase() }.toSet()
-                val fresh = incoming.filterNot { it.name.trim().lowercase() in existingNames }
-                val duplicates = incoming.size - fresh.size
+                val fresh = decoded.rules.filterNot { it.name.trim().lowercase() in existingNames }
+                val duplicates = decoded.rules.size - fresh.size
 
                 val allowance = if (isProEntitled.value) {
                     fresh.size
@@ -243,12 +277,19 @@ class RulesViewModel @Inject constructor(
                 toImport.forEach { ruleRepository.insertRule(it) }
 
                 val blocked = fresh.size - toImport.size
+                val skipped = decoded.invalid + decoded.duplicatedInFile
                 _sharingMessage.value = buildString {
                     append(
                         if (toImport.size == 1) "Imported 1 rule."
                         else "Imported ${toImport.size} rules."
                     )
                     if (duplicates > 0) append(" $duplicates already existed.")
+                    if (skipped > 0) {
+                        append(
+                            if (skipped == 1) " 1 entry in the file was unusable and was skipped."
+                            else " $skipped entries in the file were unusable and were skipped."
+                        )
+                    }
                     if (blocked > 0) {
                         append(" $blocked more need Pro — you're at the free limit of ${FreeTierLimits.MAX_RULES}.")
                     }

--- a/app/src/test/java/com/pennywiseai/tracker/data/rules/RuleSharingCodecTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/rules/RuleSharingCodecTest.kt
@@ -5,6 +5,7 @@ import com.pennywiseai.tracker.domain.model.rule.ConditionOperator
 import com.pennywiseai.tracker.domain.model.rule.RuleAction
 import com.pennywiseai.tracker.domain.model.rule.RuleCondition
 import com.pennywiseai.tracker.domain.model.rule.TransactionField
+import com.pennywiseai.tracker.domain.model.rule.supportedOperators
 import com.pennywiseai.tracker.domain.model.rule.TransactionRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -189,5 +190,31 @@ class RuleSharingCodecTest {
         """.trimIndent()
 
         assertThrows(IllegalArgumentException::class.java) { RuleSharingCodec.decode(text) }
+    }
+
+    @Test
+    fun `an operator that field never offers fails the file`() {
+        // MERCHANT is a text field; the editor only ever offers CONTAINS /
+        // EQUALS / STARTS_WITH for it, so GREATER_THAN could only come from a
+        // hand-written file and would never fire.
+        val text = """
+            {"version":1,"rules":[
+              {"name":"Nonsense","conditions":[
+                {"field":"MERCHANT","operator":"GREATER_THAN","value":"Zomato"}],
+               "actions":[{"field":"CATEGORY","actionType":"SET","value":"Food & Dining"}]}
+            ]}
+        """.trimIndent()
+
+        assertThrows(IllegalArgumentException::class.java) { RuleSharingCodec.decode(text) }
+    }
+
+    @Test
+    fun `every field's default operator is one it supports`() {
+        // Guards the picker/importer contract: the editor's first offered
+        // operator per field must be one the importer would also accept.
+        for (field in TransactionField.entries) {
+            val operators = supportedOperators(field)
+            assertTrue("$field offers no operators", operators.isNotEmpty())
+        }
     }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/data/rules/RuleSharingCodecTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/rules/RuleSharingCodecTest.kt
@@ -1,0 +1,118 @@
+package com.pennywiseai.tracker.data.rules
+
+import com.pennywiseai.tracker.domain.model.rule.ActionType
+import com.pennywiseai.tracker.domain.model.rule.ConditionOperator
+import com.pennywiseai.tracker.domain.model.rule.RuleAction
+import com.pennywiseai.tracker.domain.model.rule.RuleCondition
+import com.pennywiseai.tracker.domain.model.rule.TransactionField
+import com.pennywiseai.tracker.domain.model.rule.TransactionRule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Rules are shared between people (#741), so the file has to survive the round
+ * trip and has to refuse anything that isn't one.
+ */
+class RuleSharingCodecTest {
+
+    private fun rule(
+        name: String,
+        isSystemTemplate: Boolean = false
+    ) = TransactionRule(
+        name = name,
+        description = "Categorise $name",
+        priority = 50,
+        conditions = listOf(
+            RuleCondition(
+                field = TransactionField.MERCHANT,
+                operator = ConditionOperator.CONTAINS,
+                value = name
+            )
+        ),
+        actions = listOf(
+            RuleAction(
+                field = TransactionField.CATEGORY,
+                actionType = ActionType.SET,
+                value = "Food & Dining"
+            )
+        ),
+        isSystemTemplate = isSystemTemplate
+    )
+
+    @Test
+    fun `round trips a rule's matching and its effect`() {
+        val original = rule("Zomato")
+
+        val decoded = RuleSharingCodec.decode(RuleSharingCodec.encode(listOf(original)))
+
+        assertEquals(1, decoded.size)
+        val imported = decoded.single()
+        assertEquals(original.name, imported.name)
+        assertEquals(original.description, imported.description)
+        assertEquals(original.priority, imported.priority)
+        assertEquals(original.conditions, imported.conditions)
+        assertEquals(original.actions, imported.actions)
+        assertEquals(original.isActive, imported.isActive)
+    }
+
+    @Test
+    fun `imported rules get fresh ids so a file can be applied twice`() {
+        val original = rule("Zomato")
+
+        val imported = RuleSharingCodec.decode(RuleSharingCodec.encode(listOf(original))).single()
+
+        assertNotEquals(original.id, imported.id)
+        assertEquals(false, imported.isSystemTemplate)
+    }
+
+    @Test
+    fun `built-in templates are not exported`() {
+        val rules = listOf(rule("Zomato"), rule("Salary", isSystemTemplate = true))
+
+        assertEquals(listOf("Zomato"), RuleSharingCodec.exportable(rules).map { it.name })
+        assertEquals(listOf("Zomato"), RuleSharingCodec.decode(RuleSharingCodec.encode(rules)).map { it.name })
+    }
+
+    @Test
+    fun `a file that is not a rule set is rejected`() {
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            RuleSharingCodec.decode("""{"transactions":[]}""")
+        }
+        assertTrue(error.message!!.isNotBlank())
+    }
+
+    @Test
+    fun `a newer format version is refused rather than half-read`() {
+        val text = """{"version":99,"rules":[]}"""
+
+        assertThrows(IllegalArgumentException::class.java) { RuleSharingCodec.decode(text) }
+    }
+
+    @Test
+    fun `rules missing conditions or actions are dropped`() {
+        val text = """
+            {"version":1,"rules":[
+              {"name":"No conditions","conditions":[],"actions":[
+                {"field":"CATEGORY","actionType":"SET","value":"Food & Dining"}]}
+            ]}
+        """.trimIndent()
+
+        assertThrows(IllegalArgumentException::class.java) { RuleSharingCodec.decode(text) }
+    }
+
+    @Test
+    fun `unknown keys from a future build are ignored`() {
+        val text = """
+            {"version":1,"somethingNew":true,"rules":[
+              {"name":"Zomato","conditions":[
+                {"field":"MERCHANT","operator":"CONTAINS","value":"Zomato"}],
+               "actions":[{"field":"CATEGORY","actionType":"SET","value":"Food & Dining"}]}
+            ]}
+        """.trimIndent()
+
+        assertEquals(listOf("Zomato"), RuleSharingCodec.decode(text).map { it.name })
+    }
+}

--- a/app/src/test/java/com/pennywiseai/tracker/data/rules/RuleSharingCodecTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/rules/RuleSharingCodecTest.kt
@@ -264,4 +264,32 @@ class RuleSharingCodecTest {
             RuleSharingCodec.decode(text).rules.map { it.name }
         )
     }
+
+    @Test
+    fun `an action the engine cannot carry out fails the file`() {
+        // APPEND is meaningless for CATEGORY — the engine's applyAction falls to
+        // its else branch and the rule silently does nothing.
+        val text = """
+            {"version":1,"rules":[
+              {"name":"Dead action","conditions":[
+                {"field":"MERCHANT","operator":"CONTAINS","value":"Zomato"}],
+               "actions":[{"field":"CATEGORY","actionType":"APPEND","value":"x"}]}
+            ]}
+        """.trimIndent()
+
+        assertThrows(IllegalArgumentException::class.java) { RuleSharingCodec.decode(text) }
+    }
+
+    @Test
+    fun `a BLOCK action imports on any field`() {
+        val text = """
+            {"version":1,"rules":[
+              {"name":"Block OTPs","conditions":[
+                {"field":"SMS_TEXT","operator":"CONTAINS","value":"OTP"}],
+               "actions":[{"field":"AMOUNT","actionType":"BLOCK","value":""}]}
+            ]}
+        """.trimIndent()
+
+        assertEquals(listOf("Block OTPs"), RuleSharingCodec.decode(text).rules.map { it.name })
+    }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/data/rules/RuleSharingCodecTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/rules/RuleSharingCodecTest.kt
@@ -292,4 +292,32 @@ class RuleSharingCodecTest {
 
         assertEquals(listOf("Block OTPs"), RuleSharingCodec.decode(text).rules.map { it.name })
     }
+
+    @Test
+    fun `a TYPE action whose value is not a transaction type fails the file`() {
+        // applyAction falls back to the transaction's existing type when the
+        // value won't parse, so the rule would silently do nothing.
+        val text = """
+            {"version":1,"rules":[
+              {"name":"Bad type","conditions":[
+                {"field":"MERCHANT","operator":"CONTAINS","value":"Salary"}],
+               "actions":[{"field":"TYPE","actionType":"SET","value":"banana"}]}
+            ]}
+        """.trimIndent()
+
+        assertThrows(IllegalArgumentException::class.java) { RuleSharingCodec.decode(text) }
+    }
+
+    @Test
+    fun `a valid TYPE action imports fine`() {
+        val text = """
+            {"version":1,"rules":[
+              {"name":"Mark as income","conditions":[
+                {"field":"MERCHANT","operator":"CONTAINS","value":"Salary"}],
+               "actions":[{"field":"TYPE","actionType":"SET","value":"INCOME"}]}
+            ]}
+        """.trimIndent()
+
+        assertEquals(listOf("Mark as income"), RuleSharingCodec.decode(text).rules.map { it.name })
+    }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/data/rules/RuleSharingCodecTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/rules/RuleSharingCodecTest.kt
@@ -217,4 +217,51 @@ class RuleSharingCodecTest {
             assertTrue("$field offers no operators", operators.isNotEmpty())
         }
     }
+
+    @Test
+    fun `a non-numeric amount equality fails the file`() {
+        // "=" is an operator the editor offers for AMOUNT, and it used to skip
+        // the numeric check entirely.
+        val text = """
+            {"version":1,"rules":[
+              {"name":"Bad equals","conditions":[
+                {"field":"AMOUNT","operator":"EQUALS","value":"abc"}],
+               "actions":[{"field":"CATEGORY","actionType":"SET","value":"Food & Dining"}]}
+            ]}
+        """.trimIndent()
+
+        assertThrows(IllegalArgumentException::class.java) { RuleSharingCodec.decode(text) }
+    }
+
+    @Test
+    fun `a date that is not an ISO date fails the file`() {
+        val text = """
+            {"version":1,"rules":[
+              {"name":"Bad date","conditions":[
+                {"field":"TRANSACTION_DATE","operator":"EQUALS","value":"21-03-2026"}],
+               "actions":[{"field":"CATEGORY","actionType":"SET","value":"Food & Dining"}]}
+            ]}
+        """.trimIndent()
+
+        assertThrows(IllegalArgumentException::class.java) { RuleSharingCodec.decode(text) }
+    }
+
+    @Test
+    fun `a well-formed amount equality and ISO date import fine`() {
+        val text = """
+            {"version":1,"rules":[
+              {"name":"Exact amount","conditions":[
+                {"field":"AMOUNT","operator":"EQUALS","value":"499.50"}],
+               "actions":[{"field":"CATEGORY","actionType":"SET","value":"Food & Dining"}]},
+              {"name":"On a date","conditions":[
+                {"field":"TRANSACTION_DATE","operator":"EQUALS","value":"2026-03-21"}],
+               "actions":[{"field":"CATEGORY","actionType":"SET","value":"Travel"}]}
+            ]}
+        """.trimIndent()
+
+        assertEquals(
+            listOf("Exact amount", "On a date"),
+            RuleSharingCodec.decode(text).rules.map { it.name }
+        )
+    }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/data/rules/RuleSharingCodecTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/rules/RuleSharingCodecTest.kt
@@ -162,4 +162,32 @@ class RuleSharingCodecTest {
 
         assertThrows(IllegalArgumentException::class.java) { RuleSharingCodec.decode(oversized) }
     }
+
+    @Test
+    fun `a condition whose value is malformed for its field fails the file`() {
+        // Shape-valid (name, one condition, one action) but the AMOUNT comparison
+        // is against text, so the rule could never match anything.
+        val text = """
+            {"version":1,"rules":[
+              {"name":"Bad amount","conditions":[
+                {"field":"AMOUNT","operator":"LESS_THAN","value":"abc"}],
+               "actions":[{"field":"CATEGORY","actionType":"SET","value":"Food & Dining"}]}
+            ]}
+        """.trimIndent()
+
+        assertThrows(IllegalArgumentException::class.java) { RuleSharingCodec.decode(text) }
+    }
+
+    @Test
+    fun `an action with no value where one is required fails the file`() {
+        val text = """
+            {"version":1,"rules":[
+              {"name":"Empty set","conditions":[
+                {"field":"MERCHANT","operator":"CONTAINS","value":"Zomato"}],
+               "actions":[{"field":"CATEGORY","actionType":"SET","value":"  "}]}
+            ]}
+        """.trimIndent()
+
+        assertThrows(IllegalArgumentException::class.java) { RuleSharingCodec.decode(text) }
+    }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/data/rules/RuleSharingCodecTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/rules/RuleSharingCodecTest.kt
@@ -48,8 +48,8 @@ class RuleSharingCodecTest {
 
         val decoded = RuleSharingCodec.decode(RuleSharingCodec.encode(listOf(original)))
 
-        assertEquals(1, decoded.size)
-        val imported = decoded.single()
+        assertEquals(1, decoded.rules.size)
+        val imported = decoded.rules.single()
         assertEquals(original.name, imported.name)
         assertEquals(original.description, imported.description)
         assertEquals(original.priority, imported.priority)
@@ -62,7 +62,7 @@ class RuleSharingCodecTest {
     fun `imported rules get fresh ids so a file can be applied twice`() {
         val original = rule("Zomato")
 
-        val imported = RuleSharingCodec.decode(RuleSharingCodec.encode(listOf(original))).single()
+        val imported = RuleSharingCodec.decode(RuleSharingCodec.encode(listOf(original))).rules.single()
 
         assertNotEquals(original.id, imported.id)
         assertEquals(false, imported.isSystemTemplate)
@@ -73,7 +73,7 @@ class RuleSharingCodecTest {
         val rules = listOf(rule("Zomato"), rule("Salary", isSystemTemplate = true))
 
         assertEquals(listOf("Zomato"), RuleSharingCodec.exportable(rules).map { it.name })
-        assertEquals(listOf("Zomato"), RuleSharingCodec.decode(RuleSharingCodec.encode(rules)).map { it.name })
+        assertEquals(listOf("Zomato"), RuleSharingCodec.decode(RuleSharingCodec.encode(rules)).rules.map { it.name })
     }
 
     @Test
@@ -113,6 +113,52 @@ class RuleSharingCodecTest {
             ]}
         """.trimIndent()
 
-        assertEquals(listOf("Zomato"), RuleSharingCodec.decode(text).map { it.name })
+        assertEquals(listOf("Zomato"), RuleSharingCodec.decode(text).rules.map { it.name })
+    }
+
+    @Test
+    fun `a file mixing usable and unusable rules reports what it dropped`() {
+        val text = """
+            {"version":1,"rules":[
+              {"name":"Zomato","conditions":[
+                {"field":"MERCHANT","operator":"CONTAINS","value":"Zomato"}],
+               "actions":[{"field":"CATEGORY","actionType":"SET","value":"Food & Dining"}]},
+              {"name":"No actions","conditions":[
+                {"field":"MERCHANT","operator":"CONTAINS","value":"Swiggy"}],"actions":[]}
+            ]}
+        """.trimIndent()
+
+        val decoded = RuleSharingCodec.decode(text)
+
+        assertEquals(listOf("Zomato"), decoded.rules.map { it.name })
+        assertEquals(1, decoded.invalid)
+        assertEquals(0, decoded.duplicatedInFile)
+    }
+
+    @Test
+    fun `a name repeated inside one file lands as a single rule`() {
+        val text = """
+            {"version":1,"rules":[
+              {"name":"Zomato","conditions":[
+                {"field":"MERCHANT","operator":"CONTAINS","value":"Zomato"}],
+               "actions":[{"field":"CATEGORY","actionType":"SET","value":"Food & Dining"}]},
+              {"name":"zomato","conditions":[
+                {"field":"MERCHANT","operator":"CONTAINS","value":"Zomato"}],
+               "actions":[{"field":"CATEGORY","actionType":"SET","value":"Others"}]}
+            ]}
+        """.trimIndent()
+
+        val decoded = RuleSharingCodec.decode(text)
+
+        assertEquals(1, decoded.rules.size)
+        assertEquals("Zomato", decoded.rules.single().name)
+        assertEquals(1, decoded.duplicatedInFile)
+    }
+
+    @Test
+    fun `an oversized file is refused before it is parsed`() {
+        val oversized = "x".repeat((RuleSharingCodec.MAX_FILE_BYTES + 1).toInt())
+
+        assertThrows(IllegalArgumentException::class.java) { RuleSharingCodec.decode(oversized) }
     }
 }

--- a/app/src/test/java/com/pennywiseai/tracker/data/rules/RuleSharingCodecTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/data/rules/RuleSharingCodecTest.kt
@@ -117,7 +117,7 @@ class RuleSharingCodecTest {
     }
 
     @Test
-    fun `a file mixing usable and unusable rules reports what it dropped`() {
+    fun `one unusable entry fails the whole file, importing nothing`() {
         val text = """
             {"version":1,"rules":[
               {"name":"Zomato","conditions":[
@@ -128,11 +128,12 @@ class RuleSharingCodecTest {
             ]}
         """.trimIndent()
 
-        val decoded = RuleSharingCodec.decode(text)
-
-        assertEquals(listOf("Zomato"), decoded.rules.map { it.name })
-        assertEquals(1, decoded.invalid)
-        assertEquals(0, decoded.duplicatedInFile)
+        // The usable "Zomato" rule must NOT slip through on its own — a
+        // half-applied rule set is worse than a refused one.
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            RuleSharingCodec.decode(text)
+        }
+        assertTrue(error.message!!.contains("nothing was imported"))
     }
 
     @Test

--- a/app/src/test/java/com/pennywiseai/tracker/domain/model/rule/RuleActionExecutabilityTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/domain/model/rule/RuleActionExecutabilityTest.kt
@@ -1,0 +1,93 @@
+package com.pennywiseai.tracker.domain.model.rule
+
+import com.pennywiseai.tracker.data.database.entity.TransactionEntity
+import com.pennywiseai.tracker.data.database.entity.TransactionType
+import com.pennywiseai.tracker.domain.service.RuleEngine
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+/**
+ * Pins [supportedActionTypes] to what [RuleEngine] actually does.
+ *
+ * The rule importer refuses actions the engine can't carry out, so the two must
+ * agree: if the engine gains (or loses) the ability to apply some field/action
+ * pair and this table isn't updated, imports would start rejecting rules that
+ * work — or accepting rules that silently do nothing.
+ */
+class RuleActionExecutabilityTest {
+
+    private val engine = RuleEngine()
+
+    private val transaction = TransactionEntity(
+        amount = BigDecimal("100.00"),
+        merchantName = "Zomato",
+        category = "Food & Dining",
+        transactionType = TransactionType.EXPENSE,
+        dateTime = LocalDateTime.of(2026, 3, 21, 10, 0),
+        smsBody = "irrelevant",
+        transactionHash = "hash",
+        description = "lunch",
+        bankName = "Kotak"
+    )
+
+    /** A value that would be a visible change for [field], so a no-op is detectable. */
+    private fun probeValue(field: TransactionField, actionType: ActionType): String =
+        when {
+            actionType == ActionType.CLEAR -> ""
+            field == TransactionField.TYPE -> TransactionType.INCOME.name
+            else -> "CHANGED"
+        }
+
+    @Test
+    fun `the table matches what the engine actually applies`() {
+        for (field in TransactionField.entries) {
+            for (actionType in ActionType.entries) {
+                // BLOCK never modifies a transaction — it's handled by
+                // shouldBlockTransaction — so it can't be probed this way.
+                if (actionType == ActionType.BLOCK) continue
+
+                val action = RuleAction(
+                    field = field,
+                    actionType = actionType,
+                    value = probeValue(field, actionType)
+                )
+                val (result, _) = engine.evaluateRules(
+                    transaction = transaction,
+                    smsText = null,
+                    rules = listOf(
+                        TransactionRule(
+                            name = "probe",
+                            conditions = listOf(
+                                RuleCondition(
+                                    field = TransactionField.MERCHANT,
+                                    operator = ConditionOperator.CONTAINS,
+                                    value = "Zomato"
+                                )
+                            ),
+                            actions = listOf(action)
+                        )
+                    )
+                )
+
+                val engineChangedSomething = result != transaction
+                assertEquals(
+                    "$field + $actionType: supportedActionTypes says " +
+                        "${actionType in supportedActionTypes(field)} but the engine " +
+                        "${if (engineChangedSomething) "did" else "did not"} apply it",
+                    actionType in supportedActionTypes(field),
+                    engineChangedSomething
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `BLOCK is executable on any field`() {
+        for (field in TransactionField.entries) {
+            val action = RuleAction(field = field, actionType = ActionType.BLOCK, value = "")
+            assert(action.isExecutable()) { "$field + BLOCK should be executable" }
+        }
+    }
+}

--- a/app/src/test/java/com/pennywiseai/tracker/domain/service/RuleEngineTest.kt
+++ b/app/src/test/java/com/pennywiseai/tracker/domain/service/RuleEngineTest.kt
@@ -479,4 +479,101 @@ class RuleEngineTest {
             value = "Auto-Categorized"
         ))
     )
+
+    // --- AMOUNT equality is numeric, not textual ---
+
+    @Test
+    fun `amount equals matches a numerically equal value written differently`() {
+        // The field value is BigDecimal.toString() — "100.00" — so a rule typed
+        // as "100" used to string-compare and never fire.
+        val rule = TransactionRule(
+            name = "Exactly 100",
+            conditions = listOf(
+                RuleCondition(
+                    field = TransactionField.AMOUNT,
+                    operator = ConditionOperator.EQUALS,
+                    value = "100"
+                )
+            ),
+            actions = listOf(
+                RuleAction(TransactionField.CATEGORY, ActionType.SET, "Matched")
+            )
+        )
+
+        val (result, applications) = engine.evaluateRules(
+            transaction(amount = BigDecimal("100.00")), null, listOf(rule)
+        )
+
+        assertEquals("Matched", result.category)
+        assertEquals(1, applications.size)
+    }
+
+    @Test
+    fun `amount equals still rejects a different number`() {
+        val rule = TransactionRule(
+            name = "Exactly 100",
+            conditions = listOf(
+                RuleCondition(
+                    field = TransactionField.AMOUNT,
+                    operator = ConditionOperator.EQUALS,
+                    value = "100"
+                )
+            ),
+            actions = listOf(
+                RuleAction(TransactionField.CATEGORY, ActionType.SET, "Matched")
+            )
+        )
+
+        val (_, applications) = engine.evaluateRules(
+            transaction(amount = BigDecimal("101.00")), null, listOf(rule)
+        )
+
+        assertTrue(applications.isEmpty())
+    }
+
+    @Test
+    fun `amount not equals is numeric too`() {
+        val rule = TransactionRule(
+            name = "Anything but 100",
+            conditions = listOf(
+                RuleCondition(
+                    field = TransactionField.AMOUNT,
+                    operator = ConditionOperator.NOT_EQUALS,
+                    value = "100"
+                )
+            ),
+            actions = listOf(
+                RuleAction(TransactionField.CATEGORY, ActionType.SET, "Matched")
+            )
+        )
+
+        val (_, applications) = engine.evaluateRules(
+            transaction(amount = BigDecimal("100.00")), null, listOf(rule)
+        )
+
+        assertTrue("100.00 must not count as 'not equal to 100'", applications.isEmpty())
+    }
+
+    @Test
+    fun `non-amount equality is still a plain text match`() {
+        val rule = TransactionRule(
+            name = "Merchant is Zomato",
+            conditions = listOf(
+                RuleCondition(
+                    field = TransactionField.MERCHANT,
+                    operator = ConditionOperator.EQUALS,
+                    value = "zomato"
+                )
+            ),
+            actions = listOf(
+                RuleAction(TransactionField.CATEGORY, ActionType.SET, "Matched")
+            )
+        )
+
+        val (result, _) = engine.evaluateRules(
+            transaction(merchantName = "Zomato"), null, listOf(rule)
+        )
+
+        assertEquals("Matched", result.category)
+    }
 }


### PR DESCRIPTION
Closes #741.

## What

**Export rules** / **Import rules** in the Smart Rules overflow menu, writing a small versioned JSON file through SAF. Nothing leaves the device unless the user shares the file themselves.

```json
{
  "version": 1,
  "rules": [
    {
      "name": "EmulatorRoundTrip",
      "description": null,
      "priority": 100,
      "conditions": [
        { "field": "AMOUNT", "operator": "LESS_THAN", "value": "200", "logicalOperator": "AND" }
      ],
      "actions": [
        { "field": "CATEGORY", "actionType": "SET", "value": "Food & Dining" }
      ],
      "isActive": true
    }
  ]
}
```

## Decisions

- **The portable form is narrower than `TransactionRule`.** Ids, timestamps and the system-template flag are facts about one install, so they're dropped on export and regenerated on import.
- **Built-in templates aren't exported.** Every install already ships them; exporting would only create duplicates on the other side.
- **Imported rules get fresh ids**, so a file can be applied more than once. A rule whose *name* already exists is skipped rather than duplicated.
- **The free-tier cap still applies.** Import can't push a free user past `FreeTierLimits.MAX_RULES` — otherwise it'd be a way around the paywall the create screen enforces. The result message says how many were held back.
- **A bad file is refused outright, not half-applied.** Unknown keys are ignored (forward compatible), but a newer `version`, a non-rule-set file, an oversized file, or one containing *any* incomplete entry is rejected and nothing is imported ("1 rule in this file is incomplete, so nothing was imported."). Importing most of a shared rule set would leave someone with a half-applied config they can't easily tell from the real thing. Repeats of a name *within* one file are the one thing collapsed rather than refused — the file is unambiguous there, first one wins — and the count is reported.
- **Not included: multi-select export.** The issue suggested selecting rules to export; that means a selection mode across the whole screen. The complaint is "rule sets can't be shared", which export-all + import solves — happy to add selection later if people ask.

The Reset action moved into the same overflow menu rather than adding a third top-bar icon.

## Verification

`./init.sh app` green, plus 7 new tests in `RuleSharingCodecTest` (round trip, fresh ids, templates excluded, bad file, newer version, invalid rule, unknown keys).

End-to-end on the emulator:

1. With only built-in templates → "You don't have any custom rules to export yet." (no picker, no empty file).
2. Created a custom rule → export writes the JSON above.
3. Importing that same file again → "Imported 0 rules. 1 already existed."
4. Deleted the rule, imported the file → "Imported 1 rule." and it's back on the list.

